### PR TITLE
Add read_csv Kwargs for ERCOT read_doc

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -3159,11 +3159,14 @@ class Ercot(ISOBase):
         parse: bool = True,
         verbose: bool = False,
         request_kwargs: dict | None = None,
+        read_csv_kwargs: dict | None = None,
     ):
         logger.debug(f"Reading {doc.url}")
 
         response = requests.get(doc.url, **(request_kwargs or {})).content
-        df = pd.read_csv(io.BytesIO(response), compression="zip")
+        df = pd.read_csv(
+            io.BytesIO(response), compression="zip", **(read_csv_kwargs or {})
+        )
 
         if parse:
             df = self.parse_doc(df, verbose=verbose)


### PR DESCRIPTION
## Summary


- Adds `read_csv_kwargs` to `Ercot().read_doc()` so callers can pass in custom kwargs to Pandas `read_csv`

### Details
