### PR TITLE
PJM Metered Load Hourly

### DIFF
--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -2056,7 +2056,7 @@ class PJM(ISOBase):
         return df.sort_values("Interval Start").reset_index(drop=True)
 
     @support_date_range(frequency=None)
-    def get_hourly_metered_load(self, date, end=None, verbose=False):
+    def get_metered_load_hourly(self, date, end=None, verbose=False):
         """
         Retrieves the hourly metered load data from:
 
@@ -2077,9 +2077,9 @@ class PJM(ISOBase):
             verbose=verbose,
         )
 
-        return self._parse_hourly_metered_load(df)
+        return self._parse_metered_load_hourly(df)
 
-    def _parse_hourly_metered_load(self, df):
+    def _parse_metered_load_hourly(self, df):
         df = df.rename(
             columns={
                 "load_area": "Load Area",

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -2056,7 +2056,7 @@ class PJM(ISOBase):
         return df.sort_values("Interval Start").reset_index(drop=True)
 
     @support_date_range(frequency=None)
-    def get_metered_load_hourly(self, date, end=None, verbose=False):
+    def get_load_metered_hourly(self, date, end=None, verbose=False):
         """
         Retrieves the hourly metered load data from:
 
@@ -2077,9 +2077,9 @@ class PJM(ISOBase):
             verbose=verbose,
         )
 
-        return self._parse_metered_load_hourly(df)
+        return self._parse_load_metered_hourly(df)
 
-    def _parse_metered_load_hourly(self, df):
+    def _parse_load_metered_hourly(self, df):
         df = df.rename(
             columns={
                 "load_area": "Load Area",

--- a/gridstatus/tests/test_pjm.py
+++ b/gridstatus/tests/test_pjm.py
@@ -1439,9 +1439,9 @@ class TestPJM(BaseTestISO):
         with pytest.raises(ValueError, match="Both start and end dates must be before"):
             self.iso.get_real_time_as_market_results(date=start, end=end, error="raise")
 
-    """get_hourly_metered_load"""
+    """get_metered_load_hourly"""
 
-    def _check_hourly_metered_load(self, df):
+    def _check_metered_load_hourly(self, df):
         assert df.columns.tolist() == [
             "Interval Start",
             "Interval End",
@@ -1466,12 +1466,12 @@ class TestPJM(BaseTestISO):
 
         assert set(df["NERC Region"]) == {"RFC", "SERC", "RTO"}
 
-    def test_get_hourly_metered_load_historical_date(self):
+    def test_get_metered_load_hourly_historical_date(self):
         date = self.local_today() - pd.Timedelta(days=10)
 
-        df = self.iso.get_hourly_metered_load(date)
+        df = self.iso.get_metered_load_hourly(date)
 
-        self._check_hourly_metered_load(df)
+        self._check_metered_load_hourly(df)
 
         assert df["Interval Start"].min() == self.local_start_of_day(date)
         assert df["Interval End"].max() == self.local_start_of_day(
@@ -1480,13 +1480,13 @@ class TestPJM(BaseTestISO):
             days=1,
         )
 
-    def test_get_hourly_metered_load_historical_date_range(self):
+    def test_get_metered_load_hourly_historical_date_range(self):
         date = self.local_today() - pd.Timedelta(days=12)
         end_date = date + pd.Timedelta(days=3)
 
-        df = self.iso.get_hourly_metered_load(date, end_date)
+        df = self.iso.get_metered_load_hourly(date, end_date)
 
-        self._check_hourly_metered_load(df)
+        self._check_metered_load_hourly(df)
 
         assert df["Interval Start"].min() == self.local_start_of_day(date)
         assert df["Interval End"].max() == self.local_start_of_day(end_date)

--- a/gridstatus/tests/test_pjm.py
+++ b/gridstatus/tests/test_pjm.py
@@ -1439,9 +1439,9 @@ class TestPJM(BaseTestISO):
         with pytest.raises(ValueError, match="Both start and end dates must be before"):
             self.iso.get_real_time_as_market_results(date=start, end=end, error="raise")
 
-    """get_metered_load_hourly"""
+    """get_load_metered_hourly"""
 
-    def _check_metered_load_hourly(self, df):
+    def _check_load_metered_hourly(self, df):
         assert df.columns.tolist() == [
             "Interval Start",
             "Interval End",
@@ -1466,12 +1466,12 @@ class TestPJM(BaseTestISO):
 
         assert set(df["NERC Region"]) == {"RFC", "SERC", "RTO"}
 
-    def test_get_metered_load_hourly_historical_date(self):
+    def test_get_load_metered_hourly_historical_date(self):
         date = self.local_today() - pd.Timedelta(days=10)
 
-        df = self.iso.get_metered_load_hourly(date)
+        df = self.iso.get_load_metered_hourly(date)
 
-        self._check_metered_load_hourly(df)
+        self._check_load_metered_hourly(df)
 
         assert df["Interval Start"].min() == self.local_start_of_day(date)
         assert df["Interval End"].max() == self.local_start_of_day(
@@ -1480,13 +1480,13 @@ class TestPJM(BaseTestISO):
             days=1,
         )
 
-    def test_get_metered_load_hourly_historical_date_range(self):
+    def test_get_load_metered_hourly_historical_date_range(self):
         date = self.local_today() - pd.Timedelta(days=12)
         end_date = date + pd.Timedelta(days=3)
 
-        df = self.iso.get_metered_load_hourly(date, end_date)
+        df = self.iso.get_load_metered_hourly(date, end_date)
 
-        self._check_metered_load_hourly(df)
+        self._check_load_metered_hourly(df)
 
         assert df["Interval Start"].min() == self.local_start_of_day(date)
         assert df["Interval End"].max() == self.local_start_of_day(end_date)


### PR DESCRIPTION
- Adds `PJM().get_metered_load_hourly` to get PJM hourly metered load data
- https://dataminer2.pjm.com/feed/hrl_load_metered/definition
