### PR TITLE
ERCOT DAM LMP By Bus DST Fix

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -3171,7 +3171,11 @@ class Ercot(ISOBase):
                 # So, it's N during DST And Y during Standard Time
                 # Pandas wants True for DST and False for Standard Time
                 # during ambiguous times
-                ambiguous = doc["DSTFlag"] == "N"
+                # Some ERCOT datasets use a boolean, some use a string
+                if doc["DSTFlag"].dtype == bool:
+                    ambiguous = ~doc["DSTFlag"]
+                else:
+                    ambiguous = doc["DSTFlag"] == "N"
 
             try:
                 doc["Interval Start"] = doc["Interval Start"].dt.tz_localize(

--- a/gridstatus/ercot_api/ercot_api.py
+++ b/gridstatus/ercot_api/ercot_api.py
@@ -1068,7 +1068,7 @@ class ErcotAPI:
                     break  # Exit the loop if the operation is successful
 
                 except Exception as e:
-                    if "Rate limit is exceeded" in response.decode("utf-8"):
+                    if "429 Client Error" in str(e):
                         # Rate limited, so sleep for a longer time
                         log(
                             f"Rate limited. Sleeping {self.sleep_seconds * 10} seconds",

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -27,7 +27,9 @@ LOAD_FORECAST_URL = (
 )
 
 """ZONAL LOAD FORECAST CONSTANTS"""
-ZONAL_LOAD_FORECAST_INDEX_URL = "https://reports-public.ieso.ca/public/OntarioZonalDemand"
+ZONAL_LOAD_FORECAST_INDEX_URL = (
+    "https://reports-public.ieso.ca/public/OntarioZonalDemand"
+)
 
 # Each forecast file contains data from the day in the filename going forward for
 # 34 days. The most recent file does not have a date in the filename.
@@ -53,7 +55,9 @@ FUEL_MIX_TEMPLATE_URL = f"{FUEL_MIX_INDEX_URL}/PUB_GenOutputCapability_YYYYMMDD.
 MAXIMUM_DAYS_IN_PAST_FOR_COMPLETE_GENERATOR_REPORT = 90
 
 """HISTORICAL FUEL MIX CONSTANTS"""
-HISTORICAL_FUEL_MIX_INDEX_URL = "https://reports-public.ieso.ca/public/GenOutputbyFuelHourly/"
+HISTORICAL_FUEL_MIX_INDEX_URL = (
+    "https://reports-public.ieso.ca/public/GenOutputbyFuelHourly/"
+)
 
 # Updated once a day and each file contains data for an entire year.
 HISTORICAL_FUEL_MIX_TEMPLATE_URL = (

--- a/gridstatus/tests/test_ercot.py
+++ b/gridstatus/tests/test_ercot.py
@@ -464,13 +464,17 @@ class TestErcot(BaseTestISO):
             "Load Forecast",
         ]
 
-        assert df["Interval Start"].min() == self.local_start_of_today() + pd.Timedelta(
+        # Use DateOffset for comparisons because it takes into account DST
+        assert df[
+            "Interval Start"
+        ].min() == self.local_start_of_today() + pd.DateOffset(
             days=1,
         )
-        assert df["Interval End"].max() == self.local_start_of_today() + pd.Timedelta(
+        assert df["Interval End"].max() == self.local_start_of_today() + pd.DateOffset(
             days=7,
         )
 
+        # This can use a timedelta because it doesn't span a day
         assert (df["Interval End"] - df["Interval Start"]).unique() == pd.Timedelta(
             hours=1,
         )

--- a/gridstatus/tests/test_ercot_api.py
+++ b/gridstatus/tests/test_ercot_api.py
@@ -704,6 +704,37 @@ class TestErcotAPI(TestHelperMixin):
         assert df["Interval Start"].min() == past_date.normalize()
         assert df["Interval End"].max() == past_end_date.normalize()
 
+    def test_get_lmp_by_bus_dam_dst_end(self):
+        date = "2024-11-03"
+
+        df = self.iso.get_lmp_by_bus_dam(date)
+
+        assert not df[["Interval Start", "Location"]].duplicated().any()
+
+        # Check that 01:00 local time is duplicated
+        unique_interval_strings = df["Interval Start"].astype(str).unique()
+        assert len(unique_interval_strings) == 25
+
+        assert "2024-11-03 01:00:00-05:00" in unique_interval_strings
+        assert "2024-11-03 01:00:00-06:00" in unique_interval_strings
+
+    def test_get_lmp_by_bus_dam_dst_start(self):
+        date = "2024-03-10"
+
+        df = self.iso.get_lmp_by_bus_dam(date)
+
+        assert not df[["Interval Start", "Location"]].duplicated().any()
+
+        # Check that there is a gap at 02:00 local time
+        unique_interval_strings = df["Interval Start"].astype(str).unique()
+
+        assert len(unique_interval_strings) == 23
+
+        assert "2024-03-10 01:00:00-06:00" in unique_interval_strings
+        # This hour does not exist
+        assert "2024-03-10 02:00:00-06:00" not in unique_interval_strings
+        assert "2024-03-10 03:00:00-05:00" in unique_interval_strings
+
     """shadow_prices_dam"""
 
     expected_shadow_prices_dam_columns = [


### PR DESCRIPTION
## Summary

- Fixes DST end issue in `ErcotAPI().get_lmp_by_bus_dam()` caused by `DSTFlag` column being a bool instead of a string
- Adds tests for both DST start and end for LMP by bus DAM


### Details
