### PR TITLE
Fix ERCOT API Hourly Solar and Wind Tests

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -1906,6 +1906,9 @@ class Ercot(ISOBase):
         # replace _ in column names with spaces
         df.columns = df.columns.str.replace("_", " ")
 
+        return self._rename_hourly_wind_or_solar_report(df)
+
+    def _rename_hourly_wind_or_solar_report(self, df):
         df = df.rename(
             columns={
                 # on Sept 26, 2024 ercot added this column
@@ -1923,6 +1926,7 @@ class Ercot(ISOBase):
                 "ACTUAL LZ NORTH": "GEN LZ NORTH",
             },
         )
+
         return df
 
     def get_reported_outages(self, date=None, end=None, verbose=False):

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -1927,6 +1927,10 @@ class Ercot(ISOBase):
             },
         )
 
+        # Add HSL SYSTEM WIDE if it is not in the data (older data may not have it)
+        if "HSL SYSTEM WIDE" not in df:
+            df["HSL SYSTEM WIDE"] = pd.NA
+
         return df
 
     def get_reported_outages(self, date=None, end=None, verbose=False):

--- a/gridstatus/ercot_api/ercot_api.py
+++ b/gridstatus/ercot_api/ercot_api.py
@@ -295,10 +295,6 @@ class ErcotAPI:
 
         data = Ercot()._rename_hourly_wind_or_solar_report(data)
 
-        # Add HSL SYSTEM WIDE if it is not in the data (older data may not have it)
-        if "HSL SYSTEM WIDE" not in data:
-            data["HSL SYSTEM WIDE"] = pd.NA
-
         return data
 
     @support_date_range(frequency=None)
@@ -351,10 +347,6 @@ class ErcotAPI:
         )
 
         data = Ercot()._rename_hourly_wind_or_solar_report(data)
-
-        # Add HSL SYSTEM WIDE if it is not in the data (older data may not have it)
-        if "HSL SYSTEM WIDE" not in data:
-            data["HSL SYSTEM WIDE"] = pd.NA
 
         return data
 

--- a/gridstatus/ercot_api/ercot_api.py
+++ b/gridstatus/ercot_api/ercot_api.py
@@ -293,6 +293,8 @@ class ErcotAPI:
             .sort_values(["Interval Start", "Publish Time"])
         )
 
+        data = Ercot()._rename_hourly_wind_or_solar_report(data)
+
         return data
 
     @support_date_range(frequency=None)
@@ -343,6 +345,8 @@ class ErcotAPI:
             .drop(columns=["Time", "postDatetime"])
             .sort_values(["Interval Start", "Publish Time"])
         )
+
+        data = Ercot()._rename_hourly_wind_or_solar_report(data)
 
         return data
 

--- a/gridstatus/ercot_api/ercot_api.py
+++ b/gridstatus/ercot_api/ercot_api.py
@@ -295,6 +295,10 @@ class ErcotAPI:
 
         data = Ercot()._rename_hourly_wind_or_solar_report(data)
 
+        # Add HSL SYSTEM WIDE if it is not in the data (older data may not have it)
+        if "HSL SYSTEM WIDE" not in data:
+            data["HSL SYSTEM WIDE"] = pd.NA
+
         return data
 
     @support_date_range(frequency=None)
@@ -347,6 +351,10 @@ class ErcotAPI:
         )
 
         data = Ercot()._rename_hourly_wind_or_solar_report(data)
+
+        # Add HSL SYSTEM WIDE if it is not in the data (older data may not have it)
+        if "HSL SYSTEM WIDE" not in data:
+            data["HSL SYSTEM WIDE"] = pd.NA
 
         return data
 

--- a/gridstatus/tests/test_ercot_api.py
+++ b/gridstatus/tests/test_ercot_api.py
@@ -67,22 +67,23 @@ class TestErcotAPI(TestHelperMixin):
             "Interval Start",
             "Interval End",
             "Publish Time",
-            "ACTUAL SYSTEM WIDE",
+            "SYSTEM WIDE GEN",
             "COP HSL SYSTEM WIDE",
             "STWPF SYSTEM WIDE",
             "WGRPP SYSTEM WIDE",
-            "ACTUAL LZ SOUTH HOUSTON",
+            "GEN LZ SOUTH HOUSTON",
             "COP HSL LZ SOUTH HOUSTON",
             "STWPF LZ SOUTH HOUSTON",
             "WGRPP LZ SOUTH HOUSTON",
-            "ACTUAL LZ WEST",
+            "GEN LZ WEST",
             "COP HSL LZ WEST",
             "STWPF LZ WEST",
             "WGRPP LZ WEST",
-            "ACTUAL LZ NORTH",
+            "GEN LZ NORTH",
             "COP HSL LZ NORTH",
             "STWPF LZ NORTH",
             "WGRPP LZ NORTH",
+            "SYSTEM WIDE HSL",
         ]
 
         assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()
@@ -127,7 +128,7 @@ class TestErcotAPI(TestHelperMixin):
             "Interval Start",
             "Interval End",
             "Publish Time",
-            "GEN SYSTEM WIDE",
+            "SYSTEM WIDE GEN",
             "COP HSL SYSTEM WIDE",
             "STPPF SYSTEM WIDE",
             "PVGRPP SYSTEM WIDE",
@@ -155,6 +156,7 @@ class TestErcotAPI(TestHelperMixin):
             "COP HSL CenterEast",
             "STPPF CenterEast",
             "PVGRPP CenterEast",
+            "SYSTEM WIDE HSL",
         ]
 
         assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()

--- a/gridstatus/tests/test_ercot_api.py
+++ b/gridstatus/tests/test_ercot_api.py
@@ -67,7 +67,7 @@ class TestErcotAPI(TestHelperMixin):
             "Interval Start",
             "Interval End",
             "Publish Time",
-            "SYSTEM WIDE GEN",
+            "GEN SYSTEM WIDE",
             "COP HSL SYSTEM WIDE",
             "STWPF SYSTEM WIDE",
             "WGRPP SYSTEM WIDE",
@@ -83,7 +83,7 @@ class TestErcotAPI(TestHelperMixin):
             "COP HSL LZ NORTH",
             "STWPF LZ NORTH",
             "WGRPP LZ NORTH",
-            "SYSTEM WIDE HSL",
+            "HSL SYSTEM WIDE",
         ]
 
         assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()
@@ -128,7 +128,7 @@ class TestErcotAPI(TestHelperMixin):
             "Interval Start",
             "Interval End",
             "Publish Time",
-            "SYSTEM WIDE GEN",
+            "GEN SYSTEM WIDE",
             "COP HSL SYSTEM WIDE",
             "STPPF SYSTEM WIDE",
             "PVGRPP SYSTEM WIDE",
@@ -156,7 +156,7 @@ class TestErcotAPI(TestHelperMixin):
             "COP HSL CenterEast",
             "STPPF CenterEast",
             "PVGRPP CenterEast",
-            "SYSTEM WIDE HSL",
+            "HSL SYSTEM WIDE",
         ]
 
         assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()


### PR DESCRIPTION
## Summary
- Fixes the hourly solar and wind report tests for `ErcotAPI`

### (*Optional*) Details
- Tests were failing after the changes from https://github.com/gridstatus/gridstatus/pull/432 and due to changes in the data
