### PR TITLE
feat(ENG 984): IESO Forecast Surplus Baseload

### DIFF
--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -2171,7 +2171,9 @@ class IESO(ISOBase):
                 else:
                     surplus_state = SurplusState.NO_SURPLUS.value
 
-                interval_start = date_forecast + pd.Timedelta(hours=hour - 1)
+                interval_start = (
+                    date_forecast + pd.Timedelta(hours=hour - 1)
+                ).tz_localize(self.default_timezone)
                 interval_end = interval_start + pd.Timedelta(hours=1)
 
                 data.append(

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -5,6 +5,7 @@ import re
 import time
 import xml.etree.ElementTree as ET
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from enum import Enum
 from typing import Literal
 from urllib.error import HTTPError
 
@@ -104,6 +105,22 @@ IESO_ZONE_MAPPING = {
     "PQQC": "Quebec Q4C",
     "PQXY": "Quebec X2Y",
 }
+
+
+class SurplusState(str, Enum):
+    """Enum for surplus baseload generation states.
+
+    The state is determined by the Action field in the report:
+    - No Action (empty/null) -> No Surplus (white)
+    - Other -> Managed with exports/curtailments/VG dispatch (green)
+    - Manoeuvre -> Potential to dispatch nuclear units (yellow)
+    - Shutdown -> Potential to shutdown nuclear units (red)
+    """
+
+    NO_SURPLUS = "No Surplus"
+    MANAGED_WITH_EXPORTS = "Managed with Exports"
+    NUCLEAR_DISPATCH = "Nuclear Dispatch"
+    NUCLEAR_SHUTDOWN = "Nuclear Shutdown"
 
 
 class IESO(ISOBase):
@@ -2079,3 +2096,104 @@ class IESO(ISOBase):
             if hour not in hours_with_values:
                 row = next(r for r in report_data if r["DeliveryHour"] == hour)
                 row[column_name] = None
+
+    @support_date_range(frequency="DAY_START")
+    def get_forecast_surplus_baseload(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Get the forecast surplus baseload for a given date.
+
+        Args:
+            date: Date to get the forecast surplus baseload for
+            end: End date for range
+            verbose: Whether to print verbose output
+
+        Returns:
+            pd.DataFrame: DataFrame containing the forecast surplus baseload data with columns:
+                - Interval Start: Start time of the interval
+                - Interval End: End time of the interval
+                - Publish Time: When the forecast was published
+                - Surplus Baseload MW: Amount of surplus baseload generation
+                - Surplus State: State of surplus (No Surplus, Managed with Exports, Nuclear Dispatch, Nuclear Shutdown)
+                - Action: Raw action field from the report
+                - Export Forecast MW: Forecasted exports
+                - Minimum Generation Status: Status of minimum generation
+        """
+        if date == "latest":
+            return self.get_forecast_surplus_baseload("today", verbose)
+
+        if isinstance(date, tuple):
+            date_str = pd.Timestamp(date[0]).strftime("%Y%m%d")
+        else:
+            date_str = pd.Timestamp(date).strftime("%Y%m%d")
+
+        url = f"https://www.ieso.ca/-/media/Files/IESO/uploaded/sbg/PUB_SurplusBaseloadGen_{date_str}_v1"
+        r = self._request(url)
+        json_data = xmltodict.parse(r.text)
+
+        publish_time = pd.Timestamp(
+            json_data["Document"]["DocHeader"]["CreatedAt"],
+            tz=self.default_timezone,
+        )
+
+        data = []
+        for daily_forecast in json_data["Document"]["DocBody"]["DailyForecast"]:
+            date_forecast = pd.Timestamp(daily_forecast["DateForecast"])
+            export_forecast = float(daily_forecast["ExportForecast"])
+            min_gen_status = daily_forecast["MinGenerationStatus"]
+
+            for hourly_forecast in daily_forecast["HourlyForecast"]:
+                hour = int(hourly_forecast["Hour"])
+                energy_mw = (
+                    float(hourly_forecast["EnergyMW"])
+                    if hourly_forecast["EnergyMW"]
+                    else None
+                )
+                action = hourly_forecast.get("Action")
+
+                if not energy_mw or energy_mw == 0:
+                    surplus_state = SurplusState.NO_SURPLUS.value
+                elif action == "Manoeuvre":
+                    surplus_state = SurplusState.NUCLEAR_DISPATCH.value
+                elif action == "Shutdown":
+                    surplus_state = SurplusState.NUCLEAR_SHUTDOWN.value
+                elif action == "Other":
+                    surplus_state = SurplusState.MANAGED_WITH_EXPORTS.value
+                else:
+                    surplus_state = SurplusState.NO_SURPLUS.value
+
+                interval_start = date_forecast + pd.Timedelta(hours=hour - 1)
+                interval_end = interval_start + pd.Timedelta(hours=1)
+
+                data.append(
+                    {
+                        "Interval Start": interval_start,
+                        "Interval End": interval_end,
+                        "Publish Time": publish_time,
+                        "Surplus Baseload MW": energy_mw,
+                        "Surplus State": surplus_state,
+                        "Action": action,
+                        "Export Forecast MW": export_forecast,
+                        "Minimum Generation Status": min_gen_status,
+                    },
+                )
+
+        df = pd.DataFrame(data)
+        df = utils.move_cols_to_front(
+            df,
+            [
+                "Interval Start",
+                "Interval End",
+                "Publish Time",
+                "Surplus Baseload MW",
+                "Surplus State",
+                "Action",
+                "Export Forecast MW",
+                "Minimum Generation Status",
+            ],
+        )
+
+        return df.sort_values("Interval Start")

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -2097,8 +2097,8 @@ class IESO(ISOBase):
                 row = next(r for r in report_data if r["DeliveryHour"] == hour)
                 row[column_name] = None
 
-    @support_date_range(frequency="DAY")
-    def get_forecast_surplus_baseload(
+    @support_date_range(frequency="DAY_START")
+    def get_forecast_surplus_baseload_generation(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
@@ -2126,7 +2126,7 @@ class IESO(ISOBase):
             yesterday = pd.Timestamp.now(
                 tz=self.default_timezone,
             ).normalize() - pd.Timedelta(days=1)
-            return self.get_forecast_surplus_baseload(yesterday)
+            return self.get_forecast_surplus_baseload_generation(yesterday)
 
         if isinstance(date, tuple):
             publish_date_str = pd.Timestamp(date[0]).strftime("%Y%m%d")

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -2188,8 +2188,10 @@ class IESO(ISOBase):
                 )
 
         df = pd.DataFrame(data)
-        df = utils.move_cols_to_front(
-            df,
+        df.sort_values("Interval Start", inplace=True)
+        df.reset_index(drop=True, inplace=True)
+
+        return df[
             [
                 "Interval Start",
                 "Interval End",
@@ -2199,7 +2201,5 @@ class IESO(ISOBase):
                 "Action",
                 "Export Forecast MW",
                 "Minimum Generation Status",
-            ],
-        )
-
-        return df.sort_values("Interval Start")
+            ]
+        ]

--- a/gridstatus/tests/source_specific/test_ieso.py
+++ b/gridstatus/tests/source_specific/test_ieso.py
@@ -961,3 +961,91 @@ class TestIESO(BaseTestISO):
         assert report_data[0]["Test Capacity"] == 100.0
         assert report_data[1]["DeliveryHour"] == 2
         assert report_data[1]["Test Capacity"] == 200.0
+
+    """get_forecast_surplus_baseload"""
+
+    def test_get_forecast_surplus_baseload_single_date(self):
+        today = pd.Timestamp.now(tz=self.default_timezone).normalize()
+        yesterday = today - pd.Timedelta(days=1)
+        with file_vcr.use_cassette(
+            "test_get_forecast_surplus_baseload_single_date.yaml",
+        ):
+            df = self.iso.get_forecast_surplus_baseload(yesterday)
+
+        assert isinstance(df, pd.DataFrame)
+        self._check_forecast_surplus_baseload(df)
+
+        assert df["Interval Start"].min().date() == today.date()
+        assert df["Interval End"].max().date() == today.date() + pd.Timedelta(days=10)
+
+    def test_get_forecast_surplus_baseload_date_range(self):
+        today = pd.Timestamp.now(tz=self.default_timezone).normalize()
+        start = today - pd.Timedelta(days=3)
+        end = today
+        with file_vcr.use_cassette(
+            "test_get_forecast_surplus_baseload_date_range.yaml",
+        ):
+            df = self.iso.get_forecast_surplus_baseload(start, end=end)
+
+        assert isinstance(df, pd.DataFrame)
+        self._check_forecast_surplus_baseload(df)
+
+        assert df["Interval Start"].min().date() == start.date() + pd.Timedelta(days=1)
+        assert df["Interval End"].max().date() == end.date() + pd.Timedelta(days=10)
+
+    def test_get_forecast_surplus_baseload_latest(self):
+        with file_vcr.use_cassette("test_get_forecast_surplus_baseload_latest.yaml"):
+            df = self.iso.get_forecast_surplus_baseload("latest")
+
+        assert isinstance(df, pd.DataFrame)
+        self._check_forecast_surplus_baseload(df)
+
+    def _check_forecast_surplus_baseload(self, df: pd.DataFrame) -> None:
+        required_columns = [
+            "Interval Start",
+            "Interval End",
+            "Publish Time",
+            "Surplus Baseload MW",
+            "Surplus State",
+            "Action",
+            "Export Forecast MW",
+            "Minimum Generation Status",
+        ]
+        assert all(col in df.columns for col in required_columns)
+
+        assert self._check_is_datetime_type(df["Interval Start"])
+        assert self._check_is_datetime_type(df["Interval End"])
+        assert self._check_is_datetime_type(df["Publish Time"])
+
+        assert (
+            df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
+        ).all()
+
+        assert (
+            df["Surplus State"]
+            .isin(
+                [
+                    "No Surplus",
+                    "Managed with Exports",
+                    "Nuclear Dispatch",
+                    "Nuclear Shutdown",
+                ],
+            )
+            .all()
+        )
+
+        assert df["Action"].isin(["Other", "Manoeuvre", "Shutdown", None]).all()
+
+        assert is_numeric_dtype(df["Surplus Baseload MW"])
+        assert is_numeric_dtype(df["Export Forecast MW"])
+
+        assert df["Publish Time"].nunique() == len(
+            pd.date_range(
+                df["Publish Time"].min().date(),
+                df["Publish Time"].max().date(),
+                freq="D",
+            ),
+        )
+        assert df["Publish Time"].iloc[0].date() == df[
+            "Interval Start"
+        ].min().date() - pd.Timedelta(days=1)

--- a/gridstatus/tests/source_specific/test_ieso.py
+++ b/gridstatus/tests/source_specific/test_ieso.py
@@ -964,13 +964,13 @@ class TestIESO(BaseTestISO):
 
     """get_forecast_surplus_baseload"""
 
-    def test_get_forecast_surplus_baseload_single_date(self):
+    def test_get_forecast_surplus_baseload_generation_single_date(self):
         today = pd.Timestamp.now(tz=self.default_timezone).normalize()
         yesterday = today - pd.Timedelta(days=1)
         with file_vcr.use_cassette(
-            "test_get_forecast_surplus_baseload_single_date.yaml",
+            f"test_get_forecast_surplus_baseload_generation_{yesterday.strftime('%Y-%m-%d')}.yaml",
         ):
-            df = self.iso.get_forecast_surplus_baseload(yesterday)
+            df = self.iso.get_forecast_surplus_baseload_generation(yesterday)
 
         assert isinstance(df, pd.DataFrame)
         self._check_forecast_surplus_baseload(df)
@@ -978,14 +978,14 @@ class TestIESO(BaseTestISO):
         assert df["Interval Start"].min().date() == today.date()
         assert df["Interval End"].max().date() == today.date() + pd.Timedelta(days=10)
 
-    def test_get_forecast_surplus_baseload_date_range(self):
+    def test_get_forecast_surplus_baseload_generation_date_range(self):
         today = pd.Timestamp.now(tz=self.default_timezone).normalize()
         start = today - pd.Timedelta(days=3)
         end = today
         with file_vcr.use_cassette(
-            "test_get_forecast_surplus_baseload_date_range.yaml",
+            f"test_get_forecast_surplus_baseload_generation_{start.strftime('%Y-%m-%d')}_{end.strftime('%Y-%m-%d')}.yaml",
         ):
-            df = self.iso.get_forecast_surplus_baseload(start, end=end)
+            df = self.iso.get_forecast_surplus_baseload_generation(start, end=end)
 
         assert isinstance(df, pd.DataFrame)
         self._check_forecast_surplus_baseload(df)
@@ -993,9 +993,11 @@ class TestIESO(BaseTestISO):
         assert df["Interval Start"].min().date() == start.date() + pd.Timedelta(days=1)
         assert df["Interval End"].max().date() == end.date() + pd.Timedelta(days=10)
 
-    def test_get_forecast_surplus_baseload_latest(self):
-        with file_vcr.use_cassette("test_get_forecast_surplus_baseload_latest.yaml"):
-            df = self.iso.get_forecast_surplus_baseload("latest")
+    def test_get_forecast_surplus_baseload_generation_latest(self):
+        with file_vcr.use_cassette(
+            "test_get_forecast_surplus_baseload_generation_latest.yaml",
+        ):
+            df = self.iso.get_forecast_surplus_baseload_generation("latest")
 
         assert isinstance(df, pd.DataFrame)
         self._check_forecast_surplus_baseload(df)

--- a/gridstatus/tests/source_specific/test_ieso.py
+++ b/gridstatus/tests/source_specific/test_ieso.py
@@ -1041,7 +1041,8 @@ class TestIESO(BaseTestISO):
         assert is_numeric_dtype(df["Surplus Baseload MW"])
         assert is_numeric_dtype(df["Export Forecast MW"])
 
-        assert df["Publish Time"].nunique() == len(
+        publish_days = df["Publish Time"].nunique()
+        assert publish_days == len(
             pd.date_range(
                 df["Publish Time"].min().date(),
                 df["Publish Time"].max().date(),
@@ -1051,3 +1052,5 @@ class TestIESO(BaseTestISO):
         assert df["Publish Time"].iloc[0].date() == df[
             "Interval Start"
         ].min().date() - pd.Timedelta(days=1)
+        assert len(df) == 24 * 10 * publish_days
+        assert len(df.columns) == 8


### PR DESCRIPTION
## Summary
Adds the `ieso_forecast_surplus_baseload_generation`. 

```
from gridstatus.ieso import IESO
ieso = IESO()
df = ieso.get_forecast_surplus_baseload_generation(date="2025-04-17")
df2 = ieso.get_forecast_surplus_baseload_generation(date="latest")
print(df)
print(df2)
```

## Details
This gets a little funky since the URL is asking for publish time. It's simpler than resource adequacy in that they just publish one report per day and it does not get updated, but If you wanted all the forecasts for a given interval, (say, `2025-04-18 01:00`) you'd have to query the 10 days of preceding reports and filter them. Not the end of the world, but might be a bit unintuitive. 

According to the spec, the columns are up to the developer a bit, so I take a crack at it but could use @cwaldoch 's final opinion on it. 

They are:

```
"Interval Start",
 "Interval End",
 "Publish Time",
 "Surplus Baseload MW",
 "Surplus State",
 "Action",
 "Export Forecast MW",
 "Minimum Generation Status",
```
Example report is here: https://www.ieso.ca/-/media/Files/IESO/uploaded/sbg/PUB_SurplusBaseloadGen_20250417_v1
And I've attached a json version here, which converts the xml to a json [surplus_forecast.json](https://github.com/user-attachments/files/19815216/surplus_forecast.json)

Let me know if there's a different approach I should use. There are probably a fair number of ways to make this work.