### PR TITLE
Reduce Error Logging from CAISO

### DIFF
--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -331,6 +331,7 @@ class CAISO(ISOBase):
         raw_data: bool = False,
         verbose: bool = False,
         sleep: int = 5,
+        max_retries: int = 3,
     ) -> pd.DataFrame | None:
         start, end = _caiso_handle_start_end(start, end)
         config = copy.deepcopy(config)
@@ -346,16 +347,22 @@ class CAISO(ISOBase):
         logger.info(f"Fetching URL: {url}")
 
         retry_num = 0
-        while retry_num < 3:
+        while retry_num < max_retries:
             r = requests.get(url)
 
             if r.status_code == 200:
                 break
 
             retry_num += 1
-            logger.error(f"Failed to get data from CAISO. Error: {r.status_code}")
-            logger.error(f"Retrying {retry_num}...")
+            logger.info(
+                f"Failed to get data from CAISO. Error: {r.status_code}. Retrying...{retry_num} / {max_retries}",
+            )
+
             time.sleep(sleep)
+
+        if r.status_code == 429:
+            logger.warning("CAISO rate limit exceeded..")
+            return None
 
         # this is when no data is available
         if (

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -359,9 +359,10 @@ class CAISO(ISOBase):
             )
 
             time.sleep(sleep)
+            sleep *= retry_num
 
         if r.status_code == 429:
-            logger.warning("CAISO rate limit exceeded..")
+            logger.warning(f"CAISO rate limit exceeded. Tried {retry_num} times.")
             return None
 
         # this is when no data is available


### PR DESCRIPTION
## Summary

- We currently log two errors every single time we are rate limited by CAISO. This is excessive and we don't need to log an error in this situation because we are aware of the problem
- This PR changes the error to an info log and adds a warning if we exceed our retries and are rate limited

### Details
