### PR TITLE
feat(ENG 1545): IESO Constraint Shadow Prices

### DIFF
--- a/gridstatus/tests/source_specific/test_ieso.py
+++ b/gridstatus/tests/source_specific/test_ieso.py
@@ -1819,3 +1819,42 @@ class TestIESO(BaseTestISO):
 
         assert data["Interval Start"].min() == pd.Timestamp(start_date)
         assert data["Interval End"].max() == pd.Timestamp(end_date)
+
+    def _check_shadow_prices(self, df: pd.DataFrame):
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+        assert set(df.columns) == {
+            "Interval Start",
+            "Interval End",
+            "Publish Time",
+            "Last Modified",
+            "Constraint",
+            "Shadow Price",
+        }
+        assert self._check_is_datetime_type(df["Interval Start"])
+        assert self._check_is_datetime_type(df["Interval End"])
+        assert self._check_is_datetime_type(df["Publish Time"])
+        assert self._check_is_datetime_type(df["Last Modified"])
+        assert df["Shadow Price"].dtype == "float64"
+
+    def test_get_shadow_prices_real_time_5_min_latest(self):
+        with file_vcr.use_cassette(
+            "test_get_shadow_prices_real_time_5_min_latest.yaml",
+        ):
+            df = self.iso.get_shadow_prices_real_time_5_min("latest")
+            self._check_shadow_prices(df)
+            assert df["Interval Start"].is_monotonic_increasing
+
+    @pytest.mark.parametrize(
+        "date, end",
+        [
+            ("2025-04-01", "2025-04-03"),
+        ],
+    )
+    def test_get_shadow_prices_real_time_5_min_historical_range(self, date, end):
+        start = pd.Timestamp(date, tz=self.default_timezone).normalize()
+        end = pd.Timestamp(end, tz=self.default_timezone).normalize()
+        cassette_name = f"test_get_shadow_prices_real_time_5_min_historical_range_{start.date()}_{end.date()}.yaml"
+        with file_vcr.use_cassette(cassette_name):
+            df = self.iso.get_shadow_prices_real_time_5_min(start, end=end)
+            self._check_shadow_prices(df)


### PR DESCRIPTION
## Summary
[DRAFT UNTIL SITE LINK IS LIVE]
Adds the `ieso_shadow_prices_real_time_5_min` dataset. 

```
from gridstatus.ieso import IESO
ieso = IESO()

df = ieso.get_shadow_prices_real_time_5_min(date="latest")
df2 = ieso.get_shadow_prices_real_time_5_min(date="2025-04-02")

print(df)
print(df2)
```

### Details
Currently these are not updating on the `public/` reports site, but they should hit any time now since they are on a 6 day lag. 

Prod: https://reports-public.ieso.ca/public/RealtimeConstrShadowPrices/
Sandbox: https://reports-public-sandbox.ieso.ca/public/RealtimeConstrShadowPrices/

Bit of a heady report since each report contains only one hour of 5 minute data, with the version number being seemingly synonymous with the hour (I don't actually use the version number for anything, but it could be that each hour gets more than one version/each day gets more than 24 versions). It could be that it has a more complex updating regime but we'll have to see how it actually updates once it goes live. This should get us 95% of the way there though. 

The code follows a similar pattern as adequacy report, getting the version files (w/ multiprocessing and retry logic), parsing, etc. For now it repeats that logic, but definitely starting to see a more general pattern that we could apply to some of these types of report getter methods.