### PR TITLE
feat(ENG 1319): ISONE 5 Min LMPs (via API)

### DIFF
--- a/gridstatus/isone_api/isone_api.py
+++ b/gridstatus/isone_api/isone_api.py
@@ -881,6 +881,8 @@ class ISONEAPI:
         """
 
         if date == "latest":
+            # NB: We don't quite know when this is published each day,
+            # and don't have a /current/all option for final data, so grab the full day on "latest"
             return self.get_lmp_real_time_5_min_prelim("today")
 
         url = f"{self.base_url}/fiveminutelmp/final/day/{date.strftime('%Y%m%d')}/starthour/{date.hour:02d}"

--- a/gridstatus/isone_api/isone_api.py
+++ b/gridstatus/isone_api/isone_api.py
@@ -836,6 +836,44 @@ class ISONEAPI:
         ].sort_values(["Interval Start", "Location"])
 
     @support_date_range("DAY_START")
+    def get_lmp_real_time_5_min_final(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """
+        Get the real-time 5 minute LMP final data for specified date range.
+
+        Args:
+            date (str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp]): The start date for the data request. Use "latest" for most recent data.
+            end (str | pd.Timestamp | None): The end date for the data request. Only used if date is not "latest".
+            verbose (bool): Whether to print verbose logging information.
+
+        Returns:
+            pd.DataFrame: A DataFrame containing the real-time 5 minute LMP final data.
+        """
+
+        if date == "latest":
+            return self.get_lmp_real_time_5_min_final("today", verbose)
+        else:
+            url = f"{self.base_url}/fiveminutelmp/final/info"
+            response = self.make_api_call(url)
+            df = pd.DataFrame(response["FiveMinLmps"]["FiveMinLmp"])
+            df["Interval Start"] = pd.to_datetime(
+                df["BeginDate"],
+                utc=True,
+            ).dt.tz_convert(
+                self.default_timezone,
+            )
+            df["Interval End"] = df["Interval Start"] + pd.Timedelta(
+                minutes=5,
+            )
+            return df
+
+            # return self._handle_lmp_real_time_hourly(url, verbose)
+
+    @support_date_range("DAY_START")
     def get_lmp_real_time_hourly_prelim(
         self,
         date: str | pd.Timestamp = "latest",

--- a/gridstatus/isone_api/isone_api.py
+++ b/gridstatus/isone_api/isone_api.py
@@ -835,7 +835,33 @@ class ISONEAPI:
             ]
         ].sort_values(["Interval Start", "Location"])
 
-    @support_date_range("DAY_START")
+    @support_date_range("HOUR_START")
+    def get_lmp_real_time_5_min_prelim(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """
+        Get the real-time 5 minute LMP preliminary data for specified date range.
+
+        Args:
+            date (str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp]): The start date for the data request. Use "latest" for most recent data.
+            end (str | pd.Timestamp | None): The end date for the data request. Only used if date is not "latest".
+            verbose (bool): Whether to print verbose logging information.
+
+        Returns:
+            pd.DataFrame: A DataFrame containing the real-time 5 minute LMP preliminary data.
+        """
+
+        if date == "latest":
+            url = f"{self.base_url}/fiveminutelmp/prelim/current/all"
+        else:
+            url = f"{self.base_url}/fiveminutelmp/prelim/day/{date.strftime('%Y%m%d')}/starthour/{date.hour:02d}"
+
+        return self._handle_lmp_real_time(url, verbose, interval_minutes=5)
+
+    @support_date_range("HOUR_START")
     def get_lmp_real_time_5_min_final(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
@@ -855,23 +881,10 @@ class ISONEAPI:
         """
 
         if date == "latest":
-            return self.get_lmp_real_time_5_min_final("today", verbose)
-        else:
-            url = f"{self.base_url}/fiveminutelmp/final/info"
-            response = self.make_api_call(url)
-            df = pd.DataFrame(response["FiveMinLmps"]["FiveMinLmp"])
-            df["Interval Start"] = pd.to_datetime(
-                df["BeginDate"],
-                utc=True,
-            ).dt.tz_convert(
-                self.default_timezone,
-            )
-            df["Interval End"] = df["Interval Start"] + pd.Timedelta(
-                minutes=5,
-            )
-            return df
+            return self.get_lmp_real_time_5_min_prelim("today")
 
-            # return self._handle_lmp_real_time_hourly(url, verbose)
+        url = f"{self.base_url}/fiveminutelmp/final/day/{date.strftime('%Y%m%d')}/starthour/{date.hour:02d}"
+        return self._handle_lmp_real_time(url, verbose, interval_minutes=5)
 
     @support_date_range("DAY_START")
     def get_lmp_real_time_hourly_prelim(
@@ -897,7 +910,7 @@ class ISONEAPI:
         else:
             url = f"{self.base_url}/hourlylmp/rt/prelim/day/{date.strftime('%Y%m%d')}"
 
-        return self._handle_lmp_real_time_hourly(url, verbose)
+        return self._handle_lmp_real_time(url, verbose)
 
     @support_date_range("DAY_START")
     def get_lmp_real_time_hourly_final(
@@ -922,20 +935,26 @@ class ISONEAPI:
             return self.get_lmp_real_time_hourly_prelim("today", verbose)
 
         url = f"{self.base_url}/hourlylmp/rt/final/day/{date.strftime('%Y%m%d')}"
-        return self._handle_lmp_real_time_hourly(url, verbose)
+        return self._handle_lmp_real_time(url, verbose)
 
-    def _handle_lmp_real_time_hourly(
+    def _handle_lmp_real_time(
         self,
         url: str,
         verbose: bool = False,
+        interval_minutes: int = 60,
     ) -> pd.DataFrame:
         response = self.make_api_call(url)
-        df = pd.DataFrame(response["HourlyLmps"]["HourlyLmp"])
+
+        if interval_minutes == 60:
+            df = pd.DataFrame(response["HourlyLmps"]["HourlyLmp"])
+        else:
+            df = pd.DataFrame(response["FiveMinLmps"]["FiveMinLmp"])
+
         df["Interval Start"] = pd.to_datetime(df["BeginDate"], utc=True).dt.tz_convert(
             self.default_timezone,
         )
         df["Interval End"] = df["Interval Start"] + pd.Timedelta(
-            minutes=60,
+            minutes=interval_minutes,
         )
 
         df["Location Type"] = df["Location"].apply(lambda x: x["@LocType"])

--- a/gridstatus/tests/source_specific/test_isone_api.py
+++ b/gridstatus/tests/source_specific/test_isone_api.py
@@ -686,3 +686,125 @@ class TestISONEAPI(TestHelperMixin):
             assert result["Energy"].dtype in [np.int64, np.float64]
             assert result["Congestion"].dtype in [np.int64, np.float64]
             assert result["Loss"].dtype in [np.int64, np.float64]
+
+    def test_get_lmp_real_time_5_min_prelim_latest(self):
+        with api_vcr.use_cassette("test_get_lmp_real_time_5_min_prelim_latest.yaml"):
+            result = self.iso.get_lmp_real_time_5_min_prelim(date="latest")
+
+            assert isinstance(result, pd.DataFrame)
+            assert len(result) > 0
+            assert list(result.columns) == [
+                "Interval Start",
+                "Interval End",
+                "Location",
+                "Location Type",
+                "LMP",
+                "Energy",
+                "Congestion",
+                "Loss",
+            ]
+            assert result["LMP"].dtype in [np.int64, np.float64]
+            assert result["Energy"].dtype in [np.int64, np.float64]
+            assert result["Congestion"].dtype in [np.int64, np.float64]
+            assert result["Loss"].dtype in [np.int64, np.float64]
+            assert (
+                (result["Interval End"] - result["Interval Start"])
+                == pd.Timedelta(minutes=5)
+            ).all()
+
+    @pytest.mark.parametrize(
+        "date,end",
+        DST_CHANGE_TEST_DATES,
+    )
+    def test_get_lmp_real_time_5_min_prelim_date_range(self, date: str, end: str):
+        cassette_name = f"test_get_lmp_real_time_5_min_prelim_{date}_{end}.yaml"
+        with api_vcr.use_cassette(cassette_name):
+            result = self.iso.get_lmp_real_time_5_min_prelim(date=date, end=end)
+
+            assert isinstance(result, pd.DataFrame)
+            assert list(result.columns) == [
+                "Interval Start",
+                "Interval End",
+                "Location",
+                "Location Type",
+                "LMP",
+                "Energy",
+                "Congestion",
+                "Loss",
+            ]
+            assert (
+                min(result["Interval Start"]).date()
+                == pd.Timestamp(date).tz_localize(self.iso.default_timezone).date()
+            )
+            assert max(result["Interval End"]) == pd.Timestamp(end).tz_localize(
+                self.iso.default_timezone,
+            )
+            assert (
+                (result["Interval End"] - result["Interval Start"])
+                == pd.Timedelta(minutes=5)
+            ).all()
+            assert result["LMP"].dtype in [np.int64, np.float64]
+            assert result["Energy"].dtype in [np.int64, np.float64]
+            assert result["Congestion"].dtype in [np.int64, np.float64]
+            assert result["Loss"].dtype in [np.int64, np.float64]
+
+    def test_get_lmp_real_time_5_min_final_latest(self):
+        with api_vcr.use_cassette("test_get_lmp_real_time_5_min_final_latest.yaml"):
+            result = self.iso.get_lmp_real_time_5_min_final(date="latest")
+
+            assert isinstance(result, pd.DataFrame)
+            assert len(result) > 0
+            assert list(result.columns) == [
+                "Interval Start",
+                "Interval End",
+                "Location",
+                "Location Type",
+                "LMP",
+                "Energy",
+                "Congestion",
+                "Loss",
+            ]
+            assert result["LMP"].dtype in [np.int64, np.float64]
+            assert result["Energy"].dtype in [np.int64, np.float64]
+            assert result["Congestion"].dtype in [np.int64, np.float64]
+            assert result["Loss"].dtype in [np.int64, np.float64]
+            assert (
+                (result["Interval End"] - result["Interval Start"])
+                == pd.Timedelta(minutes=5)
+            ).all()
+
+    @pytest.mark.parametrize(
+        "date,end",
+        DST_CHANGE_TEST_DATES,
+    )
+    def test_get_lmp_real_time_5_min_final_date_range(self, date: str, end: str):
+        cassette_name = f"test_get_lmp_real_time_5_min_final_{date}_{end}.yaml"
+        with api_vcr.use_cassette(cassette_name):
+            result = self.iso.get_lmp_real_time_5_min_final(date=date, end=end)
+
+            assert isinstance(result, pd.DataFrame)
+            assert list(result.columns) == [
+                "Interval Start",
+                "Interval End",
+                "Location",
+                "Location Type",
+                "LMP",
+                "Energy",
+                "Congestion",
+                "Loss",
+            ]
+            assert (
+                min(result["Interval Start"]).date()
+                == pd.Timestamp(date).tz_localize(self.iso.default_timezone).date()
+            )
+            assert max(result["Interval End"]) == pd.Timestamp(end).tz_localize(
+                self.iso.default_timezone,
+            )
+            assert (
+                (result["Interval End"] - result["Interval Start"])
+                == pd.Timedelta(minutes=5)
+            ).all()
+            assert result["LMP"].dtype in [np.int64, np.float64]
+            assert result["Energy"].dtype in [np.int64, np.float64]
+            assert result["Congestion"].dtype in [np.int64, np.float64]
+            assert result["Loss"].dtype in [np.int64, np.float64]


### PR DESCRIPTION
## Summary
Adds the `isone_lmp_real_time_5_min_final` and `isone_lmp_real_time_5_min_prelim` datasets via the ISO NE API. There is an existing method that pulls website CSVs for `isone_lmp_real_time_5_min_prelim` though the existing dataset is referred to just as `isone_lmp_real_time_5_min`. This explicit prelim dataset via the API can replace that existing CSV dataset in downstream consumption if needed.

## Details
### ISO NE API Endpoints
Not all the endpoints I tried worked or worked as expected. Here is a summary:
![CleanShot 2025-02-28 at 13 19 44@2x](https://github.com/user-attachments/assets/8e3651be-9375-442e-acbf-e7feec2aba2c)

The `ServiceInfo` for both `prelim/info` and `/info` is the same, and the non-specified `{type}` endpoints return the same data.
![CleanShot 2025-02-28 at 13 27 46](https://github.com/user-attachments/assets/b916c074-69ff-488d-a29a-7cb6b1aed19c)

`/prelim/current/all`
![CleanShot 2025-02-28 at 13 47 36](https://github.com/user-attachments/assets/12b36792-5cad-4a1e-8abd-304dcf71692e)

`/current/all`
![CleanShot 2025-02-28 at 13 48 20](https://github.com/user-attachments/assets/3f421ac1-10ec-418b-b4af-c746b685d71f)

This also matches with a comment that this dataset currently called just ISONE RT 5 Min LMP is actually Prelim.

However using the only endpoint that seems to work for `final/` data for all nodes, one that requests a `starthour/`, it took about 3 minutes to pull a single day, ~350,000 rows.  
![CleanShot 2025-02-28 at 13 55 29](https://github.com/user-attachments/assets/5deb6ffa-a2e0-4c3b-9e41-cdff26e35301)

Same with `prelim/`, 3 minutes to pull one day. 
![CleanShot 2025-02-28 at 14 03 40](https://github.com/user-attachments/assets/19bc67ad-af94-4d1f-a8a8-3b58d4d1b43b)

There isn't another endpoint that appears like it would work, even with multiple calls. The `location_type/` endpoints are only available in `current/` format, otherwise that might be the most efficient. But I think the current implementation is the most efficient endpoint-wise.

### Tests
This is a lot of data, pulled over multiple slow calls, and parameterized to run several date ranges. This is where fixturization shines. Thought this was interesteding: local tests went from 11 minutes to _11 seconds_ from first (integration) to second (fixture) runs.

First
![CleanShot 2025-02-28 at 14 42 38](https://github.com/user-attachments/assets/08b53d19-3414-46d0-8bcc-2679bb8c9914)
 
Second
![CleanShot 2025-02-28 at 14 44 22](https://github.com/user-attachments/assets/410d1d90-b98c-4343-857f-0e15ced4d287)

This will slow down this test suite in CI though, until we can get the pull request CI tests fixturized.