### PR TITLE
feat(ENG 1433): MISO Load Zonal Hourly

### DIFF
--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -164,11 +164,67 @@ class MISO(ISOBase):
         if date == "latest":
             return self.get_load_forecast(date="today", verbose=verbose)
 
+        df = self._get_load_forecast_file(date)
+        df = df.loc[
+            df["Interval Start"] >= date,
+            [col for col in df if "ActualLoad" not in col],
+        ]
+
+        return df.sort_values("Interval Start").reset_index(drop=True)
+
+    @support_date_range(frequency="DAY_START")
+    def get_load_zonal_hourly(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """
+        https://docs.misoenergy.org/marketreports/YYYYMMDD_df_al.xls
+        """
+        if date == "latest":
+            return self.get_load_zonal_hourly(date="today", verbose=verbose)
+
+        df = self._get_load_forecast_file(date)
+
+        df = df.rename(
+            columns={
+                "LRZ1 ActualLoad": "LRZ1 Load",
+                "LRZ2_7 ActualLoad": "LRZ2 7 Load",
+                "LRZ3_5 ActualLoad": "LRZ3 5 Load",
+                "LRZ4 ActualLoad": "LRZ4 Load",
+                "LRZ6 ActualLoad": "LRZ6 Load",
+                "LRZ8_9_10 ActualLoad": "LRZ8 9 10 Load",
+                "MISO ActualLoad": "MISO Load",
+            },
+        )
+
+        df = utils.move_cols_to_front(
+            df,
+            ["Interval Start", "Interval End", "Publish Time"],
+        ).drop(columns=["Market Day", "HourEnding"])
+
+        df = df.sort_values("Interval Start").reset_index(drop=True)
+        df = df[df["Interval Start"] <= date]
+        return df[
+            [
+                "Interval Start",
+                "Interval End",
+                "Publish Time",
+                "LRZ1 Load",
+                "LRZ2 7 Load",
+                "LRZ3 5 Load",
+                "LRZ4 Load",
+                "LRZ6 Load",
+                "LRZ8 9 10 Load",
+                "MISO Load",
+            ]
+        ]
+
+    def _get_load_forecast_file(self, date: str | pd.Timestamp) -> pd.DataFrame:
         url = f"https://docs.misoenergy.org/marketreports/{date.strftime('%Y%m%d')}_df_al.xls"  # noqa
-
-        logger.info(f"Downloading load forecast data from {url}")
+        logger.info(f"Downloading hourly load and load forecast data from {url}")
         df = pd.read_excel(url, sheet_name="Sheet1", skiprows=4, skipfooter=1)
-
         df = df.dropna(subset=["HourEnding"])
         df = df.loc[df["HourEnding"] != "HourEnding"]
         df.loc[:, "HourEnding"] = df["HourEnding"].astype(int)
@@ -186,19 +242,7 @@ class MISO(ISOBase):
         df["Publish Time"] = date.normalize()
 
         df.columns = df.columns.map(lambda x: x.replace("(MWh)", "").strip())
-
-        df = utils.move_cols_to_front(
-            df,
-            ["Interval Start", "Interval End", "Publish Time"],
-        ).drop(columns=["Market Day", "HourEnding"])
-
-        # Include only forecasts for the current day into the future
-        df = df.loc[
-            df["Interval Start"] >= date,
-            [col for col in df if "ActualLoad" not in col],
-        ]
-
-        return df.sort_values("Interval Start").reset_index(drop=True)
+        return df
 
     def _get_load_data(self, verbose: bool = False) -> dict:
         url = "https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerServices.asmx?messageType=gettotalload&returnType=json"  # noqa

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -216,13 +216,13 @@ class MISO(ISOBase):
             [
                 "Interval Start",
                 "Interval End",
-                "LRZ1 Load",
-                "LRZ2 7 Load",
-                "LRZ3 5 Load",
-                "LRZ4 Load",
-                "LRZ6 Load",
-                "LRZ8 9 10 Load",
-                "MISO Load",
+                "LRZ1",
+                "LRZ2 7",
+                "LRZ3 5",
+                "LRZ4",
+                "LRZ6",
+                "LRZ8 9 10",
+                "MISO",
             ]
         ]
 

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -176,7 +176,7 @@ class MISO(ISOBase):
         return df.sort_values("Interval Start").reset_index(drop=True)
 
     @support_date_range(frequency="DAY_START")
-    def get_load_zonal_hourly(
+    def get_zonal_load_hourly(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | None = None,
@@ -187,7 +187,7 @@ class MISO(ISOBase):
         """
         if date == "latest":
             yesterday = pd.Timestamp.today() - pd.Timedelta(days=1)
-            return self.get_load_zonal_hourly(date=yesterday, verbose=verbose)
+            return self.get_zonal_load_hourly(date=yesterday, verbose=verbose)
 
         # NB: Report available is based on publish time, which is 12am the next day
         date = date + pd.Timedelta(days=1)

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -169,7 +169,10 @@ class MISO(ISOBase):
             df["Interval Start"] >= date,
             [col for col in df if "ActualLoad" not in col],
         ]
-
+        df = utils.move_cols_to_front(
+            df,
+            ["Interval Start", "Interval End", "Publish Time"],
+        ).drop(columns=["Market Day", "HourEnding"])
         return df.sort_values("Interval Start").reset_index(drop=True)
 
     @support_date_range(frequency="DAY_START")

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -195,13 +195,13 @@ class MISO(ISOBase):
 
         df = df.rename(
             columns={
-                "LRZ1 ActualLoad": "LRZ1 Load",
-                "LRZ2_7 ActualLoad": "LRZ2 7 Load",
-                "LRZ3_5 ActualLoad": "LRZ3 5 Load",
-                "LRZ4 ActualLoad": "LRZ4 Load",
-                "LRZ6 ActualLoad": "LRZ6 Load",
-                "LRZ8_9_10 ActualLoad": "LRZ8 9 10 Load",
-                "MISO ActualLoad": "MISO Load",
+                "LRZ1 ActualLoad": "LRZ1",
+                "LRZ2_7 ActualLoad": "LRZ2 7",
+                "LRZ3_5 ActualLoad": "LRZ3 5",
+                "LRZ4 ActualLoad": "LRZ4",
+                "LRZ6 ActualLoad": "LRZ6",
+                "LRZ8_9_10 ActualLoad": "LRZ8 9 10",
+                "MISO ActualLoad": "MISO",
             },
         )
 

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -207,7 +207,7 @@ class MISO(ISOBase):
 
         df = utils.move_cols_to_front(
             df,
-            ["Interval Start", "Interval End", "Publish Time"],
+            ["Interval Start", "Interval End"],
         ).drop(columns=["Market Day", "HourEnding"])
 
         df = df.sort_values("Interval Start").reset_index(drop=True)
@@ -216,7 +216,6 @@ class MISO(ISOBase):
             [
                 "Interval Start",
                 "Interval End",
-                "Publish Time",
                 "LRZ1 Load",
                 "LRZ2 7 Load",
                 "LRZ3 5 Load",

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -183,8 +183,11 @@ class MISO(ISOBase):
         https://docs.misoenergy.org/marketreports/YYYYMMDD_df_al.xls
         """
         if date == "latest":
-            return self.get_load_zonal_hourly(date="today", verbose=verbose)
+            yesterday = pd.Timestamp.today() - pd.Timedelta(days=1)
+            return self.get_load_zonal_hourly(date=yesterday, verbose=verbose)
 
+        # NB: Report available is based on publish time, which is 12am the next day
+        date = date + pd.Timedelta(days=1)
         df = self._get_load_forecast_file(date)
 
         df = df.rename(
@@ -205,7 +208,7 @@ class MISO(ISOBase):
         ).drop(columns=["Market Day", "HourEnding"])
 
         df = df.sort_values("Interval Start").reset_index(drop=True)
-        df = df[df["Interval Start"] <= date]
+        df = df.dropna()
         return df[
             [
                 "Interval Start",

--- a/gridstatus/tests/source_specific/test_miso.py
+++ b/gridstatus/tests/source_specific/test_miso.py
@@ -925,14 +925,13 @@ class TestMISO(BaseTestISO):
         assert df.columns.tolist() == [
             "Interval Start",
             "Interval End",
-            "Publish Time",
-            "LRZ1 Load",
-            "LRZ2 7 Load",
-            "LRZ3 5 Load",
-            "LRZ4 Load",
-            "LRZ6 Load",
-            "LRZ8 9 10 Load",
-            "MISO Load",
+            "LRZ1",
+            "LRZ2 7",
+            "LRZ3 5",
+            "LRZ4",
+            "LRZ6",
+            "LRZ8 9 10",
+            "MISO",
         ]
 
         assert (df["Interval End"] - df["Interval Start"]).unique() == pd.Timedelta(
@@ -946,7 +945,6 @@ class TestMISO(BaseTestISO):
             self._check_load_zonal_hourly(df)
 
             expected_start_date = self.local_start_of_today() - pd.DateOffset(days=1)
-            assert df["Publish Time"].unique() == self.local_start_of_today()
             assert df["Interval Start"].min() == expected_start_date
             assert df["Interval End"].max() == expected_start_date + pd.DateOffset(
                 days=1,

--- a/gridstatus/tests/source_specific/test_miso.py
+++ b/gridstatus/tests/source_specific/test_miso.py
@@ -919,9 +919,9 @@ class TestMISO(BaseTestISO):
             ]
             assert min(df["Interval Start"]).date() == pd.Timestamp(date).date()
 
-    """get_load_zonal_hourly"""
+    """get_zonal_load_hourly"""
 
-    def _check_load_zonal_hourly(self, df):
+    def _check_zonal_load_hourly(self, df):
         assert df.columns.tolist() == [
             "Interval Start",
             "Interval End",
@@ -938,11 +938,11 @@ class TestMISO(BaseTestISO):
             "1h",
         )
 
-    def test_get_load_zonal_hourly_latest(self):
-        cassette_name = "test_get_load_zonal_hourly_latest.yaml"
+    def test_get_zonal_load_hourly_latest(self):
+        cassette_name = "test_get_zonal_load_hourly_latest.yaml"
         with miso_vcr.use_cassette(cassette_name):
-            df = self.iso.get_load_zonal_hourly("latest")
-            self._check_load_zonal_hourly(df)
+            df = self.iso.get_zonal_load_hourly("latest")
+            self._check_zonal_load_hourly(df)
 
             expected_start_date = self.local_start_of_today() - pd.DateOffset(days=1)
             assert df["Interval Start"].min() == expected_start_date
@@ -954,15 +954,15 @@ class TestMISO(BaseTestISO):
         "date,end",
         test_dates,
     )
-    def test_get_load_zonal_hourly_historical_date_range(self, date, end):
-        cassette_name = f"test_get_load_zonal_hourly_historical_date_range_{pd.Timestamp(date).strftime('%Y-%m-%d')}_{pd.Timestamp(end).strftime('%Y-%m-%d')}.yaml"
+    def test_get_zonal_load_hourly_historical_date_range(self, date, end):
+        cassette_name = f"test_get_zonal_load_hourly_historical_date_range_{pd.Timestamp(date).strftime('%Y-%m-%d')}_{pd.Timestamp(end).strftime('%Y-%m-%d')}.yaml"
         with miso_vcr.use_cassette(cassette_name):
-            df = self.iso.get_load_zonal_hourly(
+            df = self.iso.get_zonal_load_hourly(
                 start=date,
                 end=end,
             )
 
-            self._check_load_zonal_hourly(df)
+            self._check_zonal_load_hourly(df)
 
             assert df["Interval Start"].min() == self.local_start_of_day(date)
             assert df["Interval End"].max() == self.local_start_of_day(


### PR DESCRIPTION
## Summary
Adds the `miso_load_zonal_hourly` dataset. Consolidates some code between the `load_forecast` method as well, since it is the same file.

### Details
Column names are from the dataset spec. 