### PR TITLE
fix[ENG 880] Add small fix to ERCOT temp method

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -2821,7 +2821,7 @@ class Ercot(ISOBase):
         )
 
         # NOTE(kladar): ERCOT is currently publishing a duplicate for the Fall 2024 DST transition
-        # we will remove the duplicates here and adjust the times to be correct
+        # we will remove the duplicates here and adjust the times to be our best guess at what is correct
         dst_transition_date = pd.Timestamp("2024-11-03")
         if dst_transition_date.date() in df["Interval Start"].dt.date.values:
             logger.info("Problematic DST transition detected, fixing duplicate hour")

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -2826,7 +2826,7 @@ class Ercot(ISOBase):
         if dst_transition_date.date() in df["Interval Start"].dt.date.values:
             log.info("Problematic DST transition detected, fixing duplicate hour")
 
-            # take half the duplicate rows and adjust them to 1:00
+            # take half the duplicate rows and adjust them to 1:00 to fix missing interval
             duplicate_mask = df["Interval Start"] == pd.Timestamp(
                 "2024-11-03 02:00:00-0600",
             )
@@ -2837,7 +2837,7 @@ class Ercot(ISOBase):
             )
             df["Interval End"] = df["Interval Start"] + pd.Timedelta(hours=1)
 
-            # after the correction, some duplicates remain, so we remove them
+            # after the correction, the straight duplicate intervals remain, so we remove them
             df = df.drop_duplicates(subset=["Interval Start", "Publish Time"])
 
         return df.sort_values("Interval Start")

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -27,7 +27,7 @@ from gridstatus.ercot_60d_utils import (
     process_sced_gen,
     process_sced_load,
 )
-from gridstatus.gs_logging import log
+from gridstatus.gs_logging import log, logger
 from gridstatus.lmp_config import lmp_config
 
 LOCATION_TYPE_HUB = "Trading Hub"
@@ -2824,7 +2824,7 @@ class Ercot(ISOBase):
         # we will remove the duplicates here and adjust the times to be correct
         dst_transition_date = pd.Timestamp("2024-11-03")
         if dst_transition_date.date() in df["Interval Start"].dt.date.values:
-            log.info("Problematic DST transition detected, fixing duplicate hour")
+            logger.info("Problematic DST transition detected, fixing duplicate hour")
 
             # take half the duplicate rows and adjust them to 1:00 to fix missing interval
             duplicate_mask = df["Interval Start"] == pd.Timestamp(

--- a/gridstatus/gs_logging.py
+++ b/gridstatus/gs_logging.py
@@ -2,7 +2,7 @@ import logging
 
 
 def setup_gs_logger(level=logging.DEBUG):
-    logger = logging.getLogger("gs_etl")
+    logger = logging.getLogger("gridstatus")
     logger.setLevel(level)
     handler = logging.StreamHandler()
     handler.setLevel(level)  # Set handler level to the same as logger

--- a/gridstatus/tests/test_ercot.py
+++ b/gridstatus/tests/test_ercot.py
@@ -1525,6 +1525,9 @@ class TestErcot(BaseTestISO):
             == self.local_start_of_today() + self.temperature_forecast_start_offset
         )
 
+        dst_transition_date = pd.Timestamp("2024-11-03")
+        if dst_transition_date.date() in df["Interval Start"].dt.date.values:
+            self.temperature_forecast_end_offset = pd.DateOffset(days=9, hours=0)
         assert (
             df["Interval End"].max()
             == self.local_start_of_today() + self.temperature_forecast_end_offset


### PR DESCRIPTION
## Summary
Adds a duplicate/skipped interval fix for the problematic temperature forecast DST transition in ERCOT. Handles the backfill case where multiple publish times exist for the problematic interval.

### Details

Before the fix
![CleanShot 2024-10-29 at 10 00 44@2x](https://github.com/user-attachments/assets/59c9dba8-3362-40e3-8d8c-9e736e170675)


After the fix:
![CleanShot 2024-10-29 at 10 04 30@2x](https://github.com/user-attachments/assets/74be5a4a-b21e-4e89-9d35-b5d9a99eefb6)

