### PR TITLE
PJM Round before Pivot

### DIFF
--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -536,15 +536,7 @@ class PJM(ISOBase):
             verbose=verbose,
         )
 
-        # pivot on area
-        load = load.pivot_table(
-            index=["Time", "Interval Start"],
-            columns="area",
-            values="instantaneous_load",
-            aggfunc="first",
-        ).reset_index()
-
-        # round to nearest minute
+        # round to nearest minute before the pivot
         # need to round in utc time
         load["Interval Start"] = (
             load["Interval Start"]
@@ -553,6 +545,14 @@ class PJM(ISOBase):
             .dt.tz_convert(self.default_timezone)
         )
         load["Time"] = load["Interval Start"]
+
+        # pivot on area
+        load = load.pivot_table(
+            index=["Time", "Interval Start"],
+            columns="area",
+            values="instantaneous_load",
+            aggfunc="first",
+        ).reset_index()
 
         load["Interval End"] = load["Interval Start"] + pd.Timedelta(minutes=5)
 


### PR DESCRIPTION
## Summary


- In `PJM().get_load`, round before doing the pivot to avoid creating duplicate rows

### Details
