### PR TITLE
Remove date parameter

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -3368,7 +3368,6 @@ class Ercot(ISOBase):
 
         docs = self._get_documents(
             report_type_id=ERCOT_INDICATIVE_LMP_BY_SETTLEMENT_POINT_RTID,
-            date=date,
             extension="csv",
             published_before=end,
             published_after=date,


### PR DESCRIPTION
I noticed `get_indicative_lmp_by_settlement_point` wasn't updating with new data. The problem was we were passing an extra data parameter to `_get_documents` that was filtering data more than we intended. just `published_before` and `published_after` are enoguh