### PR TITLE
ERCOT Fix Real Time AS Monitor, Real Time System Conditions, and Forecasts Publish Dates DST Issue

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -1864,9 +1864,10 @@ class Ercot(ISOBase):
 
         now = pd.Timestamp.now(tz=self.default_timezone)
 
-        # Determine if during the repeated DST hour. Pandas wants ambiguous=True if
-        # it is during the repeated hour. US/Central is UTC-6 during standard time
-        # and UTC-5 during DST.
+        # Determine if during the repeated DST hour. Pandas wants ambiguous=True if the
+        # time is DST during the repeated hour. US/Central is UTC-6 during standard time
+        # and UTC-5 during DST. Outside the repeated hour, Pandas doesn't care about
+        # ambiguous=True or ambiguous=False.
         ambiguous = (now.utcoffset().total_seconds() / 3600) == -5.0
 
         df.insert(

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -1862,10 +1862,20 @@ class Ercot(ISOBase):
             1
         ]  # Split the string on ': ' to get just the time part
 
+        now = pd.Timestamp.now(tz=self.default_timezone)
+
+        # Determine if during the repeated DST hour. Pandas wants ambiguous=True if
+        # it is during the repeated hour. US/Central is UTC-6 during standard time
+        # and UTC-5 during DST.
+        ambiguous = (now.utcoffset().total_seconds() / 3600) == -5.0
+
         df.insert(
             0,
             "Time",
-            pd.to_datetime(time_text).tz_localize(self.default_timezone),
+            pd.to_datetime(time_text).tz_localize(
+                self.default_timezone,
+                ambiguous=ambiguous,
+            ),
         )
 
         return df


### PR DESCRIPTION
## Summary

- Fixes `Ercot().get_as_monitor()` and `Ercot().get_real_time_system_conditions()` by specifying whether a time is ambiguous (True during DST)
- Fixes forecasts that use the `PublishDate` using the "xhr" that ERCOT adds to the second set of file names generated during the repeated hour at DST end. The fix is to ignore the provided offset and use one based on whether the file is the second set.

### Details
