### PR TITLE
[ENG-968] ERCOT Solar and Wind Actual and Forecast Updates

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -1967,6 +1967,14 @@ class Ercot(ISOBase):
                 "ACTUAL LZ SOUTH HOUSTON": "GEN LZ SOUTH HOUSTON",
                 "ACTUAL LZ WEST": "GEN LZ WEST",
                 "ACTUAL LZ NORTH": "GEN LZ NORTH",
+                # Older versions of wind power production by geographical region use
+                # "ACTUAL" instead of "GEN"
+                # https://data.ercot.com/data-product-archive/NP4-742-CD
+                "ACTUAL PANHANDLE": "GEN PANHANDLE",
+                "ACTUAL COASTAL": "GEN COASTAL",
+                "ACTUAL SOUTH": "GEN SOUTH",
+                "ACTUAL WEST": "GEN WEST",
+                "ACTUAL NORTH": "GEN NORTH",
             },
         )
 

--- a/gridstatus/ercot_api/ercot_api.py
+++ b/gridstatus/ercot_api/ercot_api.py
@@ -78,9 +78,19 @@ SHADOW_PRICES_SCED_ENDPOINT = "/np6-86-cd/shdw_prices_bnd_trns_const"
 # https://data.ercot.com/data-product-archive/NP4-732-CD
 HOURLY_WIND_POWER_PRODUCTION_ENDPOINT = "/np4-732-cd/wpp_hrly_avrg_actl_fcast"
 
+# Wind Power Production - Hourly Averaged Actual and Forecasted Values by Geographical Region # noqa
+# https://data.ercot.com/data-product-archive/NP4-742-CD
+HOURLY_WIND_POWER_PRODUCTION_BY_GEOGRAPHICAL_REGION_ENDPOINT = (
+    "/np4-742-cd/wpp_hrly_actual_fcast_geo"
+)
+
+# Solar Power Production
+# https://data.ercot.com/data-product-archive/NP4-737-CD
+HOURLY_SOLAR_POWER_PRODUCTION_ENDPOINT = "/np4-737-cd/spp_hrly_avrg_actl_fcast"
+
 # Solar Power Production - Hourly Averaged Actual and Forecasted Values by Geographical Region # noqa
 # https://data.ercot.com/data-product-archive/NP4-745-CD
-HOURLY_SOLAR_POWER_PRODUCTION_BY_GEOGRAPHICAL_REGION_REPORT_ENDPOINT = (
+HOURLY_SOLAR_POWER_PRODUCTION_BY_GEOGRAPHICAL_REGION_ENDPOINT = (
     "/np4-745-cd/spp_hrly_actual_fcast_geo"
 )
 
@@ -261,8 +271,7 @@ class ErcotAPI:
         # General information about the public reports
         return self.make_api_call(BASE_URL, verbose=verbose)
 
-    @support_date_range(frequency=None)
-    def get_hourly_wind_report(self, date, end=None, verbose=False):
+    def get_wind_actual_and_forecast_hourly(self, date, end=None, verbose=False):
         """Get Wind Power Production - Hourly Averaged Actual and Forecasted Values
 
         Arguments:
@@ -273,6 +282,45 @@ class ErcotAPI:
         Returns:
             pandas.DataFrame: A DataFrame with hourly wind power production reports
         """
+        return self._get_wind_actual_and_forecast_hourly(
+            endpoint=HOURLY_WIND_POWER_PRODUCTION_ENDPOINT,
+            date=date,
+            end=end,
+            verbose=verbose,
+        )
+
+    def get_wind_actual_and_forecast_by_geographical_region_hourly(
+        self,
+        date,
+        end=None,
+        verbose=False,
+    ):
+        """Get Wind Power Production - Hourly Averaged Actual and Forecasted Values by
+        Geographical Region
+
+        Arguments:
+            date (str): the date to fetch reports for.
+            end (str, optional): the end date to fetch reports for. Defaults to None.
+            verbose (bool, optional): print verbose output. Defaults to False.
+
+        Returns:
+            pandas.DataFrame: A DataFrame with hourly wind power production reports
+        """
+        return self._get_wind_actual_and_forecast_hourly(
+            endpoint=HOURLY_WIND_POWER_PRODUCTION_BY_GEOGRAPHICAL_REGION_ENDPOINT,
+            date=date,
+            end=end,
+            verbose=verbose,
+        )
+
+    @support_date_range(frequency=None)
+    def _get_wind_actual_and_forecast_hourly(
+        self,
+        endpoint: str,
+        date,
+        end=None,
+        verbose=False,
+    ):
         if date == "latest":
             date = self._local_now() - pd.Timedelta(hours=1)
             end = self._local_now()
@@ -282,16 +330,16 @@ class ErcotAPI:
         # Only use the historical API because it allows us to filter on posted time (
         # publish time)
         data = self.get_historical_data(
-            endpoint=HOURLY_WIND_POWER_PRODUCTION_ENDPOINT,
+            endpoint=endpoint,
             start_date=date,
             end_date=end,
             verbose=verbose,
             add_post_datetime=True,
         )
 
-        return self._handle_hourly_wind_report(data, verbose=verbose)
+        return self._handle_wind_actual_and_forecast_hourly(data, verbose=verbose)
 
-    def _handle_hourly_wind_report(self, data, verbose=False):
+    def _handle_wind_actual_and_forecast_hourly(self, data, verbose=False):
         data = Ercot().parse_doc(data, verbose=verbose)
 
         data.columns = data.columns.str.replace("_", " ")
@@ -313,8 +361,30 @@ class ErcotAPI:
 
         return data
 
-    @support_date_range(frequency=None)
-    def get_hourly_solar_report(self, date, end=None, verbose=False):
+    def get_solar_actual_and_forecast_hourly(self, date, end=None, verbose=False):
+        """Get Solar Power Production - Hourly Averaged Actual and Forecasted Values
+
+        Arguments:
+            date (str): the date to fetch reports for.
+            end (str, optional): the end date to fetch reports for. Defaults to None.
+            verbose (bool, optional): print verbose output. Defaults to False.
+
+        Returns:
+            pandas.DataFrame: A DataFrame with hourly solar power production reports
+        """
+        return self._get_solar_actual_and_forecast_hourly(
+            endpoint=HOURLY_SOLAR_POWER_PRODUCTION_ENDPOINT,
+            date=date,
+            end=end,
+            verbose=verbose,
+        )
+
+    def get_solar_actual_and_forecast_by_geographical_region_hourly(
+        self,
+        date,
+        end=None,
+        verbose=False,
+    ):
         """Get Solar Power Production - Hourly Averaged Actual and Forecasted Values by
         Geographical Region
 
@@ -326,6 +396,21 @@ class ErcotAPI:
         Returns:
             pandas.DataFrame: A DataFrame with hourly wind power production reports
         """
+        return self._get_solar_actual_and_forecast_hourly(
+            endpoint=HOURLY_SOLAR_POWER_PRODUCTION_BY_GEOGRAPHICAL_REGION_ENDPOINT,
+            date=date,
+            end=end,
+            verbose=verbose,
+        )
+
+    @support_date_range(frequency=None)
+    def _get_solar_actual_and_forecast_hourly(
+        self,
+        endpoint,
+        date,
+        end=None,
+        verbose=False,
+    ):
         if date == "latest":
             date = self._local_now() - pd.Timedelta(hours=1)
             end = self._local_now()
@@ -335,16 +420,16 @@ class ErcotAPI:
         # Only use the historical API because it allows us to filter on posted time (
         # publish time)
         data = self.get_historical_data(
-            endpoint=HOURLY_SOLAR_POWER_PRODUCTION_BY_GEOGRAPHICAL_REGION_REPORT_ENDPOINT,  # noqa
+            endpoint=endpoint,
             start_date=date,
             end_date=end,
             verbose=verbose,
             add_post_datetime=True,
         )
 
-        return self._handle_hourly_solar_report(data, verbose=verbose)
+        return self._handle_solar_actual_and_forecast_hourly(data, verbose=verbose)
 
-    def _handle_hourly_solar_report(self, data, verbose=False):
+    def _handle_solar_actual_and_forecast_hourly(self, data, verbose=False):
         data = Ercot().parse_doc(data, verbose=verbose)
 
         data.columns = data.columns.str.replace("_", " ")

--- a/gridstatus/ercot_api/ercot_api.py
+++ b/gridstatus/ercot_api/ercot_api.py
@@ -78,21 +78,121 @@ SHADOW_PRICES_SCED_ENDPOINT = "/np6-86-cd/shdw_prices_bnd_trns_const"
 # https://data.ercot.com/data-product-archive/NP4-732-CD
 HOURLY_WIND_POWER_PRODUCTION_ENDPOINT = "/np4-732-cd/wpp_hrly_avrg_actl_fcast"
 
+WIND_ACTUAL_AND_FORECAST_COLUMNS = [
+    "Interval Start",
+    "Interval End",
+    "Publish Time",
+    "GEN SYSTEM WIDE",
+    "COP HSL SYSTEM WIDE",
+    "STWPF SYSTEM WIDE",
+    "WGRPP SYSTEM WIDE",
+    "HSL SYSTEM WIDE",
+    "GEN LZ SOUTH HOUSTON",
+    "COP HSL LZ SOUTH HOUSTON",
+    "STWPF LZ SOUTH HOUSTON",
+    "WGRPP LZ SOUTH HOUSTON",
+    "GEN LZ WEST",
+    "COP HSL LZ WEST",
+    "STWPF LZ WEST",
+    "WGRPP LZ WEST",
+    "GEN LZ NORTH",
+    "COP HSL LZ NORTH",
+    "STWPF LZ NORTH",
+    "WGRPP LZ NORTH",
+]
+
 # Wind Power Production - Hourly Averaged Actual and Forecasted Values by Geographical Region # noqa
 # https://data.ercot.com/data-product-archive/NP4-742-CD
 HOURLY_WIND_POWER_PRODUCTION_BY_GEOGRAPHICAL_REGION_ENDPOINT = (
     "/np4-742-cd/wpp_hrly_actual_fcast_geo"
 )
 
+WIND_ACTUAL_AND_FORECAST_BY_GEOGRAPHICAL_REGION_COLUMNS = [
+    "Interval Start",
+    "Interval End",
+    "Publish Time",
+    "GEN SYSTEM WIDE",
+    "COP HSL SYSTEM WIDE",
+    "STWPF SYSTEM WIDE",
+    "WGRPP SYSTEM WIDE",
+    "HSL SYSTEM WIDE",
+    "GEN PANHANDLE",
+    "COP HSL PANHANDLE",
+    "STWPF PANHANDLE",
+    "WGRPP PANHANDLE",
+    "GEN COASTAL",
+    "COP HSL COASTAL",
+    "STWPF COASTAL",
+    "WGRPP COASTAL",
+    "GEN SOUTH",
+    "COP HSL SOUTH",
+    "STWPF SOUTH",
+    "WGRPP SOUTH",
+    "GEN WEST",
+    "COP HSL WEST",
+    "STWPF WEST",
+    "WGRPP WEST",
+    "GEN NORTH",
+    "COP HSL NORTH",
+    "STWPF NORTH",
+    "WGRPP NORTH",
+]
+
 # Solar Power Production
 # https://data.ercot.com/data-product-archive/NP4-737-CD
 HOURLY_SOLAR_POWER_PRODUCTION_ENDPOINT = "/np4-737-cd/spp_hrly_avrg_actl_fcast"
+
+SOLAR_ACTUAL_AND_FORECAST_COLUMNS = [
+    "Interval Start",
+    "Interval End",
+    "Publish Time",
+    "GEN SYSTEM WIDE",
+    "COP HSL SYSTEM WIDE",
+    "STPPF SYSTEM WIDE",
+    "PVGRPP SYSTEM WIDE",
+    "HSL SYSTEM WIDE",
+]
 
 # Solar Power Production - Hourly Averaged Actual and Forecasted Values by Geographical Region # noqa
 # https://data.ercot.com/data-product-archive/NP4-745-CD
 HOURLY_SOLAR_POWER_PRODUCTION_BY_GEOGRAPHICAL_REGION_ENDPOINT = (
     "/np4-745-cd/spp_hrly_actual_fcast_geo"
 )
+
+SOLAR_ACTUAL_AND_FORECAST_BY_GEOGRAPHICAL_REGION_COLUMNS = [
+    "Interval Start",
+    "Interval End",
+    "Publish Time",
+    "GEN SYSTEM WIDE",
+    "COP HSL SYSTEM WIDE",
+    "STPPF SYSTEM WIDE",
+    "PVGRPP SYSTEM WIDE",
+    "HSL SYSTEM WIDE",
+    "GEN CenterWest",
+    "COP HSL CenterWest",
+    "STPPF CenterWest",
+    "PVGRPP CenterWest",
+    "GEN NorthWest",
+    "COP HSL NorthWest",
+    "STPPF NorthWest",
+    "PVGRPP NorthWest",
+    "GEN FarWest",
+    "COP HSL FarWest",
+    "STPPF FarWest",
+    "PVGRPP FarWest",
+    "GEN FarEast",
+    "COP HSL FarEast",
+    "STPPF FarEast",
+    "PVGRPP FarEast",
+    "GEN SouthEast",
+    "COP HSL SouthEast",
+    "STPPF SouthEast",
+    "PVGRPP SouthEast",
+    "GEN CenterEast",
+    "COP HSL CenterEast",
+    "STPPF CenterEast",
+    "PVGRPP CenterEast",
+]
 
 # Settlement Point Price for each Settlement Point, produced from SCED LMPs every 15 minutes. # noqa
 # https://data.ercot.com/data-product-archive/NP6-905-CD
@@ -286,6 +386,7 @@ class ErcotAPI:
             endpoint=HOURLY_WIND_POWER_PRODUCTION_ENDPOINT,
             date=date,
             end=end,
+            columns=WIND_ACTUAL_AND_FORECAST_COLUMNS,
             verbose=verbose,
         )
 
@@ -310,6 +411,7 @@ class ErcotAPI:
             endpoint=HOURLY_WIND_POWER_PRODUCTION_BY_GEOGRAPHICAL_REGION_ENDPOINT,
             date=date,
             end=end,
+            columns=WIND_ACTUAL_AND_FORECAST_BY_GEOGRAPHICAL_REGION_COLUMNS,
             verbose=verbose,
         )
 
@@ -319,6 +421,7 @@ class ErcotAPI:
         endpoint: str,
         date,
         end=None,
+        columns=None,
         verbose=False,
     ):
         if date == "latest":
@@ -337,9 +440,13 @@ class ErcotAPI:
             add_post_datetime=True,
         )
 
-        return self._handle_wind_actual_and_forecast_hourly(data, verbose=verbose)
+        return self._handle_wind_actual_and_forecast_hourly(
+            data,
+            columns=columns,
+            verbose=verbose,
+        )
 
-    def _handle_wind_actual_and_forecast_hourly(self, data, verbose=False):
+    def _handle_wind_actual_and_forecast_hourly(self, data, columns, verbose=False):
         data = Ercot().parse_doc(data, verbose=verbose)
 
         data.columns = data.columns.str.replace("_", " ")
@@ -359,7 +466,7 @@ class ErcotAPI:
 
         data = Ercot()._rename_hourly_wind_or_solar_report(data)
 
-        return data
+        return data[columns]
 
     def get_solar_actual_and_forecast_hourly(self, date, end=None, verbose=False):
         """Get Solar Power Production - Hourly Averaged Actual and Forecasted Values
@@ -376,6 +483,7 @@ class ErcotAPI:
             endpoint=HOURLY_SOLAR_POWER_PRODUCTION_ENDPOINT,
             date=date,
             end=end,
+            columns=SOLAR_ACTUAL_AND_FORECAST_COLUMNS,
             verbose=verbose,
         )
 
@@ -400,6 +508,7 @@ class ErcotAPI:
             endpoint=HOURLY_SOLAR_POWER_PRODUCTION_BY_GEOGRAPHICAL_REGION_ENDPOINT,
             date=date,
             end=end,
+            columns=SOLAR_ACTUAL_AND_FORECAST_BY_GEOGRAPHICAL_REGION_COLUMNS,
             verbose=verbose,
         )
 
@@ -409,6 +518,7 @@ class ErcotAPI:
         endpoint,
         date,
         end=None,
+        columns=None,
         verbose=False,
     ):
         if date == "latest":
@@ -427,9 +537,13 @@ class ErcotAPI:
             add_post_datetime=True,
         )
 
-        return self._handle_solar_actual_and_forecast_hourly(data, verbose=verbose)
+        return self._handle_solar_actual_and_forecast_hourly(
+            data,
+            columns=columns,
+            verbose=verbose,
+        )
 
-    def _handle_solar_actual_and_forecast_hourly(self, data, verbose=False):
+    def _handle_solar_actual_and_forecast_hourly(self, data, columns, verbose=False):
         data = Ercot().parse_doc(data, verbose=verbose)
 
         data.columns = data.columns.str.replace("_", " ")
@@ -449,7 +563,7 @@ class ErcotAPI:
 
         data = Ercot()._rename_hourly_wind_or_solar_report(data)
 
-        return data
+        return data[columns]
 
     @support_date_range(frequency=None)
     def get_as_prices(self, date, end=None, verbose=False):

--- a/gridstatus/tests/source_specific/test_ercot_api.py
+++ b/gridstatus/tests/source_specific/test_ercot_api.py
@@ -67,9 +67,9 @@ class TestErcotAPI(TestHelperMixin):
             days_to_add_if_no_end=1,
         ) == self.local_start_of_day(datetime.date(2021, 11, 7))
 
-    """get_hourly_wind_report"""
+    """get_wind_actual_and_forecast_hourly"""
 
-    def _check_hourly_wind_report(self, df):
+    def _check_wind_actual_and_forecast_hourly(self, df):
         assert df.columns.tolist() == [
             "Interval Start",
             "Interval End",
@@ -95,32 +95,34 @@ class TestErcotAPI(TestHelperMixin):
 
         assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()
 
-    @pytest.mark.integration
-    def test_get_hourly_wind_report_today(self):
-        df = self.iso.get_hourly_wind_report("today")
+    @api_vcr.use_cassette("test_get_wind_actual_and_forecast_hourly_today.yaml")
+    def test_get_wind_actual_and_forecast_hourly_today(self):
+        df = self.iso.get_wind_actual_and_forecast_hourly("today")
 
         # The data should start at the beginning of two days ago
         assert df[
             "Interval Start"
         ].min() == self.local_start_of_today() - pd.DateOffset(days=2)
 
-        self._check_hourly_wind_report(df)
+        self._check_wind_actual_and_forecast_hourly(df)
 
-    @pytest.mark.integration
-    def test_get_hourly_wind_report_latest(self):
-        df = self.iso.get_hourly_wind_report("latest")
+    @api_vcr.use_cassette("test_get_wind_actual_and_forecast_hourly_latest.yaml")
+    def test_get_wind_actual_and_forecast_hourly_latest(self):
+        df = self.iso.get_wind_actual_and_forecast_hourly("latest")
 
         assert df["Publish Time"].nunique() == 1
-        self._check_hourly_wind_report(df)
+        self._check_wind_actual_and_forecast_hourly(df)
 
-    @pytest.mark.integration
-    def test_get_hourly_wind_report_historical_date_range(self):
+    @api_vcr.use_cassette(
+        "test_get_wind_actual_and_forecast_hourly_date_range.yaml",
+    )
+    def test_get_wind_actual_and_forecast_hourly_date_range(self):
         date = self.local_today() - pd.DateOffset(days=HISTORICAL_DAYS_THRESHOLD * 3)
         end = date + pd.Timedelta(hours=2)
 
-        df = self.iso.get_hourly_wind_report(date, end, verbose=True)
+        df = self.iso.get_wind_actual_and_forecast_hourly(date, end, verbose=True)
 
-        self._check_hourly_wind_report(df)
+        self._check_wind_actual_and_forecast_hourly(df)
 
         assert df["Publish Time"].nunique() == 2
 
@@ -131,9 +133,150 @@ class TestErcotAPI(TestHelperMixin):
             date.date(),
         ) + pd.DateOffset(days=7)
 
-    """get_hourly_solar_report"""
+    """get_wind_actual_and_forecast_by_geographical_region_hourly"""
 
-    def _check_hourly_solar_report(self, df):
+    def _check_wind_actual_and_forecast_by_geographical_region_hourly(self, df):
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "Publish Time",
+            "GEN SYSTEM WIDE",
+            "COP HSL SYSTEM WIDE",
+            "STWPF SYSTEM WIDE",
+            "WGRPP SYSTEM WIDE",
+            "GEN PANHANDLE",
+            "COP HSL PANHANDLE",
+            "STWPF PANHANDLE",
+            "WGRPP PANHANDLE",
+            "GEN COASTAL",
+            "COP HSL COASTAL",
+            "STWPF COASTAL",
+            "WGRPP COASTAL",
+            "GEN SOUTH",
+            "COP HSL SOUTH",
+            "STWPF SOUTH",
+            "WGRPP SOUTH",
+            "GEN WEST",
+            "COP HSL WEST",
+            "STWPF WEST",
+            "WGRPP WEST",
+            "GEN NORTH",
+            "COP HSL NORTH",
+            "STWPF NORTH",
+            "WGRPP NORTH",
+            "HSL SYSTEM WIDE",
+        ]
+
+        assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()
+
+    @api_vcr.use_cassette(
+        "test_get_wind_actual_and_forecast_by_geographical_region_hourly_today.yaml",
+    )
+    def test_get_wind_actual_and_forecast_by_geographical_region_hourly_today(self):
+        df = self.iso.get_wind_actual_and_forecast_by_geographical_region_hourly(
+            "today",
+        )
+
+        # The data should start at the beginning of two days ago
+        assert df[
+            "Interval Start"
+        ].min() == self.local_start_of_today() - pd.DateOffset(days=2)
+
+        self._check_wind_actual_and_forecast_by_geographical_region_hourly(df)
+
+    @api_vcr.use_cassette(
+        "test_get_wind_actual_and_forecast_by_geographical_region_hourly_latest.yaml",
+    )
+    def test_get_wind_actual_and_forecast_by_geographical_region_hourly_latest(self):
+        df = self.iso.get_wind_actual_and_forecast_by_geographical_region_hourly(
+            "latest",
+        )
+
+        assert df["Publish Time"].nunique() == 1
+        self._check_wind_actual_and_forecast_by_geographical_region_hourly(df)
+
+    @api_vcr.use_cassette(
+        "test_get_wind_actual_and_forecast_by_geographical_region_hourly_date_range.yaml",  # noqa: E501
+    )
+    def test_get_wind_actual_and_forecast_by_geographical_region_hourly_date_range(
+        self,
+    ):
+        date = self.local_today() - pd.DateOffset(days=HISTORICAL_DAYS_THRESHOLD * 3)
+        end = date + pd.Timedelta(hours=2)
+
+        df = self.iso.get_wind_actual_and_forecast_by_geographical_region_hourly(
+            date,
+            end,
+            verbose=True,
+        )
+
+        self._check_wind_actual_and_forecast_by_geographical_region_hourly(df)
+
+        assert df["Publish Time"].nunique() == 2
+
+        assert df["Interval Start"].min() == self.local_start_of_day(
+            date.date(),
+        ) - pd.DateOffset(days=2)
+        assert df["Interval End"].max() >= self.local_start_of_day(
+            date.date(),
+        ) + pd.DateOffset(days=7)
+
+    """get_solar_actual_and_forecast_hourly"""
+
+    def _check_solar_actual_and_forecast_hourly(self, df):
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "Publish Time",
+            "GEN SYSTEM WIDE",
+            "COP HSL SYSTEM WIDE",
+            "STPPF SYSTEM WIDE",
+            "PVGRPP SYSTEM WIDE",
+            "HSL SYSTEM WIDE",
+        ]
+
+        assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()
+
+    @api_vcr.use_cassette("test_get_solar_actual_and_forecast_hourly_today.yaml")
+    def test_get_solar_actual_and_forecast_hourly_today(self):
+        df = self.iso.get_solar_actual_and_forecast_hourly("today")
+
+        # We don't know the exact number of publish times
+        # The data should start at the beginning of two days ago
+        assert df[
+            "Interval Start"
+        ].min() == self.local_start_of_today() - pd.DateOffset(days=2)
+
+        self._check_solar_actual_and_forecast_hourly(df)
+
+    @api_vcr.use_cassette("test_get_solar_actual_and_forecast_hourly_latest.yaml")
+    def test_get_solar_actual_and_forecast_hourly_latest(self):
+        df = self.iso.get_solar_actual_and_forecast_hourly("latest")
+
+        assert df["Publish Time"].nunique() == 1
+        self._check_solar_actual_and_forecast_hourly(df)
+
+    @api_vcr.use_cassette("test_get_solar_actual_and_forecast_hourly_date_range.yaml")
+    def test_get_solar_actual_and_forecast_hourly_date_range(self):
+        date = self.local_today() - pd.DateOffset(days=HISTORICAL_DAYS_THRESHOLD * 3)
+        end = date + pd.Timedelta(hours=2)
+
+        df = self.iso.get_solar_actual_and_forecast_hourly(date, end, verbose=True)
+
+        self._check_solar_actual_and_forecast_hourly(df)
+
+        assert df["Publish Time"].nunique() == 2
+
+        assert df["Interval Start"].min() == self.local_start_of_day(
+            date.date(),
+        ) - pd.DateOffset(days=2)
+        assert df["Interval End"].max() >= self.local_start_of_day(
+            date.date(),
+        ) + pd.DateOffset(days=7)
+
+    """get_solar_actual_and_forecast_by_geographical_region_hourly"""
+
+    def _check_solar_actual_and_forecast_by_geographical_region_hourly(self, df):
         assert df.columns.tolist() == [
             "Interval Start",
             "Interval End",
@@ -171,9 +314,13 @@ class TestErcotAPI(TestHelperMixin):
 
         assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()
 
-    @pytest.mark.integration
-    def test_get_hourly_solar_report_today(self):
-        df = self.iso.get_hourly_solar_report("today")
+    @api_vcr.use_cassette(
+        "test_get_solar_actual_and_forecast_by_geographical_region_hourly_today.yaml",
+    )
+    def test_get_solar_actual_and_forecast_by_geographical_region_hourly_today(self):
+        df = self.iso.get_solar_actual_and_forecast_by_geographical_region_hourly(
+            "today",
+        )
 
         # We don't know the exact number of publish times
         # The data should start at the beginning of two days ago
@@ -181,23 +328,35 @@ class TestErcotAPI(TestHelperMixin):
             "Interval Start"
         ].min() == self.local_start_of_today() - pd.DateOffset(days=2)
 
-        self._check_hourly_solar_report(df)
+        self._check_solar_actual_and_forecast_by_geographical_region_hourly(df)
 
-    @pytest.mark.integration
-    def test_get_hourly_solar_report_latest(self):
-        df = self.iso.get_hourly_solar_report("latest")
+    @api_vcr.use_cassette(
+        "test_get_solar_actual_and_forecast_by_geographical_region_hourly_latest.yaml",
+    )
+    def test_get_solar_actual_and_forecast_by_geographical_region_hourly_latest(self):
+        df = self.iso.get_solar_actual_and_forecast_by_geographical_region_hourly(
+            "latest",
+        )
 
         assert df["Publish Time"].nunique() == 1
-        self._check_hourly_solar_report(df)
+        self._check_solar_actual_and_forecast_by_geographical_region_hourly(df)
 
-    @pytest.mark.integration
-    def test_get_hourly_solar_report_historical_date_range(self):
+    @api_vcr.use_cassette(
+        "test_get_solar_actual_and_forecast_by_geographical_region_hourly_date_range.yaml",  # noqa: E501
+    )
+    def test_get_solar_actual_and_forecast_by_geographical_region_hourly_date_range(
+        self,
+    ):
         date = self.local_today() - pd.DateOffset(days=HISTORICAL_DAYS_THRESHOLD * 3)
         end = date + pd.Timedelta(hours=2)
 
-        df = self.iso.get_hourly_solar_report(date, end, verbose=True)
+        df = self.iso.get_solar_actual_and_forecast_by_geographical_region_hourly(
+            date,
+            end,
+            verbose=True,
+        )
 
-        self._check_hourly_solar_report(df)
+        self._check_solar_actual_and_forecast_by_geographical_region_hourly(df)
 
         assert df["Publish Time"].nunique() == 2
 

--- a/gridstatus/tests/source_specific/test_ercot_api.py
+++ b/gridstatus/tests/source_specific/test_ercot_api.py
@@ -95,6 +95,7 @@ class TestErcotAPI(TestHelperMixin):
 
         assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()
 
+    @pytest.mark.integration
     @api_vcr.use_cassette("test_get_wind_actual_and_forecast_hourly_today.yaml")
     def test_get_wind_actual_and_forecast_hourly_today(self):
         df = self.iso.get_wind_actual_and_forecast_hourly("today")
@@ -106,6 +107,7 @@ class TestErcotAPI(TestHelperMixin):
 
         self._check_wind_actual_and_forecast_hourly(df)
 
+    @pytest.mark.integration
     @api_vcr.use_cassette("test_get_wind_actual_and_forecast_hourly_latest.yaml")
     def test_get_wind_actual_and_forecast_hourly_latest(self):
         df = self.iso.get_wind_actual_and_forecast_hourly("latest")
@@ -113,6 +115,7 @@ class TestErcotAPI(TestHelperMixin):
         assert df["Publish Time"].nunique() == 1
         self._check_wind_actual_and_forecast_hourly(df)
 
+    @pytest.mark.integration
     @api_vcr.use_cassette(
         "test_get_wind_actual_and_forecast_hourly_date_range.yaml",
     )
@@ -169,6 +172,7 @@ class TestErcotAPI(TestHelperMixin):
 
         assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()
 
+    @pytest.mark.integration
     @api_vcr.use_cassette(
         "test_get_wind_actual_and_forecast_by_geographical_region_hourly_today.yaml",
     )
@@ -184,6 +188,7 @@ class TestErcotAPI(TestHelperMixin):
 
         self._check_wind_actual_and_forecast_by_geographical_region_hourly(df)
 
+    @pytest.mark.integration
     @api_vcr.use_cassette(
         "test_get_wind_actual_and_forecast_by_geographical_region_hourly_latest.yaml",
     )
@@ -195,6 +200,7 @@ class TestErcotAPI(TestHelperMixin):
         assert df["Publish Time"].nunique() == 1
         self._check_wind_actual_and_forecast_by_geographical_region_hourly(df)
 
+    @pytest.mark.integration
     @api_vcr.use_cassette(
         "test_get_wind_actual_and_forecast_by_geographical_region_hourly_date_range.yaml",  # noqa: E501
     )
@@ -237,6 +243,7 @@ class TestErcotAPI(TestHelperMixin):
 
         assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()
 
+    @pytest.mark.integration
     @api_vcr.use_cassette("test_get_solar_actual_and_forecast_hourly_today.yaml")
     def test_get_solar_actual_and_forecast_hourly_today(self):
         df = self.iso.get_solar_actual_and_forecast_hourly("today")
@@ -249,6 +256,7 @@ class TestErcotAPI(TestHelperMixin):
 
         self._check_solar_actual_and_forecast_hourly(df)
 
+    @pytest.mark.integration
     @api_vcr.use_cassette("test_get_solar_actual_and_forecast_hourly_latest.yaml")
     def test_get_solar_actual_and_forecast_hourly_latest(self):
         df = self.iso.get_solar_actual_and_forecast_hourly("latest")
@@ -256,6 +264,7 @@ class TestErcotAPI(TestHelperMixin):
         assert df["Publish Time"].nunique() == 1
         self._check_solar_actual_and_forecast_hourly(df)
 
+    @pytest.mark.integration
     @api_vcr.use_cassette("test_get_solar_actual_and_forecast_hourly_date_range.yaml")
     def test_get_solar_actual_and_forecast_hourly_date_range(self):
         date = self.local_today() - pd.DateOffset(days=HISTORICAL_DAYS_THRESHOLD * 3)
@@ -314,6 +323,7 @@ class TestErcotAPI(TestHelperMixin):
 
         assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()
 
+    @pytest.mark.integration
     @api_vcr.use_cassette(
         "test_get_solar_actual_and_forecast_by_geographical_region_hourly_today.yaml",
     )
@@ -330,6 +340,7 @@ class TestErcotAPI(TestHelperMixin):
 
         self._check_solar_actual_and_forecast_by_geographical_region_hourly(df)
 
+    @pytest.mark.integration
     @api_vcr.use_cassette(
         "test_get_solar_actual_and_forecast_by_geographical_region_hourly_latest.yaml",
     )
@@ -341,6 +352,7 @@ class TestErcotAPI(TestHelperMixin):
         assert df["Publish Time"].nunique() == 1
         self._check_solar_actual_and_forecast_by_geographical_region_hourly(df)
 
+    @pytest.mark.integration
     @api_vcr.use_cassette(
         "test_get_solar_actual_and_forecast_by_geographical_region_hourly_date_range.yaml",  # noqa: E501
     )

--- a/gridstatus/tests/source_specific/test_ercot_api.py
+++ b/gridstatus/tests/source_specific/test_ercot_api.py
@@ -6,7 +6,14 @@ import pytest
 from gridstatus.base import Markets
 from gridstatus.ercot import ELECTRICAL_BUS_LOCATION_TYPE
 from gridstatus.ercot_api.api_parser import VALID_VALUE_TYPES
-from gridstatus.ercot_api.ercot_api import HISTORICAL_DAYS_THRESHOLD, ErcotAPI
+from gridstatus.ercot_api.ercot_api import (
+    HISTORICAL_DAYS_THRESHOLD,
+    SOLAR_ACTUAL_AND_FORECAST_BY_GEOGRAPHICAL_REGION_COLUMNS,
+    SOLAR_ACTUAL_AND_FORECAST_COLUMNS,
+    WIND_ACTUAL_AND_FORECAST_BY_GEOGRAPHICAL_REGION_COLUMNS,
+    WIND_ACTUAL_AND_FORECAST_COLUMNS,
+    ErcotAPI,
+)
 from gridstatus.tests.base_test_iso import TestHelperMixin
 from gridstatus.tests.source_specific.test_ercot import RESOURCE_AS_OFFERS_COLUMNS
 from gridstatus.tests.vcr_utils import RECORD_MODE, setup_vcr
@@ -70,29 +77,7 @@ class TestErcotAPI(TestHelperMixin):
     """get_wind_actual_and_forecast_hourly"""
 
     def _check_wind_actual_and_forecast_hourly(self, df):
-        assert df.columns.tolist() == [
-            "Interval Start",
-            "Interval End",
-            "Publish Time",
-            "GEN SYSTEM WIDE",
-            "COP HSL SYSTEM WIDE",
-            "STWPF SYSTEM WIDE",
-            "WGRPP SYSTEM WIDE",
-            "GEN LZ SOUTH HOUSTON",
-            "COP HSL LZ SOUTH HOUSTON",
-            "STWPF LZ SOUTH HOUSTON",
-            "WGRPP LZ SOUTH HOUSTON",
-            "GEN LZ WEST",
-            "COP HSL LZ WEST",
-            "STWPF LZ WEST",
-            "WGRPP LZ WEST",
-            "GEN LZ NORTH",
-            "COP HSL LZ NORTH",
-            "STWPF LZ NORTH",
-            "WGRPP LZ NORTH",
-            "HSL SYSTEM WIDE",
-        ]
-
+        assert df.columns.tolist() == WIND_ACTUAL_AND_FORECAST_COLUMNS
         assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()
 
     @pytest.mark.integration
@@ -139,36 +124,10 @@ class TestErcotAPI(TestHelperMixin):
     """get_wind_actual_and_forecast_by_geographical_region_hourly"""
 
     def _check_wind_actual_and_forecast_by_geographical_region_hourly(self, df):
-        assert df.columns.tolist() == [
-            "Interval Start",
-            "Interval End",
-            "Publish Time",
-            "GEN SYSTEM WIDE",
-            "COP HSL SYSTEM WIDE",
-            "STWPF SYSTEM WIDE",
-            "WGRPP SYSTEM WIDE",
-            "GEN PANHANDLE",
-            "COP HSL PANHANDLE",
-            "STWPF PANHANDLE",
-            "WGRPP PANHANDLE",
-            "GEN COASTAL",
-            "COP HSL COASTAL",
-            "STWPF COASTAL",
-            "WGRPP COASTAL",
-            "GEN SOUTH",
-            "COP HSL SOUTH",
-            "STWPF SOUTH",
-            "WGRPP SOUTH",
-            "GEN WEST",
-            "COP HSL WEST",
-            "STWPF WEST",
-            "WGRPP WEST",
-            "GEN NORTH",
-            "COP HSL NORTH",
-            "STWPF NORTH",
-            "WGRPP NORTH",
-            "HSL SYSTEM WIDE",
-        ]
+        assert (
+            df.columns.tolist()
+            == WIND_ACTUAL_AND_FORECAST_BY_GEOGRAPHICAL_REGION_COLUMNS
+        )
 
         assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()
 
@@ -230,16 +189,7 @@ class TestErcotAPI(TestHelperMixin):
     """get_solar_actual_and_forecast_hourly"""
 
     def _check_solar_actual_and_forecast_hourly(self, df):
-        assert df.columns.tolist() == [
-            "Interval Start",
-            "Interval End",
-            "Publish Time",
-            "GEN SYSTEM WIDE",
-            "COP HSL SYSTEM WIDE",
-            "STPPF SYSTEM WIDE",
-            "PVGRPP SYSTEM WIDE",
-            "HSL SYSTEM WIDE",
-        ]
+        assert df.columns.tolist() == SOLAR_ACTUAL_AND_FORECAST_COLUMNS
 
         assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()
 
@@ -286,41 +236,10 @@ class TestErcotAPI(TestHelperMixin):
     """get_solar_actual_and_forecast_by_geographical_region_hourly"""
 
     def _check_solar_actual_and_forecast_by_geographical_region_hourly(self, df):
-        assert df.columns.tolist() == [
-            "Interval Start",
-            "Interval End",
-            "Publish Time",
-            "GEN SYSTEM WIDE",
-            "COP HSL SYSTEM WIDE",
-            "STPPF SYSTEM WIDE",
-            "PVGRPP SYSTEM WIDE",
-            "GEN CenterWest",
-            "COP HSL CenterWest",
-            "STPPF CenterWest",
-            "PVGRPP CenterWest",
-            "GEN NorthWest",
-            "COP HSL NorthWest",
-            "STPPF NorthWest",
-            "PVGRPP NorthWest",
-            "GEN FarWest",
-            "COP HSL FarWest",
-            "STPPF FarWest",
-            "PVGRPP FarWest",
-            "GEN FarEast",
-            "COP HSL FarEast",
-            "STPPF FarEast",
-            "PVGRPP FarEast",
-            "GEN SouthEast",
-            "COP HSL SouthEast",
-            "STPPF SouthEast",
-            "PVGRPP SouthEast",
-            "GEN CenterEast",
-            "COP HSL CenterEast",
-            "STPPF CenterEast",
-            "PVGRPP CenterEast",
-            "HSL SYSTEM WIDE",
-        ]
-
+        assert (
+            df.columns.tolist()
+            == SOLAR_ACTUAL_AND_FORECAST_BY_GEOGRAPHICAL_REGION_COLUMNS
+        )
         assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()
 
     @pytest.mark.integration


### PR DESCRIPTION
## Summary

- Adds `ErcotAPI().get_wind_actual_and_forecast_by_geographical_region_hourly`
- Adds `ErcotAPI().get_solar_actual_and_forecast_hourly`
- Renames for clarification and to distinguish between datasets with extra geograpical regions
  - Renames `ErcotAPI().get_hourly_wind_report` to `ErcotAPI().get_wind_actual_and_forecast_hourly`
  - Renames `ErcotAPI().get_hourly_solar_report` to `ErcotAPI().get_solar_actual_and_forecast_by_geographical_region_hourly`


### Details
