### PR TITLE
feat(ENG 1028): Bulk ERCOT API Downloads

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -3380,6 +3380,7 @@ class Ercot(ISOBase):
     def _handle_indicative_lmp_by_settlement_point(self, df: pd.DataFrame):
         columns_to_rename = {
             "IntervalId": "Interval Id",
+            "RTDTimestamp": "RTD Timestamp",
             "IntervalEnding": "Interval End",
             "SettlementPoint": "Location",
             "SettlementPointType": "Location Type",
@@ -3389,7 +3390,7 @@ class Ercot(ISOBase):
         assert set(df["RepeatedHourFlag"].unique()).issubset({"Y", "N"})
         assert set(df["IntervalRepeatedHourFlag"].unique()).issubset({"Y", "N"})
 
-        df["RTDTimestamp"] = pd.to_datetime(df["RTDTimestamp"]).dt.tz_localize(
+        df["RTD Timestamp"] = pd.to_datetime(df["RTD Timestamp"]).dt.tz_localize(
             self.default_timezone,
             ambiguous=df["RepeatedHourFlag"] == "N",
             nonexistent="shift_forward",
@@ -3406,7 +3407,7 @@ class Ercot(ISOBase):
             [
                 "Interval Start",
                 "Interval End",
-                "RTDTimestamp",
+                "RTD Timestamp",
                 "Interval Id",
                 "Location",
                 "Location Type",

--- a/gridstatus/ercot_api/ercot_api.py
+++ b/gridstatus/ercot_api/ercot_api.py
@@ -330,7 +330,9 @@ class ErcotAPI:
         parse_json: bool = True,
         method: str = "GET",
     ):
-        logger.info(f"Requesting url: {url} with params: {api_params}")
+        logger.info(
+            f"Requesting url: {url} with params: {str(api_params)[:100] + '...' if api_params and len(str(api_params)) > 100 else api_params}",
+        )
 
         # make request with exponential backoff retry strategy
         retries = 0
@@ -1371,6 +1373,9 @@ class ErcotAPI:
                     dfs.append(bytes)
                 else:
                     with ZipFile(pd.io.common.BytesIO(response)) as outer_zip:
+                        logger.debug(
+                            f"Received zip file with {len(outer_zip.namelist())} files",
+                        )
                         for inner_zip_name in outer_zip.namelist():
                             with outer_zip.open(inner_zip_name) as inner_zip_file:
                                 df = pd.read_csv(inner_zip_file, compression="zip")
@@ -1379,9 +1384,6 @@ class ErcotAPI:
                                         df["postDatetime"],
                                     )
                                 dfs.append(df)
-
-                time.sleep(self.sleep_seconds)
-
             return pd.concat(dfs) if read_as_csv else dfs
 
         else:

--- a/gridstatus/ercot_api/ercot_api.py
+++ b/gridstatus/ercot_api/ercot_api.py
@@ -1371,12 +1371,10 @@ class ErcotAPI:
                     else:
                         # Decompress the zip file and read the csv
                         df = pd.read_csv(bytes, compression="zip")
-                        logger.debug(df.head())
                         if add_post_datetime:
                             df["postDatetime"] = posted_datetime
 
                         dfs.append(df)
-                        print(f"len of dfs: {len(dfs)}")
                     # Necessary to avoid rate limiting
                     time.sleep(self.sleep_seconds)
                     break  # Exit the loop if the operation is successful


### PR DESCRIPTION
## Summary
[DRAFT, waiting for https://github.com/gridstatus/gridstatus/pull/504 which I will merge in here first] Turns out you can have up to 1000 `docId`s in the download endpoint request (but it does seem to want it to be a `POST` request)

### Details
Adds bulk download functionality to the `get_historical_data()` method stack. I don't assume this works for every dataset and affects the lower level `make_api_request()` which a lot of methods use, but we can evolve it to other methods if we want. 