### PR TITLE
fix: Disambiguate `last_modified` timezone better

### DIFF
--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -1081,7 +1081,10 @@ class IESO(ISOBase):
 
         if last_modified:
             if last_modified.tz is None:
-                last_modified = last_modified.tz_localize("UTC")
+                last_modified = utils._handle_date(
+                    last_modified,
+                    tz=self.default_timezone,
+                )
             filtered_files = [
                 (file, time)
                 for file, time in file_rows

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -998,7 +998,10 @@ class IESO(ISOBase):
 
         if last_modified:
             if last_modified.tz is None:
-                last_modified = last_modified.tz_localize(self.default_timezone)
+                last_modified = utils._handle_date(
+                    last_modified,
+                    tz=self.default_timezone,
+                )
             filtered_files = [
                 (file, time)
                 for file, time in files_and_times

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -998,7 +998,7 @@ class IESO(ISOBase):
 
         if last_modified:
             if last_modified.tz is None:
-                last_modified = last_modified.tz_localize("UTC")
+                last_modified = last_modified.tz_localize(self.default_timezone)
             filtered_files = [
                 (file, time)
                 for file, time in files_and_times

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -964,7 +964,7 @@ class IESO(ISOBase):
     def _get_latest_resource_adequacy_json(
         self,
         date: str | datetime.date | datetime.datetime,
-        last_modified: str | datetime.date | datetime.datetime | None = None,
+        last_modified: pd.Timestamp | None = None,
     ) -> tuple[dict, datetime.datetime]:
         """Retrieve the Resource Adequacy Report for a given date and convert to JSON. There are often many
         files for a given date, so this function will return the file with the highest version number. It does
@@ -997,7 +997,8 @@ class IESO(ISOBase):
             )
 
         if last_modified:
-            last_modified = pd.Timestamp(last_modified, tz=self.default_timezone)
+            if last_modified.tz is None:
+                last_modified = last_modified.tz_localize("UTC")
             filtered_files = [
                 (file, time)
                 for file, time in files_and_times
@@ -1043,7 +1044,7 @@ class IESO(ISOBase):
     def _get_all_resource_adequacy_jsons(
         self,
         date: str | datetime.date | datetime.datetime,
-        last_modified: str | datetime.date | datetime.datetime | None = None,
+        last_modified: pd.Timestamp | None = None,
     ) -> list[tuple[dict, datetime.datetime]]:
         """Retrieve all Resource Adequacy Report JSONs for a given date. There are often many
         files for a given date, so this function will return all files, the data of which may be separated
@@ -1076,7 +1077,8 @@ class IESO(ISOBase):
             )
 
         if last_modified:
-            last_modified = pd.Timestamp(last_modified, tz=self.default_timezone)
+            if last_modified.tz is None:
+                last_modified = last_modified.tz_localize("UTC")
             filtered_files = [
                 (file, time)
                 for file, time in file_rows

--- a/gridstatus/tests/source_specific/test_ieso.py
+++ b/gridstatus/tests/source_specific/test_ieso.py
@@ -552,7 +552,7 @@ class TestIESO(BaseTestISO):
     # NOTE(kladar, 2024-12-11): Tests rolled off, earliest is currently 2024-09-10, 92 days ago
     RESOURCE_ADEQUACY_TEST_DATES = [
         (
-            (pd.Timestamp.now(tz=default_timezone) - pd.Timedelta(days=92)).strftime(
+            (pd.Timestamp.now(tz=default_timezone) - pd.Timedelta(days=91)).strftime(
                 "%Y-%m-%d",
             ),
             (pd.Timestamp.now(tz=default_timezone) - pd.Timedelta(days=89)).strftime(

--- a/gridstatus/tests/source_specific/test_ieso.py
+++ b/gridstatus/tests/source_specific/test_ieso.py
@@ -549,12 +549,13 @@ class TestIESO(BaseTestISO):
     """get_resource_adequacy_report"""
 
     # NOTE(kladar): we will see how future data rolls in and historical rolls off
+    # NOTE(kladar, 2024-12-11): Tests rolled off, earliest is currently 2024-09-10, 92 days ago
     RESOURCE_ADEQUACY_TEST_DATES = [
         (
-            (pd.Timestamp.now(tz=default_timezone) - pd.Timedelta(days=119)).strftime(
+            (pd.Timestamp.now(tz=default_timezone) - pd.Timedelta(days=92)).strftime(
                 "%Y-%m-%d",
             ),
-            (pd.Timestamp.now(tz=default_timezone) - pd.Timedelta(days=115)).strftime(
+            (pd.Timestamp.now(tz=default_timezone) - pd.Timedelta(days=89)).strftime(
                 "%Y-%m-%d",
             ),
         ),
@@ -581,10 +582,10 @@ class TestIESO(BaseTestISO):
             ),
         ),
         (
-            (pd.Timestamp.now(tz=default_timezone) + pd.Timedelta(days=28)).strftime(
+            (pd.Timestamp.now(tz=default_timezone) + pd.Timedelta(days=31)).strftime(
                 "%Y-%m-%d",
             ),
-            (pd.Timestamp.now(tz=default_timezone) + pd.Timedelta(days=30)).strftime(
+            (pd.Timestamp.now(tz=default_timezone) + pd.Timedelta(days=34)).strftime(
                 "%Y-%m-%d",
             ),
         ),


### PR DESCRIPTION
## Summary
Before, we were localizing the given `last_modified` time parameter into the ISO local time (always EST). However, this is not the desired behavior and really `last_modified` can have any (or no) timezone.

### Details
Particularly this would cause an issue if the last modified was meant to be in UTC, as it was localized to EST, resulting in a radically different time than was given to the function and used to compare. 