### PR TITLE
feat(ENG 1045): IESO Resource Adequacy Retry Logic

### DIFF
--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -1318,6 +1318,9 @@ class IESO(ISOBase):
             )
 
         json_data_with_times = []
+        max_retries = 3
+        retry_delay = 2
+
         with ThreadPoolExecutor(max_workers=min(10, len(filtered_files))) as executor:
             future_to_file = {
                 executor.submit(self._fetch_and_parse_file, base_url, file): (
@@ -1329,13 +1332,30 @@ class IESO(ISOBase):
 
             for future in as_completed(future_to_file):
                 file, time = future_to_file[future]
-                try:
-                    json_data = future.result()
-                    json_data_with_times.append(
-                        (json_data, pd.Timestamp(time, tz=self.default_timezone)),
-                    )
-                except Exception as e:
-                    logger.error(f"Error processing file {file}: {str(e)}")
+                retries = 0
+                while retries < max_retries:
+                    try:
+                        logger.info(f"Processing file {file}...")
+                        json_data = future.result()
+                        json_data_with_times.append(
+                            (json_data, pd.Timestamp(time, tz=self.default_timezone)),
+                        )
+                        break
+                    except requests.exceptions.ConnectionError as e:
+                        retries += 1
+                        if retries == max_retries:
+                            logger.error(f"Error processing file {file}: {str(e)}")
+                            break
+                        logger.warning(
+                            f"Connection error processing file {file}: {str(e)}. Retrying in {retry_delay} seconds...",
+                        )
+                        time.sleep(retry_delay)
+                        retry_delay *= 2
+                    except Exception as e:
+                        logger.error(
+                            f"Unexpected error processing file {file}: {str(e)}",
+                        )
+                        break
 
         return json_data_with_times
 
@@ -1355,6 +1375,7 @@ class IESO(ISOBase):
                 data = data[key]
             return data
 
+        logger.debug("Parsing resource adequacy report file json...")
         for section_name, section_data in data_map.items():
             if "hourly" in section_data:
                 for metric_name, config in section_data["hourly"].items():

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -1,4 +1,5 @@
 import datetime
+import http.client
 import os
 import re
 import time
@@ -1341,13 +1342,15 @@ class IESO(ISOBase):
                             (json_data, pd.Timestamp(time, tz=self.default_timezone)),
                         )
                         break
-                    except requests.exceptions.ConnectionError as e:
+                    except http.client.RemoteDisconnected as e:
                         retries += 1
                         if retries == max_retries:
-                            logger.error(f"Error processing file {file}: {str(e)}")
+                            logger.error(
+                                f"Remote connection closed for file {file}: {str(e)}",
+                            )
                             break
                         logger.warning(
-                            f"Connection error processing file {file}: {str(e)}. Retrying in {retry_delay} seconds...",
+                            f"Remote connection closed for file {file}: {str(e)}. Retrying in {retry_delay} seconds...",
                         )
                         time.sleep(retry_delay)
                         retry_delay *= 2


### PR DESCRIPTION
## Summary
This adds some retry logic to the `get_resource_adequacy_report`, namely the underlying `_get_all_resource_adequacy_jsons()` method.

### Details
The error seems to be due to either a connection sensitivity on lots of requests, since we are multithreading the report pull in `vintage="all"` mode and it can pull a few dozen reports in rapid fashion, or a timing issue that the report title and link is posted by the ISO but there is no underlying report to grab (yet). It usually fails on only one file, and often the last file of the found set, so this retry logic should handle both cases moderately well without being too aggressive. Can adjust as needed. I believe I got the specific error type but I catch all and we can adjust that too, if needed. 