### PR TITLE
Remove missing column in SPP interconnection queue

### DIFF
--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -772,7 +772,6 @@ class SPP(ISOBase):
             "Cessation Date",
             "Current Cluster",
             "Cluster Group",
-            "Replacement Generator Commercial Op Date",
             "Service Type",
             "Status (Original)",
         ]


### PR DESCRIPTION
## Summary
Remove an extra column in the SPP interconnection queue data that was removed by SPP in the raw data.
