### PR TITLE
fix: make `AESO()` available at top level

### DIFF
--- a/gridstatus/__init__.py
+++ b/gridstatus/__init__.py
@@ -18,6 +18,7 @@ import gridstatus.viz
 
 from gridstatus.utils import load_folder
 
+from gridstatus.aeso import AESO
 from gridstatus.nyiso import NYISO
 from gridstatus.caiso import CAISO
 from gridstatus.ercot import Ercot
@@ -28,10 +29,11 @@ from gridstatus.pjm import PJM
 from gridstatus.eia import EIA
 from gridstatus.ieso import IESO
 
-all_isos = [NYISO, CAISO, Ercot, ISONE, MISO, SPP, PJM, IESO]
+all_isos = [AESO, NYISO, CAISO, Ercot, ISONE, MISO, SPP, PJM, IESO]
 
 
 __all__ = [
+    "AESO",
     "NYISO",
     "CAISO",
     "Ercot",

--- a/gridstatus/aeso/__init__.py
+++ b/gridstatus/aeso/__init__.py
@@ -1,0 +1,3 @@
+from gridstatus.aeso.aeso import AESO
+
+__all__ = ["AESO"]


### PR DESCRIPTION
## Summary
Adds `AESO()` to the `__init__.py` so it can be more easily imported


