### PR TITLE
Raise NoDataFoundException When ERCOT Documents are Not Found

### DIFF
--- a/gridstatus/__init__.py
+++ b/gridstatus/__init__.py
@@ -10,7 +10,7 @@ from gridstatus import tests
 import gridstatus.base
 import gridstatus.decorators
 
-from gridstatus.base import Markets, NotSupported
+from gridstatus.base import Markets, NotSupported, NoDataFoundException
 
 import gridstatus.utils
 

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -2579,11 +2579,6 @@ class Ercot(ISOBase):
         return df
 
     def _handle_price_corrections(self, docs, verbose=False):
-        # When there are no price corrections, ERCOT does not publish a file
-        # We raise a legible error message in this case
-        if not docs:
-            raise NoDataFoundException("No price correction data found")
-
         df = self.read_docs(docs, verbose=verbose)
 
         df = self._handle_settlement_point_name_and_type(df)
@@ -2860,10 +2855,6 @@ class Ercot(ISOBase):
             extension=extension,
             verbose=verbose,
         )
-        if len(documents) == 0:
-            raise ValueError(
-                f"No document found for {report_type_id} on {date}",
-            )
 
         return max(documents, key=lambda x: x.publish_date)
 
@@ -2956,6 +2947,16 @@ class Ercot(ISOBase):
 
         if date == "latest":
             return [max(matches, key=lambda x: x.publish_date)]
+
+        if not matches:
+            params = {
+                k: v
+                for k, v in locals().items()
+                if k not in ["self", "msg", "url", "docs"]
+            }
+            raise NoDataFoundException(
+                f"No documents found with the given parameters: {params}",  # noqa
+            )
 
         return matches
 

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -16,6 +16,7 @@ from gridstatus.base import (
     InterconnectionQueueStatus,
     ISOBase,
     Markets,
+    NoDataFoundException,
     NotSupported,
 )
 from gridstatus.decorators import support_date_range
@@ -2578,6 +2579,11 @@ class Ercot(ISOBase):
         return df
 
     def _handle_price_corrections(self, docs, verbose=False):
+        # When there are no price corrections, ERCOT does not publish a file
+        # We raise a legible error message in this case
+        if not docs:
+            raise NoDataFoundException("No price correction data found")
+
         df = self.read_docs(docs, verbose=verbose)
 
         df = self._handle_settlement_point_name_and_type(df)

--- a/gridstatus/tests/test_ercot.py
+++ b/gridstatus/tests/test_ercot.py
@@ -3,8 +3,7 @@ from io import StringIO
 import pandas as pd
 import pytest
 
-import gridstatus
-from gridstatus import Markets, NotSupported
+from gridstatus import Markets, NoDataFoundException, NotSupported
 from gridstatus.ercot import (
     ELECTRICAL_BUS_LOCATION_TYPE,
     Ercot,
@@ -607,7 +606,7 @@ class TestErcot(BaseTestISO):
 
     @pytest.mark.skip(reason="takes too long to run")
     def test_get_spp_rtm_historical(self):
-        rtm = gridstatus.Ercot().get_rtm_spp(2020)
+        rtm = self.iso.get_rtm_spp(2020)
         assert isinstance(rtm, pd.DataFrame)
         assert len(rtm) > 0
 
@@ -1753,3 +1752,7 @@ class TestErcot(BaseTestISO):
         assert df.columns.tolist() == cols
 
         assert df["System Lambda"].dtype == float
+
+    def test_get_documents_raises_exception_when_no_docs(self):
+        with pytest.raises(NoDataFoundException):
+            self.iso.get_load_forecast("2010-01-01")


### PR DESCRIPTION
## Summary

- Raises a `NoDataFoundException` when ERCOT documents are not found for a given configuration to allow for easier downstream debugging

### Details
