### PR TITLE
VCR Filter Headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ gridstatus/tests/fixtures/isone/vcr_cassettes
 gridstatus/tests/fixtures/pjm/vcr_cassettes
 gridstatus/tests/fixtures/ercot_api/vcr_cassettes
 gridstatus/tests/fixtures/ieso/vcr_cassettes
+gridstatus/tests/fixtures/miso_api/vcr_cassettes
 
 # Translations
 *.mo

--- a/gridstatus/tests/vcr_utils.py
+++ b/gridstatus/tests/vcr_utils.py
@@ -81,4 +81,9 @@ def setup_vcr(
         record_mode=record_mode,
         match_on=["uri", "method"],
         before_record=lambda request: before_record_callback(request, source),
+        filter_headers=[
+            ("Authorization", "XXXXXX"),
+            ("Ocp-Apim-Subscription-Key", "XXXXXX"),
+            ("X-Api-Key", "XXXXXX"),
+        ],
     )


### PR DESCRIPTION
## Summary

- Filter authentication headers from VCR cassettes
- Disables VCR cassettes in `test_ercot_api` because I couldn't figure out the filtering for the JWT request and response

### Details
