### PR TITLE
Fix plots: Make load_over_time Function Dynamic #Issue 209

### DIFF
--- a/gridstatus/tests/test_viz.py
+++ b/gridstatus/tests/test_viz.py
@@ -27,8 +27,10 @@ def test_dam_heat_map():
     fig = gridstatus.viz.dam_heat_map(df)
     assert isinstance(fig, plotly.graph_objs._figure.Figure)
 
+# uncomment to skipped test, should be fixed now with new changes to load_over_time function
+# @pytest.mark.skip(reason="Failed. TODO Fix")
 
-@pytest.mark.skip(reason="Failed. TODO Fix")
+
 def test_load_over_time():
 
     iso = gridstatus.CAISO()

--- a/gridstatus/tests/test_viz.py
+++ b/gridstatus/tests/test_viz.py
@@ -1,6 +1,6 @@
-import plotly
-import pytest
 import pandas as pd
+import plotly
+
 import gridstatus
 
 
@@ -43,23 +43,8 @@ def test_load_over_time():
     fig = gridstatus.viz.load_over_time(df, iso="CAISO")
     assert isinstance(fig, plotly.graph_objs._figure.Figure)
 
-# unit test 1 - valid df with numeric columns
 
-
-def test_load_over_time_validdataframe():
-    """
-    Test for creation a line graph with a valid dataframe input containing numeric columns.
-    """
-    data = {
-        "Time": pd.date_range(start="2021-01-01", periods=5, freq="D"),
-        "Load": [100, 200, 150, 250, 300]
-    }
-    df = pd.DataFrame(data)
-    fig = gridstatus.viz.load_over_time(df)
-    assert isinstance(
-        fig, plotly.graph_objs._figure.Figure), "Output is not a Plotly Figure instance"
-
-# unit test 2 - test with an empty df
+# unit test 1 - test with an empty df
 
 
 def test_load_over_time_emptydataframe():
@@ -70,12 +55,12 @@ def test_load_over_time_emptydataframe():
     fig = gridstatus.viz.load_over_time(df)
     assert fig is None, "Output should be None when an empty dataframe is provided"
 
-# unit test 3 - test df with only nonnumeric columns
+# unit test 2 - test df with only nonnumeric columns
 
 
 def test_load_over_time_zeronumericcolumns():
     """
-    Test func returns None when there are no numeric columns in the dataframe.
+    Test returns None if no numeric columns in df.
     """
     data = {
         "Time": pd.date_range(start="2021-01-01", periods=5, freq="D"),
@@ -85,12 +70,12 @@ def test_load_over_time_zeronumericcolumns():
     fig = gridstatus.viz.load_over_time(df)
     assert fig is None, "Output should be None when no numeric columns are present"
 
-# unit test 4: test df with only one numeric column
+# unit test 3: test df with only one numeric column
 
 
 def test_load_over_time_onenumericcolumns():
     """
-    Test creation of a line fig with one numeric columns in the df.
+    Test line fig for df with one numeric column.
     """
     data = {
         "Time": pd.date_range(start="2021-01-01", periods=5, freq="D"),
@@ -101,12 +86,12 @@ def test_load_over_time_onenumericcolumns():
     assert isinstance(
         fig, plotly.graph_objs._figure.Figure), "Output is not a Plotly Figure instance"
 
-# unit test 5:test df with two numeric columns
+# unit test 4:test df with two numeric columns
 
 
 def test_load_over_time_twonumericcolumns():
     """
-    Test func creates a line fig with two numeric columns in the dataframe.
+    Test line fig for df with two numeric columns.
     """
     data = {
         "Time": pd.date_range(start="2021-01-01", periods=5, freq="D"),
@@ -118,12 +103,12 @@ def test_load_over_time_twonumericcolumns():
     assert isinstance(
         fig, plotly.graph_objs._figure.Figure), "Output is not a Plotly Figure instance"
 
-# unit test 6: test df with three numeric columns
+# unit test 5: test df with three numeric columns
 
 
 def test_load_over_time_threenumericcolumns():
     """
-    Test func creates a line fig with three numeric columns in the dataframe.
+    Test line fig for df with three numeric columns.
     """
     data = {
         "Time": pd.date_range(start="2021-01-01", periods=5, freq="D"),
@@ -136,12 +121,12 @@ def test_load_over_time_threenumericcolumns():
     assert isinstance(
         fig, plotly.graph_objs._figure.Figure), "Output is not a Plotly Figure instance"
 
-# unit test 7: test case when iso string is provided
+# unit test 6: test case when iso string is provided
 
 
 def test_load_over_time_withiso():
     """
-    Test func creates a line fig with the correct title when an iso is provided.
+    Test line fig with correct title if iso provided.
     """
     data = {
         "Time": pd.date_range(start="2021-01-01", periods=5, freq="D"),
@@ -150,4 +135,5 @@ def test_load_over_time_withiso():
     df = pd.DataFrame(data)
     iso = "TEST_ISO"
     fig = gridstatus.viz.load_over_time(df, iso=iso)
-    assert fig.layout.title.text == f"Load Over Time - {iso}", "Title is incorrect when ISO is provided"
+    test_title = f"Load Over Time - {iso}", "Title not correct when ISO provided"
+    assert fig.layout.title.text == test_title

--- a/gridstatus/tests/test_viz.py
+++ b/gridstatus/tests/test_viz.py
@@ -1,6 +1,6 @@
 import plotly
 import pytest
-
+import pandas as pd
 import gridstatus
 
 
@@ -40,3 +40,112 @@ def test_load_over_time():
 
     fig = gridstatus.viz.load_over_time(df, iso="CAISO")
     assert isinstance(fig, plotly.graph_objs._figure.Figure)
+
+# unit test 1 - valid df with numeric columns
+
+
+def test_load_over_time_validdataframe():
+    """
+    Test for creation a line graph with a valid dataframe input containing numeric columns.
+    """
+    data = {
+        "Time": pd.date_range(start="2021-01-01", periods=5, freq="D"),
+        "Load": [100, 200, 150, 250, 300]
+    }
+    df = pd.DataFrame(data)
+    fig = gridstatus.viz.load_over_time(df)
+    assert isinstance(
+        fig, plotly.graph_objs._figure.Figure), "Output is not a Plotly Figure instance"
+
+# unit test 2 - test with an empty df
+
+
+def test_load_over_time_emptydataframe():
+    """
+    Test returns None when an empty dataframe is provided.
+    """
+    df = pd.DataFrame()
+    fig = gridstatus.viz.load_over_time(df)
+    assert fig is None, "Output should be None when an empty dataframe is provided"
+
+# unit test 3 - test df with only nonnumeric columns
+
+
+def test_load_over_time_zeronumericcolumns():
+    """
+    Test func returns None when there are no numeric columns in the dataframe.
+    """
+    data = {
+        "Time": pd.date_range(start="2021-01-01", periods=5, freq="D"),
+        "Load": ["A", "B", "C", "D", "E"]
+    }
+    df = pd.DataFrame(data)
+    fig = gridstatus.viz.load_over_time(df)
+    assert fig is None, "Output should be None when no numeric columns are present"
+
+# unit test 4: test df with only one numeric column
+
+
+def test_load_over_time_onenumericcolumns():
+    """
+    Test creation of a line fig with one numeric columns in the df.
+    """
+    data = {
+        "Time": pd.date_range(start="2021-01-01", periods=5, freq="D"),
+        "Load": [100, 200, 150, 250, 300]
+    }
+    df = pd.DataFrame(data)
+    fig = gridstatus.viz.load_over_time(df)
+    assert isinstance(
+        fig, plotly.graph_objs._figure.Figure), "Output is not a Plotly Figure instance"
+
+# unit test 5:test df with two numeric columns
+
+
+def test_load_over_time_twonumericcolumns():
+    """
+    Test func creates a line fig with two numeric columns in the dataframe.
+    """
+    data = {
+        "Time": pd.date_range(start="2021-01-01", periods=5, freq="D"),
+        "Load": [100, 200, 150, 250, 300],
+        "Load2": [50, 100, 75, 125, 150]
+    }
+    df = pd.DataFrame(data)
+    fig = gridstatus.viz.load_over_time(df)
+    assert isinstance(
+        fig, plotly.graph_objs._figure.Figure), "Output is not a Plotly Figure instance"
+
+# unit test 6: test df with three numeric columns
+
+
+def test_load_over_time_threenumericcolumns():
+    """
+    Test func creates a line fig with three numeric columns in the dataframe.
+    """
+    data = {
+        "Time": pd.date_range(start="2021-01-01", periods=5, freq="D"),
+        "Load": [100, 200, 150, 250, 300],
+        "Load2": [50, 100, 75, 125, 150],
+        "Load3": [10, 30, 60, 40, 20]
+    }
+    df = pd.DataFrame(data)
+    fig = gridstatus.viz.load_over_time(df)
+    assert isinstance(
+        fig, plotly.graph_objs._figure.Figure), "Output is not a Plotly Figure instance"
+
+# unit test 7: test case when iso string is provided
+
+
+def test_load_over_time_withiso():
+    """
+    Test func creates a line fig with the correct title when an iso is provided.
+    """
+    data = {
+        "Time": pd.date_range(start="2021-01-01", periods=5, freq="D"),
+        "Load": [100, 200, 150, 250, 300]
+    }
+    df = pd.DataFrame(data)
+    iso = "TEST_ISO"
+    fig = gridstatus.viz.load_over_time(df, iso=iso)
+    assert fig.layout.title.text == f"Load Over Time - {iso}", "Title is incorrect when ISO is provided"

--- a/gridstatus/viz.py
+++ b/gridstatus/viz.py
@@ -43,29 +43,41 @@ def dam_heat_map(df):
 
 
 def load_over_time(df, iso=None):
-    """Create a line graph of load dataframe"""
-    y = "Load"
-    if len(df.columns) > 3:
-        y = df.columns[2:]
+    """Create a line graph of load dataframe, focusing on numerical values over time"""
+    # find all columns with numeric data types (int, float etc.)
+    # need this to avoid trying to plot chart with mixed data types or without any numeric data types
+    # previous implementation would hard code the columns, this approach will be more dynamic
+    numeric_columns = df.select_dtypes(include=['number']).columns
+    fig = None
 
-    title = "Load Over Time"
-    if iso:
-        title += " - " + iso
+    if len(numeric_columns) > 0:
+        # found numeric columns, continue..
+        y = "Load"
+        if len(df.columns) > 3:
+            y = numeric_columns
 
-    fig = px.line(
-        df,
-        x=df["Time"],
-        y=y,
-        title=title,
-    )
-    # show legend
-    fig.update_layout(
-        legend=dict(
-            orientation="h",
-            title_text=None,
-            y=-0.2,
-        ),
-    )
-    fig.update_yaxes(title_text="MW")
+        title = "Load Over Time"
+        if iso:
+            title += " - " + iso
 
-    return fig
+        fig = px.line(
+            df,
+            x=df["Time"],
+            y=y,
+            title=title,
+        )
+        # show legend
+        fig.update_layout(
+            legend=dict(
+                orientation="h",
+                title_text=None,
+                y=-0.2,
+            ),
+        )
+        fig.update_yaxes(title_text="MW")
+        return fig
+    else:
+        # no numeric columns, so cannot plot the figure
+        print(
+            "No numeric columns found in dataframe. Cannot make chart without numeric data.")
+        return fig

--- a/gridstatus/viz.py
+++ b/gridstatus/viz.py
@@ -49,8 +49,7 @@ def load_over_time(df, iso=None):
     # previous implementation would hard code the columns, this approach will be more dynamic
     numeric_columns = df.select_dtypes(include=['number']).columns
     fig = None
-
-    if len(numeric_columns) > 0:
+    if len(numeric_columns) > 0 and "Time" in df.columns:
         # found numeric columns, continue..
         y = "Load"
         if len(df.columns) > 3:
@@ -75,9 +74,10 @@ def load_over_time(df, iso=None):
             ),
         )
         fig.update_yaxes(title_text="MW")
+
         return fig
+
     else:
         # no numeric columns, so cannot plot the figure
-        print(
-            "No numeric columns found in dataframe. Cannot make chart without numeric data.")
+        print("You either do not have any numeric columns or are missing the 'Time' columns in your dataframe.")
         return fig

--- a/gridstatus/viz.py
+++ b/gridstatus/viz.py
@@ -47,7 +47,7 @@ def load_over_time(df, iso=None):
     # find all columns with numeric data types (int, float etc.)
     # need this to avoid trying to plot chart with mixed data types or without any numeric data types
     # previous implementation would hard code the columns, this approach will be more dynamic
-    numeric_columns = df.select_dtypes(include=['number']).columns
+    numeric_columns = df.select_dtypes(include=["number"]).columns
     fig = None
     if len(numeric_columns) > 0 and "Time" in df.columns:
         # found numeric columns, continue..
@@ -79,5 +79,5 @@ def load_over_time(df, iso=None):
 
     else:
         # no numeric columns, so cannot plot the figure
-        print("You either do not have any numeric columns or are missing the 'Time' columns in your dataframe.")
+        print("Need numeric columns and a 'Time' column.")
         return fig


### PR DESCRIPTION
Plotting with the load_over_time function was giving an error due to hardcoded indexes to select columns to be plotted. I suggest changes to make this part dynamic so it will plot only the numerical columns and only when there are numerical columns.  Also wrote a comprehensive set of tests for the function with different test cases.

**Problem code to reproduce error:**
```
import gridstatus
import plotly.express as px
import pandas as pd

iso = gridstatus.PJM()
df = iso.get_load(date="today")

gridstatus.viz.load_over_time(df, iso="PJM")
```
**The error seen:**
```
`ValueError: Plotly Express cannot process wide-form data with columns of different type.`
```
**Solution**
Used pandas column datatype filters to identify numerical columns, then pass these to be plotted as the dependent variables (y)