### PR TITLE
feat(ENG 1542): Adequacy report update

### DIFF
--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -36,6 +36,7 @@ from gridstatus.ieso_constants import (
     NAMESPACES_FOR_XML,
     ONTARIO_LOCATION,
     PUBLIC_REPORTS_URL_PREFIX,
+    RESOURCE_ADEQUACY_REPORT_BASE_URL,
     RESOURCE_ADEQUACY_REPORT_DATA_STRUCTURE_MAP,
     ZONAL_LOAD_COLUMNS,
     ZONAL_LOAD_FORECAST_TEMPLATE_URL,
@@ -1162,14 +1163,14 @@ class IESO(ISOBase):
         Returns:
             tuple[dict, datetime.datetime]: The Resource Adequacy Report JSON and its last modified time
         """
-        base_url = "https://reports-public.ieso.ca/public/Adequacy2"
+        base_url = RESOURCE_ADEQUACY_REPORT_BASE_URL
 
         if isinstance(date, (datetime.datetime, datetime.date)):
             date_str = date.strftime("%Y%m%d")
         else:
             date_str = date.replace("-", "")
 
-        file_prefix = f"PUB_Adequacy2_{date_str}"
+        file_prefix = f"PUB_Adequacy3_{date_str}"
 
         r = self._request(base_url)
         files = re.findall(f'href="({file_prefix}.*?.xml)"', r.text)
@@ -1245,14 +1246,14 @@ class IESO(ISOBase):
         Returns:
             dict: The Resource Adequacy Report JSON for the given date
         """
-        base_url = "https://reports-public.ieso.ca/public/Adequacy2"
+        base_url = RESOURCE_ADEQUACY_REPORT_BASE_URL
 
         if isinstance(date, (datetime.datetime, datetime.date)):
             date_str = date.strftime("%Y%m%d")
         else:
             date_str = date.replace("-", "")
 
-        file_prefix = f"PUB_Adequacy2_{date_str}"
+        file_prefix = f"PUB_Adequacy3_{date_str}"
 
         r = self._request(base_url)
 

--- a/gridstatus/ieso_constants.py
+++ b/gridstatus/ieso_constants.py
@@ -157,9 +157,8 @@ ZONAL_LOAD_COLUMNS: list[str] = [
     "Diff",
 ]
 
-# TODO(kladar): Update to non-sandbox URL when the new data goes live
 RESOURCE_ADEQUACY_REPORT_BASE_URL: str = (
-    "https://reports-public-sandbox.ieso.ca/public/Adequacy3"
+    "https://reports-public.ieso.ca/public/Adequacy3"
 )
 
 RESOURCE_ADEQUACY_REPORT_DATA_STRUCTURE_MAP = frozendict.frozendict(

--- a/gridstatus/ieso_constants.py
+++ b/gridstatus/ieso_constants.py
@@ -473,6 +473,54 @@ RESOURCE_ADEQUACY_REPORT_DATA_STRUCTURE_MAP = frozendict.frozendict(
                         "path": ["AverageDemand", "Demand"],
                         "value_key": "EnergyMW",
                     },
+                    "Ontario Northeast Peak Demand": {
+                        "path": ["AreaPeakDemand", "NortheastPeakDemand", "Demand"],
+                        "value_key": "PkDemand",
+                    },
+                    "Ontario Southwest Peak Demand": {
+                        "path": ["AreaPeakDemand", "SouthwestPeakDemand", "Demand"],
+                        "value_key": "PkDemand",
+                    },
+                    "Ontario Northwest Peak Demand": {
+                        "path": ["AreaPeakDemand", "NorthwestPeakDemand", "Demand"],
+                        "value_key": "PkDemand",
+                    },
+                    "Ontario Southeast Peak Demand": {
+                        "path": ["AreaPeakDemand", "SoutheastPeakDemand", "Demand"],
+                        "value_key": "PkDemand",
+                    },
+                    "Ontario Northeast Average Demand": {
+                        "path": [
+                            "AreaAverageDemand",
+                            "NortheastAverageDemand",
+                            "Demand",
+                        ],
+                        "value_key": "AvgDemand",
+                    },
+                    "Ontario Southwest Average Demand": {
+                        "path": [
+                            "AreaAverageDemand",
+                            "SouthwestAverageDemand",
+                            "Demand",
+                        ],
+                        "value_key": "AvgDemand",
+                    },
+                    "Ontario Northwest Average Demand": {
+                        "path": [
+                            "AreaAverageDemand",
+                            "NorthwestAverageDemand",
+                            "Demand",
+                        ],
+                        "value_key": "AvgDemand",
+                    },
+                    "Ontario Southeast Average Demand": {
+                        "path": [
+                            "AreaAverageDemand",
+                            "SoutheastAverageDemand",
+                            "Demand",
+                        ],
+                        "value_key": "AvgDemand",
+                    },
                     "Ontario Wind Embedded Forecast": {
                         "path": ["WindEmbedded", "Embedded"],
                         "value_key": "EnergyMW",

--- a/gridstatus/ieso_constants.py
+++ b/gridstatus/ieso_constants.py
@@ -158,6 +158,11 @@ ZONAL_LOAD_COLUMNS: list[str] = [
     "Diff",
 ]
 
+# TODO(kladar): Update to non-sandbox URL when the new data goes live
+RESOURCE_ADEQUACY_REPORT_BASE_URL: str = (
+    "https://reports-public-sandbox.ieso.ca/public/Adequacy3"
+)
+
 RESOURCE_ADEQUACY_REPORT_DATA_STRUCTURE_MAP = frozendict.frozendict(
     {
         "supply": {

--- a/gridstatus/tests/source_specific/test_ieso.py
+++ b/gridstatus/tests/source_specific/test_ieso.py
@@ -674,14 +674,6 @@ class TestIESO(BaseTestISO):
     # NOTE(kladar, 2024-12-11): Tests rolled off, earliest is currently 2024-09-10, 92 days ago
     RESOURCE_ADEQUACY_TEST_DATES = [
         (
-            (pd.Timestamp.now(tz=default_timezone) - pd.Timedelta(days=91)).strftime(
-                "%Y-%m-%d",
-            ),
-            (pd.Timestamp.now(tz=default_timezone) - pd.Timedelta(days=89)).strftime(
-                "%Y-%m-%d",
-            ),
-        ),
-        (
             (pd.Timestamp.now(tz=default_timezone) - pd.Timedelta(days=3)).strftime(
                 "%Y-%m-%d",
             ),
@@ -700,14 +692,6 @@ class TestIESO(BaseTestISO):
                 "%Y-%m-%d",
             ),
             (pd.Timestamp.now(tz=default_timezone) + pd.Timedelta(days=3)).strftime(
-                "%Y-%m-%d",
-            ),
-        ),
-        (
-            (pd.Timestamp.now(tz=default_timezone) + pd.Timedelta(days=31)).strftime(
-                "%Y-%m-%d",
-            ),
-            (pd.Timestamp.now(tz=default_timezone) + pd.Timedelta(days=34)).strftime(
                 "%Y-%m-%d",
             ),
         ),
@@ -794,7 +778,15 @@ class TestIESO(BaseTestISO):
         "Additional Contingency Allowances",
         "Ontario Demand Forecast",
         "Ontario Peak Demand",
+        "Ontario Northeast Peak Demand",
+        "Ontario Southwest Peak Demand",
+        "Ontario Northwest Peak Demand",
+        "Ontario Southeast Peak Demand",
         "Ontario Average Demand",
+        "Ontario Northeast Average Demand",
+        "Ontario Southwest Average Demand",
+        "Ontario Northwest Average Demand",
+        "Ontario Southeast Average Demand",
         "Ontario Wind Embedded Forecast",
         "Ontario Solar Embedded Forecast",
         "Ontario Dispatchable Load Capacity",
@@ -819,7 +811,7 @@ class TestIESO(BaseTestISO):
             df = self.iso.get_resource_adequacy_report(date, vintage="latest")
 
         assert isinstance(df, pd.DataFrame)
-        assert df.shape == (24, 91)  # 24 rows and 91 columns for each file
+        assert df.shape == (24, 99)  # 24 rows and 99 columns for each file
         for col in self.REQUIRED_RESOURCE_ADEQUACY_COLUMNS:
             assert col in df.columns
 
@@ -841,7 +833,7 @@ class TestIESO(BaseTestISO):
             df = self.iso.get_resource_adequacy_report(date, end=end, vintage="latest")
 
         assert isinstance(df, pd.DataFrame)
-        assert df.shape[1] == 91
+        assert df.shape[1] == 99
         for col in self.REQUIRED_RESOURCE_ADEQUACY_COLUMNS:
             assert col in df.columns
         expected_rows = ((pd.Timestamp(end) - pd.Timestamp(date)).days) * 24
@@ -858,7 +850,7 @@ class TestIESO(BaseTestISO):
             df = self.iso.get_resource_adequacy_report(date, end=end, vintage="all")
 
         assert isinstance(df, pd.DataFrame)
-        assert df.shape[1] == 91
+        assert df.shape[1] == 99
         for col in self.REQUIRED_RESOURCE_ADEQUACY_COLUMNS:
             assert col in df.columns
 


### PR DESCRIPTION
## Summary
Dataset is live: https://reports-public.ieso.ca/public/Adequacy3/. This updates the resource adequacy report to the new format and URL. 

### Details
Adds several columns for `Ontario Demand`, which now as Area Peak and Area Average Demand for Northwest, Northeast, Southeast, and Southwest areas. 

This seems to be the only addition of columns. 
- Existing report example: https://reports-public.ieso.ca/public/Adequacy2/PUB_Adequacy2.xml
- New report example: https://reports-public-sandbox.ieso.ca/public/Adequacy3/PUB_Adequacy3_20250511_v1.xml

Other columns appear to be unchanging. 