### PR TITLE
feat(ENG 1317): CAISO Scheduling Point / Tie Combo LMPs

### DIFF
--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -2372,7 +2372,6 @@ class CAISO(ISOBase):
                 "Node",
                 "Tie",
                 "Market",
-                "GRP_TYPE",
             ],
             columns="LMP_TYPE",
             values="PRC",
@@ -2389,7 +2388,7 @@ class CAISO(ISOBase):
             },
         )
 
-        df["Node Tie"] = df["Node"] + " " + df["Tie"]
+        df["Location"] = df["Node"] + " " + df["Tie"]
         return df[
             [
                 "Interval Start",

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -196,6 +196,9 @@ OASIS_DATASET_CONFIG = {
             "node": None,
             "grp_type": [None, "ALL", "ALL_APNODES"],
         },
+        "meta": {
+            "max_query_frequency": "1h",
+        },
     },
     "lmp_scheduling_point_tie_combination_15_min": {
         "query": {
@@ -209,6 +212,9 @@ OASIS_DATASET_CONFIG = {
             "node": None,
             "grp_type": [None, "ALL", "ALL_APNODES"],
         },
+        "meta": {
+            "max_query_frequency": "1h",
+        },
     },
     "lmp_scheduling_point_tie_combination_hourly": {
         "query": {
@@ -221,6 +227,9 @@ OASIS_DATASET_CONFIG = {
             "market_run_id": "DAM",
             "node": None,
             "grp_type": [None, "ALL", "ALL_APNODES"],
+        },
+        "meta": {
+            "max_query_frequency": "1d",
         },
     },
     "demand_forecast": {
@@ -2352,7 +2361,6 @@ class CAISO(ISOBase):
             columns={
                 "NODE": "Location",
                 "TIE": "Tie",
-                "GROUP": "Group",
                 "MARKET_RUN_ID": "Market",
             },
         )
@@ -2363,9 +2371,7 @@ class CAISO(ISOBase):
                 "Interval End",
                 "Location",
                 "Tie",
-                "Group",
                 "Market",
-                "POS",
                 "GRP_TYPE",
             ],
             columns="LMP_TYPE",
@@ -2391,9 +2397,7 @@ class CAISO(ISOBase):
                 "Market",
                 "Location",
                 "Node Tie",
-                "POS",
                 "Tie",
-                "Group",
                 "GRP_TYPE",
                 "Energy",
                 "Congestion",

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -184,6 +184,45 @@ OASIS_DATASET_CONFIG = {
             "grp_type": [None, "ALL", "ALL_APNODES"],
         },
     },
+    "lmp_scheduling_point_tie_combination_5_min": {
+        "query": {
+            "path": "SingleZip",
+            "resultformat": 6,
+            "queryname": "PRC_SPTIE_LMP",
+            "version": 3,
+        },
+        "params": {
+            "market_run_id": "RTD",
+            "node": None,
+            "grp_type": [None, "ALL", "ALL_APNODES"],
+        },
+    },
+    "lmp_scheduling_point_tie_combination_15_min": {
+        "query": {
+            "path": "SingleZip",
+            "resultformat": 6,
+            "queryname": "PRC_SPTIE_LMP",
+            "version": 3,
+        },
+        "params": {
+            "market_run_id": "FMM",
+            "node": None,
+            "grp_type": [None, "ALL", "ALL_APNODES"],
+        },
+    },
+    "lmp_scheduling_point_tie_combination_hourly": {
+        "query": {
+            "path": "SingleZip",
+            "resultformat": 6,
+            "queryname": "PRC_SPTIE_LMP",
+            "version": 3,
+        },
+        "params": {
+            "market_run_id": "DAM",
+            "node": None,
+            "grp_type": [None, "ALL", "ALL_APNODES"],
+        },
+    },
     "demand_forecast": {
         "query": {
             "path": "SingleZip",
@@ -2246,4 +2285,91 @@ class CAISO(ISOBase):
 
         df.columns.name = None
 
+        return df
+
+    def get_lmp_scheduling_point_tie_combination_5_min(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Get LMP scheduling point tie combination 5-min data from CAISO.
+
+        Args:
+            date (str | pd.Timestamp): date to return data
+            end (str | pd.Timestamp | None, optional): last date of range to return data.
+                If None, returns only date. Defaults to None.
+            verbose (bool, optional): print out url being fetched. Defaults to False.
+
+        Returns:
+            pandas.DataFrame: A DataFrame of LMP scheduling point tie combination 5-min data
+        """
+
+        df = self.get_oasis_dataset(
+            dataset="lmp_scheduling_point_tie_combination_5_min",
+            date=date,
+            end=end,
+            verbose=verbose,
+            raw_data=False,
+        )
+        print("Hello world")
+        return df
+
+    def lmp_scheduling_point_tie_combination_15_min(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        df = self.get_oasis_dataset(
+            dataset="lmp_scheduling_point_tie_combination_15_min",
+            date=date,
+            end=end,
+            verbose=verbose,
+            raw_data=False,
+        )
+        return self._handle_lmp_scheduling_point_tie_combination(df)
+
+    def lmp_scheduling_point_tie_combination_hourly(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        df = self.get_oasis_dataset(
+            dataset="lmp_scheduling_point_tie_combination_hourly",
+            date=date,
+            end=end,
+            verbose=verbose,
+            raw_data=False,
+        )
+        return self._handle_lmp_scheduling_point_tie_combination(df)
+
+    def _handle_lmp_scheduling_point_tie_combination(
+        self,
+        df: pd.DataFrame,
+    ) -> pd.DataFrame:
+        # df = df.rename(
+        #     columns={
+        #         "NODE": "Location",
+        #         "TIE": "Tie",
+        #         "GROUP": "Group",
+        #         "MARKET_RUN_ID": "Market",
+        #     },
+        # )
+
+        # df = df.pivot_table(
+        #     index=["Interval Start", "Location", "Tie", "Market"],
+        #     columns="LMP_TYPE",
+        #     values="PRC",
+        #     aggfunc="first",
+        # ).reset_index()
+        # print(df)
+
+        # df.rename(
+        #     columns={
+        #         "LMP": "LMP",
+        #         "MCC": "Congestion",
+        #     },
+        # )
         return df

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -189,12 +189,10 @@ OASIS_DATASET_CONFIG = {
             "path": "SingleZip",
             "resultformat": 6,
             "queryname": "PRC_SPTIE_LMP",
-            "version": 3,
+            "version": 5,
         },
         "params": {
             "market_run_id": "RTD",
-            "node": None,
-            "grp_type": [None, "ALL", "ALL_APNODES"],
         },
     },
     "lmp_scheduling_point_tie_combination_15_min": {
@@ -202,10 +200,10 @@ OASIS_DATASET_CONFIG = {
             "path": "SingleZip",
             "resultformat": 6,
             "queryname": "PRC_SPTIE_LMP",
-            "version": 3,
+            "version": 5,
         },
         "params": {
-            "market_run_id": "FMM",
+            "market_run_id": "RTPD",
             "node": None,
             "grp_type": [None, "ALL", "ALL_APNODES"],
         },
@@ -215,7 +213,7 @@ OASIS_DATASET_CONFIG = {
             "path": "SingleZip",
             "resultformat": 6,
             "queryname": "PRC_SPTIE_LMP",
-            "version": 3,
+            "version": 5,
         },
         "params": {
             "market_run_id": "DAM",
@@ -2315,7 +2313,7 @@ class CAISO(ISOBase):
         print("Hello world")
         return df
 
-    def lmp_scheduling_point_tie_combination_15_min(
+    def get_lmp_scheduling_point_tie_combination_15_min(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
@@ -2330,7 +2328,7 @@ class CAISO(ISOBase):
         )
         return self._handle_lmp_scheduling_point_tie_combination(df)
 
-    def lmp_scheduling_point_tie_combination_hourly(
+    def get_lmp_scheduling_point_tie_combination_hourly(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -2354,7 +2354,17 @@ class CAISO(ISOBase):
         verbose: bool = False,
     ) -> pd.DataFrame:
         if date == "latest":
-            return self.get_lmp_scheduling_point_tie_day_ahead_hourly("today")
+            try:
+                df = self.get_lmp_scheduling_point_tie_day_ahead_hourly(
+                    pd.Timestamp.now(tz=self.default_timezone).normalize()
+                    + pd.Timedelta(days=1),
+                )
+            except ValueError:
+                df = self.get_lmp_scheduling_point_tie_day_ahead_hourly(
+                    "today",
+                )
+
+            return df
 
         df = self.get_oasis_dataset(
             dataset="lmp_scheduling_point_tie_combination_hourly",

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -2398,7 +2398,6 @@ class CAISO(ISOBase):
                 "Market",
                 "Node",
                 "Tie",
-                "GRP_TYPE",
                 "LMP",
                 "Energy",
                 "Congestion",

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -2312,8 +2312,7 @@ class CAISO(ISOBase):
             verbose=verbose,
             raw_data=False,
         )
-        print("Hello world")
-        return df
+        return self._handle_lmp_scheduling_point_tie_combination(df)
 
     def get_lmp_scheduling_point_tie_combination_15_min(
         self,
@@ -2349,27 +2348,44 @@ class CAISO(ISOBase):
         self,
         df: pd.DataFrame,
     ) -> pd.DataFrame:
-        # df = df.rename(
-        #     columns={
-        #         "NODE": "Location",
-        #         "TIE": "Tie",
-        #         "GROUP": "Group",
-        #         "MARKET_RUN_ID": "Market",
-        #     },
-        # )
+        df = df.rename(
+            columns={
+                "NODE": "Location",
+                "TIE": "Tie",
+                "GROUP": "Group",
+                "MARKET_RUN_ID": "Market",
+            },
+        )
 
-        # df = df.pivot_table(
-        #     index=["Interval Start", "Location", "Tie", "Market"],
-        #     columns="LMP_TYPE",
-        #     values="PRC",
-        #     aggfunc="first",
-        # ).reset_index()
-        # print(df)
+        df = df.pivot_table(
+            index=["Interval Start", "Location", "Tie", "Market"],
+            columns="LMP_TYPE",
+            values="PRC",
+            aggfunc="first",
+        ).reset_index()
 
-        # df.rename(
-        #     columns={
-        #         "LMP": "LMP",
-        #         "MCC": "Congestion",
-        #     },
-        # )
-        return df
+        df.rename(
+            columns={
+                "MCE": "Energy",
+                "MCC": "Congestion",
+                "MCL": "Loss",
+                "MGHG": "GHG",
+            },
+        )
+        df["Node Tie"] = df["Location"] + " " + df["Tie"]
+        return df[
+            [
+                "Interval Start",
+                "Interval End",
+                "Market",
+                "Location",
+                "Node Tie",
+                "POS",
+                "Tie",
+                "Group",
+                "Energy",
+                "Congestion",
+                "Loss",
+                "GHG",
+            ]
+        ]

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -193,6 +193,8 @@ OASIS_DATASET_CONFIG = {
         },
         "params": {
             "market_run_id": "RTD",
+            "node": None,
+            "grp_type": [None, "ALL", "ALL_APNODES"],
         },
     },
     "lmp_scheduling_point_tie_combination_15_min": {

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -2358,13 +2358,23 @@ class CAISO(ISOBase):
         )
 
         df = df.pivot_table(
-            index=["Interval Start", "Location", "Tie", "Market"],
+            index=[
+                "Interval Start",
+                "Interval End",
+                "Location",
+                "Tie",
+                "Group",
+                "Market",
+                "POS",
+                "GRP_TYPE",
+            ],
             columns="LMP_TYPE",
             values="PRC",
             aggfunc="first",
         ).reset_index()
 
-        df.rename(
+        df.columns.name = None
+        df = df.rename(
             columns={
                 "MCE": "Energy",
                 "MCC": "Congestion",
@@ -2372,6 +2382,7 @@ class CAISO(ISOBase):
                 "MGHG": "GHG",
             },
         )
+
         df["Node Tie"] = df["Location"] + " " + df["Tie"]
         return df[
             [
@@ -2383,6 +2394,7 @@ class CAISO(ISOBase):
                 "POS",
                 "Tie",
                 "Group",
+                "GRP_TYPE",
                 "Energy",
                 "Congestion",
                 "Loss",

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -2296,7 +2296,7 @@ class CAISO(ISOBase):
 
         return df
 
-    def get_lmp_scheduling_point_tie_combination_5_min(
+    def get_lmp_scheduling_point_tie_real_time_5_min(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
@@ -2323,7 +2323,7 @@ class CAISO(ISOBase):
         )
         return self._handle_lmp_scheduling_point_tie_combination(df)
 
-    def get_lmp_scheduling_point_tie_combination_15_min(
+    def get_lmp_scheduling_point_tie_real_time_15_min(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
@@ -2338,7 +2338,7 @@ class CAISO(ISOBase):
         )
         return self._handle_lmp_scheduling_point_tie_combination(df)
 
-    def get_lmp_scheduling_point_tie_combination_hourly(
+    def get_lmp_scheduling_point_tie_day_ahead_hourly(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
@@ -2359,7 +2359,7 @@ class CAISO(ISOBase):
     ) -> pd.DataFrame:
         df = df.rename(
             columns={
-                "NODE": "Location",
+                "NODE": "Node",
                 "TIE": "Tie",
                 "MARKET_RUN_ID": "Market",
             },
@@ -2369,7 +2369,7 @@ class CAISO(ISOBase):
             index=[
                 "Interval Start",
                 "Interval End",
-                "Location",
+                "Node",
                 "Tie",
                 "Market",
                 "GRP_TYPE",
@@ -2389,14 +2389,14 @@ class CAISO(ISOBase):
             },
         )
 
-        df["Node Tie"] = df["Location"] + " " + df["Tie"]
+        df["Node Tie"] = df["Node"] + " " + df["Tie"]
         return df[
             [
                 "Interval Start",
                 "Interval End",
-                "Market",
                 "Location",
-                "Node Tie",
+                "Market",
+                "Node",
                 "Tie",
                 "GRP_TYPE",
                 "LMP",

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -2313,6 +2313,10 @@ class CAISO(ISOBase):
         Returns:
             pandas.DataFrame: A DataFrame of LMP scheduling point tie combination 5-min data
         """
+        if date == "latest":
+            return self.get_lmp_scheduling_point_tie_real_time_5_min(
+                pd.Timestamp.now(tz=self.default_timezone),
+            )
 
         df = self.get_oasis_dataset(
             dataset="lmp_scheduling_point_tie_combination_5_min",
@@ -2329,6 +2333,11 @@ class CAISO(ISOBase):
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
+        if date == "latest":
+            return self.get_lmp_scheduling_point_tie_real_time_15_min(
+                pd.Timestamp.now(tz=self.default_timezone),
+            )
+
         df = self.get_oasis_dataset(
             dataset="lmp_scheduling_point_tie_combination_15_min",
             date=date,
@@ -2344,6 +2353,9 @@ class CAISO(ISOBase):
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
+        if date == "latest":
+            return self.get_lmp_scheduling_point_tie_day_ahead_hourly("today")
+
         df = self.get_oasis_dataset(
             dataset="lmp_scheduling_point_tie_combination_hourly",
             date=date,

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -2399,6 +2399,7 @@ class CAISO(ISOBase):
                 "Node Tie",
                 "Tie",
                 "GRP_TYPE",
+                "LMP",
                 "Energy",
                 "Congestion",
                 "Loss",

--- a/gridstatus/caiso.py
+++ b/gridstatus/caiso.py
@@ -2359,7 +2359,7 @@ class CAISO(ISOBase):
                     pd.Timestamp.now(tz=self.default_timezone).normalize()
                     + pd.Timedelta(days=1),
                 )
-            except ValueError:
+            except KeyError:
                 df = self.get_lmp_scheduling_point_tie_day_ahead_hourly(
                     "today",
                 )

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -866,15 +866,15 @@ class TestCAISO(BaseTestISO):
             ),
         ],
     )
-    def test_get_lmp_scheduling_point_tie_combination_hourly_date_range(
+    def test_get_lmp_scheduling_point_tie_day_ahead_hourly_min_date_range(
         self,
         start,
         end,
     ):
         with caiso_vcr.use_cassette(
-            f"test_get_lmp_scheduling_point_tie_combination_hourly_date_range_{start.strftime('%Y-%m-%d')}_{end.strftime('%Y-%m-%d')}.yaml",
+            f"test_get_lmp_scheduling_point_tie_day_ahead_hourly_date_range_{start.strftime('%Y-%m-%d')}_{end.strftime('%Y-%m-%d')}.yaml",
         ):
-            df = self.iso.get_lmp_scheduling_point_tie_combination_hourly(
+            df = self.iso.get_lmp_scheduling_point_tie_day_ahead_hourly(
                 start,
                 end=end,
             )
@@ -891,15 +891,15 @@ class TestCAISO(BaseTestISO):
             ),
         ],
     )
-    def test_get_lmp_scheduling_point_tie_combination_5_min_date_range(
+    def test_get_lmp_scheduling_point_tie_real_time_5_min_date_range(
         self,
         start,
         end,
     ):
         with caiso_vcr.use_cassette(
-            f"test_get_lmp_scheduling_point_tie_combination_5_min_date_range_{start.strftime('%Y-%m-%d')}_{end.strftime('%Y-%m-%d')}.yaml",
+            f"test_get_lmp_scheduling_point_tie_real_time_5_min_date_range_{start.strftime('%Y-%m-%d')}_{end.strftime('%Y-%m-%d')}.yaml",
         ):
-            df = self.iso.get_lmp_scheduling_point_tie_combination_hourly(
+            df = self.iso.get_lmp_scheduling_point_tie_real_time_5_min(
                 start,
                 end=end,
             )
@@ -916,15 +916,15 @@ class TestCAISO(BaseTestISO):
             ),
         ],
     )
-    def test_get_lmp_scheduling_point_tie_combination_15_min_date_range(
+    def test_get_lmp_scheduling_point_tie_real_time_15_min_date_range(
         self,
         start,
         end,
     ):
         with caiso_vcr.use_cassette(
-            f"test_get_lmp_scheduling_point_tie_combination_15_min_date_range_{start.strftime('%Y-%m-%d')}_{end.strftime('%Y-%m-%d')}.yaml",
+            f"test_get_lmp_scheduling_point_tie_real_time_15_min_date_range_{start.strftime('%Y-%m-%d')}_{end.strftime('%Y-%m-%d')}.yaml",
         ):
-            df = self.iso.get_lmp_scheduling_point_tie_combination_hourly(
+            df = self.iso.get_lmp_scheduling_point_tie_real_time_15_min(
                 start,
                 end=end,
             )

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -789,3 +789,91 @@ class TestCAISO(BaseTestISO):
         with caiso_vcr.use_cassette("test_get_pnodes.yaml"):
             df = self.iso.get_pnodes()
             assert df.shape[0] > 0
+
+    """get_lmp_scheduling_point_tie_combination"""
+
+    def _check_lmp_scheduling_point_tie_combination(self, df: pd.DataFrame):
+        assert df.shape[0] > 0
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "Market",
+            "Location",
+            "Node Tie",
+            "POS",
+            "Tie",
+            "Group",
+            "GRP_TYPE",
+            "Energy",
+            "Congestion",
+            "Loss",
+            "GHG",
+        ]
+
+        assert (df["Node Tie"] == df["Location"] + " " + df["Tie"]).all()
+
+        self._check_time_columns(
+            df,
+            instant_or_interval="interval",
+            skip_column_named_time=True,
+        )
+
+    @pytest.mark.parametrize("date", ["2022-10-15"])
+    def test_get_lmp_scheduling_point_tie_combination_5_min(self, date):
+        with caiso_vcr.use_cassette(
+            f"test_get_lmp_scheduling_point_tie_combination_5_min_{date}.yaml",
+        ):
+            df = self.iso.get_lmp_scheduling_point_tie_combination_5_min(date)
+            self._check_lmp_scheduling_point_tie_combination(df)
+
+            interval_minutes = (
+                df["Interval End"] - df["Interval Start"]
+            ).dt.total_seconds() / 60
+            assert (interval_minutes == 5).all()
+
+    @pytest.mark.parametrize("date", ["2022-10-15"])
+    def test_get_lmp_scheduling_point_tie_combination_15_min(self, date):
+        with caiso_vcr.use_cassette(
+            f"test_get_lmp_scheduling_point_tie_combination_15_min_{date}.yaml",
+        ):
+            df = self.iso.get_lmp_scheduling_point_tie_combination_15_min(date)
+            self._check_lmp_scheduling_point_tie_combination(df)
+
+            interval_minutes = (
+                df["Interval End"] - df["Interval Start"]
+            ).dt.total_seconds() / 60
+            assert (interval_minutes == 15).all()
+
+    @pytest.mark.parametrize("date", ["2022-10-15"])
+    def test_get_lmp_scheduling_point_tie_combination_hourly(self, date):
+        with caiso_vcr.use_cassette(
+            f"test_get_lmp_scheduling_point_tie_combination_hourly_{date}.yaml",
+        ):
+            df = self.iso.get_lmp_scheduling_point_tie_combination_hourly(date)
+            self._check_lmp_scheduling_point_tie_combination(df)
+
+            interval_minutes = (
+                df["Interval End"] - df["Interval Start"]
+            ).dt.total_seconds() / 60
+            assert (interval_minutes == 60).all()
+
+    @pytest.mark.parametrize(
+        "start, end",
+        [
+            (
+                pd.Timestamp("today").normalize() - pd.Timedelta(days=3),
+                pd.Timestamp("today").normalize() - pd.Timedelta(days=1),
+            ),
+        ],
+    )
+    def test_get_lmp_scheduling_point_tie_combination_date_range(self, start, end):
+        with caiso_vcr.use_cassette(
+            f"test_get_lmp_scheduling_point_tie_combination_date_range_{start.strftime('%Y-%m-%d')}_{end.strftime('%Y-%m-%d')}.yaml",
+        ):
+            df = self.iso.get_lmp_scheduling_point_tie_combination_hourly(
+                start,
+                end=end,
+            )
+            self._check_lmp_scheduling_point_tie_combination(df)
+
+            assert df["Interval Start"].min() >= self.local_start_of_day(start)

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -866,9 +866,63 @@ class TestCAISO(BaseTestISO):
             ),
         ],
     )
-    def test_get_lmp_scheduling_point_tie_combination_date_range(self, start, end):
+    def test_get_lmp_scheduling_point_tie_combination_hourly_date_range(
+        self,
+        start,
+        end,
+    ):
         with caiso_vcr.use_cassette(
-            f"test_get_lmp_scheduling_point_tie_combination_date_range_{start.strftime('%Y-%m-%d')}_{end.strftime('%Y-%m-%d')}.yaml",
+            f"test_get_lmp_scheduling_point_tie_combination_hourly_date_range_{start.strftime('%Y-%m-%d')}_{end.strftime('%Y-%m-%d')}.yaml",
+        ):
+            df = self.iso.get_lmp_scheduling_point_tie_combination_hourly(
+                start,
+                end=end,
+            )
+            self._check_lmp_scheduling_point_tie_combination(df)
+
+            assert df["Interval Start"].min() >= self.local_start_of_day(start)
+
+    @pytest.mark.parametrize(
+        "start, end",
+        [
+            (
+                pd.Timestamp("today").normalize() - pd.Timedelta(days=3),
+                pd.Timestamp("today").normalize() - pd.Timedelta(days=1),
+            ),
+        ],
+    )
+    def test_get_lmp_scheduling_point_tie_combination_5_min_date_range(
+        self,
+        start,
+        end,
+    ):
+        with caiso_vcr.use_cassette(
+            f"test_get_lmp_scheduling_point_tie_combination_5_min_date_range_{start.strftime('%Y-%m-%d')}_{end.strftime('%Y-%m-%d')}.yaml",
+        ):
+            df = self.iso.get_lmp_scheduling_point_tie_combination_hourly(
+                start,
+                end=end,
+            )
+            self._check_lmp_scheduling_point_tie_combination(df)
+
+            assert df["Interval Start"].min() >= self.local_start_of_day(start)
+
+    @pytest.mark.parametrize(
+        "start, end",
+        [
+            (
+                pd.Timestamp("today").normalize() - pd.Timedelta(days=3),
+                pd.Timestamp("today").normalize() - pd.Timedelta(days=1),
+            ),
+        ],
+    )
+    def test_get_lmp_scheduling_point_tie_combination_15_min_date_range(
+        self,
+        start,
+        end,
+    ):
+        with caiso_vcr.use_cassette(
+            f"test_get_lmp_scheduling_point_tie_combination_15_min_date_range_{start.strftime('%Y-%m-%d')}_{end.strftime('%Y-%m-%d')}.yaml",
         ):
             df = self.iso.get_lmp_scheduling_point_tie_combination_hourly(
                 start,

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -797,10 +797,11 @@ class TestCAISO(BaseTestISO):
         assert df.columns.tolist() == [
             "Interval Start",
             "Interval End",
-            "Market",
             "Location",
+            "Market",
             "Node",
             "Tie",
+            "LMP",
             "Energy",
             "Congestion",
             "Loss",

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -792,25 +792,22 @@ class TestCAISO(BaseTestISO):
 
     """get_lmp_scheduling_point_tie_combination"""
 
-    def _check_lmp_scheduling_point_tie_combination(self, df: pd.DataFrame):
+    def _check_lmp_scheduling_point_tie(self, df: pd.DataFrame):
         assert df.shape[0] > 0
         assert df.columns.tolist() == [
             "Interval Start",
             "Interval End",
             "Market",
             "Location",
-            "Node Tie",
-            "POS",
+            "Node",
             "Tie",
-            "Group",
-            "GRP_TYPE",
             "Energy",
             "Congestion",
             "Loss",
             "GHG",
         ]
 
-        assert (df["Node Tie"] == df["Location"] + " " + df["Tie"]).all()
+        assert (df["Location"] == df["Node"] + " " + df["Tie"]).all()
 
         self._check_time_columns(
             df,
@@ -819,12 +816,12 @@ class TestCAISO(BaseTestISO):
         )
 
     @pytest.mark.parametrize("date", ["2022-10-15"])
-    def test_get_lmp_scheduling_point_tie_combination_5_min(self, date):
+    def test_get_lmp_scheduling_point_tie_real_time_5_min(self, date):
         with caiso_vcr.use_cassette(
-            f"test_get_lmp_scheduling_point_tie_combination_5_min_{date}.yaml",
+            f"test_get_lmp_scheduling_point_tie_real_time_5_min_{date}.yaml",
         ):
-            df = self.iso.get_lmp_scheduling_point_tie_combination_5_min(date)
-            self._check_lmp_scheduling_point_tie_combination(df)
+            df = self.iso.get_lmp_scheduling_point_tie_real_time_5_min(date)
+            self._check_lmp_scheduling_point_tie(df)
 
             interval_minutes = (
                 df["Interval End"] - df["Interval Start"]
@@ -832,12 +829,12 @@ class TestCAISO(BaseTestISO):
             assert (interval_minutes == 5).all()
 
     @pytest.mark.parametrize("date", ["2022-10-15"])
-    def test_get_lmp_scheduling_point_tie_combination_15_min(self, date):
+    def test_get_lmp_scheduling_point_tie_real_time_15_min(self, date):
         with caiso_vcr.use_cassette(
-            f"test_get_lmp_scheduling_point_tie_combination_15_min_{date}.yaml",
+            f"test_get_lmp_scheduling_point_tie_real_time_15_min_{date}.yaml",
         ):
-            df = self.iso.get_lmp_scheduling_point_tie_combination_15_min(date)
-            self._check_lmp_scheduling_point_tie_combination(df)
+            df = self.iso.get_lmp_scheduling_point_tie_real_time_15_min(date)
+            self._check_lmp_scheduling_point_tie(df)
 
             interval_minutes = (
                 df["Interval End"] - df["Interval Start"]
@@ -845,12 +842,12 @@ class TestCAISO(BaseTestISO):
             assert (interval_minutes == 15).all()
 
     @pytest.mark.parametrize("date", ["2022-10-15"])
-    def test_get_lmp_scheduling_point_tie_combination_hourly(self, date):
+    def test_get_lmp_scheduling_point_tie_day_ahead_hourly(self, date):
         with caiso_vcr.use_cassette(
-            f"test_get_lmp_scheduling_point_tie_combination_hourly_{date}.yaml",
+            f"test_get_lmp_scheduling_point_tie_day_ahead_hourly_{date}.yaml",
         ):
-            df = self.iso.get_lmp_scheduling_point_tie_combination_hourly(date)
-            self._check_lmp_scheduling_point_tie_combination(df)
+            df = self.iso.get_lmp_scheduling_point_tie_day_ahead_hourly(date)
+            self._check_lmp_scheduling_point_tie(df)
 
             interval_minutes = (
                 df["Interval End"] - df["Interval Start"]
@@ -878,7 +875,7 @@ class TestCAISO(BaseTestISO):
                 start,
                 end=end,
             )
-            self._check_lmp_scheduling_point_tie_combination(df)
+            self._check_lmp_scheduling_point_tie(df)
 
             assert df["Interval Start"].min() >= self.local_start_of_day(start)
 
@@ -903,7 +900,7 @@ class TestCAISO(BaseTestISO):
                 start,
                 end=end,
             )
-            self._check_lmp_scheduling_point_tie_combination(df)
+            self._check_lmp_scheduling_point_tie(df)
 
             assert df["Interval Start"].min() >= self.local_start_of_day(start)
 
@@ -928,6 +925,6 @@ class TestCAISO(BaseTestISO):
                 start,
                 end=end,
             )
-            self._check_lmp_scheduling_point_tie_combination(df)
+            self._check_lmp_scheduling_point_tie(df)
 
             assert df["Interval Start"].min() >= self.local_start_of_day(start)


### PR DESCRIPTION
## Summary
Adds the `caiso_lmp_scheduling_point_tie_combination_5_min`, `caiso_lmp_scheduling_point_tie_combination_15_min`, and `caiso_lmp_scheduling_point_tie_combination_hourly` datasets.

```
from gridstatus.caiso import CAISO
caiso = CAISO()

df = caiso.get_lmp_scheduling_point_tie_real_time_5_min(date="2025-03-10")
print(df)

df = caiso.get_lmp_scheduling_point_tie_real_time_15_min(date="2025-03-10")
print(df)

df = caiso.get_lmp_scheduling_point_tie_day_ahead_hourly(date="2025-03-10")
print(df)
```