### PR TITLE
fix(ENG 1690): Add in 30 day rolling average in pool price

### DIFF
--- a/gridstatus/aeso/aeso.py
+++ b/gridstatus/aeso/aeso.py
@@ -325,13 +325,21 @@ class AESO:
             columns={
                 "pool_price": "Pool Price",
                 "forecast_pool_price": "Forecast Pool Price",
+                "rolling_30day_avg": "Rolling 30 Day Average Pool Price",
             },
         )
 
         if actual_or_forecast == "actual":
             df["Pool Price"] = pd.to_numeric(df["Pool Price"], errors="coerce")
             df = df[df["Pool Price"].notna()]
-            return df[["Interval Start", "Interval End", "Pool Price"]]
+            return df[
+                [
+                    "Interval Start",
+                    "Interval End",
+                    "Pool Price",
+                    "Rolling 30 Day Average Pool Price",
+                ]
+            ]
         else:
             df["Forecast Pool Price"] = pd.to_numeric(
                 df["Forecast Pool Price"],

--- a/gridstatus/tests/source_specific/test_aeso.py
+++ b/gridstatus/tests/source_specific/test_aeso.py
@@ -119,7 +119,12 @@ class TestAESO(TestHelperMixin):
 
     def _check_pool_price(self, df: pd.DataFrame) -> None:
         """Check pool price DataFrame structure and types."""
-        expected_columns = ["Interval Start", "Interval End", "Pool Price"]
+        expected_columns = [
+            "Interval Start",
+            "Interval End",
+            "Pool Price",
+            "Rolling 30 Day Average Pool Price",
+        ]
         assert df.columns.tolist() == expected_columns
         assert (
             df.dtypes["Interval Start"]


### PR DESCRIPTION
## Summary
Adds the `30 Day Rolling Average Pool Price` column in since it is available. 
