### PR TITLE
Query current day data from real-time hourly market in ISO-NE

### DIFF
--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -479,7 +479,9 @@ class ISONE(ISOBase):
 
         elif market == Markets.REAL_TIME_HOURLY:
             if date.date() > now.date():
-                raise RuntimeError(f"date {date.date()} is in the future and cannot be used to query real-time data")
+                raise RuntimeError(
+                    f"date {date.date()} is in the future and cannot be used to query real-time data"
+                )
 
             url = f"https://www.iso-ne.com/static-transform/csv/histRpts/rt-lmp/lmp_rt_prelim_{date_str}.csv"  # noqa
             data = _make_request(

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -478,6 +478,9 @@ class ISONE(ISOBase):
             data = data.rename(columns={"Local Time": "Interval Start"})
 
         elif market == Markets.REAL_TIME_HOURLY:
+            if date.date() > now.date():
+                raise RuntimeError(f"date {date.date()} is in the future and cannot be used to query real-time data")
+
             url = f"https://www.iso-ne.com/static-transform/csv/histRpts/rt-lmp/lmp_rt_prelim_{date_str}.csv"  # noqa
             data = _make_request(
                 url,

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -478,19 +478,12 @@ class ISONE(ISOBase):
             data = data.rename(columns={"Local Time": "Interval Start"})
 
         elif market == Markets.REAL_TIME_HOURLY:
-            if date.date() < now.date():
-                url = f"https://www.iso-ne.com/static-transform/csv/histRpts/rt-lmp/lmp_rt_prelim_{date_str}.csv"  # noqa
-                data = _make_request(
-                    url,
-                    skiprows=[0, 1, 2, 3, 5],
-                    verbose=verbose,
-                )
-            else:
-                # iso only publishes rolling 3 hours of data for current
-                # day real time hourly. idk why
-                raise RuntimeError(
-                    "Today not supported for hourly lmp. Try latest",
-                )
+            url = f"https://www.iso-ne.com/static-transform/csv/histRpts/rt-lmp/lmp_rt_prelim_{date_str}.csv"  # noqa
+            data = _make_request(
+                url,
+                skiprows=[0, 1, 2, 3, 5],
+                verbose=verbose,
+            )
 
         elif market == Markets.DAY_AHEAD_HOURLY:
             url = f"https://www.iso-ne.com/static-transform/csv/histRpts/da-lmp/WW_DALMP_ISO_{date_str}.csv"  # noqa


### PR DESCRIPTION
## Summary
Closes #515. Allow data from the current day to be queried from the real-time hourly market in ISO-NE, since this is now supported.

Also fixed the runtime error if a future date is passed.

### Details
Verified with the following script:
```
from gridstatus import ISONE, Markets
import pandas as pd

print(ISONE().get_lmp(
    date=pd.Timestamp.now(tz="US/EASTERN").date(),
    market=Markets.REAL_TIME_HOURLY,
))
```