### PR TITLE
GitHub Action to Update gs-etl on New Commit in gridstatus

### DIFF
--- a/.github/workflows/update_gs_etl.yaml
+++ b/.github/workflows/update_gs_etl.yaml
@@ -17,6 +17,10 @@ jobs:
       id: latest_commit
       run: echo "LATEST_COMMIT_HASH=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
+    - name: Get the latest commit message of gridstatus
+      id: commit_message
+      run: echo "COMMIT_MESSAGE=$(git show -s --format=%s)" >> $GITHUB_ENV
+
     - name: Checkout gs-etl
       uses: actions/checkout@v4
       with:
@@ -39,6 +43,10 @@ jobs:
         commit-message: Update gridstatus version
         title: 'Update gridstatus to commit $LATEST_COMMIT_HASH'
         branch: 'update-gridstatus-$LATEST_COMMIT_HASH'
-        body: 'This is an automated PR to update the gridstatus version'
+        body: |
+          This is an automated PR to update the gridstatus version.
+
+          Latest gridstatus commit message:
+          $COMMIT_MESSAGE
         base: 'main'
         path: gs-etl

--- a/.github/workflows/update_gs_etl.yaml
+++ b/.github/workflows/update_gs_etl.yaml
@@ -1,0 +1,44 @@
+name: Update gs-etl dependency
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-dependency:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout gridstatus
+      uses: actions/checkout@v4
+
+    - name: Get the latest commit hash of gridstatus
+      id: latest_commit
+      run: echo "LATEST_COMMIT_HASH=$(git rev-parse HEAD)" >> $GITHUB_ENV
+
+    - name: Checkout gs-etl
+      uses: actions/checkout@v4
+      with:
+        repository: gridstatus/gs-etl
+        token: ${{ secrets.PAT }}
+        path: gs-etl
+
+    - name: Install Poetry
+      uses: snok/install-poetry-action@v1
+
+    - name: Update gridstatus dependency in gs-etl
+      run: |
+        cd gs-etl
+        poetry add git+https://github.com/kmax12/gridstatus.git#$LATEST_COMMIT_HASH
+
+    - name: Push changes and create Pull Request
+      uses: peter-evans/create-pull-request@v6
+      with:
+        token: ${{ secrets.PAT }}
+        commit-message: Update gridstatus version
+        title: 'Update gridstatus to commit $LATEST_COMMIT_HASH'
+        branch: 'update-gridstatus-$LATEST_COMMIT_HASH'
+        body: 'This is an automated PR to update the gridstatus version'
+        base: 'main'
+        path: gs-etl


### PR DESCRIPTION
- Adds a github action that creates a PR in `gs-etl` with the latest commit to `gridstatus` on a new commit to `gridstatus`
