### PR TITLE
Use params for caiso load forecast

### DIFF
--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -565,11 +565,9 @@ class CAISO(ISOBase):
             raw_data=False,
             verbose=verbose,
             sleep=sleep,
-            params={"market_run_id": "RTM"},
+            params={"market_run_id": "RTM", "execution_type": "RTD"},
         )
-        df = df[
-            ((df["Interval End"] - df["Interval Start"]).dt.total_seconds() / 60) == 5
-        ]
+
         df = df.rename(
             columns={"MW": "Load Forecast", "TAC_AREA_NAME": "TAC Area Name"},
         )
@@ -618,11 +616,8 @@ class CAISO(ISOBase):
             raw_data=False,
             verbose=verbose,
             sleep=sleep,
-            params={"market_run_id": "RTM"},
+            params={"market_run_id": "RTM", "execution_type": "RTPD"},
         )
-        df = df[
-            ((df["Interval End"] - df["Interval Start"]).dt.total_seconds() / 60) == 15
-        ]
         df = df.rename(
             columns={"MW": "Load Forecast", "TAC_AREA_NAME": "TAC Area Name"},
         )
@@ -1318,9 +1313,7 @@ class CAISO(ISOBase):
     def get_fuel_regions(self, verbose: bool = False) -> pd.DataFrame:
         """Retrieves the (mostly static) list of fuel regions with associated data.
         This file can be joined to the gas prices on Fuel Region Id"""
-        url = (
-            "https://www.caiso.com/documents/fuelregion_electricregiondefinitions.xlsx"  # noqa
-        )
+        url = "https://www.caiso.com/documents/fuelregion_electricregiondefinitions.xlsx"  # noqa
 
         logger.info(f"Fetching {url}")
 

--- a/gridstatus/caiso/caiso_constants.py
+++ b/gridstatus/caiso/caiso_constants.py
@@ -231,6 +231,7 @@ OASIS_DATASET_CONFIG = {
         },
         "params": {
             "market_run_id": ["7DA", "2DA", "DAM", "ACTUAL", "RTM"],
+            "execution_type": [None, "RTPD", "RTD"],
         },
     },
     "as_results": {


### PR DESCRIPTION
I was looking at oasis and noticed we can use API parameters rather than filtering in python code, which feels a lot cleaner

## Testing

```python
In [1]: import gridstatus
In [2]: iso = gridstatus.CAISO()
In [3]: df_5_min = iso.get_load_forecast_5_min("today")
In [4]: df_15_min = iso.get_load_forecast_15_min("today")
In [5]: (df_5_min["Interval End"] - df_5_min["Interval Start"]).unique()
Out[5]: 
<TimedeltaArray>
['0 days 00:05:00']
Length: 1, dtype: timedelta64[ns]

In [6]: (df_15_min["Interval End"] - df_15_min["Interval Start"]).unique()
Out[6]: 
<TimedeltaArray>
['0 days 00:15:00']
Length: 1, dtype: timedelta64[ns]
```