### PR TITLE
feat(ENG 1315): MISO Look Ahead outages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 exclude: ^LICENSE/|\.(html|csv|svg|md)$
-default_stages: [pre-commit, pre-push]
+default_stages: [commit, push]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -1394,3 +1394,20 @@ class MISO(ISOBase):
             self.default_timezone,
         )
         return market_date, publish_date
+
+    @support_date_range(frequency="DAY_START")
+    def get_look_ahead_hourly(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        if date == "latest":
+            return self.get_look_ahead_hourly(date="today", verbose=verbose)
+
+        url = f"https://docs.misoenergy.org/marketreports/{date.strftime('%Y%m%d')}_sr_la_rg.csv"
+        logger.info(f"Downloading look-ahead hourly data from {url}")
+
+        df = pd.read_csv(url, skiprows=4)
+
+        return df

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -1,4 +1,3 @@
-import io
 import json
 import re
 import urllib
@@ -1408,11 +1407,8 @@ class MISO(ISOBase):
 
         url = f"https://docs.misoenergy.org/marketreports/{date.strftime('%Y%m%d')}_sr_la_rg.csv"
         logger.info(f"Downloading look-ahead hourly data from {url}")
-        response = requests.get(url)
-        content = response.content.decode("utf-8")
-
         publish_date = pd.read_csv(
-            io.StringIO(content),
+            url,
             nrows=1,
             skiprows=1,
             header=None,
@@ -1421,7 +1417,7 @@ class MISO(ISOBase):
             self.default_timezone,
         )
 
-        df_raw = pd.read_csv(io.StringIO(content), skiprows=3)
+        df_raw = pd.read_csv(url, skiprows=3)
         df = df_raw.iloc[:96]  # 24 hours * 4 regions per hour
 
         id_cols = ["Hourend_EST", "Region"]

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -1,3 +1,4 @@
+import io
 import json
 import re
 import urllib
@@ -1407,7 +1408,91 @@ class MISO(ISOBase):
 
         url = f"https://docs.misoenergy.org/marketreports/{date.strftime('%Y%m%d')}_sr_la_rg.csv"
         logger.info(f"Downloading look-ahead hourly data from {url}")
+        response = requests.get(url)
+        content = response.content.decode("utf-8")
+        publish_date = pd.read_csv(
+            io.StringIO(content),
+            nrows=1,
+            skiprows=1,
+            header=None,
+        ).iloc[0, 0]
+        publish_time = pd.to_datetime(publish_date.split(": ")[1]).tz_localize(
+            self.default_timezone,
+        )
 
-        df = pd.read_csv(url, skiprows=4)
+        df_raw = pd.read_csv(io.StringIO(content), skiprows=3)
+        from pprint import pprint as pp
 
-        return df
+        print("\nInitial DataFrame:")
+        pp(df_raw.head())
+
+        df = df_raw.iloc[:96]  # 24 hours * 4 regions per hour
+        print("\nAfter keeping first 96 rows:")
+        pp(
+            df[
+                [
+                    "Hourend_EST",
+                    "Region",
+                    "02/25/2025 Tuesday  Peak Hour: HE   9 MTLF (GW)",
+                ]
+            ],
+        )
+
+        id_cols = ["Hourend_EST", "Region"]
+        value_cols = [col for col in df_raw.columns if col not in id_cols]
+
+        df_melted = df_raw.melt(
+            id_vars=id_cols,
+            value_vars=value_cols,
+            var_name="date_col",
+            value_name="value",
+        )
+        print("\nAfter melt:")
+        # print(df_melted.head())
+
+        df_melted["date"] = df_melted["date_col"].str.extract(r"(\d{2}/\d{2}/\d{4})")
+        df_melted["type"] = (
+            df_melted["date_col"]
+            .str.contains("Outage")
+            .map({True: "Outage", False: "MTLF"})
+        )
+        # print("\nAfter adding date and type:")
+        # print(df_melted)
+
+        df_wide = df_melted.pivot(
+            index=["Hourend_EST", "Region", "date"],
+            columns="type",
+            values="value",
+        ).reset_index()
+
+        df_wide["Interval End"] = pd.to_datetime(
+            df_wide["date"]
+            + " "
+            + df_wide["Hourend_EST"].str.extract(r"Hour (\d+)")[0]
+            + ":00",
+        ).dt.tz_localize(self.default_timezone)
+
+        df_wide["Interval Start"] = df_wide["Interval End"] - pd.Timedelta(hours=1)
+
+        df_wide["Interval Start"] = df_wide["Interval Start"].dt.tz_convert("UTC")
+        df_wide["Interval End"] = df_wide["Interval End"].dt.tz_convert("UTC")
+        df_wide["Publish Time"] = publish_time.tz_convert("UTC")
+
+        # print("\nAfter datetime processing:")
+        # print(df_wide.head())
+
+        final_df = df_wide[
+            [
+                "Interval Start",
+                "Interval End",
+                "Publish Time",
+                "Region",
+                "MTLF",
+                "Outage",
+            ]
+        ].sort_values(["Interval Start", "Region"])
+
+        # print("\nFinal DataFrame:")
+        # print(final_df.head())
+
+        return final_df

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -1407,21 +1407,12 @@ class MISO(ISOBase):
 
         url = f"https://docs.misoenergy.org/marketreports/{date.strftime('%Y%m%d')}_sr_la_rg.csv"
         logger.info(f"Downloading look-ahead hourly data from {url}")
-        publish_date = pd.read_csv(
-            url,
-            nrows=1,
-            skiprows=1,
-            header=None,
-        ).iloc[0, 0]
-        publish_time = pd.to_datetime(publish_date.split(": ")[1]).tz_localize(
-            self.default_timezone,
-        )
 
-        df_raw = pd.read_csv(url, skiprows=3)
-        df = df_raw.iloc[:96]  # 24 hours * 4 regions per hour
+        publish_time = date.normalize()
 
+        df = pd.read_csv(url, skiprows=3, skipfooter=15)
         id_cols = ["Hourend_EST", "Region"]
-        value_cols = [col for col in df_raw.columns if col not in id_cols]
+        value_cols = [col for col in df.columns if col not in id_cols]
 
         df_melted = df.melt(
             id_vars=id_cols,

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -1410,7 +1410,7 @@ class MISO(ISOBase):
 
         publish_time = date.normalize()
 
-        df = pd.read_csv(url, skiprows=3, skipfooter=15)
+        df = pd.read_csv(url, skiprows=3, skipfooter=15, engine="python")
         id_cols = ["Hourend_EST", "Region"]
         value_cols = [col for col in df.columns if col not in id_cols]
 

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -10,7 +10,7 @@ import requests
 from gridstatus import utils
 from gridstatus.base import ISOBase, Markets, NoDataFoundException, NotSupported
 from gridstatus.decorators import support_date_range
-from gridstatus.gs_logging import log, logger
+from gridstatus.gs_logging import logger
 from gridstatus.lmp_config import lmp_config
 
 
@@ -124,7 +124,7 @@ class MISO(ISOBase):
 
         url = f"https://docs.misoenergy.org/marketreports/{date.strftime('%Y%m%d')}_df_al.xls"  # noqa
 
-        log(msg=f"Downloading load forecast data from {url}", verbose=verbose)
+        logger.info(f"Downloading load forecast data from {url}")
         df = pd.read_excel(url, sheet_name="Sheet1", skiprows=4, skipfooter=1)
 
         df = df.dropna(subset=["HourEnding"])
@@ -205,7 +205,7 @@ class MISO(ISOBase):
         # Example url: https://docs.misoenergy.org/marketreports/20240327_mom.xlsx
         url = f"https://docs.misoenergy.org/marketreports/{date.strftime('%Y%m%d')}_mom.xlsx"  # noqa
 
-        log(f"Downloading mom forecast data from {url}", verbose)
+        logger.info(f"Downloading mom forecast data from {url}")
 
         try:
             # Ignore the UserWarning from openpyxl about styles
@@ -279,8 +279,8 @@ class MISO(ISOBase):
             raise NotSupported("Only historical data is available for final LMPs")
 
         if not date.weekday() == 0:
-            log("Weekly LMP data is only available for Mondays", verbose)
-            log("Changing date to the previous Monday", verbose)
+            logger.warning("Weekly LMP data is only available for Mondays")
+            logger.warning("Changing date to the previous Monday")
             date -= pd.DateOffset(days=date.weekday())
 
         # The data file contains data starting two weeks before the date and
@@ -387,7 +387,7 @@ class MISO(ISOBase):
                     "Only today, yesterday, and latest are supported for 5 min LMPs",
                 )
 
-            log(f"Downloading LMP data from {url}", verbose)
+            logger.info(f"Downloading LMP data from {url}")
             data = pd.read_csv(url)
 
             data["Interval Start"] = pd.to_datetime(data["INTERVAL"]).dt.tz_localize(
@@ -419,7 +419,7 @@ class MISO(ISOBase):
             elif market == Markets.REAL_TIME_HOURLY_PRELIM:
                 url = f"https://docs.misoenergy.org/marketreports/{date_str}_rt_lmp_prelim.csv"
 
-            log(f"Downloading LMP data from {url}", verbose)
+            logger.info(f"Downloading LMP data from {url}")
             raw_data = pd.read_csv(url, skiprows=4)
             data = self._handle_hourly_lmp(date, raw_data)
             interval_duration = 60
@@ -493,7 +493,7 @@ class MISO(ISOBase):
         # use dam to get location types
         today = utils._handle_date("today", self.default_timezone)
         url = f"https://docs.misoenergy.org/marketreports/{today.strftime('%Y%m%d')}_da_expost_lmp.csv"  # noqa
-        log(f"Downloading LMP data from {url}", verbose)
+        logger.info(f"Downloading LMP data from {url}")
         today_dam_data = pd.read_csv(url, skiprows=4)
         node_to_type = (
             today_dam_data[["Node", "Type"]]
@@ -507,7 +507,7 @@ class MISO(ISOBase):
         url = "https://www.misoenergy.org/api/giqueue/getprojects"
 
         msg = f"Downloading interconnection queue from {url}"
-        log(msg, verbose)
+        logger.info(msg)
 
         response = requests.get(url)
         return utils.get_response_blob(response)
@@ -626,7 +626,7 @@ class MISO(ISOBase):
 
         url = f"https://docs.misoenergy.org/marketreports/{date.strftime('%Y%m%d')}_mom.xlsx"  # noqa
 
-        log(f"Downloading outages {type} data from {url}", verbose)
+        logger.info(f"Downloading outages {type} data from {url}")
 
         skiprows = 6
         nrows = 17


### PR DESCRIPTION
## Summary
Adds the MISO `look_ahead_hourly` dataset. Also triggers MISO New Source Review, so typehints, logging, and fixturized tests have been implemented. 

## Details
### Data
Each file has a 7 day forecast of hourly data for Outage and MLTF information for each of the 4 regions. Each final df then has 24 hours * 7 days * 4 regions * 2 types = 1344 interval values. Once widen the Outage and MLTF are a column, so 672 rows per df. 
![CleanShot 2025-02-25 at 11 52 48](https://github.com/user-attachments/assets/9aa8eff2-3ea8-40ca-a56b-45a08f24da7d)

### DST Behavior
It seems this dataset does not observe DST, as both the spring forward and fall back dates contain all 24 hours. It would significantly affect their data model if they had a different number of hours, so makes sense they skipped it. Also helps the fairly naive, brittle trimming of the dataframe I am doing to leave behind the stats and disclaimer. 

Spring Forward 2024
![CleanShot 2025-02-25 at 10 27 55@2x](https://github.com/user-attachments/assets/6afda417-1c8d-4ba8-b403-3ce98f7b040c)

Fall Back 2024
![CleanShot 2025-02-25 at 10 31 32@2x](https://github.com/user-attachments/assets/e9bbf1ee-2323-4d2b-913d-b2bcc95967fb)

### New Source Review
VCRification of the existing MISO tests was fairly straightforward, as was adding typehints and our system logger. LMK if questions here. 

VCR on second run reduces test time by ~20%

Initial run (integration-mode)
![CleanShot 2025-02-25 at 12 30 18](https://github.com/user-attachments/assets/5ac0abcf-5442-4149-badc-3a3e4a7ee299)

Subsequent local runs (fixturized unit-mode)
![CleanShot 2025-02-25 at 12 34 37](https://github.com/user-attachments/assets/dd442027-1176-4245-a0e5-6106afe612a0)

It's the `test_get_lmp_real_time_5_min_final_historical_date_range` that take a long time, whether fixturized or not (it's the data serialization into memory that takes a while methinks. Just a lot of data). Skipping that results in a super fast test suite, 80% faster than integration mode:

Skipping slow test:
![CleanShot 2025-02-25 at 12 41 36](https://github.com/user-attachments/assets/2a379fc6-af3d-4c3d-9bf0-53e59807f52e)

Neat