### PR TITLE
IESO Price Location Fix

### DIFF
--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -2144,6 +2144,9 @@ class IESO(ISOBase):
             .reset_index(drop=True)
         )
 
+        # Strip out the :HUB from the location
+        df["Location"] = df["Location"].str.replace(":HUB", "")
+
         return df
 
     @support_date_range(frequency="DAY_START")
@@ -2235,6 +2238,9 @@ class IESO(ISOBase):
             .sort_values(["Interval Start", "Location"])
             .reset_index(drop=True)
         )
+
+        # Strip out the :HUB from the location
+        df["Location"] = df["Location"].str.replace(":HUB", "")
 
         return df
 
@@ -2356,6 +2362,9 @@ class IESO(ISOBase):
             .reset_index(drop=True)
         )
 
+        # Strip out the :LMP from the location
+        df["Location"] = df["Location"].str.replace(":LMP", "")
+
         return df
 
     @support_date_range(frequency="DAY_START")
@@ -2471,6 +2480,9 @@ class IESO(ISOBase):
             .sort_values(["Interval Start", "Location"])
             .reset_index(drop=True)
         )
+
+        # Strip out the :LMP from the location
+        df["Location"] = df["Location"].str.replace(":LMP", "")
 
         return df
 

--- a/gridstatus/tests/source_specific/test_ieso.py
+++ b/gridstatus/tests/source_specific/test_ieso.py
@@ -1271,6 +1271,18 @@ class TestIESO(BaseTestISO):
 
         assert data[TIME_COLUMN].is_monotonic_increasing
 
+        assert list(data["Location"].unique()) == [
+            "EAST",
+            "ESSA",
+            "NIAGARA",
+            "NORTHEAST",
+            "NORTHWEST",
+            "OTTAWA",
+            "SOUTHWEST",
+            "TORONTO",
+            "WEST",
+        ]
+
     def test_get_lmp_real_time_5_min_virtual_zonal_latest(self):
         with file_vcr.use_cassette(
             "test_get_lmp_real_time_5_min_virtual_zonal_latest.yaml",
@@ -1374,6 +1386,27 @@ class TestIESO(BaseTestISO):
 
         assert data[TIME_COLUMN].is_monotonic_increasing
 
+        assert list(data["Location"].unique()) == [
+            "EC.MARITIMES_NYSI",
+            "MB.SEVENSISTERS_MBSK",
+            "MB.WHITESHELL_MBSI",
+            "MD.CALVERTCLIFF_MISI",
+            "MD.CALVERTCLIFF_NYSI",
+            "MI.LUDINGTON_MISI",
+            "MN.INTFALLS_MNSI",
+            "NY.ROSETON_NYSI",
+            "PQ.BEAUHARNOIS_PQBE",
+            "PQ.BRYSON_PQXY",
+            "PQ.KIPAWA_PQHZ",
+            "PQ.MACLAREN_PQDA",
+            "PQ.MASSON_PQHA",
+            "PQ.OUTAOUAIS_PQAT",
+            "PQ.PAUGAN_PQPC",
+            "PQ.QUYON_PQQC",
+            "PQ.RAPIDDESISLE_PQDZ",
+            "WC.PRAIRERANGES_MISI",
+        ]
+
     def test_get_lmp_real_time_5_min_intertie_latest(self):
         with file_vcr.use_cassette(
             "test_get_lmp_real_time_5_min_intertie_latest.yaml",
@@ -1470,7 +1503,6 @@ class TestIESO(BaseTestISO):
         ).all()
 
         assert data[TIME_COLUMN].is_monotonic_increasing
-
         assert (data["Location"] == ONTARIO_LOCATION).all()
 
     def test_get_lmp_real_time_5_min_ontario_zonal_latest(self):


### PR DESCRIPTION
## Summary

- Removes the `:HUB` from the "Location" column for the IESO virtual zonal LMP datasets
- Removes the `:LMP` from the "Location" column for the IESO intertie LMP datasets
