### PR TITLE
fix[ENG 810] Resolve undated times correctly and bust cloudfront cache

### DIFF
--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -1466,13 +1466,14 @@ def _get_historical(
     Returns:
         pd.DataFrame: A pandas dataframe of the data
     """
-
+    # NOTE: The cache buster is necessary because CAISO will serve cached data from cloudfront on the same url if the url has not changed.
+    cache_buster = int(pd.Timestamp.now(tz=CAISO.default_timezone).timestamp())
     if utils.is_today(date, CAISO.default_timezone):
-        url: str = f"{_BASE}/{file}.csv"
+        url: str = f"{_BASE}/{file}.csv?_={cache_buster}"
         latest = True
     else:
         date_str: str = date.strftime("%Y%m%d")
-        url: str = f"{_HISTORY_BASE}/{date_str}/{file}.csv"
+        url: str = f"{_HISTORY_BASE}/{date_str}/{file}.csv?_={cache_buster}"
         latest = False
     msg: str = f"Fetching URL: {url}"
     log(msg, verbose)

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -1448,19 +1448,6 @@ class CAISO(ISOBase):
             print("\n")
 
 
-def _make_timestamp(time_str, today, timezone="US/Pacific"):
-    hour, minute = map(int, time_str.split(":"))
-    ts = pd.Timestamp(
-        year=today.year,
-        month=today.month,
-        day=today.day,
-        hour=hour,
-        minute=minute,
-    )
-    ts = ts.tz_localize(timezone, ambiguous=True)
-    return ts
-
-
 def _get_historical(
     file: str,
     date: str | pd.Timestamp,
@@ -1509,7 +1496,7 @@ def _get_historical(
             date = date - pd.Timedelta(days=1)
 
     df["Time"] = df["Time"].apply(
-        _make_timestamp,
+        caiso_utils.make_timestamp,
         today=date,
         timezone=CAISO.default_timezone,
     )

--- a/gridstatus/caiso_utils.py
+++ b/gridstatus/caiso_utils.py
@@ -1,6 +1,21 @@
 import pandas as pd
 
 
+# NOTE: Currently the gridstatus.CAISO.default_timezone is in the caiso.py file, which imports caiso_utils.py and thus
+# it can't be set to the value without causing a circular import, which is why they are hardcoded here.
+def make_timestamp(time_str: str, today: pd.Timestamp, timezone: str = "US/Pacific"):
+    hour, minute = map(int, time_str.split(":"))
+    ts = pd.Timestamp(
+        year=today.year,
+        month=today.month,
+        day=today.day,
+        hour=hour,
+        minute=minute,
+    )
+    ts = ts.tz_localize(timezone, ambiguous=True)
+    return ts
+
+
 def check_latest_value_time(df: pd.DataFrame, column: str):
     """Check if the latest value time is from the previous day and update the date accordingly
 
@@ -11,6 +26,11 @@ def check_latest_value_time(df: pd.DataFrame, column: str):
     Returns:
         pd.Timestamp: Latest time
     """
+    current_local_date = pd.Timestamp.now(tz="US/Pacific").date()
     latest_time_str = df.loc[df[column].last_valid_index(), "Time"]
-    latest_time = pd.Timestamp(latest_time_str, tz="US/Pacific")
+    latest_time = make_timestamp(
+        latest_time_str,
+        today=current_local_date,
+        timezone="US/Pacific",
+    )
     return latest_time


### PR DESCRIPTION
## Summary
Makes sure we're getting todays date in the CAISO timezone. Before it was returning the UTC date and pairing it with the local time, causing a silent failure.

Also adds the epoch current epoch time to the URL to bust the cloudfront cache on file return.

### (*Optional*) Details
Moves _make_timestamp to caiso_utils, updates check_latest_value_time, etc. Hard to test for sure without replicating the system where pandas is running as well as running it at the times where it becomes an issue, but makes sense from a first principles approach.

Local tests passing.
![CleanShot 2024-10-08 at 10 30 39@2x](https://github.com/user-attachments/assets/4746358b-632e-4517-8ac3-f17a65bc0adb)
