### PR TITLE
fix(ENG-1030): IESO Adequacy Forecast Report fixes

### DIFF
--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -1161,9 +1161,9 @@ class IESO(ISOBase):
 
             if "fuel_type_hourly" in section_data:
                 fuel_type_config = section_data["fuel_type_hourly"]
-                resources = get_nested_data(document_body, fuel_type_config["path"])
-                if not isinstance(resources, list):
-                    resources = [resources]
+                resources = list(
+                    get_nested_data(document_body, fuel_type_config["path"]),
+                )
 
                 for resource in resources:
                     fuel_type = resource.get("FuelType")

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -938,6 +938,9 @@ class IESO(ISOBase):
         Returns:
             pd.DataFrame: The Resource Adequacy Report df for the given date
         """
+        if last_modified:
+            last_modified = utils._handle_date(last_modified, tz=self.default_timezone)
+
         if vintage == "latest":
             json_data, file_last_modified = self._get_latest_resource_adequacy_json(
                 date,

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -1797,7 +1797,7 @@ class IESO(ISOBase):
         for key in path[:-1]:
             if key not in current:
                 logger.debug(
-                    f"Path segment {current} {path}:'{key}' not found in data structure",
+                    f"Path segment {path} has no key '{key}' in the data structure. Investigate the report data map definition.",
                 )
                 return
             current = current[key]

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -1142,7 +1142,8 @@ class IESO(ISOBase):
         # TODO(Kladar): this is clunky and could definitely be generalized to reduce
         # linecount, but it works for now. I kind of move around the report JSON to where I want
         # to extract data and then extract it, and that movement could be abstracted away
-        def get_nested_data(data, path):
+        # NOTE(kladar): suggested libraries that does this sort of thing are `dpath` and `glom` https://github.com/mahmoud/glom
+        def get_nested_data(data: dict, path: list[str]) -> dict:
             """Helper function to traverse nested data using a path."""
             for key in path:
                 data = data[key]

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -1751,10 +1751,6 @@ class IESO(ISOBase):
                             "path": ["Schedules", "Schedule"],
                             "value_key": "EnergyMW",
                         },
-                        "Estimated": {
-                            "path": ["Estimates", "Estimate"],
-                            "value_key": "EnergyMW",
-                        },
                         "Capacity": {
                             "path": ["Capacities", "Capacity"],
                             "value_key": "EnergyMW",
@@ -1810,7 +1806,9 @@ class IESO(ISOBase):
         current = data
         for key in path[:-1]:
             if key not in current:
-                logger.debug(f"Path segment '{key}' not found in data structure")
+                logger.debug(
+                    f"Path segment {current} {path}:'{key}' not found in data structure",
+                )
                 return
             current = current[key]
 


### PR DESCRIPTION
## Summary
There is some funky behavior going on with the current IESO Adequacy Report. This cleans the report up a bit further and fixes the current column issue, as well as some other improvements.

### Details
The report structure map has seen some improvements and generalizations to make it clearer and more standardized. More could be done here, but it continues to be more legible and generalized. As we do more XML report parsing I could see this developing into a repeatable, robust design pattern for parsing these reports. 

Dataframe shape debugging code now at the end of the process to accurately reflect df shape. Sorting now includes `Last Modified` it has been moved to the front of the df with the other timestamp columns.

There is no `Estimated` section for `Total Exports` (like there is for `Total Imports`) so this removed from the structure map. While not technically a breaking issue, it would throw up a warning each time it was run: 

![CleanShot 2024-12-22 at 15 49 23@2x](https://github.com/user-attachments/assets/4e44c7dc-b43d-4468-9b7e-32041115729b)