### PR TITLE
feat(ENG 1690): AESO Pool Price, Forecast Pool Price, and System Marginal Price

### DIFF
--- a/gridstatus/aeso/aeso.py
+++ b/gridstatus/aeso/aeso.py
@@ -319,7 +319,7 @@ class AESO:
                 df["Forecast Pool Price"],
                 errors="coerce",
             )
-            df["Publish Time"] = df["Interval Start"] - pd.Timedelta(hours=4)
+            df["Publish Time"] = df["Interval Start"] - pd.Timedelta(hours=3)
             return df[
                 [
                     "Interval Start",
@@ -342,11 +342,11 @@ class AESO:
         Returns:
             DataFrame containing system marginal price data
         """
-        if date == "latest":
-            return self.get_system_marginal_price(date="today")
-
         start_date = pd.Timestamp(date).strftime("%Y-%m-%d")
         end_date = pd.Timestamp(end).strftime("%Y-%m-%d") if end else None
+
+        if date == "latest":
+            return self.get_system_marginal_price(date="today")
 
         endpoint = f"systemmarginalprice-api/v1.1/price/systemMarginalPrice?startDate={start_date}"
         if end_date:
@@ -362,9 +362,4 @@ class AESO:
                 "volume": "Volume",
             },
         )
-        df["System Marginal Price"] = pd.to_numeric(
-            df["System Marginal Price"],
-            errors="coerce",
-        )
-        df["Volume"] = pd.to_numeric(df["Volume"], errors="coerce")
         return df[["Time", "System Marginal Price", "Volume"]]

--- a/gridstatus/aeso/aeso.py
+++ b/gridstatus/aeso/aeso.py
@@ -379,4 +379,4 @@ class AESO:
             errors="coerce",
         )
         df["Volume"] = pd.to_numeric(df["Volume"], errors="coerce")
-        return df[["Time", "System Marginal Price", "Volume"]]
+        return df[["Time", "System Marginal Price", "Volume"]].sort_values(by="Time")

--- a/gridstatus/tests/source_specific/test_aeso.py
+++ b/gridstatus/tests/source_specific/test_aeso.py
@@ -142,19 +142,13 @@ class TestAESO(TestHelperMixin):
 
         request_time = pd.Timestamp.now(tz=self.iso.default_timezone)
         for _, row in df.iterrows():
-            time_diff = row["Interval Start"] - request_time
-            if time_diff > pd.Timedelta(hours=2):
-                # More than 2 hours out: publish time is request time
-                assert row["Publish Time"] == request_time
-            elif time_diff > pd.Timedelta(hours=1):
-                # 1-2 hours out: publish time is 2 hours before interval
-                assert row["Publish Time"] == row["Interval Start"] - pd.Timedelta(
-                    hours=2,
-                )
+            if row["Interval Start"] > request_time:
+                # For future intervals: use request time floored to 5 minutes
+                assert row["Publish Time"] == request_time.floor("5min")
             else:
-                # Less than 1 hour out: publish time is 1 hour before interval
+                # For past/current intervals: use 5 minutes before interval start
                 assert row["Publish Time"] == row["Interval Start"] - pd.Timedelta(
-                    hours=1,
+                    minutes=5,
                 )
 
     def test_get_pool_price_latest(self):

--- a/gridstatus/tests/source_specific/test_aeso.py
+++ b/gridstatus/tests/source_specific/test_aeso.py
@@ -1,6 +1,7 @@
 import os
 
 import pandas as pd
+import pytest
 
 from gridstatus.aeso.aeso import AESO
 from gridstatus.aeso.aeso_constants import (
@@ -98,3 +99,114 @@ class TestAESO(TestHelperMixin):
             df = self.iso.get_asset_list(asset_id="NONEXISTENT")
             self._check_asset_list(df)
             assert len(df) == 0
+
+    def _check_pool_price(self, df: pd.DataFrame) -> None:
+        """Check pool price DataFrame structure and types."""
+        expected_columns = ["Interval Start", "Interval End", "Pool Price"]
+        assert df.columns.tolist() == expected_columns
+        assert (
+            df.dtypes["Interval Start"]
+            == f"datetime64[ns, {self.iso.default_timezone}]"
+        )
+        assert (
+            df.dtypes["Interval End"] == f"datetime64[ns, {self.iso.default_timezone}]"
+        )
+        assert pd.api.types.is_numeric_dtype(df["Pool Price"])
+        assert (
+            df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
+        ).all()
+
+    def _check_forecast_pool_price(self, df: pd.DataFrame) -> None:
+        """Check forecast pool price DataFrame structure and types."""
+        expected_columns = [
+            "Interval Start",
+            "Interval End",
+            "Publish Time",
+            "Forecast Pool Price",
+        ]
+        assert df.columns.tolist() == expected_columns
+        assert (
+            df.dtypes["Interval Start"]
+            == f"datetime64[ns, {self.iso.default_timezone}]"
+        )
+        assert (
+            df.dtypes["Interval End"] == f"datetime64[ns, {self.iso.default_timezone}]"
+        )
+        assert (
+            df.dtypes["Publish Time"] == f"datetime64[ns, {self.iso.default_timezone}]"
+        )
+        assert pd.api.types.is_numeric_dtype(df["Forecast Pool Price"])
+        assert (
+            df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
+        ).all()
+        assert (
+            df["Interval Start"] - df["Publish Time"] == pd.Timedelta(hours=4)
+        ).all()
+
+    def test_get_pool_price_latest(self):
+        """Test getting latest pool price data."""
+        with api_vcr.use_cassette("test_get_pool_price_latest.yaml"):
+            df = self.iso.get_pool_price(date="latest")
+            self._check_pool_price(df)
+            assert len(df) > 0
+
+    @pytest.mark.parametrize(
+        "start_date,end_date,expected_hours",
+        [
+            (
+                pd.Timestamp("2024-01-01"),
+                pd.Timestamp("2024-01-04"),
+                96,
+            ),
+        ],
+    )
+    def test_get_pool_price_historical_range(
+        self,
+        start_date: pd.Timestamp,
+        end_date: pd.Timestamp,
+        expected_hours: int,
+    ) -> None:
+        """Test getting historical pool price data."""
+        with api_vcr.use_cassette(
+            f"test_get_pool_price_historical_range_{start_date.strftime('%Y-%m-%d')}.yaml",
+        ):
+            df = self.iso.get_pool_price(
+                date=start_date,
+                end=end_date,
+            )
+            self._check_pool_price(df)
+            assert len(df) == expected_hours
+
+    def test_get_forecast_pool_price_latest(self):
+        """Test getting latest forecast pool price data."""
+        with api_vcr.use_cassette("test_get_forecast_pool_price_latest.yaml"):
+            df = self.iso.get_forecast_pool_price(date="latest")
+            self._check_forecast_pool_price(df)
+            assert len(df) > 0
+
+    @pytest.mark.parametrize(
+        "start_date,end_date,expected_hours",
+        [
+            (
+                pd.Timestamp("2024-01-01"),
+                pd.Timestamp("2024-01-04"),
+                96,
+            ),
+        ],
+    )
+    def test_get_forecast_pool_price_historical_range(
+        self,
+        start_date: pd.Timestamp,
+        end_date: pd.Timestamp,
+        expected_hours: int,
+    ) -> None:
+        """Test getting historical forecast pool price data."""
+        with api_vcr.use_cassette(
+            f"test_get_forecast_pool_price_historical_range_{start_date.strftime('%Y-%m-%d')}.yaml",
+        ):
+            df = self.iso.get_forecast_pool_price(
+                date=start_date,
+                end=end_date,
+            )
+            self._check_forecast_pool_price(df)
+            assert len(df) == expected_hours

--- a/gridstatus/tests/source_specific/test_aeso.py
+++ b/gridstatus/tests/source_specific/test_aeso.py
@@ -140,7 +140,7 @@ class TestAESO(TestHelperMixin):
             df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
         ).all()
         assert (
-            df["Interval Start"] - df["Publish Time"] == pd.Timedelta(hours=4)
+            df["Interval Start"] - df["Publish Time"] == pd.Timedelta(hours=3)
         ).all()
 
     def test_get_pool_price_latest(self):

--- a/gridstatus/tests/source_specific/test_aeso.py
+++ b/gridstatus/tests/source_specific/test_aeso.py
@@ -210,3 +210,42 @@ class TestAESO(TestHelperMixin):
             )
             self._check_forecast_pool_price(df)
             assert len(df) == expected_hours
+
+    def _check_system_marginal_price(self, df: pd.DataFrame) -> None:
+        """Check system marginal price DataFrame structure and types."""
+        expected_columns = ["Time", "System Marginal Price", "Volume"]
+        assert df.columns.tolist() == expected_columns
+        assert df.dtypes["Time"] == f"datetime64[ns, {self.iso.default_timezone}]"
+        assert pd.api.types.is_numeric_dtype(df["System Marginal Price"])
+        assert pd.api.types.is_numeric_dtype(df["Volume"])
+
+    def test_get_system_marginal_price_latest(self):
+        """Test getting latest system marginal price data."""
+        with api_vcr.use_cassette("test_get_system_marginal_price_latest.yaml"):
+            df = self.iso.get_system_marginal_price(date="latest")
+            self._check_system_marginal_price(df)
+            assert len(df) > 0
+
+    @pytest.mark.parametrize(
+        "start_date,end_date",
+        [
+            (
+                pd.Timestamp("2024-01-01"),
+                pd.Timestamp("2024-01-04"),
+            ),
+        ],
+    )
+    def test_get_system_marginal_price_historical_range(
+        self,
+        start_date: pd.Timestamp,
+        end_date: pd.Timestamp,
+    ) -> None:
+        """Test getting historical system marginal price data."""
+        with api_vcr.use_cassette(
+            f"test_get_system_marginal_price_historical_range_{start_date.strftime('%Y-%m-%d')}_{end_date.strftime('%Y-%m-%d')}.yaml",
+        ):
+            df = self.iso.get_system_marginal_price(
+                date=start_date,
+                end=end_date,
+            )
+            self._check_system_marginal_price(df)


### PR DESCRIPTION
## Summary
Adds pricing datasets, including:

- `aeso_pool_price`
- `aeso_pool_price_forecast`
- `aeso_system_marginal_price`

## Details
### Pool Price and Forecast Pool Price

This is an hourly dataset that pertains to hourly intervals, so this has an `Interval Start` and `Interval End` for the actuals and an `Interval Start`, `Interval End`, and `Publish Time` for forecast data. I think it does make sense to split up actual and forecast into separate datasets just to simplify downstream systems and updates that happen within the same report. 

It looks like the forecast is first published 3 hours ahead of the actual price (e.g. Hour Ending 16 will publish at Hour Ending 13). 
![CleanShot 2025-06-04 at 13 16 12@2x](https://github.com/user-attachments/assets/cc5b8232-9883-4a22-aa91-69875b950532)

However, it looks like there is a silent update going on in the data between intervals where price forecasts are updating, with not a lot of metadata to show for it:

![CleanShot 2025-06-04 at 13 49 29@2x](https://github.com/user-attachments/assets/b2c45294-af19-4f36-aac1-f3255947b682)

![CleanShot 2025-06-04 at 13 55 04@2x](https://github.com/user-attachments/assets/930ee61d-d352-40fb-869a-bf7ce1cf5387)

[According to the docs](http://ets.aeso.ca/Market/Reports/Manual/HelpText/current-actual-forecast-metadata.pdf), they are updating the forecast every 5 minutes. They are basically constantly, silently updating over the course of the next 3 hours. You can see this yourself by hitting "Ok" on the ETS over the course of an hour on the `Actual Forecast` report: http://ets.aeso.ca/ I've added some logic to figure out the publish time dynamically based on the current time. 

- If the interval is in the past, use the 5 minutes before the interval timestamp
- If the interval is in the future, take the request time (now) and floor to the 5 minute mark.

Downstream systems will hopefully be able to handle the rest. Open to many other approaches as well. 

![CleanShot 2025-06-04 at 13 58 36@2x](https://github.com/user-attachments/assets/ad0b70b5-78c1-41b7-8fee-240d6039c930)

Actual prices themselves are on about a two hour lag from current time.

### System Marginal Price
System Marginal Prices update seemingly whenever the price changes, and thus are actually an instantaneous dataset (rather than an interval dataset). The API returns start and end times, but it just updates the previous record to end and then sets the new record to be until the end of the day. In light of that, I just return the `Time` column.

**API Response Example**
![CleanShot 2025-06-04 at 13 31 06@2x](https://github.com/user-attachments/assets/728cb13f-a439-44f3-a70a-c7e7559b8595)

**ETS System Reporting**
![CleanShot 2025-06-04 at 13 35 39@2x](https://github.com/user-attachments/assets/3765c046-577e-43fd-ab1b-6627a0a1cb64)

