### PR TITLE
feat(ENG 1548): IESO Zonal Load

### DIFF
--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -2745,7 +2745,7 @@ class IESO(ISOBase):
             df["Date"]
             + pd.to_timedelta(df["Hour"] - 1, unit="h")
             + pd.to_timedelta((df["Interval"] - 1) * 5, unit="m")
-        ).tz_localize(self.default_timezone)
+        ).dt.tz_localize(self.default_timezone)
         df["Interval End"] = df["Interval Start"] + pd.Timedelta(minutes=5)
         df = df.drop(columns=["Date", "Hour", "Interval"])
         df = utils.move_cols_to_front(df, ["Interval Start", "Interval End"])

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -2741,19 +2741,12 @@ class IESO(ISOBase):
         return df
 
     def _parse_daily_zonal_5_min_csv(self, df: pd.DataFrame) -> pd.DataFrame:
-        df = df.copy()
-        df["Date"] = pd.to_datetime(df["Date"], format="%m/%d/%y")
-        df["Hour"] = df["Hour"].astype(int)
-        df["Interval"] = df["Interval"].astype(int)
-        base_time = (
+        df["Interval Start"] = (
             df["Date"]
             + pd.to_timedelta(df["Hour"] - 1, unit="h")
             + pd.to_timedelta((df["Interval"] - 1) * 5, unit="m")
-        )
-        df["Interval Start"] = base_time.dt.tz_localize(self.default_timezone)
+        ).tz_localize(self.default_timezone)
         df["Interval End"] = df["Interval Start"] + pd.Timedelta(minutes=5)
-        drop_cols = ["Date", "Hour", "Interval"]
-        df = df.drop(columns=[col for col in drop_cols if col in df.columns])
-        cols_to_front = ["Interval Start", "Interval End"]
-        df = utils.move_cols_to_front(df, cols_to_front)
+        df = df.drop(columns=["Date", "Hour", "Interval"])
+        df = utils.move_cols_to_front(df, ["Interval Start", "Interval End"])
         return df.reset_index(drop=True)

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -2788,7 +2788,7 @@ class IESO(ISOBase):
                 mask = (df["Interval Start"] >= date) & (df["Interval Start"] < end)
                 df = df[mask]
         return (
-            df[[col for col in ZONAL_LOAD_COLUMNS if col in df.columns]]
+            df[ZONAL_LOAD_COLUMNS]
             .sort_values(["Interval Start"])
             .reset_index(drop=True)
         )

--- a/gridstatus/ieso_constants.py
+++ b/gridstatus/ieso_constants.py
@@ -140,6 +140,24 @@ INTERTIE_ACTUAL_SCHEDULE_FLOW_HOURLY_COLUMNS: list[str] = [
     "PQX2Y Import",
 ]
 
+ZONAL_LOAD_COLUMNS: list[str] = [
+    "Interval Start",
+    "Interval End",
+    "Ontario Demand",
+    "Northwest",
+    "Northeast",
+    "Ottawa",
+    "East",
+    "Toronto",
+    "Essa",
+    "Bruce",
+    "Southwest",
+    "Niagara",
+    "West",
+    "Zones Total",
+    "Diff",
+]
+
 RESOURCE_ADEQUACY_REPORT_DATA_STRUCTURE_MAP = frozendict.frozendict(
     {
         "supply": {

--- a/gridstatus/tests/source_specific/test_ieso.py
+++ b/gridstatus/tests/source_specific/test_ieso.py
@@ -13,6 +13,7 @@ from gridstatus.ieso_constants import (
     MAXIMUM_DAYS_IN_PAST_FOR_LOAD,
     ONTARIO_LOCATION,
     RESOURCE_ADEQUACY_REPORT_DATA_STRUCTURE_MAP,
+    ZONAL_LOAD_COLUMNS,
 )
 from gridstatus.tests.base_test_iso import BaseTestISO
 from gridstatus.tests.vcr_utils import RECORD_MODE, setup_vcr
@@ -1602,11 +1603,13 @@ class TestIESO(BaseTestISO):
 
     """get_load_daily_zonal_5_min"""
 
-    def _check_load_zonal_5_min(self, data: pd.DataFrame) -> None:
+    def _check_load_zonal(self, data: pd.DataFrame, frequency_minutes: int) -> None:
         assert isinstance(data, pd.DataFrame)
         assert data.shape[0] >= 0
+        assert set(data.columns) == set(ZONAL_LOAD_COLUMNS)
         assert (
-            data["Interval End"] - data["Interval Start"] == pd.Timedelta(minutes=5)
+            data["Interval End"] - data["Interval Start"]
+            == pd.Timedelta(minutes=frequency_minutes)
         ).all()
 
         numeric_cols = [
@@ -1618,64 +1621,41 @@ class TestIESO(BaseTestISO):
     def test_get_load_daily_zonal_5_min_latest(self):
         with file_vcr.use_cassette("test_get_load_zonal_5_min_latest.yaml"):
             data = self.iso.get_load_zonal_5_min("latest")
-
-        self._check_load_zonal_5_min(data)
-
-        today = pd.Timestamp.now(tz=self.default_timezone).normalize()
-        assert (data["Interval Start"].dt.date == today.date()).all()
+        self._check_load_zonal(data, 5)
 
     def test_get_load_zonal_5_min_historical_date_range(self):
-        start = pd.Timestamp.now(tz=self.default_timezone).normalize() - pd.DateOffset(
-            days=3,
-        )
-        end = start + pd.DateOffset(days=1)
+        # NB: Data stopped updating here
+        start = pd.Timestamp("2025-04-20", tz=self.default_timezone)
+        end = pd.Timestamp("2025-04-22", tz=self.default_timezone)
 
         with file_vcr.use_cassette(
             f"test_get_load_zonal_5_min_historical_date_range_{start.date()}_{end.date()}.yaml",
         ):
             data = self.iso.get_load_zonal_5_min(start, end=end)
 
-        self._check_load_zonal_5_min(data)
+        self._check_load_zonal(data, 5)
 
         assert data["Interval Start"].min() == start
         assert data["Interval End"].max() == end
 
     """get_load_daily_zonal_hourly"""
 
-    def _check_load_zonal_hourly(self, data: pd.DataFrame) -> None:
-        assert isinstance(data, pd.DataFrame)
-        assert data.shape[0] >= 0
-        assert (
-            data["Interval End"] - data["Interval Start"] == pd.Timedelta(hours=1)
-        ).all()
+    def test_get_load_zonal_hourly_latest(self):
+        with file_vcr.use_cassette("test_get_load_zonal_hourly_latest.yaml"):
+            data = self.iso.get_load_zonal_hourly("latest")
+        self._check_load_zonal(data, 60)
 
-        numeric_cols = [
-            col for col in data.columns if col not in ["Interval Start", "Interval End"]
-        ]
-        for col in numeric_cols:
-            assert is_numeric_dtype(data[col])
-
-    def test_get_load_daily_zonal_hourly_latest(self):
-        with file_vcr.use_cassette("test_get_load_daily_zonal_hourly_latest.yaml"):
-            data = self.iso.get_load_daily_zonal_hourly("latest")
-
-        self._check_load_daily_zonal_hourly(data)
-
-        today = pd.Timestamp.now(tz=self.default_timezone).normalize()
-        assert (data["Interval Start"].dt.date == today.date()).all()
-
-    def test_get_load_daily_zonal_hourly_historical_date_range(self):
-        start = pd.Timestamp.now(tz=self.default_timezone).normalize() - pd.DateOffset(
-            days=3,
-        )
-        end = start + pd.DateOffset(days=1)
+    def test_get_load_zonal_hourly_historical_date_range(self):
+        # NB: Data stopped updating here
+        start = pd.Timestamp("2025-04-20", tz=self.default_timezone)
+        end = pd.Timestamp("2025-04-22", tz=self.default_timezone)
 
         with file_vcr.use_cassette(
-            f"test_get_load_daily_zonal_hourly_historical_date_range_{start.date()}_{end.date()}.yaml",
+            f"test_get_load_zonal_hourly_historical_date_range_{start.date()}_{end.date()}.yaml",
         ):
-            data = self.iso.get_load_daily_zonal_hourly(start, end=end)
+            data = self.iso.get_load_zonal_hourly(start, end=end)
 
-        self._check_load_daily_zonal_hourly(data)
+        self._check_load_zonal(data, 60)
 
         assert data["Interval Start"].min() == start
         assert data["Interval End"].max() == end

--- a/gridstatus/tests/source_specific/test_ieso.py
+++ b/gridstatus/tests/source_specific/test_ieso.py
@@ -1537,7 +1537,7 @@ class TestIESO(BaseTestISO):
         assert data[TIME_COLUMN].min() == start
         assert data[TIME_COLUMN].max() == end - pd.Timedelta(minutes=60)
 
-        """get_transmission_outages_planned"""
+    """get_transmission_outages_planned"""
 
     def _check_transmission_outages_planned(self, data: pd.DataFrame) -> None:
         assert isinstance(data, pd.DataFrame)
@@ -1599,3 +1599,83 @@ class TestIESO(BaseTestISO):
                 subset=[c for c in data.columns if c != "Publish Time"],
             ).any()
         )
+
+    """get_load_daily_zonal_5_min"""
+
+    def _check_load_zonal_5_min(self, data: pd.DataFrame) -> None:
+        assert isinstance(data, pd.DataFrame)
+        assert data.shape[0] >= 0
+        assert (
+            data["Interval End"] - data["Interval Start"] == pd.Timedelta(minutes=5)
+        ).all()
+
+        numeric_cols = [
+            col for col in data.columns if col not in ["Interval Start", "Interval End"]
+        ]
+        for col in numeric_cols:
+            assert is_numeric_dtype(data[col])
+
+    def test_get_load_daily_zonal_5_min_latest(self):
+        with file_vcr.use_cassette("test_get_load_zonal_5_min_latest.yaml"):
+            data = self.iso.get_load_zonal_5_min("latest")
+
+        self._check_load_zonal_5_min(data)
+
+        today = pd.Timestamp.now(tz=self.default_timezone).normalize()
+        assert (data["Interval Start"].dt.date == today.date()).all()
+
+    def test_get_load_zonal_5_min_historical_date_range(self):
+        start = pd.Timestamp.now(tz=self.default_timezone).normalize() - pd.DateOffset(
+            days=3,
+        )
+        end = start + pd.DateOffset(days=1)
+
+        with file_vcr.use_cassette(
+            f"test_get_load_zonal_5_min_historical_date_range_{start.date()}_{end.date()}.yaml",
+        ):
+            data = self.iso.get_load_zonal_5_min(start, end=end)
+
+        self._check_load_zonal_5_min(data)
+
+        assert data["Interval Start"].min() == start
+        assert data["Interval End"].max() == end
+
+    """get_load_daily_zonal_hourly"""
+
+    def _check_load_zonal_hourly(self, data: pd.DataFrame) -> None:
+        assert isinstance(data, pd.DataFrame)
+        assert data.shape[0] >= 0
+        assert (
+            data["Interval End"] - data["Interval Start"] == pd.Timedelta(hours=1)
+        ).all()
+
+        numeric_cols = [
+            col for col in data.columns if col not in ["Interval Start", "Interval End"]
+        ]
+        for col in numeric_cols:
+            assert is_numeric_dtype(data[col])
+
+    def test_get_load_daily_zonal_hourly_latest(self):
+        with file_vcr.use_cassette("test_get_load_daily_zonal_hourly_latest.yaml"):
+            data = self.iso.get_load_daily_zonal_hourly("latest")
+
+        self._check_load_daily_zonal_hourly(data)
+
+        today = pd.Timestamp.now(tz=self.default_timezone).normalize()
+        assert (data["Interval Start"].dt.date == today.date()).all()
+
+    def test_get_load_daily_zonal_hourly_historical_date_range(self):
+        start = pd.Timestamp.now(tz=self.default_timezone).normalize() - pd.DateOffset(
+            days=3,
+        )
+        end = start + pd.DateOffset(days=1)
+
+        with file_vcr.use_cassette(
+            f"test_get_load_daily_zonal_hourly_historical_date_range_{start.date()}_{end.date()}.yaml",
+        ):
+            data = self.iso.get_load_daily_zonal_hourly(start, end=end)
+
+        self._check_load_daily_zonal_hourly(data)
+
+        assert data["Interval Start"].min() == start
+        assert data["Interval End"].max() == end


### PR DESCRIPTION
## Summary
Adds the `ieso_get_load_zonal_hourly` and the `get_load_zonal_5_min` datasets. These are daily published datasets, so we will likely add some more real-time datasets as they become available. 

```
from gridstatus.ieso import IESO
ieso = IESO()

df = ieso.get_load_zonal_hourly(date="latest")
df2 = ieso.get_load_zonal_hourly(date="2025-04-21")
print(df) 
print(df2)

df3 = ieso.get_load_zonal_5_min(date="latest")
df4 = ieso.get_load_zonal_5_min(date="2025-04-21")
print(df3)
print(df4)
```

### Details
I don't grab versioned files since these are actuals. Since the files return the full year of data, I do some filtering down to what is relevant for the query. We could return the whole year. I might also have the `@support_date_range` frequency wrong here. 