### PR TITLE
feat(ENG-1403): NYISO AS Prices

### DIFF
--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -31,6 +31,8 @@ BTM_SOLAR_FORECAST_DATASET = "btmdaforecast"
 INTERFACE_LIMITS_AND_FLOWS_DATASET = "ExternalLimitsFlows"
 LAKE_ERIE_CIRCULATION_REAL_TIME_DATASET = "eriecirculationrt"
 LAKE_ERIE_CIRCULATION_DAY_AHEAD_DATASET = "eriecirculationda"
+AS_PRICES_DAY_AHEAD_HOURLY_DATASET = "damasp"
+AS_PRICES_REAL_TIME_5_MIN_DATASET = "rtasp"
 
 """
 Pricing data:
@@ -55,6 +57,8 @@ DATASET_INTERVAL_MAP: Dict[str, DatasetInterval] = {
     INTERFACE_LIMITS_AND_FLOWS_DATASET: DatasetInterval("start", 5),
     LAKE_ERIE_CIRCULATION_REAL_TIME_DATASET: DatasetInterval("instantaneous", None),
     LAKE_ERIE_CIRCULATION_DAY_AHEAD_DATASET: DatasetInterval("instantaneous", None),
+    AS_PRICES_DAY_AHEAD_HOURLY_DATASET: DatasetInterval("start", 60),
+    AS_PRICES_REAL_TIME_5_MIN_DATASET: DatasetInterval("start", 5),
 }
 
 

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -1298,15 +1298,7 @@ class NYISO(ISOBase):
                 report (will refer to month and year)
         """
         if date == "latest":
-            try:
-                return self.get_as_prices_real_time_5_min(
-                    (
-                        pd.Timestamp.now(tz=self.default_timezone).normalize()
-                        + pd.DateOffset(days=1)
-                    ).strftime("%Y-%m-%d"),
-                )
-            except urllib.error.HTTPError:
-                return self.get_as_prices_real_time_5_min("today")
+            return self.get_as_prices_real_time_5_min("today")
 
         df = self._download_nyiso_archive(
             date=date,

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -1244,9 +1244,11 @@ class NYISO(ISOBase):
         df.set_index("", inplace=True)
         return df.dropna(how="any", axis="columns")
 
-    def get_as_prices_day_ahead(
+    @support_date_range(frequency=None)
+    def get_as_prices_day_ahead_hourly(
         self,
-        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
         """Pull the most recent ancillary service market report's market clearing prices
@@ -1255,3 +1257,12 @@ class NYISO(ISOBase):
             date (pandas.Timestamp): date that will be used to pull latest capacity
                 report (will refer to month and year)
         """
+
+    @support_date_range(frequency=None)
+    def get_as_prices_real_time_5_min(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        pass

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -1319,7 +1319,7 @@ class NYISO(ISOBase):
     def _handle_as_prices(
         self,
         df: pd.DataFrame,
-        interval_duration_minutes: int,
+        rt_or_dam: Literal["rt", "dam"],
     ) -> pd.DataFrame:
         df = df.rename(
             columns={
@@ -1330,9 +1330,13 @@ class NYISO(ISOBase):
                 "NYCA Regulation Capacity ($/MWHr)": "Regulation Capacity",
             },
         )
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(
-            minutes=interval_duration_minutes,
-        )
+        if rt_or_dam == "rt":
+            df["Interval End"] = df["Interval Start"]
+            df["Interval Start"] = df["Interval Start"] - pd.Timedelta(minutes=5)
+        else:
+            df["Interval End"] = df["Interval Start"] + pd.Timedelta(
+                minutes=60,
+            )
 
         return df[
             [

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -1252,7 +1252,7 @@ class NYISO(ISOBase):
         df.set_index("", inplace=True)
         return df.dropna(how="any", axis="columns")
 
-    @support_date_range(frequency=None)
+    @support_date_range(frequency="DAY_START")
     def get_as_prices_day_ahead_hourly(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
@@ -1284,7 +1284,7 @@ class NYISO(ISOBase):
         df = self._handle_as_prices(df, 60)
         return df
 
-    @support_date_range(frequency=None)
+    @support_date_range(frequency="DAY_START")
     def get_as_prices_real_time_5_min(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -1168,7 +1168,11 @@ class NYISO(ISOBase):
 
         return df.sort_values("Time").reset_index(drop=True)
 
-    def _get_load_forecast_file_date(self, date: pd.Timestamp) -> pd.Timestamp:
+    def _get_load_forecast_file_date(
+        self,
+        date: pd.Timestamp,
+        verbose: bool = False,
+    ) -> pd.Timestamp:
         """Retrieves the last updated time for load forecast file from the archive"""
         data = pd.read_html(
             "http://mis.nyiso.com/public/P-7list.htm",

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -1281,7 +1281,7 @@ class NYISO(ISOBase):
             verbose=verbose,
             dataset_name="damasp",
         )
-        df = self._handle_as_prices(df, 60)
+        df = self._handle_as_prices(df, rt_or_dam="dam")
         return df
 
     @support_date_range(frequency="DAY_START")
@@ -1313,7 +1313,7 @@ class NYISO(ISOBase):
             verbose=verbose,
             dataset_name="rtasp",
         )
-        df = self._handle_as_prices(df, 5)
+        df = self._handle_as_prices(df, rt_or_dam="rt")
         return df
 
     def _handle_as_prices(

--- a/gridstatus/tests/source_specific/test_nyiso.py
+++ b/gridstatus/tests/source_specific/test_nyiso.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 import pandas as pd
 import pytest
 
@@ -887,7 +889,7 @@ class TestNYISO(BaseTestISO):
     def _check_as_prices(
         self,
         df: pd.DataFrame,
-        interval_duration_minutes: int,
+        rt_or_dam: Literal["rt", "dam"],
         start: pd.Timestamp | None = None,
         end: pd.Timestamp | None = None,
     ):
@@ -904,7 +906,7 @@ class TestNYISO(BaseTestISO):
         assert df.shape[0] >= 0
         assert (
             df["Interval End"] - df["Interval Start"]
-            == pd.Timedelta(minutes=interval_duration_minutes)
+            == pd.Timedelta(minutes=60 if rt_or_dam == "rt" else 5)
         ).all()
 
         if start is not None:
@@ -926,7 +928,7 @@ class TestNYISO(BaseTestISO):
             "test_get_as_prices_day_ahead_hourly_latest.yaml",
         ):
             df = self.iso.get_as_prices_day_ahead_hourly(date="latest")
-            self._check_as_prices(df, interval_duration_minutes=60)
+            self._check_as_prices(df, rt_or_dam="dam")
 
     @pytest.mark.parametrize(
         "start,end",
@@ -941,7 +943,7 @@ class TestNYISO(BaseTestISO):
             df = self.iso.get_as_prices_day_ahead_hourly(start=start, end=end)
             self._check_as_prices(
                 df,
-                interval_duration_minutes=60,
+                rt_or_dam="dam",
                 start=start,
                 end=end,
             )
@@ -953,7 +955,7 @@ class TestNYISO(BaseTestISO):
             "test_get_as_prices_real_time_5_min_latest.yaml",
         ):
             df = self.iso.get_as_prices_real_time_5_min(date="latest")
-            self._check_as_prices(df, interval_duration_minutes=5)
+            self._check_as_prices(df, rt_or_dam="rt")
 
     @pytest.mark.parametrize(
         "start,end",
@@ -966,4 +968,4 @@ class TestNYISO(BaseTestISO):
             f"test_get_as_prices_real_time_5_min_historical_range_{start}_{end}.yaml",
         ):
             df = self.iso.get_as_prices_real_time_5_min(start=start, end=end)
-            self._check_as_prices(df, interval_duration_minutes=5, start=start, end=end)
+            self._check_as_prices(df, rt_or_dam="rt", start=start, end=end)

--- a/gridstatus/tests/source_specific/test_nyiso.py
+++ b/gridstatus/tests/source_specific/test_nyiso.py
@@ -906,7 +906,7 @@ class TestNYISO(BaseTestISO):
         assert df.shape[0] >= 0
         assert (
             df["Interval End"] - df["Interval Start"]
-            == pd.Timedelta(minutes=60 if rt_or_dam == "rt" else 5)
+            == pd.Timedelta(minutes=60 if rt_or_dam == "dam" else 5)
         ).all()
 
         if start is not None:

--- a/gridstatus/tests/source_specific/test_nyiso.py
+++ b/gridstatus/tests/source_specific/test_nyiso.py
@@ -910,7 +910,7 @@ class TestNYISO(BaseTestISO):
         ).all()
 
         if start is not None:
-            assert df["Interval Start"].min() >= pd.Timestamp(
+            assert df["Interval Start"].min().round("5min") >= pd.Timestamp(
                 start,
                 tz=self.iso.default_timezone,
             )


### PR DESCRIPTION
## Summary
Adds the `nyiso_as_prices_day_ahead_hourly` and `nyiso_as_prices_real_time_5_min` datasets. Also does New Source Review of the `nyiso.py` and `test_nyiso.py` files.

```
from gridstatus.nyiso import NYISO
nyiso = NYISO()

df = nyiso.get_as_prices_day_ahead_hourly("latest")
df2 = nyiso.get_as_prices_day_ahead_hourly("2016-06-23")
df3 = nyiso.get_as_prices_real_time_5_min("latest")
df4 = nyiso.get_as_prices_real_time_5_min("2016-06-23")

print(df)
print(df2)
print(df3)
print(df4)
```

## Details
### Data
This data goes back to 1999 conceivably, but changes format a couple times over the years. It has a consistent format back to ~2016-07-01, so that's all that this supports right now. Seems pretty straightforward.

### Quality of Life
Updates the nyiso files to
- have function typehints
- use the new logging
- include the hidden method `_handle_time()` since it's only used in the NYISO class (`self._handle_time`)
- break up some tests that are doing many things (`various_edt_to_est`, etc)
- update the tests to use VCR

**Before Local Fixtures**
![CleanShot 2025-03-20 at 14 37 27@2x](https://github.com/user-attachments/assets/1e246ca2-3808-40c1-ae21-0e703d62b764)

**After Local Fixtures** _Time reduction: ~70%_
![CleanShot 2025-03-20 at 15 29 32@2x](https://github.com/user-attachments/assets/d85db497-7536-4426-9877-9773965c65b6)
