### PR TITLE
Add ERCOT SPP Day Ahead Hourly to ERCOT API

### DIFF
--- a/gridstatus/tests/test_ercot_api.py
+++ b/gridstatus/tests/test_ercot_api.py
@@ -927,6 +927,50 @@ class TestErcotAPI(TestHelperMixin):
         assert df["Interval Start"].min() == self.local_start_of_day(start_date)
         assert df["Interval End"].max() == self.local_start_of_day(end_date)
 
+    """get_spp_day_ahead_hourly"""
+
+    def _check_spp_day_ahead_hourly(self, df):
+        assert df.columns.tolist() == [
+            "Time",
+            "Interval Start",
+            "Interval End",
+            "Location",
+            "Location Type",
+            "Market",
+            "SPP",
+        ]
+
+        assert (
+            (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(minutes=60)
+        ).all()
+
+        assert sorted(df["Location Type"].unique().tolist()) == [
+            "Load Zone",
+            "Load Zone DC Tie",
+            "Resource Node",
+            "Trading Hub",
+        ]
+
+        assert df["Market"].unique().tolist() == ["DAY_AHEAD_HOURLY"]
+
+    def test_get_spp_day_ahead_hourly_historical_date_range(self):
+        start_date = self.local_today() - pd.DateOffset(days=100)
+
+        end_date = start_date + pd.DateOffset(days=2)
+
+        df = ErcotAPI().get_spp_day_ahead_hourly(
+            date=start_date,
+            end=end_date,
+            verbose=True,
+        )
+
+        self._check_spp_day_ahead_hourly(df)
+
+        assert df["Interval Start"].nunique() == 24 * 2
+
+        assert df["Interval Start"].min() == self.local_start_of_day(start_date)
+        assert df["Interval End"].max() == self.local_start_of_day(end_date)
+
     """get_historical_data"""
 
     def test_get_historical_data(self):


### PR DESCRIPTION
- Adds `get_spp_day_ahead_hourly` to the `ErcotAPI` to retrieve historical SPP day-ahead hourly prices.
- https://data.ercot.com/data-product-archive/NP4-190-CD
