### PR TITLE
chore(ENG 1005): rename to `load forecast`

### DIFF
--- a/gridstatus/isone_api/isone_api.py
+++ b/gridstatus/isone_api/isone_api.py
@@ -613,15 +613,15 @@ class ISONEAPI:
             "Interval End": "Interval End",
             "CreationDate": "Publish Time",
             "ReliabilityRegion": "Location",
-            "LoadMw": "Load",
+            "LoadMw": "Load Forecast",
             "ReliabilityRegionLoadPercentage": "Regional Percentage",
         }
         system_cols = {
             "BeginDate": "Interval Start",
             "Interval End": "Interval End",
             "CreationDate": "Publish Time",
-            "LoadMw": "Load",
-            "NetLoadMw": "Net Load",
+            "LoadMw": "Load Forecast",
+            "NetLoadMw": "Net Load Forecast",
         }
         if "ReliabilityRegion" in df.columns:
             df = df.rename(columns=regional_cols)
@@ -631,10 +631,13 @@ class ISONEAPI:
             )
         else:
             df = df.rename(columns=system_cols)
-            df["Net Load"] = pd.to_numeric(df["Net Load"], errors="coerce")
+            df["Net Load Forecast"] = pd.to_numeric(
+                df["Net Load Forecast"],
+                errors="coerce",
+            )
 
         df = df.sort_values(["Interval Start", "Publish Time"])
-        df["Load"] = pd.to_numeric(df["Load"], errors="coerce")
+        df["Load Forecast"] = pd.to_numeric(df["Load Forecast"], errors="coerce")
 
         log.info(
             f"Processed load forecast data: {len(df)} entries from {df['Interval Start'].min()} to {df['Interval Start'].max()}",

--- a/gridstatus/tests/source_specific/test_isone_api.py
+++ b/gridstatus/tests/source_specific/test_isone_api.py
@@ -214,8 +214,8 @@ class TestISONEAPI:
             "Interval Start",
             "Interval End",
             "Publish Time",
-            "Load",
-            "Net Load",
+            "Load Forecast",
+            "Net Load Forecast",
         ]
         assert (
             min(result["Interval Start"]).date()
@@ -224,9 +224,9 @@ class TestISONEAPI:
         assert max(result["Interval End"]) == pd.Timestamp(end).tz_localize(
             self.iso.default_timezone,
         )
-        assert result["Load"].dtype in [np.int64, np.float64]
-        assert result["Net Load"].dtype in [np.int64, np.float64]
-        assert (result["Load"] > 0).all()
+        assert result["Load Forecast"].dtype in [np.int64, np.float64]
+        assert result["Net Load Forecast"].dtype in [np.int64, np.float64]
+        assert (result["Load Forecast"] > 0).all()
         assert (
             (result["Interval End"] - result["Interval Start"]) == pd.Timedelta(hours=1)
         ).all()
@@ -246,7 +246,7 @@ class TestISONEAPI:
                 "Interval End",
                 "Publish Time",
                 "Location",
-                "Load",
+                "Load Forecast",
                 "Regional Percentage",
             ]
             assert (
@@ -270,8 +270,8 @@ class TestISONEAPI:
                 ".Z.WCMASS",
                 ".Z.NEMASSBOST",
             }
-            assert result["Load"].dtype in [np.int64, np.float64]
-            assert (result["Load"] > 0).all()
+            assert result["Load Forecast"].dtype in [np.int64, np.float64]
+            assert (result["Load Forecast"] > 0).all()
             assert result["Regional Percentage"].dtype == np.float64
             assert (
                 (result["Regional Percentage"] >= 0)


### PR DESCRIPTION
## Summary
Renames the `Load` column in `isone_reliability_region_load_forecast` to `Load Forecast` to follow the convention set across other ISOs and datasets.

### Details
This also updates the methods for `ISONEAPI.get_hourly_load_forecast()`, which is the API method for hourly load forecast. There is also a "flat file" scraper for this data which is more heavily used since it came first. More in this ticket on ISONE API implementation https://www.notion.so/gridstatus/Future-ISONE-Datasets-122e835f42aa806f8f0adec85ac3e6d2?pvs=4
