### PR TITLE
ERCOT AS Reports Bid Curve Column Type Update

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -2564,7 +2564,7 @@ class Ercot(ISOBase):
 
         def _make_bid_curve(df):
             return [
-                tuple(x)
+                list(x)
                 for x in df[["MW Offered", f"{as_name} Offer Price"]].values.tolist()
             ]
 

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -1004,6 +1004,18 @@ class TestErcot(BaseTestISO):
             == [five_days_ago.date(), four_days_ago.date()]
         ).all()
 
+        bid_curve_columns = [
+            "Bid Curve - RRSPFR",
+            "Bid Curve - RRSUFR",
+            "Bid Curve - RRSFFR",
+            "Bid Curve - ECRSM",
+            "Bid Curve - ECRSS",
+            "Bid Curve - REGUP",
+            "Bid Curve - REGDN",
+            "Bid Curve - ONNS",
+            "Bid Curve - OFFNS",
+        ]
+
         cols = [
             "Time",
             "Interval Start",
@@ -1025,18 +1037,15 @@ class TestErcot(BaseTestISO):
             "Total Self-Arranged AS - RegDown",
             "Total Self-Arranged AS - NonSpin",
             "Total Self-Arranged AS - NSPNM",
-            "Bid Curve - RRSPFR",
-            "Bid Curve - RRSUFR",
-            "Bid Curve - RRSFFR",
-            "Bid Curve - ECRSM",
-            "Bid Curve - ECRSS",
-            "Bid Curve - REGUP",
-            "Bid Curve - REGDN",
-            "Bid Curve - ONNS",
-            "Bid Curve - OFFNS",
-        ]
+        ] + bid_curve_columns
 
         assert df.columns.tolist() == cols
+
+        for col in bid_curve_columns:
+            # Check that the first non-null value is a list of lists
+            first_non_null_value = df[col].dropna().iloc[0]
+            assert isinstance(first_non_null_value, list)
+            assert all(isinstance(x, list) for x in first_non_null_value)
 
     """get_reported_outages"""
 

--- a/gridstatus/tests/source_specific/test_ercot_api.py
+++ b/gridstatus/tests/source_specific/test_ercot_api.py
@@ -371,25 +371,24 @@ class TestErcotAPI(TestHelperMixin):
     """get_as_reports"""
 
     def _check_as_reports(self, df, before_full_columns=False):
-        shared_columns = [
-            "Interval Start",
-            "Interval End",
-            "Total Cleared AS - RegUp",
-            "Total Cleared AS - RegDown",
-            "Total Cleared AS - NonSpin",
-            "Total Self-Arranged AS - RegUp",
-            "Total Self-Arranged AS - RegDown",
-            "Total Self-Arranged AS - NonSpin",
-            "Bid Curve - REGUP",
-            "Bid Curve - REGDN",
-            "Bid Curve - ONNS",
-            "Bid Curve - OFFNS",
-        ]
-
+        # Earlier datasets only have these limited columns
         if before_full_columns:
-            assert df.columns.tolist() == shared_columns
+            columns = [
+                "Interval Start",
+                "Interval End",
+                "Total Cleared AS - RegUp",
+                "Total Cleared AS - RegDown",
+                "Total Cleared AS - NonSpin",
+                "Total Self-Arranged AS - RegUp",
+                "Total Self-Arranged AS - RegDown",
+                "Total Self-Arranged AS - NonSpin",
+                "Bid Curve - REGUP",
+                "Bid Curve - REGDN",
+                "Bid Curve - ONNS",
+                "Bid Curve - OFFNS",
+            ]
         else:
-            full_columns = [
+            columns = [
                 "Interval Start",
                 "Interval End",
                 "Total Cleared AS - RRSPFR",
@@ -420,7 +419,26 @@ class TestErcotAPI(TestHelperMixin):
                 "Bid Curve - OFFNS",
             ]
 
-            assert df.columns.tolist() == full_columns
+        assert df.columns.tolist() == columns
+
+        bid_curve_columns = [
+            "Bid Curve - RRSPFR",
+            "Bid Curve - RRSUFR",
+            "Bid Curve - RRSFFR",
+            "Bid Curve - ECRSM",
+            "Bid Curve - ECRSS",
+            "Bid Curve - REGUP",
+            "Bid Curve - REGDN",
+            "Bid Curve - ONNS",
+            "Bid Curve - OFFNS",
+        ]
+
+        for column in bid_curve_columns:
+            if column in df.columns:
+                # Column should be a list of lists
+                first_non_null_value = df[column].dropna().iloc[0]
+                assert isinstance(first_non_null_value, list)
+                assert all(isinstance(x, list) for x in first_non_null_value)
 
         self._check_time_columns(
             df,


### PR DESCRIPTION
## Summary

- Converts the bid curve columns in Ercot().get_as_reports() from lists of tuples to lists of lists
- This format matches the bid curve columns in other Ercot report datasets


### Details
