### PR TITLE
[ENG-1390] Consistent SCED Timestamp Column Naming

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -1704,8 +1704,8 @@ class Ercot(ISOBase):
 
             return df
 
-        load_resource = handle_time(load_resource, time_col="SCED Time Stamp")
-        gen_resource = handle_time(gen_resource, time_col="SCED Time Stamp")
+        load_resource = handle_time(load_resource, time_col="SCED Timestamp")
+        gen_resource = handle_time(gen_resource, time_col="SCED Timestamp")
         # no repeated hour flag like other ERCOT data
         # likely will error on DST change
         smne = handle_time(smne, time_col="Interval Time", is_interval_end=True)

--- a/gridstatus/ercot_60d_utils.py
+++ b/gridstatus/ercot_60d_utils.py
@@ -182,7 +182,7 @@ DAM_PTP_OBLIGATION_OPTION_AWARDS_COLUMNS = DAM_PTP_OBLIGATION_OPTION_COLUMNS[:-1
 SCED_GEN_RESOURCE_COLUMNS = [
     "Interval Start",
     "Interval End",
-    "SCED Time Stamp",
+    "SCED Timestamp",
     "QSE",
     "DME",
     "Resource Name",
@@ -214,7 +214,7 @@ SCED_GEN_RESOURCE_COLUMNS = [
 SCED_LOAD_RESOURCE_COLUMNS = [
     "Interval Start",
     "Interval End",
-    "SCED Time Stamp",
+    "SCED Timestamp",
     "QSE",
     "DME",
     "Resource Name",
@@ -755,7 +755,7 @@ def process_sced_gen(df):
     time_cols = [
         "Interval Start",
         "Interval End",
-        "SCED Time Stamp",
+        "SCED Timestamp",
     ]
 
     resource_cols = ["QSE", "DME", "Resource Name", "Resource Type"]
@@ -825,7 +825,7 @@ def process_sced_load(df):
     time_cols = [
         "Interval Start",
         "Interval End",
-        "SCED Time Stamp",
+        "SCED Timestamp",
     ]
 
     resource_cols = ["QSE", "DME", "Resource Name"]

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -769,8 +769,8 @@ class TestErcot(BaseTestISO):
         gen_resource = df_dict[SCED_GEN_RESOURCE_KEY]
         smne = df_dict[SCED_SMNE_KEY]
 
-        assert load_resource["SCED Time Stamp"].dt.date.unique()[0] == days_ago_65
-        assert gen_resource["SCED Time Stamp"].dt.date.unique()[0] == days_ago_65
+        assert load_resource["SCED Timestamp"].dt.date.unique()[0] == days_ago_65
+        assert gen_resource["SCED Timestamp"].dt.date.unique()[0] == days_ago_65
         assert smne["Interval Time"].dt.date.unique()[0] == days_ago_65
 
         check_60_day_sced_disclosure(df_dict)
@@ -805,12 +805,12 @@ class TestErcot(BaseTestISO):
 
         self._check_60_day_sced_disclosure(df_dict)
 
-        assert load_resource["SCED Time Stamp"].dt.date.unique().tolist() == [
+        assert load_resource["SCED Timestamp"].dt.date.unique().tolist() == [
             days_ago_66,
             days_ago_65,
         ]
 
-        assert gen_resource["SCED Time Stamp"].dt.date.unique().tolist() == [
+        assert gen_resource["SCED Timestamp"].dt.date.unique().tolist() == [
             days_ago_66,
             days_ago_65,
         ]


### PR DESCRIPTION
## Summary

- Changes column name from SCED Time Stamp to SCED Timestamp to be consistent and prepare for upcoming database changes
- https://docs.gridstatus.io/changelog/march-2025/11-march-add-_utc-suffix-to-dataset-columns-where-it-is-missing

### Details
