### PR TITLE
fix(ENG 1619): Clean up IESO Tests and Methods

### DIFF
--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -26,7 +26,6 @@ from gridstatus.gs_logging import logger
 from gridstatus.ieso_constants import (
     FUEL_MIX_TEMPLATE_URL,
     HISTORICAL_FUEL_MIX_TEMPLATE_URL,
-    IESO_ZONE_MAPPING,
     INTERTIE_ACTUAL_SCHEDULE_FLOW_HOURLY_COLUMNS,
     INTERTIE_FLOW_5_MIN_COLUMNS,
     MAXIMUM_DAYS_IN_PAST_FOR_COMPLETE_GENERATOR_REPORT,
@@ -609,42 +608,10 @@ class IESO(ISOBase):
 
         return interval_load_demand_triples
 
-    @support_date_range(frequency="HOUR_START")
-    def get_mcp_real_time_5_min(
-        self,
-        date: str | datetime.date | datetime.datetime,
-        end: datetime.date | datetime.datetime | None = None,
-        verbose: bool = False,
-    ):
-        retired_data_warning()
-
-        # This file always has the latest data for the current hour
-        if date == "latest":
-            url = "https://reports-public.ieso.ca/public/RealtimeMktPrice/PUB_RealtimeMktPrice.csv"  # noqa: E501
-        else:
-            hour = date.hour
-            # The report has the hour ending in the filename so we need to add 1 to
-            # get the file for the hour ending
-            url = f"https://reports-public.ieso.ca/public/RealtimeMktPrice/PUB_RealtimeMktPrice_{date.strftime('%Y%m%d')}{hour + 1:02d}.csv"  # noqa: E501
-
-        try:
-            data = pd.read_csv(
-                url,
-                skiprows=4,
-                header=None,
-                usecols=[0, 1, 2, 3, 4],
-                names=["Hour Ending", "Interval", "Component", "Location", "Price"],
-            )
-        except HTTPError as e:
-            if e.code == 404:
-                raise NotSupported(
-                    f"MCP data is not available for the requested date {date}. Try using the historical method.",  # noqa: E501
-                )
-
-        data["Delivery Date"] = date.date()
-        data["Location"] = data["Location"].map(IESO_ZONE_MAPPING)
-
-        return self._handle_mcp_data(data)
+    def get_mcp_real_time_5_min(self):
+        raise NotSupported(
+            "MCP data is no longer available. For real time pricing information, use the `get_lmp_real_time_5_min` method instead. For historical MCP data, use the `get_mcp_historical_5_min` method.",
+        )
 
     @support_date_range(frequency="YEAR_START")
     def get_mcp_historical_5_min(

--- a/gridstatus/ieso_constants.py
+++ b/gridstatus/ieso_constants.py
@@ -20,16 +20,6 @@ LOAD_FORECAST_URL: str = (
     "https://www.ieso.ca/-/media/Files/IESO/Power-Data/Ontario-Demand-multiday.ashx"
 )
 
-"""ZONAL LOAD FORECAST CONSTANTS"""
-ZONAL_LOAD_FORECAST_INDEX_URL: str = (
-    "https://reports-public.ieso.ca/public/OntarioZonalDemand"
-)
-
-# Each forecast file contains data from the day in the filename going forward for
-# 34 days. The most recent file does not have a date in the filename.
-ZONAL_LOAD_FORECAST_TEMPLATE_URL: str = (
-    f"{ZONAL_LOAD_FORECAST_INDEX_URL}/PUB_OntarioZonalDemand_YYYYMMDD.xml"
-)
 
 # The farthest in the past that forecast files are available
 MAXIMUM_DAYS_IN_PAST_FOR_ZONAL_LOAD_FORECAST: int = 90

--- a/gridstatus/tests/source_specific/test_ieso.py
+++ b/gridstatus/tests/source_specific/test_ieso.py
@@ -2178,7 +2178,7 @@ class TestIESO(BaseTestISO):
 
     def test_get_solar_embedded_forecast_all_versions(self):
         date = pd.Timestamp.now(tz=self.default_timezone).normalize() - pd.DateOffset(
-            days=1,
+            days=2,
         )
 
         with file_vcr.use_cassette(
@@ -2268,14 +2268,12 @@ class TestIESO(BaseTestISO):
             "Interval Start",
             "Interval End",
             "Publish Time",
-            "Last Modified",
             "Constraint",
             "Shadow Price",
         }
         assert self._check_is_datetime_type(df["Interval Start"])
         assert self._check_is_datetime_type(df["Interval End"])
         assert self._check_is_datetime_type(df["Publish Time"])
-        assert self._check_is_datetime_type(df["Last Modified"])
         assert df["Shadow Price"].dtype == "float64"
 
     def test_get_shadow_prices_real_time_5_min_latest(self):
@@ -2293,11 +2291,9 @@ class TestIESO(BaseTestISO):
         ],
     )
     def test_get_shadow_prices_real_time_5_min_historical_range(self, date, end):
-        start = pd.Timestamp(date, tz=self.default_timezone).normalize()
-        end = pd.Timestamp(end, tz=self.default_timezone).normalize()
-        cassette_name = f"test_get_shadow_prices_real_time_5_min_historical_range_{start.date()}_{end.date()}.yaml"
+        cassette_name = f"test_get_shadow_prices_real_time_5_min_historical_range_{pd.Timestamp(date, tz=self.default_timezone).date()}_{pd.Timestamp(end, tz=self.default_timezone).date()}.yaml"
         with file_vcr.use_cassette(cassette_name):
-            df = self.iso.get_shadow_prices_real_time_5_min(start, end=end)
+            df = self.iso.get_shadow_prices_real_time_5_min(date, end=end)
             self._check_shadow_prices(df)
 
     def test_get_shadow_prices_day_ahead_hourly_latest(self):
@@ -2311,17 +2307,13 @@ class TestIESO(BaseTestISO):
     @pytest.mark.parametrize(
         "date, end",
         [
-            ("2025-05-01", "2025-05-03"),
+            ("2025-05-05", "2025-05-07"),
         ],
     )
     def test_get_shadow_prices_day_ahead_hourly_historical_range(self, date, end):
-        start = pd.Timestamp(date, tz=self.default_timezone).normalize()
-        end = pd.Timestamp(end, tz=self.default_timezone).normalize()
-        cassette_name = (
-            f"test_get_shadow_prices_day_ahead_hourly_{start.date()}_{end.date()}.yaml"
-        )
+        cassette_name = f"test_get_shadow_prices_day_ahead_hourly_historical_range_{pd.Timestamp(date, tz=self.default_timezone).date()}_{pd.Timestamp(end, tz=self.default_timezone).date()}.yaml"
         with file_vcr.use_cassette(cassette_name):
-            df = self.iso.get_shadow_prices_day_ahead_hourly(start, end=end)
+            df = self.iso.get_shadow_prices_day_ahead_hourly(date, end=end)
             self._check_shadow_prices(df)
 
         """get_lmp_real_time_operating_reserves"""
@@ -2364,8 +2356,6 @@ class TestIESO(BaseTestISO):
             data = self.iso.get_lmp_real_time_operating_reserves("latest")
 
         self._check_lmp_real_time_5_min_operating_reserves(data)
-
-        # Check that the data is for today
         today = pd.Timestamp.now(tz=self.default_timezone).normalize()
         assert (data["Interval Start"].dt.date == today.date()).all()
 

--- a/gridstatus/tests/source_specific/test_ieso.py
+++ b/gridstatus/tests/source_specific/test_ieso.py
@@ -1991,10 +1991,6 @@ class TestIESO(BaseTestISO):
 
         assert df["Publish Time"].nunique() > 1
 
-        for publish_time in df["Publish Time"].unique():
-            subset = df[df["Publish Time"] == publish_time]
-            assert len(subset) == 24
-
     def test_get_wind_embedded_forecast_latest(self):
         with file_vcr.use_cassette("test_get_wind_embedded_forecast_latest.yaml"):
             df = self.iso.get_wind_embedded_forecast("latest")


### PR DESCRIPTION
## Summary
Cleans up the various out of date IESO methods and their tests now that we're in a stable post-market renewal state. Let me know if I removed or marked `NotSupported` something that shouldn't be. 

### Details
~The `lmp_day_ahead_hourly` latest tests are failing because of the trading day failure in IESO I believe, so they should start passing tomorrow.~ looks like they are passing now

There are some datasets that only maintain 30 days, so for those methods (MCP, HOEP) I called them unsupported since there will be no data in about 9 days. I set their tests to check for the error raise (and pared them down to one test, where applicable). 

For methods where the data is coming from a different source and method (e.g. `load_forecast`), I put where the new data can be found in the error message.

It seems like the wind and solar generation forecasts can be missing intervals. There might be a pattern to this since the `publish time` = `12:38:07-05:00` was the issue on both 2025-05-19 and 2025-05-20, though for different forecast hour intervals (5 and 15, respectively). I'll keep an eye on this, and I handle the error to `continue` and log the error just once per file rather than for each missing data point. Update the relevant `all` test to not check for data length. 

Lastly, I also fixturize the generator report tests and do some minor updates to other tests to clean them up a bit. 