### PR TITLE
feat(ENG 911): PJM Area Control Error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 exclude: ^LICENSE/|\.(html|csv|svg|md)$
-default_stages: [commit, push]
+default_stages: [pre-commit, pre-push]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -2650,3 +2650,30 @@ class PJM(ISOBase):
         )
 
         return df
+
+    @support_date_range(frequency=None)
+    def get_area_control_error(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """
+        Retrieves the area control error data from:
+        https://dataminer2.pjm.com/feed/area_control_error/definition
+        """
+        if date == "latest":
+            date = "today"
+
+        df = self._get_pjm_json(
+            "area_control_error",
+            start=date,
+            end=end,
+            params={
+                "fields": "datetime_beginning_utc,ace_mw",
+            },
+            interval_duration_min=0.25,
+            verbose=verbose,
+        )
+
+        return df

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -2675,5 +2675,10 @@ class PJM(ISOBase):
             interval_duration_min=0.25,
             verbose=verbose,
         )
+        df = df.rename(
+            columns={
+                "ace_mw": "Area Control Error",
+            },
+        )
 
-        return df
+        return df[["Interval Start", "Interval End", "Area Control Error"]]

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -2679,5 +2679,4 @@ class PJM(ISOBase):
                 "ace_mw": "Area Control Error",
             },
         )
-        print(df)
         return df[["Time", "Area Control Error"]]

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -2672,7 +2672,6 @@ class PJM(ISOBase):
             params={
                 "fields": "datetime_beginning_utc,ace_mw",
             },
-            interval_duration_min=0.25,
             verbose=verbose,
         )
         df = df.rename(
@@ -2680,5 +2679,5 @@ class PJM(ISOBase):
                 "ace_mw": "Area Control Error",
             },
         )
-
-        return df[["Interval Start", "Interval End", "Area Control Error"]]
+        print(df)
+        return df[["Time", "Area Control Error"]]

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -165,14 +165,9 @@ class TestPJM(BaseTestISO):
         ],
     )
     def test_get_lmp_hourly(self, market: Markets):
-        markets = [
-            Markets.REAL_TIME_HOURLY,
-            Markets.DAY_AHEAD_HOURLY,
-        ]
-
-        for m in markets:
-            logger.info(self.iso.iso_id, m)
-            self._lmp_tests(m)
+        with pjm_vcr.use_cassette(f"test_get_lmp_hourly_{market}.yaml"):
+            logger.info(self.iso.iso_id, market)
+            self._lmp_tests(market)
 
     @pytest.mark.parametrize(
         "date, end",

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -2077,17 +2077,12 @@ class TestPJM(BaseTestISO):
 
             assert isinstance(df, pd.DataFrame)
             assert df.columns.tolist() == [
-                "Interval Start",
-                "Interval End",
+                "Time",
                 "Area Control Error",
             ]
 
             assert df["Area Control Error"].dtype in [np.float64, np.int64]
-            assert df["Interval Start"].min().date() == pd.Timestamp(date).date()
-            assert df["Interval End"].max().date() <= pd.Timestamp(end).date()
-            assert (df["Interval End"] - df["Interval Start"]).unique() == pd.Timedelta(
-                seconds=15,
-            )
+            assert df["Time"].min().date() == pd.Timestamp(date).date()
 
     @pytest.mark.parametrize(
         "date",

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -2096,4 +2096,16 @@ class TestPJM(BaseTestISO):
         with pjm_vcr.use_cassette(f"test_get_area_control_error_{date}.yaml"):
             df = self.iso.get_area_control_error(date)
 
-            assert self.iso.get_area_control_error("latest").equals(df)
+            assert isinstance(df, pd.DataFrame)
+            assert df.columns.tolist() == [
+                "Time",
+                "Area Control Error",
+            ]
+
+            assert df["Area Control Error"].dtype in [np.float64, np.int64]
+            assert df["Time"].min() <= self.local_start_of_today() + pd.Timedelta(
+                seconds=15,
+            )
+            assert df["Time"].max() <= self.local_start_of_today() + pd.Timedelta(
+                days=1,
+            )

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -2047,12 +2047,12 @@ class TestPJM(BaseTestISO):
                 hours=1,
             )
 
-    def test_get_day_ahead_demand_bids_date_range(self, date: str):
+    def test_get_day_ahead_demand_bids_date_range(self):
         start = self.local_start_of_today() - pd.DateOffset(days=30)
         end = start + pd.Timedelta(hours=4)
 
         with pjm_vcr.use_cassette(
-            f"test_get_day_ahead_demand_bids_date_range_{date.strftime('%Y-%m-%d')}_{end.strftime('%Y-%m-%d')}.yaml",
+            f"test_get_day_ahead_demand_bids_date_range_{start.strftime('%Y-%m-%d')}_{end.strftime('%Y-%m-%d')}.yaml",
         ):
             df = self.iso.get_day_ahead_demand_bids(start=start, end=end)
 


### PR DESCRIPTION
## Summary
Adds the 15-second dataset `pjm_area_control_error`. Also triggers some "New Source Review" upgrades to PJM.

### Details
To get area control error data yourself:
```
from gridstatus.pjm import PJM
pjm = PJM()
df = pjm.get_area_control_error(date="2025-02-01")
print(df)
```

#### New Source Review
Updates to all typehinted functions and tackles a good chunk of VCR testing, covering about 40% of current integration tests. Reduces local testing by ~85%, all things equal.

**Old**
![CleanShot 2025-02-06 at 18 19 10](https://github.com/user-attachments/assets/2c127084-daf8-422c-8d98-01904fad13a7)

**New**
![CleanShot 2025-02-06 at 18 56 27](https://github.com/user-attachments/assets/aa765064-169e-4eaf-8b09-8a7251e1fb73)
