### PR TITLE
feat(ENG 1346): PJM dispatch reserves

### DIFF
--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -2763,7 +2763,12 @@ class PJM(ISOBase):
         https://dataminer2.pjm.com/feed/rt_dispatch_reserves/definition
         """
         if date == "latest":
-            date = "today"
+            # TODO: This is a hack to get the data for the previous day
+            # because the data is not available for the current day. Thinking about
+            # adding a "yesterday" to @support_date_range
+            date = (
+                pd.Timestamp.now(self.default_timezone) - pd.Timedelta(days=1)
+            ).strftime("%Y-%m-%d")
 
         df = self._get_pjm_json(
             "rt_dispatch_reserves",

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -1729,7 +1729,7 @@ class PJM(ISOBase):
 
         return df.sort_values("Publish Time").reset_index(drop=True)
 
-    def to_local_datetime(self, df, column_name):
+    def to_local_datetime(self, df: pd.DataFrame, column_name: str) -> pd.Series:
         return pd.to_datetime(df[column_name]).dt.tz_localize(
             self.default_timezone,
         )
@@ -2680,3 +2680,122 @@ class PJM(ISOBase):
             },
         )
         return df[["Time", "Area Control Error"]]
+
+    @support_date_range(frequency=None)
+    def get_dispatched_reserves_prelim(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """
+        Retrieves the dispatched reserves preliminary data from:
+        https://dataminer2.pjm.com/feed/dispatched_reserves/definition
+        """
+        if date == "latest":
+            date = "today"
+
+        df = self._get_pjm_json(
+            "dispatched_reserves",
+            start=date,
+            end=end,
+            params={
+                "fields": "datetime_beginning_utc,area,reserve_type,reserve_quantity,reserve_requirement,reliability_requirement,extended_requirement,mw_adjustment,market_clearing_price,shortage_indicator",
+            },
+            interval_duration_min=5,
+            verbose=verbose,
+        )
+
+        df = df.rename(
+            columns={
+                "area": "Area",
+                "reserve_type": "Reserve Type",
+                "reserve_quantity": "Reserve Quantity",
+                "reserve_requirement": "Reserve Requirement",
+                "reliability_requirement": "Reliability Requirement",
+                "extended_requirement": "Extended Requirement",
+                "mw_adjustment": "MW Adjustment",
+                "market_clearing_price": "Market Clearing Price",
+                "shortage_indicator": "Shortage Indicator",
+            },
+        )
+
+        df["Area"] = df["Area"].str.replace("Mid-Atlantic/Dominion", "MAD")
+        df["Ancillary Service"] = df["Area"] + "-" + df["Reserve Type"]
+
+        df = df.replace({"Area": self.locale_abbreviated_to_full})
+
+        return df[
+            [
+                "Interval Start",
+                "Interval End",
+                "Ancillary Service",
+                "Area",
+                "Reserve Quantity",
+                "Reserve Requirement",
+                "Reliability Requirement",
+                "Extended Requirement",
+                "MW Adjustment",
+                "Market Clearing Price",
+                "Shortage Indicator",
+            ]
+        ]
+
+    @support_date_range(frequency=None)
+    def get_dispatched_reserves_verified(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """
+        Retrieves the dispatched reserves verified data from:
+        https://dataminer2.pjm.com/feed/rt_dispatch_reserves/definition
+        """
+        if date == "latest":
+            date = "today"
+
+        df = self._get_pjm_json(
+            "rt_dispatch_reserves",
+            start=date,
+            end=end,
+            params={
+                "fields": "datetime_beginning_utc,area,reserve_type,total_reserve_mw,reserve_reqmt_mw,reliability_reqmt_mw,extended_reqmt_mw,additional_extended_reqmt_mw,deficit_mw",
+            },
+            interval_duration_min=5,
+            verbose=verbose,
+        )
+
+        df = df.rename(
+            columns={
+                "area": "Area",
+                "reserve_type": "Reserve Type",
+                "total_reserve_mw": "Total Reserve",
+                "reserve_reqmt_mw": "Reserve Requirement",
+                "reliability_reqmt_mw": "Reliability Requirement",
+                "extended_reqmt_mw": "Extended Requirement",
+                "additional_extended_reqmt_mw": "Additional Extended Requirement",
+                "deficit_mw": "Deficit",
+            },
+        )
+        full_name_to_abbreviation = {
+            v: k for k, v in self.locale_abbreviated_to_full.items()
+        }
+        df["Ancillary Service"] = (
+            df["Area"].replace(full_name_to_abbreviation) + "-" + df["Reserve Type"]
+        )
+
+        return df[
+            [
+                "Interval Start",
+                "Interval End",
+                "Ancillary Service",
+                "Area",
+                "Total Reserve",
+                "Reserve Requirement",
+                "Reliability Requirement",
+                "Extended Requirement",
+                "Additional Extended Requirement",
+                "Deficit",
+            ]
+        ]

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -2,7 +2,7 @@ import math
 import os
 import warnings
 from datetime import datetime
-from typing import BinaryIO, Optional
+from typing import BinaryIO
 
 import pandas as pd
 import pytz
@@ -2102,8 +2102,8 @@ class PJM(ISOBase):
     def get_wind_generation_by_area(
         self,
         date: str | pd.Timestamp,
-        end: Optional[str | pd.Timestamp] = None,
-        verbose: Optional[bool] = False,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
     ):
         """
         Retrieves the current wind generation information from:
@@ -2171,8 +2171,8 @@ class PJM(ISOBase):
     def get_dam_as_market_results(
         self,
         date: str | pd.Timestamp,
-        end: Optional[str | pd.Timestamp] = None,
-        verbose: Optional[bool] = False,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
     ):
         """
         Retrieves the day-ahead ancillary service market results from :
@@ -2260,8 +2260,8 @@ class PJM(ISOBase):
     def get_real_time_as_market_results(
         self,
         date: str | pd.Timestamp,
-        end: Optional[str | pd.Timestamp] = None,
-        verbose: Optional[bool] = False,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
     ):
         """
         Retrieves the real-time ancillary service market results from :
@@ -2384,7 +2384,12 @@ class PJM(ISOBase):
         return df.sort_values("Interval Start").reset_index(drop=True)
 
     @support_date_range(frequency=None)
-    def get_load_metered_hourly(self, date, end=None, verbose=False):
+    def get_load_metered_hourly(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ):
         """
         Retrieves the hourly metered load data from:
 
@@ -2435,7 +2440,12 @@ class PJM(ISOBase):
         return df.sort_values("Interval Start").reset_index(drop=True)
 
     @support_date_range(frequency=None)
-    def get_forecasted_generation_outages(self, date, end=None, verbose=False):
+    def get_forecasted_generation_outages(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ):
         """
         Retrieves the forecasted generation outages for the next 90 days from:
 

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -2126,6 +2126,18 @@ class TestPJM(BaseTestISO):
         "Shortage Indicator",
     ]
 
+    expected_reserve_areas = [
+        "PJM RTO Reserve Zone",
+        "Mid-Atlantic/Dominion Reserve Subzone",
+    ]
+    expected_ancillary_services = [
+        "MAD-Primary Reserve",
+        "MAD-Synchronized Reserve",
+        "PJM_RTO-Primary Reserve",
+        "PJM_RTO-Synchronized Reserve",
+        "PJM_RTO-Thirty-Minute Reserve",
+    ]
+
     @pytest.mark.parametrize(
         "date",
         [
@@ -2149,6 +2161,14 @@ class TestPJM(BaseTestISO):
 
             assert df["Ancillary Service"].dtype == object
             assert df["Area"].dtype == object
+            assert (
+                df["Area"].unique().tolist().sort()
+                == self.expected_reserve_areas.sort()
+            )
+            assert (
+                df["Ancillary Service"].unique().tolist().sort()
+                == self.expected_ancillary_services.sort()
+            )
             assert df["Reserve Quantity"].dtype in [np.float64, np.int64]
             assert df["Reserve Requirement"].dtype in [np.float64, np.int64]
             assert df["Reliability Requirement"].dtype in [np.float64, np.int64]
@@ -2175,6 +2195,14 @@ class TestPJM(BaseTestISO):
 
             assert df["Ancillary Service"].dtype == object
             assert df["Area"].dtype == object
+            assert (
+                df["Area"].unique().tolist().sort()
+                == self.expected_reserve_areas.sort()
+            )
+            assert (
+                df["Ancillary Service"].unique().tolist().sort()
+                == self.expected_ancillary_services.sort()
+            )
             assert df["Reserve Quantity"].dtype in [np.float64, np.int64]
             assert df["Reserve Requirement"].dtype in [np.float64, np.int64]
             assert df["Reliability Requirement"].dtype in [np.float64, np.int64]
@@ -2220,6 +2248,14 @@ class TestPJM(BaseTestISO):
 
             assert df["Ancillary Service"].dtype == object
             assert df["Area"].dtype == object
+            assert (
+                df["Area"].unique().tolist().sort()
+                == self.expected_reserve_areas.sort()
+            )
+            assert (
+                df["Ancillary Service"].unique().tolist().sort()
+                == self.expected_ancillary_services.sort()
+            )
             assert df["Total Reserve"].dtype in [np.float64, np.int64]
             assert df["Reserve Requirement"].dtype in [np.float64, np.int64]
             assert df["Reliability Requirement"].dtype in [np.float64, np.int64]
@@ -2247,6 +2283,14 @@ class TestPJM(BaseTestISO):
 
             assert df["Ancillary Service"].dtype == object
             assert df["Area"].dtype == object
+            assert (
+                df["Area"].unique().tolist().sort()
+                == self.expected_reserve_areas.sort()
+            )
+            assert (
+                df["Ancillary Service"].unique().tolist().sort()
+                == self.expected_ancillary_services.sort()
+            )
             assert df["Total Reserve"].dtype in [np.float64, np.int64]
             assert df["Reserve Requirement"].dtype in [np.float64, np.int64]
             assert df["Reliability Requirement"].dtype in [np.float64, np.int64]

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -2109,3 +2109,147 @@ class TestPJM(BaseTestISO):
             assert df["Time"].max() <= self.local_start_of_today() + pd.Timedelta(
                 days=1,
             )
+
+    """get_dispatched_reserves_prelim"""
+
+    expected_dispatched_reserves_prelim_cols = [
+        "Interval Start",
+        "Interval End",
+        "Ancillary Service",
+        "Area",
+        "Reserve Quantity",
+        "Reserve Requirement",
+        "Reliability Requirement",
+        "Extended Requirement",
+        "MW Adjustment",
+        "Market Clearing Price",
+        "Shortage Indicator",
+    ]
+
+    @pytest.mark.parametrize(
+        "date",
+        [
+            "today",
+            "latest",
+        ],
+    )
+    def test_get_dispatched_reserves_prelim_today_or_latest(self, date):
+        with pjm_vcr.use_cassette(
+            f"test_get_dispatched_reserves_prelim_today_or_latest_{date}.yaml",
+        ):
+            df = self.iso.get_dispatched_reserves_prelim(date)
+
+            assert isinstance(df, pd.DataFrame)
+            assert df.columns.tolist() == self.expected_dispatched_reserves_prelim_cols
+
+            assert df["Interval Start"].min() >= self.local_start_of_today()
+            assert df[
+                "Interval End"
+            ].max() <= self.local_start_of_today() + pd.Timedelta(days=1)
+
+            assert df["Ancillary Service"].dtype == object
+            assert df["Area"].dtype == object
+            assert df["Reserve Quantity"].dtype in [np.float64, np.int64]
+            assert df["Reserve Requirement"].dtype in [np.float64, np.int64]
+            assert df["Reliability Requirement"].dtype in [np.float64, np.int64]
+            assert df["Extended Requirement"].dtype in [np.float64, np.int64]
+            assert df["MW Adjustment"].dtype in [np.float64, np.int64]
+            assert df["Market Clearing Price"].dtype in [np.float64, np.int64]
+            assert df["Shortage Indicator"].dtype in [bool]
+
+    def test_get_dispatched_reserves_prelim_historical_range(self):
+        past_date = self.local_today() - pd.Timedelta(days=5)
+        past_end_date = past_date + pd.Timedelta(days=3)
+        with pjm_vcr.use_cassette(
+            f"test_get_dispatched_reserves_prelim_historical_range_{past_date.strftime('%Y-%m-%d')}_{past_end_date.strftime('%Y-%m-%d')}.yaml",
+        ):
+            df = self.iso.get_dispatched_reserves_prelim(past_date, past_end_date)
+
+            assert isinstance(df, pd.DataFrame)
+            assert df.columns.tolist() == self.expected_dispatched_reserves_prelim_cols
+
+            assert df["Interval Start"].min() >= self.local_start_of_day(past_date)
+            assert df["Interval End"].max() <= self.local_start_of_day(
+                past_end_date,
+            ) + pd.Timedelta(days=1)
+
+            assert df["Ancillary Service"].dtype == object
+            assert df["Area"].dtype == object
+            assert df["Reserve Quantity"].dtype in [np.float64, np.int64]
+            assert df["Reserve Requirement"].dtype in [np.float64, np.int64]
+            assert df["Reliability Requirement"].dtype in [np.float64, np.int64]
+            assert df["Extended Requirement"].dtype in [np.float64, np.int64]
+            assert df["MW Adjustment"].dtype in [np.float64, np.int64]
+            assert df["Market Clearing Price"].dtype in [np.float64, np.int64]
+            assert df["Shortage Indicator"].dtype in [bool]
+
+    """get_dispatched_reserves_verified"""
+
+    expected_dispatched_reserves_verified_cols = [
+        "Interval Start",
+        "Interval End",
+        "Ancillary Service",
+        "Area",
+        "Total Reserve",
+        "Reserve Requirement",
+        "Reliability Requirement",
+        "Extended Requirement",
+        "Additional Extended Requirement",
+        "Deficit",
+    ]
+
+    @pytest.mark.parametrize(
+        "date",
+        [
+            "latest",
+        ],
+    )
+    def test_get_dispatched_reserves_verified_latest(self, date):
+        with pjm_vcr.use_cassette(f"test_get_dispatched_reserves_verified_{date}.yaml"):
+            df = self.iso.get_dispatched_reserves_verified(date)
+
+            assert isinstance(df, pd.DataFrame)
+            assert (
+                df.columns.tolist() == self.expected_dispatched_reserves_verified_cols
+            )
+
+            assert df[
+                "Interval Start"
+            ].min() >= self.local_start_of_today() - pd.Timedelta(days=1)
+            assert df["Interval End"].max() <= self.local_start_of_today()
+
+            assert df["Ancillary Service"].dtype == object
+            assert df["Area"].dtype == object
+            assert df["Total Reserve"].dtype in [np.float64, np.int64]
+            assert df["Reserve Requirement"].dtype in [np.float64, np.int64]
+            assert df["Reliability Requirement"].dtype in [np.float64, np.int64]
+            assert df["Extended Requirement"].dtype in [np.float64, np.int64]
+            assert df["Additional Extended Requirement"].dtype in [np.float64, np.int64]
+            assert df["Deficit"].dtype in [np.float64, np.int64]
+
+    def test_get_dispatched_reserves_verified_historical_range(self):
+        past_date = self.local_today() - pd.Timedelta(days=5)
+        past_end_date = past_date + pd.Timedelta(days=3)
+        with pjm_vcr.use_cassette(
+            f"test_get_dispatched_reserves_verified_historical_range_{past_date.strftime('%Y-%m-%d')}_{past_end_date.strftime('%Y-%m-%d')}.yaml",
+        ):
+            df = self.iso.get_dispatched_reserves_verified(past_date, past_end_date)
+
+            assert isinstance(df, pd.DataFrame)
+            assert (
+                df.columns.tolist() == self.expected_dispatched_reserves_verified_cols
+            )
+
+            assert df["Interval Start"].min() >= self.local_start_of_day(past_date)
+            assert df["Interval End"].max() <= self.local_start_of_day(
+                past_end_date,
+            ) + pd.Timedelta(days=1)
+
+            assert df["Ancillary Service"].dtype == object
+            assert df["Area"].dtype == object
+            assert df["Total Reserve"].dtype in [np.float64, np.int64]
+            assert df["Reserve Requirement"].dtype in [np.float64, np.int64]
+            assert df["Reliability Requirement"].dtype in [np.float64, np.int64]
+            assert df["Extended Requirement"].dtype in [np.float64, np.int64]
+            assert df["Additional Extended Requirement"].dtype in [np.float64, np.int64]
+            assert df["Deficit"].dtype in [np.float64, np.int64]


### PR DESCRIPTION
## Summary
Adds the `pjm_dispatched_reserves_prelim` and `pjm_dispatched_reserves_verifed` datasets.

```
from gridstatus.pjm import PJM
pjm = PJM()
df = pjm.get_dispatched_reserves_prelim(date="2025-03-03")
print(df)

df2 = pjm.get_dispatched_reserves_verified(date="2025-03-03")
print(df2)
```

### Details
Ran into this the other day with another set of `prelim` and `verified` datasets, where the `verified` is published the next day (and thus not available in a `today` format for `support_date_range`. I put a TODO in to add a `yesterday` option to `support_date_range` which I can do in this PR if we think it'll not have much in the way of side effects, or hold off until later. 

Also adds some final typehints to `PJM()` methods. I might also smuggle in another round of fixturization of some tests, just to keep that rolling since there are a lot for PJM. 


