### PR TITLE
Update NYISO data sources

### DIFF
--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -599,15 +599,15 @@ class NYISO(ISOBase):
             * State
             * In-Service Date
             * Name Plate Rating (V) MW
-            * 2022 CRIS MW Summer
-            * 2022 CRIS MW Winter
-            * 2022 Capability MW Summer
-            * 2022 Capability MW Winter
+            * 2024 CRIS MW Summer
+            * 2024 CRIS MW Winter
+            * 2024 Capability MW Summer
+            * 2024 Capability MW Winter
             * Is Dual Fuel
             * Unit Type
             * Fuel Type 1
             * Fuel Type 2
-            * 2021 Net Energy GWh
+            * 2023 Net Energy GWh
             * Notes
             * Generator Type
         """
@@ -620,13 +620,13 @@ class NYISO(ISOBase):
 
         # need to be updated once a year. approximately around end of april
         # find it here: https://www.nyiso.com/gold-book-resources
-        capacity_url_2023 = "https://www.nyiso.com/documents/20142/37320118/2023-NYCA-Generators.xlsx/145ca922-064c-133f-b3e8-3b4a30ed2845"  # noqa
+        capacity_url_2024 = "https://www.nyiso.com/documents/20142/44474211/2024-NYCA-Generators.xlsx/41a5cba2-523a-9fe0-9830-a523839a2831"  # noqa
 
-        msg = f"Requesting {capacity_url_2023}"
+        msg = f"Requesting {capacity_url_2024}"
         log(msg, verbose)
 
         generators = pd.read_excel(
-            capacity_url_2023,
+            capacity_url_2024,
             sheet_name=[
                 "Table III-2a",
                 "Table III-2b",
@@ -650,15 +650,15 @@ class NYISO(ISOBase):
             "State",
             "In-Service Date",
             "Name Plate Rating (V) MW",
-            "2023 CRIS MW Summer",
-            "2023 CRIS MW Winter",
-            "2023 Capability MW Summer",
-            "2023 Capability MW Winter",
+            "2024 CRIS MW Summer",
+            "2024 CRIS MW Winter",
+            "2024 Capability MW Summer",
+            "2024 Capability MW Winter",
             "Is Dual Fuel",
             "Unit Type",
             "Fuel Type 1",
             "Fuel Type 2",
-            "2022 Net Energy GWh",
+            "2023 Net Energy GWh",
             "Notes",
             "Generator Type",
         ]
@@ -942,6 +942,10 @@ class NYISO(ISOBase):
             year_code = 27447313
         elif date.year == 2023:
             year_code = 35397361
+        elif date.year == 2024:
+            year_code = 42146126
+        elif date.year == 2025:
+            year_code = 48997190
         else:
             raise ValueError(
                 "Year not currently supported. Please file an issue.",

--- a/gridstatus/tests/source_specific/test_nyiso.py
+++ b/gridstatus/tests/source_specific/test_nyiso.py
@@ -20,11 +20,17 @@ class TestNYISO(BaseTestISO):
 
     @pytest.mark.integration
     def test_get_capacity_prices(self):
-        # test 2022, 2023, and today
+        # test 2022, 2023, 2024, and 2025
         df = self.iso.get_capacity_prices(date="Dec 1, 2022", verbose=True)
         assert not df.empty, "DataFrame came back empty"
 
         df = self.iso.get_capacity_prices(date="Jan 1, 2023", verbose=True)
+        assert not df.empty, "DataFrame came back empty"
+
+        df = self.iso.get_capacity_prices(date="Jan 1, 2024", verbose=True)
+        assert not df.empty, "DataFrame came back empty"
+
+        df = self.iso.get_capacity_prices(date="Jan 1, 2025", verbose=True)
         assert not df.empty, "DataFrame came back empty"
 
         # TODO: missing report: https://github.com/kmax12/gridstatus/issues/309


### PR DESCRIPTION
## Summary

Generator and capacity data for NYISO is available at URLs with opaque identifiers that change on a per year basis. This PR updates the URLs for 2024/2025.

### Details

The updated generators list for 2024 is included (the 2025 list should become available later this spring), along with the 2024 and 2025 year codes for ICAP results.