### PR TITLE
Fix for ERCOT DAM AS Offers with Repeated Offers

### DIFF
--- a/gridstatus/ercot_60d_utils.py
+++ b/gridstatus/ercot_60d_utils.py
@@ -353,9 +353,18 @@ def process_as_offer_curves(df):
             )
 
             if len(subset) > 1:
-                raise ValueError(
-                    f"More than one row found for {column_list} for {resource_name}",
-                )
+                # We've identified an issue with this specific resource name where
+                # there are sometimes multiple offers for the same service at the same
+                # interval. In theory this should never happen. The QUANTITY MW are
+                # only different by 0.1, so we just take the row with the lowest
+                # quantity. This is a temporary fix until we can figure out why this
+                # is happening.
+                if resource_name == "CANYONRO_LD1":
+                    subset = subset.sort_values("QUANTITY MW1").iloc[0]
+                else:
+                    raise ValueError(
+                        f"More than one row found for {column_list} for {resource_name}",  # noqa
+                    )
 
             # Only keep the number of block indicators that are non-null
             keep_block_count = subset[block_columns].notna().sum().sum()


### PR DESCRIPTION
## Summary

- Addresses an issue where one resource in ERCOT DAM AS Offers has repeated offers for the same service at the same interval
- This issue previously caused the data retrieval to fail. The fix choses one of the rows to keep in a consistent manner.

### Details
