### PR TITLE
feat(ENG 1683): AESO Unit Status

### DIFF
--- a/gridstatus/aeso/aeso.py
+++ b/gridstatus/aeso/aeso.py
@@ -12,6 +12,7 @@ from gridstatus.aeso.aeso_constants import (
     RESERVES_COLUMN_MAPPING,
     SUPPLY_DEMAND_COLUMN_MAPPING,
 )
+from gridstatus.base import NotSupported
 from gridstatus.decorators import support_date_range
 
 
@@ -532,7 +533,11 @@ class AESO:
         df["Volume"] = pd.to_numeric(df["Volume"], errors="coerce")
         return df[["Time", "System Marginal Price", "Volume"]].sort_values(by="Time")
 
-    def get_unit_status(self) -> pd.DataFrame:
+    def get_unit_status(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        verbose: bool = False,
+    ) -> pd.DataFrame:
         """
         Get current unit status data for all assets in the AESO system.
 
@@ -546,6 +551,9 @@ class AESO:
             - Net Generation: Current net generation in MW
             - Dispatched Contingency Reserve: Amount of contingency reserve dispatched in MW
         """
+        if date != "latest":
+            raise NotSupported()
+
         endpoint = "currentsupplydemand-api/v1/csd/generation/assets/current"
         data = self._make_request(endpoint)
 

--- a/gridstatus/aeso/aeso.py
+++ b/gridstatus/aeso/aeso.py
@@ -531,3 +531,62 @@ class AESO:
         )
         df["Volume"] = pd.to_numeric(df["Volume"], errors="coerce")
         return df[["Time", "System Marginal Price", "Volume"]].sort_values(by="Time")
+
+    def get_unit_status(self) -> pd.DataFrame:
+        """
+        Get current unit status data for all assets in the AESO system.
+
+        Returns:
+            DataFrame containing unit status data with columns:
+            - Time: Timestamp of the data
+            - Asset: Asset identifier
+            - Fuel Type: Type of fuel used
+            - Sub Fuel Type: Sub-category of fuel type
+            - Maximum Capability: Maximum generation capability in MW
+            - Net Generation: Current net generation in MW
+            - Dispatched Contingency Reserve: Amount of contingency reserve dispatched in MW
+        """
+        endpoint = "currentsupplydemand-api/v1/csd/generation/assets/current"
+        data = self._make_request(endpoint)
+
+        df = pd.json_normalize(
+            data["return"],
+            record_path="asset_list",
+            meta=["last_updated_datetime_utc"],
+        )
+
+        df["Time"] = pd.to_datetime(
+            df["last_updated_datetime_utc"],
+            utc=True,
+        ).dt.tz_convert(self.default_timezone)
+
+        df = df.rename(
+            columns={
+                "asset": "Asset",
+                "fuel_type": "Fuel Type",
+                "sub_fuel_type": "Sub Fuel Type",
+                "maximum_capability": "Maximum Capability",
+                "net_generation": "Net Generation",
+                "dispatched_contingency_reserve": "Dispatched Contingency Reserve",
+            },
+        )
+
+        numeric_columns = [
+            "Maximum Capability",
+            "Net Generation",
+            "Dispatched Contingency Reserve",
+        ]
+        for col in numeric_columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+
+        return df[
+            [
+                "Time",
+                "Asset",
+                "Fuel Type",
+                "Sub Fuel Type",
+                "Maximum Capability",
+                "Net Generation",
+                "Dispatched Contingency Reserve",
+            ]
+        ]

--- a/gridstatus/tests/source_specific/test_aeso.py
+++ b/gridstatus/tests/source_specific/test_aeso.py
@@ -493,6 +493,6 @@ class TestAESO(TestHelperMixin):
     def test_get_unit_status(self):
         """Test getting current unit status data."""
         with api_vcr.use_cassette("test_get_unit_status.yaml"):
-            df = self.iso.get_unit_status()
+            df = self.iso.get_unit_status(date="latest")
             self._check_unit_status(df)
             assert len(df) > 0

--- a/gridstatus/tests/source_specific/test_aeso.py
+++ b/gridstatus/tests/source_specific/test_aeso.py
@@ -462,3 +462,37 @@ class TestAESO(TestHelperMixin):
                     else interval_day_7am - pd.Timedelta(days=1)
                 )
                 assert row["Publish Time"] == expected_publish
+
+    def _check_unit_status(self, df: pd.DataFrame) -> None:
+        """Check unit status DataFrame structure and types."""
+        expected_columns = [
+            "Time",
+            "Asset",
+            "Fuel Type",
+            "Sub Fuel Type",
+            "Maximum Capability",
+            "Net Generation",
+            "Dispatched Contingency Reserve",
+        ]
+        assert df.columns.tolist() == expected_columns
+        assert df.dtypes["Time"] == f"datetime64[ns, {self.iso.default_timezone}]"
+        assert df["Asset"].dtype == "object"
+        assert df["Fuel Type"].dtype == "object"
+        assert df["Sub Fuel Type"].dtype == "object"
+
+        numeric_columns = [
+            "Maximum Capability",
+            "Net Generation",
+            "Dispatched Contingency Reserve",
+        ]
+        for col in numeric_columns:
+            assert pd.api.types.is_numeric_dtype(df[col]), (
+                f"Column {col} should be numeric"
+            )
+
+    def test_get_unit_status(self):
+        """Test getting current unit status data."""
+        with api_vcr.use_cassette("test_get_unit_status.yaml"):
+            df = self.iso.get_unit_status()
+            self._check_unit_status(df)
+            assert len(df) > 0


### PR DESCRIPTION
## Summary
Adds the `aeso_unit_status` dateset. This is another `Time`-based instantaneous sampling dataset like `interchange`, `reserves` etc. 

```
from gridstatus.aeso.aeso import AESO
aeso = AESO()
df = aeso.get_unit_status()
print(df)
print(df.columns)
```

(These AESO datasets all have their quirks so going to push them through via one PR at a time, sorry if it's a lot today. I have 3 more I think). 

### Details
Pretty straightforward, no historical data available, values from the API are updated ~minutely. 