### PR TITLE
fix(ENG 1659): ISONE Load Forecast API

### DIFF
--- a/gridstatus/isone_api/isone_api.py
+++ b/gridstatus/isone_api/isone_api.py
@@ -494,7 +494,7 @@ class ISONEAPI:
         return df[columns]
 
     @support_date_range("DAY_START")
-    def get_hourly_load_forecast(
+    def get_load_forecast_hourly(
         self,
         date: str | pd.Timestamp = "latest",
         end: str | pd.Timestamp | None = None,

--- a/gridstatus/tests/source_specific/test_isone_api.py
+++ b/gridstatus/tests/source_specific/test_isone_api.py
@@ -208,10 +208,10 @@ class TestISONEAPI(TestHelperMixin):
         "date,end",
         DST_CHANGE_TEST_DATES,
     )
-    def test_get_hourly_load_forecast(self, date, end):
-        cassette_name = f"test_get_hourly_load_forecast_{date}_{end}.yaml"
+    def test_get_load_forecast_hourly(self, date, end):
+        cassette_name = f"test_get_load_forecast_hourly_{date}_{end}.yaml"
         with api_vcr.use_cassette(cassette_name):
-            result = self.iso.get_hourly_load_forecast(date=date, end=end)
+            result = self.iso.get_load_forecast_hourly(date=date, end=end)
 
             assert isinstance(result, pd.DataFrame)
             assert list(result.columns) == [


### PR DESCRIPTION
## Summary
Updates the ISONE load forecast method to follow naming our conventions

### Details
