### PR TITLE
feat(ENG 1371): CAISO 15 Min Tie Flows and Renewable Forecast

### DIFF
--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -2236,7 +2236,7 @@ class CAISO(ISOBase):
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
-        """Get solar generation HASP hourly data from CAISO.
+        """Get solar and wind generation HASP hourly data from CAISO.
 
         Args:
             date (str | pd.Timestamp): date to return data
@@ -2245,7 +2245,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame of solar generation HASP hourly data
+            pandas.DataFrame: A DataFrame of solar and wind generation HASP hourly data
         """
         if date == "latest":
             try:

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -2274,7 +2274,7 @@ class CAISO(ISOBase):
                 "Interval Start",
                 "Interval End",
                 "Location",
-                "Renewable Type",
-                "MW",
+                "Solar",
+                "Wind",
             ]
         ]

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -2248,17 +2248,9 @@ class CAISO(ISOBase):
             pandas.DataFrame: A DataFrame of solar and wind generation HASP hourly data
         """
         if date == "latest":
-            try:
-                df = self.get_hasp_renewable_forecast_hourly(
-                    pd.Timestamp.now(tz=self.default_timezone).normalize()
-                    + pd.Timedelta(days=1),
-                )
-            except KeyError:
-                df = self.get_hasp_renewable_forecast_hourly(
-                    "today",
-                )
-
-            return df
+            return self.get_hasp_renewable_forecast_hourly(
+                pd.Timestamp.now(tz=self.default_timezone) + pd.Timedelta(minutes=60),
+            )
 
         df = self.get_oasis_dataset(
             dataset="hasp_renewable_forecast_hourly",

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -2248,14 +2248,14 @@ class CAISO(ISOBase):
             pandas.DataFrame: A DataFrame of solar and wind generation HASP hourly data
         """
         if date == "latest":
-            now = pd.Timestamp.now(tz=self.default_timezone)
-            if now.minute >= 30:
-                latest_hour = now + pd.Timedelta(hours=1)
-            else:
-                latest_hour = now
-            return self.get_hasp_renewable_forecast_hourly(
-                latest_hour,
-            )
+            try:
+                return self.get_hasp_renewable_forecast_hourly(
+                    pd.Timestamp.now(tz=self.default_timezone) + pd.Timedelta(hours=2),
+                )  # NB: This is a hack to get the latest forecast
+            except KeyError:
+                return self.get_hasp_renewable_forecast_hourly(
+                    pd.Timestamp.now(tz=self.default_timezone) + pd.Timedelta(hours=1),
+                )
 
         df = self.get_oasis_dataset(
             dataset="hasp_renewable_forecast_hourly",

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -2289,10 +2289,12 @@ class CAISO(ISOBase):
         ).reset_index()
 
         df.columns.name = None
+        df["Publish Time"] = df["Interval Start"] - pd.Timedelta(minutes=90)
         return df[
             [
                 "Interval Start",
                 "Interval End",
+                "Publish Time",
                 "Location",
                 "Solar",
                 "Wind",

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -1865,6 +1865,26 @@ class CAISO(ISOBase):
 
         return self._process_tie_flows_data(df)
 
+    def get_tie_flows_real_time_15_min(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        if date == "latest":
+            date = pd.Timestamp.utcnow().round("15min")
+            end = date + pd.Timedelta(minutes=15)
+
+        df = self.get_oasis_dataset(
+            dataset="tie_flows_real_time_15_min",
+            date=date,
+            end=end,
+            verbose=verbose,
+            raw_data=False,
+        )
+
+        return self._process_tie_flows_data(df)
+
     def _process_tie_flows_data(self, df: pd.DataFrame) -> pd.DataFrame:
         df = df.drop(
             columns=[

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -2248,8 +2248,13 @@ class CAISO(ISOBase):
             pandas.DataFrame: A DataFrame of solar and wind generation HASP hourly data
         """
         if date == "latest":
+            now = pd.Timestamp.now(tz=self.default_timezone)
+            if now.minute >= 30:
+                latest_hour = now + pd.Timedelta(hours=1)
+            else:
+                latest_hour = now
             return self.get_hasp_renewable_forecast_hourly(
-                pd.Timestamp.now(tz=self.default_timezone) + pd.Timedelta(minutes=60),
+                latest_hour,
             )
 
         df = self.get_oasis_dataset(

--- a/gridstatus/caiso/caiso_constants.py
+++ b/gridstatus/caiso/caiso_constants.py
@@ -302,4 +302,18 @@ OASIS_DATASET_CONFIG = {
             "market_run_id": DAY_AHEAD_MARKET_MARKET_RUN_ID,
         },
     },
+    "hasp_renewable_forecast_hourly": {
+        "query": {
+            "path": "SingleZip",
+            "resultformat": 6,
+            "queryname": "SLD_REN_FCST",
+            "version": 1,
+        },
+        "params": {
+            "market_run_id": "HASP",
+        },
+        "meta": {
+            "max_query_frequency": "1h",
+        },
+    },
 }

--- a/gridstatus/caiso/caiso_constants.py
+++ b/gridstatus/caiso/caiso_constants.py
@@ -326,7 +326,7 @@ OASIS_DATASET_CONFIG = {
             "market_run_id": "HASP",
         },
         "meta": {
-            "max_query_frequency": "1h",
+            "max_query_frequency": "1d",
         },
     },
 }

--- a/gridstatus/caiso/caiso_constants.py
+++ b/gridstatus/caiso/caiso_constants.py
@@ -3,6 +3,7 @@ HISTORY_BASE = "https://www.caiso.com/outlook/history"
 
 DAY_AHEAD_MARKET_MARKET_RUN_ID = "DAM"
 REAL_TIME_DISPATCH_MARKET_RUN_ID = "RTD"
+REAL_TIME_DISPATCH_15_MIN_MARKET_RUN_ID = "RTPD"
 
 OASIS_DATASET_CONFIG = {
     "transmission_interface_usage": {
@@ -289,6 +290,18 @@ OASIS_DATASET_CONFIG = {
         "params": {
             "baa_grp_id": "ALL",
             "market_run_id": REAL_TIME_DISPATCH_MARKET_RUN_ID,
+        },
+    },
+    "tie_flows_real_time_15_min": {
+        "query": {
+            "path": "SingleZip",
+            "resultformat": 6,
+            "queryname": "ENE_EIM_TRANSFER_TIE",
+            "version": 4,
+        },
+        "params": {
+            "baa_grp_id": "ALL",
+            "market_run_id": REAL_TIME_DISPATCH_15_MIN_MARKET_RUN_ID,
         },
     },
     "tie_schedule_day_ahead_hourly": {

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -1017,6 +1017,14 @@ class TestCAISO(BaseTestISO):
                 "Solar",
                 "Wind",
             ]
+            assert df["Interval Start"].min() >= pd.Timestamp(
+                date,
+                tz=self.iso.default_timezone,
+            )
+            assert df["Interval End"].max() <= pd.Timestamp(
+                end,
+                tz=self.iso.default_timezone,
+            )
 
     def test_get_tie_flows_real_time_15_min_latest(self):
         with caiso_vcr.use_cassette("test_get_tie_flows_real_time_15_min_latest.yaml"):
@@ -1055,5 +1063,11 @@ class TestCAISO(BaseTestISO):
                 "Market",
                 "MW",
             ]
-            assert df["Interval Start"].min() >= date
-            assert df["Interval End"].max() <= end
+            assert df["Interval Start"].min() >= pd.Timestamp(
+                date,
+                tz=self.iso.default_timezone,
+            )
+            assert df["Interval End"].max() <= pd.Timestamp(
+                end,
+                tz=self.iso.default_timezone,
+            )

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -980,3 +980,80 @@ class TestCAISO(BaseTestISO):
             assert df["Interval End"].max() <= self.local_start_of_day(
                 end,
             ) + pd.Timedelta(days=1)
+
+    def test_get_hasp_renewable_forecast_hourly_latest(self):
+        with caiso_vcr.use_cassette(
+            "test_get_hasp_renewable_forecast_hourly_latest.yaml",
+        ):
+            df = self.iso.get_hasp_renewable_forecast_hourly("latest")
+            assert df.shape[0] > 0
+            assert df.columns.tolist() == [
+                "Interval Start",
+                "Interval End",
+                "Location",
+                "Solar",
+                "Wind",
+            ]
+
+    @pytest.mark.parametrize(
+        "date, end",
+        [
+            (
+                "2025-03-20",
+                "2025-03-22",
+            ),
+        ],
+    )
+    def test_get_hasp_renewable_forecast_hourly_date_range(self, date, end):
+        with caiso_vcr.use_cassette(
+            f"test_get_hasp_renewable_forecast_hourly_date_range_{date}_{end}.yaml",
+        ):
+            df = self.iso.get_hasp_renewable_forecast_hourly(date, end=end)
+            assert df.shape[0] > 0
+            assert df.columns.tolist() == [
+                "Interval Start",
+                "Interval End",
+                "Location",
+                "Solar",
+                "Wind",
+            ]
+
+    def test_get_tie_flows_real_time_15_min_latest(self):
+        with caiso_vcr.use_cassette("test_get_tie_flows_real_time_15_min_latest.yaml"):
+            df = self.iso.get_tie_flows_real_time_15_min("latest")
+            assert df.shape[0] > 0
+            assert df.columns.tolist() == [
+                "Interval Start",
+                "Interval End",
+                "Interface ID",
+                "Tie Name",
+                "From BAA",
+                "To BAA",
+                "Market",
+                "MW",
+            ]
+
+    @pytest.mark.parametrize(
+        "date, end",
+        [
+            ("2025-03-20", "2025-03-22"),
+        ],
+    )
+    def test_get_tie_flows_real_time_15_min_date_range(self, date, end):
+        with caiso_vcr.use_cassette(
+            f"test_get_tie_flows_real_time_15_min_date_range_{date}_{end}.yaml",
+        ):
+            df = self.iso.get_tie_flows_real_time_15_min(date, end=end)
+            assert df.shape[0] > 0
+            assert df.columns.tolist() == [
+                "Interval Start",
+                "Interval End",
+                "Interface ID",
+                "Tie Name",
+                "From BAA",
+                "To BAA",
+                "Market",
+                "MW",
+            ]
+            assert df["Interval Start"].min() >= date
+            assert df["Interval End"].max() <= end

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -990,10 +990,14 @@ class TestCAISO(BaseTestISO):
             assert df.columns.tolist() == [
                 "Interval Start",
                 "Interval End",
+                "Publish Time",
                 "Location",
                 "Solar",
                 "Wind",
             ]
+            assert (
+                (df["Interval Start"] - df["Publish Time"]) == pd.Timedelta(minutes=90)
+            ).all()
 
     @pytest.mark.parametrize(
         "date, end",
@@ -1013,6 +1017,7 @@ class TestCAISO(BaseTestISO):
             assert df.columns.tolist() == [
                 "Interval Start",
                 "Interval End",
+                "Publish Time",
                 "Location",
                 "Solar",
                 "Wind",
@@ -1025,6 +1030,9 @@ class TestCAISO(BaseTestISO):
                 end,
                 tz=self.iso.default_timezone,
             )
+            assert (
+                (df["Interval Start"] - df["Publish Time"]) == pd.Timedelta(minutes=90)
+            ).all()
 
     def test_get_tie_flows_real_time_15_min_latest(self):
         with caiso_vcr.use_cassette("test_get_tie_flows_real_time_15_min_latest.yaml"):


### PR DESCRIPTION
## Summary
Adds the `hasp_renewable_forecast` and `tie_flows_real_time_15_min` datasets for CAISO

```
from gridstatus import CAISO
caiso = CAISO()

df = caiso.get_hasp_renewable_forecast_hourly("2025-03-20")
print(df)

df = caiso.get_tie_flows_real_time_15_min("2025-03-20")
print(df)
```

### Details
There is already a real time tie flows dataset called `Real Time`, which is actually the `5 Minute Real Time` version of this 15 Min tie flow dataset. It has the same data model and was straightforward to add.

The renewables forecast data is technically a day ahead, hourly forecast. The market operator does not provide a publish time timestamp. We can try to add one if we want. The description from CAISO is that it is published each day for the next day before the market clearing results are published. 
![CleanShot 2025-03-24 at 11 45 04@2x](https://github.com/user-attachments/assets/a6ae968c-68a4-4c25-b556-28195a167fd7)

