### PR TITLE
Implement another approach to ERCOT API bulk document downloading

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -3380,8 +3380,8 @@ class Ercot(ISOBase):
     def _handle_indicative_lmp_by_settlement_point(self, df: pd.DataFrame):
         columns_to_rename = {
             "IntervalId": "Interval Id",
-            "RTDTimestamp": "RTD Timestamp",
             "IntervalEnding": "Interval End",
+            "RTDTimestamp": "RTD Timestamp",
             "SettlementPoint": "Location",
             "SettlementPointType": "Location Type",
             "LMP": "LMP",

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -3380,6 +3380,7 @@ class Ercot(ISOBase):
     def _handle_indicative_lmp_by_settlement_point(self, df: pd.DataFrame):
         columns_to_rename = {
             "IntervalId": "Interval Id",
+            "RTDTimestamp": "RTD Timestamp",
             "IntervalEnding": "Interval End",
             "SettlementPoint": "Location",
             "SettlementPointType": "Location Type",
@@ -3389,7 +3390,7 @@ class Ercot(ISOBase):
         assert set(df["RepeatedHourFlag"].unique()).issubset({"Y", "N"})
         assert set(df["IntervalRepeatedHourFlag"].unique()).issubset({"Y", "N"})
 
-        df["RTDTimestamp"] = pd.to_datetime(df["RTDTimestamp"]).dt.tz_localize(
+        df["RTD Timestamp"] = pd.to_datetime(df["RTD Timestamp"]).dt.tz_localize(
             self.default_timezone,
             ambiguous=df["RepeatedHourFlag"] == "N",
             nonexistent="shift_forward",
@@ -3406,7 +3407,7 @@ class Ercot(ISOBase):
             [
                 "Interval Start",
                 "Interval End",
-                "RTDTimestamp",
+                "RTD Timestamp",
                 "Interval Id",
                 "Location",
                 "Location Type",

--- a/gridstatus/ercot_api/ercot_api.py
+++ b/gridstatus/ercot_api/ercot_api.py
@@ -1425,13 +1425,12 @@ class ErcotAPI:
         doc_ids: list[str],
         emil_id: str,
     ) -> list[pd.io.common.BytesIO]:
-        # Collect docIds from the links
         documents = []
         doc_id_batches = [
             doc_ids[i : i + self.batch_size]
             for i in range(0, len(doc_ids), self.batch_size)
         ]
-        process_doc_ids = []
+        processed_doc_ids = []
         for batch in doc_id_batches:
             payload = {"docIds": batch}
             response = self.make_api_call(
@@ -1446,15 +1445,15 @@ class ErcotAPI:
                     f"Received zip file with {len(outer_zip.namelist())} files",
                 )
 
-                # namelist is in reverse order of suppied docIds, so we need to reverse it
+                # namelist is in reverse order of supplied docIds, so we need to reverse it
                 for inner_zip_name in reversed(outer_zip.namelist()):
-                    process_doc_ids.append(inner_zip_name.split(".")[0])
+                    processed_doc_ids.append(inner_zip_name.split(".")[0])
                     with outer_zip.open(inner_zip_name) as inner_zip_file:
                         documents.append(pd.io.common.BytesIO(inner_zip_file.read()))
 
         # Ensure that the order of the documents matches the order of the supplied
         # docIds since downstream code expects this
-        assert doc_ids == process_doc_ids, "docIds order does not match"
+        assert doc_ids == processed_doc_ids, "docIds order does not match"
         return documents
 
     def _get_historical_data_links(

--- a/gridstatus/ercot_api/ercot_api.py
+++ b/gridstatus/ercot_api/ercot_api.py
@@ -330,7 +330,9 @@ class ErcotAPI:
         parse_json: bool = True,
         method: str = "GET",
     ):
-        logger.info(f"Requesting url: {url} with params: {api_params}")
+        logger.info(
+            f"Requesting url: {url} with params: {str(api_params)[:100] + '...' if api_params and len(str(api_params)) > 100 else api_params}",
+        )
 
         # make request with exponential backoff retry strategy
         retries = 0
@@ -1371,6 +1373,9 @@ class ErcotAPI:
                     dfs.append(bytes)
                 else:
                     with ZipFile(pd.io.common.BytesIO(response)) as outer_zip:
+                        logger.debug(
+                            f"Received zip file with {len(outer_zip.namelist())} files",
+                        )
                         for inner_zip_name in outer_zip.namelist():
                             with outer_zip.open(inner_zip_name) as inner_zip_file:
                                 df = pd.read_csv(inner_zip_file, compression="zip")
@@ -1379,9 +1384,6 @@ class ErcotAPI:
                                         df["postDatetime"],
                                     )
                                 dfs.append(df)
-
-                time.sleep(self.sleep_seconds)
-
             return pd.concat(dfs) if read_as_csv else dfs
 
         else:

--- a/gridstatus/ercot_api/ercot_api.py
+++ b/gridstatus/ercot_api/ercot_api.py
@@ -1371,12 +1371,10 @@ class ErcotAPI:
                     else:
                         # Decompress the zip file and read the csv
                         df = pd.read_csv(bytes, compression="zip")
-                        logger.debug(df.head())
                         if add_post_datetime:
                             df["postDatetime"] = posted_datetime
 
                         dfs.append(df)
-                        print(f"len of dfs: {len(dfs)}")
                     # Necessary to avoid rate limiting
                     time.sleep(self.sleep_seconds)
                     break  # Exit the loop if the operation is successful

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -1863,7 +1863,7 @@ class TestErcot(BaseTestISO):
             assert df.columns.tolist() == [
                 "Interval Start",
                 "Interval End",
-                "RTDTimestamp",
+                "RTD Timestamp",
                 "Interval Id",
                 "Interval Repeated Hour Flag",
                 "Location",

--- a/gridstatus/tests/source_specific/test_ercot_api.py
+++ b/gridstatus/tests/source_specific/test_ercot_api.py
@@ -1454,7 +1454,7 @@ class TestErcotAPI(TestHelperMixin):
             assert df.columns.tolist() == [
                 "Interval Start",
                 "Interval End",
-                "RTDTimestamp",
+                "RTD Timestamp",
                 "Interval Id",
                 "Location",
                 "Location Type",


### PR DESCRIPTION
Took another stab at implementing the bulk data download.

Per our discussion this morning, I wanted to separate the downloading of the data from the processing of it. In the future, it should be a little bit easier to tease these piece apart. for example, if we wanted to write these data to S3 before processing it. 

In my opinion it also made this code more maintainable since the parsing logic is now the same regardless of it we are bulk downloading or individually downloading. 

My biggest concern is this approach takes more memory since we are storing both file bytes and parsed dataframes in memory. Before, we only stored the parsed dataframe. I'm not sure this matters, but it might on render where we try to run jobs on as small boxes as possible. 