### PR TITLE
feat(ENG 1549): IESO Renewable forecasts

### DIFF
--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -3069,7 +3069,9 @@ class IESO(ISOBase):
         ]
         df = pd.concat(dfs).reset_index(drop=True)
         df.drop_duplicates(inplace=True)
-        df = df[df["Organization Type"] == "Embedded" & df["Type"] == "Solar"]
+        df = df[
+            (df["Organization Type"] == "Embedded") & (df["Type"] == "Solar")
+        ].reset_index(drop=True)
         df.drop(columns=["Organization Type", "Type"], inplace=True)
         return df
 
@@ -3093,7 +3095,9 @@ class IESO(ISOBase):
         ]
         df = pd.concat(dfs).reset_index(drop=True)
         df.drop_duplicates(inplace=True)
-        df = df[df["Organization Type"] == "Embedded" & df["Type"] == "Wind"]
+        df = df[
+            (df["Organization Type"] == "Embedded") & (df["Type"] == "Wind")
+        ].reset_index(drop=True)
         df.drop(columns=["Organization Type", "Type"], inplace=True)
         return df
 
@@ -3117,7 +3121,9 @@ class IESO(ISOBase):
         ]
         df = pd.concat(dfs).reset_index(drop=True)
         df.drop_duplicates(inplace=True)
-        df = df[df["Organization Type"] == "Market Participant" & df["Type"] == "Solar"]
+        df = df[
+            (df["Organization Type"] == "Market Participant") & (df["Type"] == "Solar")
+        ].reset_index(drop=True)
         df.drop(columns=["Organization Type", "Type"], inplace=True)
         return df
 
@@ -3140,9 +3146,10 @@ class IESO(ISOBase):
             for json_data, last_modified_time in json_data_with_times
         ]
         df = pd.concat(dfs).reset_index(drop=True)
-        df = df[df["Organization Type"] == "Market Participant" & df["Type"] == "Wind"]
+        df = df[
+            (df["Organization Type"] == "Market Participant") & (df["Type"] == "Wind")
+        ].reset_index(drop=True)
         df.drop(columns=["Organization Type", "Type"], inplace=True)
-        df.drop_duplicates(inplace=True)
         return df
 
     def _get_variable_generation_forecast_json(
@@ -3250,6 +3257,8 @@ class IESO(ISOBase):
             org_type = org["OrganizationType"].title()
 
             for fuel_data in org["FuelData"]:
+                fuel_type = fuel_data["FuelType"].title()
+
                 for resource in fuel_data["ResourceData"]:
                     zone = resource["ZoneName"]
                     if zone == "OntarioTotal":
@@ -3282,27 +3291,13 @@ class IESO(ISOBase):
                                     "Publish Time": publish_time,
                                     "Last Modified": last_modified_time,
                                     "Organization Type": org_type,
+                                    "Type": fuel_type,
                                     "Zone": zone,
-                                    "Output MW": output,
+                                    "Generation Forecast": output,
                                 },
                             )
 
         df = pd.DataFrame(data)
-
-        df_wide = df.pivot_table(
-            index=[
-                "Interval Start",
-                "Interval End",
-                "Publish Time",
-                "Last Modified",
-                "Zone",
-            ],
-            columns="Organization Type",
-            values="Output MW",
-        ).reset_index()
-
-        df_wide.columns.name = None
-
-        return df_wide.sort_values(
+        return df.sort_values(
             ["Interval Start", "Publish Time", "Last Modified", "Zone"],
         ).reset_index(drop=True)

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -3050,7 +3050,7 @@ class IESO(ISOBase):
         return data
 
     @support_date_range(frequency="DAY_START")
-    def get_solar_generation_forecast(
+    def get_solar_generation_embedded_forecast(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
@@ -3069,10 +3069,12 @@ class IESO(ISOBase):
         ]
         df = pd.concat(dfs).reset_index(drop=True)
         df.drop_duplicates(inplace=True)
+        df = df[df["Organization Type"] == "Embedded" & df["Type"] == "Solar"]
+        df.drop(columns=["Organization Type", "Type"], inplace=True)
         return df
 
     @support_date_range(frequency="DAY_START")
-    def get_wind_generation_forecast(
+    def get_wind_generation_embedded_forecast(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
@@ -3090,6 +3092,56 @@ class IESO(ISOBase):
             for json_data, last_modified_time in json_data_with_times
         ]
         df = pd.concat(dfs).reset_index(drop=True)
+        df.drop_duplicates(inplace=True)
+        df = df[df["Organization Type"] == "Embedded" & df["Type"] == "Wind"]
+        df.drop(columns=["Organization Type", "Type"], inplace=True)
+        return df
+
+    @support_date_range(frequency="DAY_START")
+    def get_solar_generation_market_participant_forecast(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: pd.Timestamp | None = None,
+        vintage: Literal["latest", "all"] = "latest",
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        json_data_with_times = self._get_variable_generation_forecast_json(
+            date,
+            end,
+            vintage,
+        )
+
+        dfs = [
+            self._parse_variable_generation_forecast(json_data, last_modified_time)
+            for json_data, last_modified_time in json_data_with_times
+        ]
+        df = pd.concat(dfs).reset_index(drop=True)
+        df.drop_duplicates(inplace=True)
+        df = df[df["Organization Type"] == "Market Participant" & df["Type"] == "Solar"]
+        df.drop(columns=["Organization Type", "Type"], inplace=True)
+        return df
+
+    @support_date_range(frequency="DAY_START")
+    def get_wind_generation_market_participant_forecast(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: pd.Timestamp | None = None,
+        vintage: Literal["latest", "all"] = "latest",
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        json_data_with_times = self._get_variable_generation_forecast_json(
+            date,
+            end,
+            vintage,
+        )
+
+        dfs = [
+            self._parse_variable_generation_forecast(json_data, last_modified_time)
+            for json_data, last_modified_time in json_data_with_times
+        ]
+        df = pd.concat(dfs).reset_index(drop=True)
+        df = df[df["Organization Type"] == "Market Participant" & df["Type"] == "Wind"]
+        df.drop(columns=["Organization Type", "Type"], inplace=True)
         df.drop_duplicates(inplace=True)
         return df
 

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -3050,7 +3050,7 @@ class IESO(ISOBase):
         return data
 
     @support_date_range(frequency="DAY_START")
-    def get_solar_generation_embedded_forecast(
+    def get_solar_embedded_forecast(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
@@ -3074,7 +3074,7 @@ class IESO(ISOBase):
         return df
 
     @support_date_range(frequency="DAY_START")
-    def get_wind_generation_embedded_forecast(
+    def get_wind_embedded_forecast(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
@@ -3098,7 +3098,7 @@ class IESO(ISOBase):
         return df
 
     @support_date_range(frequency="DAY_START")
-    def get_solar_generation_market_participant_forecast(
+    def get_solar_market_participant_forecast(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
@@ -3122,7 +3122,7 @@ class IESO(ISOBase):
         return df
 
     @support_date_range(frequency="DAY_START")
-    def get_wind_generation_market_participant_forecast(
+    def get_wind_market_participant_forecast(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -3091,16 +3091,7 @@ class IESO(ISOBase):
         ]
         df = pd.concat(dfs).reset_index(drop=True)
         df.drop_duplicates(inplace=True)
-        return df[
-            [
-                "Interval Start",
-                "Interval End",
-                "Publish Time",
-                "Last Modified",
-                "Column",
-                "Output MW",
-            ]
-        ]
+        return df
 
     def _get_variable_generation_forecast_json(
         self,
@@ -3204,7 +3195,7 @@ class IESO(ISOBase):
         data = []
 
         for org in document_body["OrganizationData"]:
-            org_type = org["OrganizationType"]
+            org_type = org["OrganizationType"].title()
 
             for fuel_data in org["FuelData"]:
                 for resource in fuel_data["ResourceData"]:
@@ -3260,4 +3251,6 @@ class IESO(ISOBase):
 
         df_wide.columns.name = None
 
-        return df_wide.sort_values(["Interval Start", "Zone"]).reset_index(drop=True)
+        return df_wide.sort_values(
+            ["Interval Start", "Publish Time", "Last Modified", "Zone"],
+        ).reset_index(drop=True)

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -3093,7 +3093,7 @@ class IESO(ISOBase):
         )
         base_url = f"{PUBLIC_REPORTS_URL_PREFIX}/VGForecastSummary"
 
-        if isinstance(date, (datetime.datetime, datetime.date)):
+        if isinstance(date, (pd.Timestamp, pd.Timestamp)):
             date_str = date.strftime("%Y%m%d")
         else:
             date_str = date.replace("-", "")
@@ -3191,7 +3191,11 @@ class IESO(ISOBase):
                             forecast["ForecastDate"],
                         ).tz_localize(self.default_timezone)
 
-                        for interval in forecast["ForecastInterval"]:
+                        intervals = forecast["ForecastInterval"]
+                        if not isinstance(intervals, list):
+                            intervals = [intervals]
+
+                        for interval in intervals:
                             hour = int(interval["ForecastHour"])
                             output = float(interval["MWOutput"])
 

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -3099,6 +3099,14 @@ class IESO(ISOBase):
             (df["Organization Type"] == "Embedded") & (df["Type"] == "Wind")
         ].reset_index(drop=True)
         df.drop(columns=["Organization Type", "Type"], inplace=True)
+
+        if end:
+            df = df[
+                (df["Interval Start"] >= date) & (df["Interval Start"] <= end)
+            ].reset_index(drop=True)
+        elif date != "latest":
+            df = df[df["Interval Start"] >= date].reset_index(drop=True)
+
         return df
 
     @support_date_range(frequency="DAY_START")
@@ -3125,6 +3133,14 @@ class IESO(ISOBase):
             (df["Organization Type"] == "Market Participant") & (df["Type"] == "Solar")
         ].reset_index(drop=True)
         df.drop(columns=["Organization Type", "Type"], inplace=True)
+
+        if end:
+            df = df[
+                (df["Interval Start"] >= date) & (df["Interval Start"] <= end)
+            ].reset_index(drop=True)
+        elif date != "latest":
+            df = df[df["Interval Start"] >= date].reset_index(drop=True)
+
         return df
 
     @support_date_range(frequency="DAY_START")
@@ -3150,6 +3166,14 @@ class IESO(ISOBase):
             (df["Organization Type"] == "Market Participant") & (df["Type"] == "Wind")
         ].reset_index(drop=True)
         df.drop(columns=["Organization Type", "Type"], inplace=True)
+
+        if end:
+            df = df[
+                (df["Interval Start"] >= date) & (df["Interval Start"] <= end)
+            ].reset_index(drop=True)
+        elif date != "latest":
+            df = df[df["Interval Start"] >= date].reset_index(drop=True)
+
         return df
 
     def _get_variable_generation_forecast_json(
@@ -3173,13 +3197,15 @@ class IESO(ISOBase):
             f"Getting variable generation forecast for {date} to {end} for {vintage} vintage...",
         )
         base_url = f"{PUBLIC_REPORTS_URL_PREFIX}/VGForecastSummary"
-
-        if isinstance(date, (pd.Timestamp, pd.Timestamp)):
-            date_str = date.strftime("%Y%m%d")
+        if date == "latest":
+            file_prefix = "PUB_VGForecastSummary"
         else:
-            date_str = date.replace("-", "")
+            if isinstance(date, (pd.Timestamp, pd.Timestamp)):
+                date_str = date.strftime("%Y%m%d")
+            else:
+                date_str = date.replace("-", "")
 
-        file_prefix = f"PUB_VGForecastSummary_{date_str}"
+            file_prefix = f"PUB_VGForecastSummary_{date_str}"
 
         r = self._request(base_url)
 

--- a/gridstatus/tests/source_specific/test_ieso.py
+++ b/gridstatus/tests/source_specific/test_ieso.py
@@ -1886,10 +1886,6 @@ class TestIESO(BaseTestISO):
 
         self._check_variable_generation_forecast(df)
 
-        today = pd.Timestamp.now(tz=self.default_timezone).normalize()
-        assert (df["Interval Start"].dt.date == today.date()).all()
-        assert len(df) == 24
-
     def test_get_variable_generation_forecast_historical_date_range(self):
         start = pd.Timestamp.now(tz=self.default_timezone).normalize() - pd.DateOffset(
             days=3,


### PR DESCRIPTION
## Summary
Adds the variable generation datasets: `solar_embedded_forecast`, `solar_market_participant_forecast`, `wind_embedded_forecast`, and `wind_market_participant_forecast` following the data modeling discussion. 

```
df = ieso.get_solar_embedded_forecast("2025-05-01", vintage="all")
df2 = ieso.get_solar_market_participant_forecast("2025-05-01", vintage="all")
df3 = ieso.get_wind_embedded_forecast("2025-05-01", vintage="all")
df4 = ieso.get_wind_market_participant_forecast("2025-05-01", vintage="all")

print(df)
print(df.columns)

print(df2)
print(df2.columns)

print(df3)
print(df3.columns)

print(df4)
print(df4.columns)
```

### Details
[Here's an example report](https://reports-public.ieso.ca/public/VGForecastSummary/PUB_VGForecastSummary_20250501_v15.xml).