### PR TITLE
[ENG-229] - Change CAISO Load file URL

### DIFF
--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -1466,7 +1466,7 @@ def _get_historical(
     verbose: bool = False,
 ) -> pd.DataFrame:
 
-    if date == "today":
+    if utils.is_today(date, CAISO.default_timezone):
         url: str = f"{_BASE}/{file}.csv"
     else:
         date_str: str = date.strftime("%Y%m%d")

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -1460,8 +1460,12 @@ def _make_timestamp(time_str, today, timezone="US/Pacific"):
     return ts
 
 
-def _get_historical(file: str, date: str | pd.Timestamp, verbose: bool = False) -> pd.DataFrame:
-    
+def _get_historical(
+    file: str,
+    date: str | pd.Timestamp,
+    verbose: bool = False,
+) -> pd.DataFrame:
+
     if date == "today":
         url: str = f"{_BASE}/{file}.csv"
     else:
@@ -1498,6 +1502,7 @@ def _get_historical(file: str, date: str | pd.Timestamp, verbose: bool = False) 
     df.insert(2, "Interval End", df["Time"] + pd.Timedelta(minutes=5))
 
     return df
+
 
 def _get_oasis(config, start, end=None, raw_data=False, verbose=False, sleep=5):
     start, end = _caiso_handle_start_end(start, end)

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -1460,19 +1460,15 @@ def _make_timestamp(time_str, today, timezone="US/Pacific"):
     return ts
 
 
-def _get_historical(file, date, verbose=False):
-    try:
-        date_str = date.strftime("%Y%m%d")
-        url = _HISTORY_BASE + "/%s/%s.csv" % (date_str, file)
-        msg = f"Fetching URL: {url}"
-        log(msg, verbose)
-    except Exception:
-        # fallback if today and no historical file yet
-        if utils.is_today(date, CAISO.default_timezone):
-            url = _BASE + "/%s.csv" % file
-            msg = f"Fetching URL: {url}"
-            log(msg, verbose)
-
+def _get_historical(file: str, date: str | pd.Timestamp, verbose: bool = False) -> pd.DataFrame:
+    
+    if date == "today":
+        url: str = f"{_BASE}/{file}.csv"
+    else:
+        date_str: str = date.strftime("%Y%m%d")
+        url: str = f"{_HISTORY_BASE}/{date_str}/{file}.csv"
+    msg: str = f"Fetching URL: {url}"
+    log(msg, verbose)
     df = pd.read_csv(url)
 
     # sometimes there are extra rows at the end, so this lets us ignore them
@@ -1502,7 +1498,6 @@ def _get_historical(file, date, verbose=False):
     df.insert(2, "Interval End", df["Time"] + pd.Timedelta(minutes=5))
 
     return df
-
 
 def _get_oasis(config, start, end=None, raw_data=False, verbose=False, sleep=5):
     start, end = _caiso_handle_start_end(start, end)

--- a/gridstatus/tests/test_ercot_api.py
+++ b/gridstatus/tests/test_ercot_api.py
@@ -452,6 +452,7 @@ class TestErcotAPI(TestHelperMixin):
         assert df["Interval Start"].min() == self.local_start_of_today()
         assert df["Interval End"].max() <= self.local_now()
 
+    @pytest.mark.slow
     def test_get_lmp_by_settlement_point_historical_date(self):
         historical_date = datetime.date(2021, 11, 6)
         df = self.iso.get_lmp_by_settlement_point(historical_date, verbose=True)
@@ -909,6 +910,7 @@ class TestErcotAPI(TestHelperMixin):
 
         assert df["Market"].unique().tolist() == ["REAL_TIME_15_MIN"]
 
+    @pytest.mark.slow
     def test_get_spp_real_time_15_min_historical_date_range(self):
         start_date = self.local_today() - pd.DateOffset(days=100)
 
@@ -975,7 +977,7 @@ class TestErcotAPI(TestHelperMixin):
 
     def test_get_historical_data(self):
         start_date = datetime.date(2023, 1, 1)
-        end_date = datetime.date(2023, 1, 4)
+        end_date = datetime.date(2023, 1, 3)
 
         data = self.iso.get_historical_data(
             "/np4-745-cd/spp_hrly_actual_fcast_geo",
@@ -1021,9 +1023,9 @@ class TestErcotAPI(TestHelperMixin):
 
         assert data["DELIVERY_DATE"].min().date() == datetime.date(2022, 12, 30)
         # This a forecast
-        assert data["DELIVERY_DATE"].max().date() == datetime.date(2023, 1, 10)
+        assert data["DELIVERY_DATE"].max().date() == datetime.date(2023, 1, 9)
         # Any change in the shape would be a regression since this is historical data
-        assert data.shape == (15552, 31)
+        assert data.shape == (10368, 31)
 
         start_date = datetime.date(2020, 12, 1)
         end_date = datetime.date(2020, 12, 2)

--- a/gridstatus/tests/test_miso.py
+++ b/gridstatus/tests/test_miso.py
@@ -75,7 +75,7 @@ class TestMISO(BaseTestISO):
         self._check_lmp_weekly(df)
 
     def test_get_lmp_weekly_historical_date_range(self):
-        start = self.local_today() - pd.Timedelta(days=300)
+        start = self.local_today() - pd.Timedelta(days=100)
         # Make sure to span a week
         end = start + pd.Timedelta(days=12)
         df = self.iso.get_lmp_weekly(start, end)
@@ -85,7 +85,7 @@ class TestMISO(BaseTestISO):
         )
 
         assert df["Interval Start"].min() == most_recent_monday
-        assert df["Interval End"].max() == most_recent_monday + pd.Timedelta(days=21)
+        assert df["Interval End"].max() == most_recent_monday + pd.Timedelta(days=14)
 
         self._check_lmp_weekly(df)
 
@@ -253,7 +253,7 @@ class TestMISO(BaseTestISO):
         assert df["Publish Time"].dt.date.unique() == pd.to_datetime(past_date).date()
 
     def test_get_solar_forecast_historical_date_range(self):
-        past_date = self.local_today() - pd.Timedelta(days=200)
+        past_date = self.local_today() - pd.Timedelta(days=100)
         end_date = past_date + pd.Timedelta(days=3)
 
         df = self.iso.get_solar_forecast(
@@ -298,7 +298,7 @@ class TestMISO(BaseTestISO):
         assert df["Publish Time"].dt.date.unique() == pd.to_datetime(past_date).date()
 
     def test_get_wind_forecast_historical_date_range(self):
-        past_date = self.local_today() - pd.Timedelta(days=200)
+        past_date = self.local_today() - pd.Timedelta(days=100)
         end_date = past_date + pd.Timedelta(days=3)
 
         df = self.iso.get_wind_forecast(

--- a/gridstatus/tests/test_pjm.py
+++ b/gridstatus/tests/test_pjm.py
@@ -1439,6 +1439,15 @@ class TestPJM(BaseTestISO):
         with pytest.raises(ValueError, match="Both start and end dates must be before"):
             self.iso.get_real_time_as_market_results(date=start, end=end, error="raise")
 
+    def test_get_interconnection_queue(self):
+        from gridstatus.base import _interconnection_columns
+
+        queue = self.iso.get_interconnection_queue()
+        # todo make sure datetime columns are right type
+        assert isinstance(queue, pd.DataFrame)
+        assert queue.shape[0] > 0
+        assert set(_interconnection_columns).issubset(queue.columns)
+
     """get_load_metered_hourly"""
 
     def _check_load_metered_hourly(self, df):

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -97,7 +97,10 @@ def make_availability_table():
     return markdown
 
 
-def _handle_date(date, tz=None):
+def _handle_date(
+    date: str | pd.Timestamp | None,
+    tz: str | None = None,
+) -> pd.Timestamp | None:
     if date is None:
         return date
 
@@ -216,7 +219,10 @@ def get_response_blob(resp: requests.Response) -> io.BytesIO:
 
 
 def download_csvs_from_zip_url(
-    url, process_csv=None, verbose=False, strip_whitespace_from_cols=False
+    url,
+    process_csv=None,
+    verbose=False,
+    strip_whitespace_from_cols=False,
 ):
     z = get_zip_folder(url, verbose=verbose)
 
@@ -239,7 +245,7 @@ def download_csvs_from_zip_url(
     return df
 
 
-def is_today(date, tz):
+def is_today(date: str | pd.Timestamp, tz: str) -> bool:
     return _handle_date(date, tz=tz).date() == pd.Timestamp.now(tz=tz).date()
 
 


### PR DESCRIPTION
## Summary 
This changes the approach to CAISO load file getting slightly. Pulls from the `latest` file first, given that it could be more up to date than the history file if today's data is desired. Also adds type annotations to the function and variables, switches to using f-strings, some other python best practice stuff.

## Details
@kmax12 Mostly gauging how much latitude there is to alter the functionality of this code (for example, removing the `try - except` block, with the desire in the future to handle exceptions separately, given that there are some other failure modes I could see this running into)

## Tests
Tried running just the `tests/test_caiso.py` and it seems to have hung a bit, as well as running into a certificate error that might be straightforwardly remedied. Details:

![CleanShot 2024-09-23 at 15 35 36@2x](https://github.com/user-attachments/assets/726298fa-b4cc-40f0-b8f9-671e9d95a154)
