### PR TITLE
fix(ENG 1684): Some tweaks to AESO interchange and reserves columns

### DIFF
--- a/gridstatus/aeso/aeso_constants.py
+++ b/gridstatus/aeso/aeso_constants.py
@@ -47,20 +47,14 @@ FUEL_MIX_COLUMN_MAPPING: dict[str, str] = {
     "wind": "Wind",
 }
 
-INTERCHANGE_COLUMN_MAPPING: dict[str, str] = {
-    "time": "Time",
-    "path": "Path",
-    "actual_flow": "Actual Flow",
-}
-
 RESERVES_COLUMN_MAPPING: dict[str, str] = {
     "time": "Time",
     "contingency_reserve_required": "Contingency Reserve Required",
     "dispatched_contigency_reserve_total": "Dispatched Contingency Reserve Total",
-    "dispatched_contingency_reserve_gen": "Dispatched Contingency Reserve Gen",
+    "dispatched_contingency_reserve_gen": "Dispatched Contingency Reserve Generation",
     "dispatched_contingency_reserve_other": "Dispatched Contingency Reserve Other",
-    "ffr_armed_dispatch": "FFR Armed Dispatch",
-    "ffr_offered_volume": "FFR Offered Volume",
+    "ffr_armed_dispatch": "Fast Frequency Response Dispatched",
+    "ffr_offered_volume": "Fast Frequency Response Offered",
     "long_lead_time_volume": "Long Lead Time Volume",
 }
 


### PR DESCRIPTION
## Summary
Some slight schema changes to `interchange` and a couple renames to `reserves`

### Details
Instead of `actual flow` and `path` columns, this pivots out the 3 main interchange paths into their own columns, `British Columbia Flow`, `Montana Flow`, and `Saskatchewan Flow`, plus adds the combined `Net Interchange Flow`.

And then expands the `FFR` into `Fast Frequency Response` for reserves. 