### PR TITLE
Add CAISO Fuel Regions

### DIFF
--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -647,6 +647,21 @@ class CAISO(ISOBase):
         ]
         return df
 
+    def get_fuel_regions(self, verbose=False):
+        """Retrieves the (mostly static) list of fuel regions with associated data.
+        This file can be joined to the gas prices on Fuel Region Id"""
+        url = "https://www.caiso.com/documents/fuelregion_electricregiondefinitions.xlsx"  # noqa
+
+        log(f"Fetching {url}", verbose=verbose)
+
+        # Only want the "GPI_Fuel_Region" sheet
+        return pd.read_excel(url, sheet_name="GPI_Fuel_Region").rename(
+            columns={
+                "Fuel Region": "Fuel Region Id",
+                "Cap & Trade Credit": "Cap and Trade Credit",
+            },
+        )
+
     @support_date_range(frequency="31D")
     def get_ghg_allowance(
         self,

--- a/gridstatus/tests/test_caiso.py
+++ b/gridstatus/tests/test_caiso.py
@@ -223,6 +223,21 @@ class TestCAISO(BaseTestISO):
         )
         assert len(df) == 24 * 2
 
+    """get_fuel_regions"""
+
+    def test_get_fuel_regions(self):
+        df = self.iso.get_fuel_regions()
+        assert df.columns.tolist() == [
+            "Fuel Region Id",
+            "Pricing Hub",
+            "Transportation Cost",
+            "Fuel Reimbursement Rate",
+            "Cap and Trade Credit",
+            "Miscellaneous Costs",
+            "Balancing Authority",
+        ]
+        assert df.shape[0] > 180
+
     """get_ghg_allowance"""
 
     def test_get_ghg_allowance(self):


### PR DESCRIPTION
- Adds `CAISO().get_fuel_regions()` method
- Retrieves the file available at https://www.caiso.com/library/iso-fuel-region-and-electric-region-definitions
