### PR TITLE
feat(ENG 1593): PJM Load Forecast 5 Min

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,20 @@ test-unit:
 	uv pip install vcrpy
 	$(PYTEST_CMD) $(UNIT_ONLY)
 
+.PHONY: test-one-off
+test-one-off:
+ifndef market
+	$(error market parameter is required. Usage: make test-one-off market=MARKET test=TEST_NAME)
+endif
+ifndef test
+	$(error test parameter is required. Usage: make test-one-off market=MARKET test=TEST_NAME)
+endif
+ifeq ($(market),ercot)
+	uv run pytest gridstatus/tests/source_specific/test_$(market).py::TestErcot::$(test)
+else
+	uv run pytest gridstatus/tests/source_specific/test_$(market).py::Test$(shell echo $(market) | tr '[:lower:]' '[:upper:]')::$(test)
+endif
+
 .PHONY: installdeps-dev
 installdeps-dev:
 	uv sync

--- a/Makefile
+++ b/Makefile
@@ -68,18 +68,25 @@ test-unit:
 	uv pip install vcrpy
 	$(PYTEST_CMD) $(UNIT_ONLY)
 
+#TODO(kladar): Maybe gridstatus gets a CLI in the future for things like this.
+#NB: This is for running a single test without having to fully specify the
+#    path and the pytest command.
+#    Usage: make test-one-off market=MARKET test=TEST_NAME
+#    Example: make test-one-off market=pjm test=test_get_load_forecast_5_min_latest
 .PHONY: test-one-off
 test-one-off:
+#NB: First two blocks are for error checking.
 ifndef market
 	$(error market parameter is required. Usage: make test-one-off market=MARKET test=TEST_NAME)
 endif
 ifndef test
 	$(error test parameter is required. Usage: make test-one-off market=MARKET test=TEST_NAME)
 endif
+#NB: This puts the market in the right capitalization for the path. Ercot is not ALL CAPS like the other market test classes: TestErcot vs TestCAISO, etc.
 ifeq ($(market),ercot)
-	uv run pytest gridstatus/tests/source_specific/test_$(market).py::TestErcot::$(test)
+	uv run pytest -vvv gridstatus/tests/source_specific/test_$(market).py::TestErcot::$(test)
 else
-	uv run pytest gridstatus/tests/source_specific/test_$(market).py::Test$(shell echo $(market) | tr '[:lower:]' '[:upper:]')::$(test)
+	uv run pytest -vvv gridstatus/tests/source_specific/test_$(market).py::Test$(shell echo $(market) | tr '[:lower:]' '[:upper:]')::$(test)
 endif
 
 .PHONY: installdeps-dev

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -286,7 +286,6 @@ class PJM(ISOBase):
         """
         if date == "latest":
             return self.get_load_forecast_5_min(
-                # pd.Timestamp.now(tz=self.default_timezone).floor("5min"),
                 "today",
                 verbose=verbose,
             )

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -296,7 +296,7 @@ class PJM(ISOBase):
             ),
         }
 
-        filter_timestamp_name = "forecast_datetime_beginning"
+        filter_timestamp_name = "evaluated_at"
 
         data = self._get_pjm_json(
             self.load_forecast_5_min_endpoint_name,

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -62,6 +62,7 @@ class PJM(ISOBase):
 
     load_forecast_endpoint_name = "load_frcstd_7_day"
     load_forecast_historical_endpoint_name = "load_frcstd_hist"
+    load_forecast_5_min_endpoint_name = "very_short_load_frcst"
 
     def __init__(
         self,
@@ -333,6 +334,41 @@ class PJM(ISOBase):
         return data.sort_values(["Interval Start", "Publish Time"]).reset_index(
             drop=True,
         )
+
+    @support_date_range(frequency=None)
+    def get_load_forecast_5_min(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """
+        Load forecast made today extending for six days in 5 minute intervals.
+        """
+        if date == "latest":
+            return self.get_load_forecast_5_min(
+                pd.Timestamp.now(tz=self.default_timezone).floor("5min"),
+                verbose=verbose,
+            )
+
+        params = {
+            "fields": (
+                "evaluated_at_utc,forecast_datetime_beginning_utc,forecast_datetime_ending_utc,forecast_area,forecast_load_mw"
+            ),
+        }
+
+        filter_timestamp_name = "datetime_beginning"
+
+        data = self._get_pjm_json(
+            self.load_forecast_5_min_endpoint_name,
+            start=None,
+            end=end,
+            params=params,
+            verbose=verbose,
+            filter_timestamp_name=filter_timestamp_name,
+        )
+
+        return self._handle_load_forecast(data)
 
     def get_pnode_ids(self) -> pd.DataFrame:
         data = {

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -282,7 +282,7 @@ class PJM(ISOBase):
         verbose: bool = False,
     ) -> pd.DataFrame:
         """
-        Load forecast made today extending for six days in 5 minute intervals.
+        Load forecast made today extending for 2 hours in 5 minute intervals.
         """
         if date == "latest":
             return self.get_load_forecast_5_min(

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -2486,3 +2486,28 @@ class TestPJM(BaseTestISO):
             self._check_lmp_real_time_unverified_hourly(df)
             assert df["Interval Start"].min() >= self.local_start_of_day(past_date)
             assert df["Interval End"].max() <= self.local_start_of_day(past_end_date)
+
+    """get_load_forecast_5_min"""
+
+    def test_get_load_forecast_5_min_latest(self):
+        with pjm_vcr.use_cassette("test_get_load_forecast_5_min_latest.yaml"):
+            df = self.iso.get_load_forecast_5_min("latest")
+            assert isinstance(df, pd.DataFrame)
+            assert not df.empty
+            assert df.columns.tolist() == self.load_forecast_columns
+            assert df["Interval Start"].min() == self.local_start_of_day("today")
+
+    def test_get_load_forecast_5_min_historical_range(self):
+        past_date = self.local_today() - pd.Timedelta(days=29)
+        past_end_date = past_date + pd.Timedelta(days=2)
+        with pjm_vcr.use_cassette(
+            f"test_get_load_forecast_5_min_historical_range_{past_date.strftime('%Y-%m-%d')}_{past_end_date.strftime('%Y-%m-%d')}.yaml",
+        ):
+            df = self.iso.get_load_forecast_5_min(past_date, past_end_date)
+            assert isinstance(df, pd.DataFrame)
+            assert not df.empty
+            assert df.columns.tolist() == self.load_forecast_columns
+            assert df["Interval Start"].min() == self.local_start_of_day(past_date)
+            assert df["Interval End"].max() == self.local_start_of_day(
+                past_end_date,
+            ) + pd.Timedelta(hours=1)

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -2510,4 +2510,4 @@ class TestPJM(BaseTestISO):
             assert df["Interval Start"].min() == self.local_start_of_day(past_date)
             assert df["Interval End"].max() == self.local_start_of_day(
                 past_end_date,
-            ) + pd.Timedelta(hours=1)
+            ) + pd.Timedelta(minutes=175)


### PR DESCRIPTION
## Summary
Adds the `pjm_load_forecast_5_min` dataset

```
from gridstatus.pjm import PJM
pjm = PJM()
df = pjm.get_load_forecast_5_min("2025-05-12")
print(df)
print(df.dtypes)
```

### Details
Pretty straighforward, going for the same columns as the hourly forecast. 

Also added a make command to make running single source-specific tests easier. Could probably go about that in all kinds of ways but bout time I simplified that a bit. 

```
$ make test-one-off market=pjm test=test_get_load_forecast_5_min_historical_range
```