### PR TITLE
Add nomogram/branch shadow prices

### DIFF
--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -202,7 +202,7 @@ class CAISO(ISOBase):
         """
 
         for dataset_name, config in OASIS_DATASET_CONFIG.items():
-            if dataset is not None and dataset_name not in dataset:
+            if dataset is not None and dataset_name != dataset:
                 continue
             print(colored(f"Dataset: {dataset_name}", "cyan"))
             if len(config["params"]) == 0:
@@ -2275,3 +2275,163 @@ class CAISO(ISOBase):
                 "Wind",
             ]
         ]
+
+    @support_date_range(frequency="31D")
+    def get_nomogram_branch_shadow_prices_day_ahead_hourly(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Returns hourly day-ahead nomogram/branch shadow price forecast.
+
+        Args:
+            date (str | pd.Timestamp): date to return data
+            end (str | pd.Timestamp | None, optional): last date of range to return data.
+                If None, returns only date. Defaults to None.
+            verbose (bool, optional): print out url being fetched.
+
+        Returns:
+            pandas.DataFrame: A DataFrame with the shadow price forecast
+        """
+        if date == "latest":
+            return self.get_nomogram_branch_shadow_prices_day_ahead_hourly(
+                pd.Timestamp.now(tz=self.default_timezone)
+            )
+
+        df = self.get_oasis_dataset(
+            dataset="nomogram_branch_shadow_prices",
+            date=date,
+            end=end,
+            params={"market_run_id": "DAM"},
+            verbose=verbose,
+            raw_data=False,
+        )
+
+        df = df.rename(
+            columns={
+                "NOMOGRAM_ID": "Location",
+                "PRC": "Price",
+            },
+        )
+
+        return df[["Interval Start", "Interval End", "Location", "Price"]]
+
+    def get_nomogram_branch_shadow_prices_hasp_hourly(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Returns nomogram/branch shadow price HASP hourly data from CAISO.
+
+        Args:
+            date (str | pd.Timestamp): date to return data
+            end (str | pd.Timestamp | None, optional): last date of range to return data.
+                If None, returns only date. Defaults to None.
+            verbose (bool, optional): print out url being fetched.
+
+        Returns:
+            pandas.DataFrame: A DataFrame with the shadow price HASP data
+        """
+        if date == "latest":
+            return self.get_nomogram_branch_shadow_prices_hasp_hourly(
+                pd.Timestamp.now(tz=self.default_timezone)
+            )
+
+        df = self.get_oasis_dataset(
+            dataset="nomogram_branch_shadow_prices",
+            date=date,
+            end=end,
+            params={"market_run_id": "HASP"},
+            verbose=verbose,
+            raw_data=False,
+        )
+
+        df = df.rename(
+            columns={
+                "NOMOGRAM_ID": "Location",
+                "PRC": "Price",
+            },
+        )
+
+        return df[["Interval Start", "Interval End", "Location", "Price"]]
+
+    def get_nomogram_branch_shadow_price_forecast_15_min(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Returns 15-minute nomogram/branch shadow price forecast from the Real-Time Pre-Dispatch Market.
+
+        Args:
+            date (str | pd.Timestamp): date to return data
+            end (str | pd.Timestamp | None, optional): last date of range to return data.
+                If None, returns only date. Defaults to None.
+            verbose (bool, optional): print out url being fetched.
+
+        Returns:
+            pandas.DataFrame: A DataFrame with the shadow price forecast
+        """
+        if date == "latest":
+            return self.get_nomogram_branch_shadow_price_forecast_15_min(
+                pd.Timestamp.now(tz=self.default_timezone)
+            )
+
+        df = self.get_oasis_dataset(
+            dataset="nomogram_branch_shadow_prices",
+            date=date,
+            end=end,
+            params={"market_run_id": "RTM"},
+            verbose=verbose,
+            raw_data=False,
+        )
+
+        df = df.rename(
+            columns={
+                "NOMOGRAM_ID": "Location",
+                "PRC": "Price",
+            },
+        )
+
+        return df[["Interval Start", "Interval End", "Location", "Price"]]
+
+    def get_interval_nomogram_branch_shadow_prices_real_time_5_min(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Get 5-min nomogram/branch shadow prices from CAISO.
+
+        Args:
+            date (str | pd.Timestamp): date to return data
+            end (str | pd.Timestamp | None, optional): last date of range to return data.
+                If None, returns only date. Defaults to None.
+            verbose (bool, optional): print out url being fetched.
+
+        Returns:
+            pandas.DataFrame: A DataFrame with the shadow prices
+        """
+        if date == "latest":
+            return self.get_interval_nomogram_branch_shadow_prices_real_time_5_min(
+                pd.Timestamp.now(tz=self.default_timezone)
+            )
+
+        df = self.get_oasis_dataset(
+            dataset="interval_nomogram_branch_shadow_prices",
+            date=date,
+            end=end,
+            verbose=verbose,
+            raw_data=False,
+        )
+
+        df = df.rename(
+            columns={
+                "NOMOGRAM_ID": "Location",
+                "PRC": "Price",
+            },
+        )
+
+        return df[["Interval Start", "Interval End", "Location", "Price"]]

--- a/gridstatus/caiso/caiso_constants.py
+++ b/gridstatus/caiso/caiso_constants.py
@@ -330,4 +330,15 @@ OASIS_DATASET_CONFIG = {
             "max_query_frequency": "1d",
         },
     },
+    "nomogram_branch_shadow_prices": {
+        "query": {
+            "path": "SingleZip",
+            "resultformat": 6,
+            "queryname": "PRC_NOMOGRAM",
+            "version": 1,
+        },
+        "params": {
+            "market_run_id": ["DAM", "HASP", "RTPD"],
+        },
+    },
 }

--- a/gridstatus/caiso/caiso_constants.py
+++ b/gridstatus/caiso/caiso_constants.py
@@ -338,7 +338,16 @@ OASIS_DATASET_CONFIG = {
             "version": 1,
         },
         "params": {
-            "market_run_id": ["DAM", "HASP", "RTPD"],
+            "market_run_id": ["DAM", "HASP", "RTM"],
         },
+    },
+    "interval_nomogram_branch_shadow_prices": {
+        "query": {
+            "path": "SingleZip",
+            "resultformat": 6,
+            "queryname": "PRC_RTM_NOMOGRAM",
+            "version": 1,
+        },
+        "params": {},
     },
 }

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -1085,3 +1085,119 @@ class TestCAISO(BaseTestISO):
                 end,
                 tz=self.iso.default_timezone,
             )
+
+    @pytest.mark.parametrize(
+        "date, end",
+        [
+            ("2025-03-20", "2025-03-22"),
+        ],
+    )
+    def test_get_nomogram_branch_shadow_prices_day_ahead_hourly(self, date, end):
+        with caiso_vcr.use_cassette(
+            f"test_get_nomogram_branch_shadow_prices_day_ahead_hourly_{date}_{end}.yaml",
+        ):
+            df = self.iso.get_nomogram_branch_shadow_prices_day_ahead_hourly(
+                date, end=end
+            )
+            assert df.shape[0] > 0
+            assert df.columns.tolist() == [
+                "Interval Start",
+                "Interval End",
+                "Location",
+                "Price",
+            ]
+            assert df["Interval Start"].min() >= pd.Timestamp(
+                date,
+                tz=self.iso.default_timezone,
+            )
+            assert df["Interval End"].max() <= pd.Timestamp(
+                end,
+                tz=self.iso.default_timezone,
+            )
+
+    @pytest.mark.parametrize(
+        "date, end",
+        [
+            ("2025-03-20", "2025-03-22"),
+        ],
+    )
+    def test_get_nomogram_branch_shadow_prices_hasp_hourly(self, date, end):
+        with caiso_vcr.use_cassette(
+            f"get_nomogram_branch_shadow_prices_hasp_hourly_{date}_{end}.yaml",
+        ):
+            df = self.iso.get_nomogram_branch_shadow_prices_hasp_hourly(date, end=end)
+            assert df.shape[0] > 0
+            assert df.columns.tolist() == [
+                "Interval Start",
+                "Interval End",
+                "Location",
+                "Price",
+            ]
+            assert df["Interval Start"].min() >= pd.Timestamp(
+                date,
+                tz=self.iso.default_timezone,
+            )
+            assert df["Interval End"].max() <= pd.Timestamp(
+                end,
+                tz=self.iso.default_timezone,
+            )
+
+    @pytest.mark.parametrize(
+        "date, end",
+        [
+            ("2025-03-20", "2025-03-22"),
+        ],
+    )
+    def test_get_nomogram_branch_shadow_price_forecast_15_min(self, date, end):
+        with caiso_vcr.use_cassette(
+            f"get_nomogram_branch_shadow_price_forecast_15_min_{date}_{end}.yaml",
+        ):
+            df = self.iso.get_nomogram_branch_shadow_price_forecast_15_min(
+                date, end=end
+            )
+            assert df.shape[0] > 0
+            assert df.columns.tolist() == [
+                "Interval Start",
+                "Interval End",
+                "Location",
+                "Price",
+            ]
+            assert df["Interval Start"].min() >= pd.Timestamp(
+                date,
+                tz=self.iso.default_timezone,
+            )
+            assert df["Interval End"].max() <= pd.Timestamp(
+                end,
+                tz=self.iso.default_timezone,
+            )
+
+    @pytest.mark.parametrize(
+        "date, end",
+        [
+            ("2025-03-20", "2025-03-22"),
+        ],
+    )
+    def test_get_interval_nomogram_branch_shadow_prices_real_time_5_min(
+        self, date, end
+    ):
+        with caiso_vcr.use_cassette(
+            f"get_interval_nomogram_branch_shadow_prices_real_time_5_min_{date}_{end}.yaml",
+        ):
+            df = self.iso.get_interval_nomogram_branch_shadow_prices_real_time_5_min(
+                date, end=end
+            )
+            assert df.shape[0] > 0
+            assert df.columns.tolist() == [
+                "Interval Start",
+                "Interval End",
+                "Location",
+                "Price",
+            ]
+            assert df["Interval Start"].min() >= pd.Timestamp(
+                date,
+                tz=self.iso.default_timezone,
+            )
+            assert df["Interval End"].max() <= pd.Timestamp(
+                end,
+                tz=self.iso.default_timezone,
+            )


### PR DESCRIPTION
## Summary
Closes #407

### Details
Adds the following functions:
* `get_nomogram_branch_shadow_prices_day_ahead_hourly()`
* `get_nomogram_branch_shadow_prices_hasp_hourly()`
* `get_nomogram_branch_shadow_price_forecast_15_min()`
* `get_interval_nomogram_branch_shadow_prices_real_time_5_min()`
