### PR TITLE
feat(ENG 1688): AESO Generator Outages

### DIFF
--- a/gridstatus/aeso/aeso.py
+++ b/gridstatus/aeso/aeso.py
@@ -618,7 +618,7 @@ class AESO:
             DataFrame containing generator outage data
         """
         if date == "latest":
-            current_time = pd.Timestamp.now()
+            current_time = pd.Timestamp.now(tz=self.default_timezone)
             return self.get_generator_outages_hourly(
                 date=current_time,
                 end=current_time + pd.DateOffset(months=4),
@@ -709,7 +709,7 @@ class AESO:
         # NB: Pivot the data to get the by-fuel type outage.
         df_pivot = df.pivot_table(
             index=["Interval Start", "Interval End", "Publish Time"],
-            columns="Fuel Type",
+            columns=["Sub Fuel Type"],
             values="Operating Outage",
             aggfunc="sum",
         ).reset_index()
@@ -719,7 +719,14 @@ class AESO:
             [
                 col
                 for col in df_pivot.columns
-                if col not in ["Interval Start", "Interval End", "Publish Time"]
+                if col
+                not in [
+                    "Interval Start",
+                    "Interval End",
+                    "Publish Time",
+                    "Mothball Outage",
+                    "Total Outage",
+                ]
             ]
         ].sum(axis=1)
 
@@ -750,7 +757,10 @@ class AESO:
             "Interval End",
             "Publish Time",
             "Total Outage",
-            "Gas",
+            "Simple Cycle",
+            "Combined Cycle",
+            "Cogeneration",
+            "Gas Fired Steam",
             "Coal",
             "Hydro",
             "Wind",

--- a/gridstatus/aeso/aeso.py
+++ b/gridstatus/aeso/aeso.py
@@ -621,7 +621,7 @@ class AESO:
             current_time = pd.Timestamp.now(tz=self.default_timezone)
             return self.get_generator_outages_hourly(
                 date=current_time,
-                end=current_time + pd.DateOffset(months=24),
+                end=current_time + pd.DateOffset(months=4),
             )
         else:
             start_date = pd.Timestamp(date)

--- a/gridstatus/tests/source_specific/test_aeso.py
+++ b/gridstatus/tests/source_specific/test_aeso.py
@@ -511,6 +511,7 @@ class TestAESO(TestHelperMixin):
             "Solar",
             "Energy Storage",
             "Biomass and Other",
+            "Mothball Outage",
         ]
         assert df.columns.tolist() == expected_columns
         assert (

--- a/gridstatus/tests/source_specific/test_aeso.py
+++ b/gridstatus/tests/source_specific/test_aeso.py
@@ -504,7 +504,10 @@ class TestAESO(TestHelperMixin):
             "Interval End",
             "Publish Time",
             "Total Outage",
-            "Gas",
+            "Simple Cycle",
+            "Combined Cycle",
+            "Cogeneration",
+            "Gas Fired Steam",
             "Coal",
             "Hydro",
             "Wind",
@@ -538,7 +541,13 @@ class TestAESO(TestHelperMixin):
                 f"Column {col} should be numeric"
             )
 
-        assert (df["Total Outage"] == df[numeric_columns[1:]].sum(axis=1)).all()
+        # NB: Total Outage should be sum of all numeric columns except Mothball Outage and Total Outage
+        outage_columns = [
+            col
+            for col in numeric_columns
+            if col not in ["Mothball Outage", "Total Outage"]
+        ]
+        assert (df["Total Outage"] == df[outage_columns].sum(axis=1)).all()
 
     def test_get_generator_outages_hourly_latest(self):
         """Test getting latest generator outages data."""

--- a/gridstatus/tests/source_specific/test_aeso.py
+++ b/gridstatus/tests/source_specific/test_aeso.py
@@ -496,3 +496,82 @@ class TestAESO(TestHelperMixin):
             df = self.iso.get_unit_status(date="latest")
             self._check_unit_status(df)
             assert len(df) > 0
+
+    def _check_generator_outages_hourly(self, df: pd.DataFrame) -> None:
+        """Check generator outages DataFrame structure and types."""
+        expected_columns = [
+            "Interval Start",
+            "Interval End",
+            "Publish Time",
+            "Total Outage",
+            "Gas",
+            "Coal",
+            "Hydro",
+            "Wind",
+            "Solar",
+            "Energy Storage",
+            "Biomass and Other",
+        ]
+        assert df.columns.tolist() == expected_columns
+        assert (
+            df.dtypes["Interval Start"]
+            == f"datetime64[ns, {self.iso.default_timezone}]"
+        )
+        assert (
+            df.dtypes["Interval End"] == f"datetime64[ns, {self.iso.default_timezone}]"
+        )
+        assert (
+            df.dtypes["Publish Time"] == f"datetime64[ns, {self.iso.default_timezone}]"
+        )
+        assert (
+            df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
+        ).all()
+
+        numeric_columns = [
+            col
+            for col in df.columns
+            if col not in ["Interval Start", "Interval End", "Publish Time"]
+        ]
+        for col in numeric_columns:
+            assert pd.api.types.is_numeric_dtype(df[col]), (
+                f"Column {col} should be numeric"
+            )
+
+        assert (df["Total Outage"] == df[numeric_columns[1:]].sum(axis=1)).all()
+
+    def test_get_generator_outages_hourly_latest(self):
+        """Test getting latest generator outages data."""
+        with api_vcr.use_cassette("test_get_generator_outages_hourly_latest.yaml"):
+            df = self.iso.get_generator_outages_hourly(date="latest")
+            self._check_generator_outages_hourly(df)
+            assert len(df) > 0
+
+    @pytest.mark.parametrize(
+        "start_date,end_date",
+        [
+            (
+                pd.Timestamp("2024-01-01"),
+                pd.Timestamp("2024-01-04"),
+            ),
+        ],
+    )
+    def test_get_generator_outages_hourly_historical_range(
+        self,
+        start_date: pd.Timestamp,
+        end_date: pd.Timestamp,
+    ) -> None:
+        """Test getting historical generator outages data."""
+        with api_vcr.use_cassette(
+            f"test_get_generator_outages_hourly_historical_range_{start_date.strftime('%Y-%m-%d')}_{end_date.strftime('%Y-%m-%d')}.yaml",
+        ):
+            df = self.iso.get_generator_outages_hourly(
+                date=start_date,
+                end=end_date,
+            )
+            self._check_generator_outages_hourly(df)
+            assert df["Interval Start"].min() >= start_date.tz_localize(
+                self.iso.default_timezone,
+            )
+            assert df["Interval Start"].max() <= end_date.tz_localize(
+                self.iso.default_timezone,
+            )


### PR DESCRIPTION
## Summary
Adds the `aeso_generation_outages_hourly` dataset. There are a lot of ins and outs of this dataset. More below

```
from gridstatus.aeso.aeso import AESO
aeso = AESO()
df = aeso.get_generator_outages_hourly(date="latest")
print(df)
print(df.columns)

df2 = aeso.get_generator_outages_hourly(date="2025-06-10", end="2026-06-10")
print(df2)
```

## Details
### Source
[The endpoint can be tried here](https://developer-apim.aeso.ca/api-details#api=aiesgencapacity-api-v1&operation=getAIESControlReport), and there is data available for the range 2011-01-01 to 2027-06-12 (24 months in the future). While this data is hourly, there is no ETS system equivalent, only summary reports such as the [Current Daily Outage Report](http://ets.aeso.ca/). ETS is updated every few minutes it seems. 

More info on some of the calculations, fuel types, updates, etc can be found in [that report's metadata page](http://ets.aeso.ca/Market/Reports/Manual/HelpText/current-daily-outage-metadata.pdf).

### "Latest"
Technically there are 24 months in the future which are "latest". However, that's a lot of hourly data to grab in a "latest" fashion and is quite slow. The daily outage report in ETS gives the next 4 months, which seems more reasonable, and we can make sure the user knows the next 24 months are available if they want them. So `latest` gives current time plus 4 months, but a `date="2025-06-12", end="2027-06-12")` will return data for the whole range.

The latest being mildly complex spills over into the handling of start and end dates as well, which is why this has some nested logic. There might be some ongoing DST issues, though this seems to resolve most of them. 

```
if date == "latest":
            current_time = pd.Timestamp.now()
            return self.get_generator_outages_hourly(
                date=current_time,
                end=current_time + pd.DateOffset(months=4),
            )
        else:
            start_date = pd.Timestamp(date)
            if start_date.tz is None:
                start_date = start_date.tz_localize(self.default_timezone)
            else:
                start_date = start_date.tz_convert(self.default_timezone)

            end_date = pd.Timestamp(end) if end else None
            if end_date is not None:
                if end_date.tz is None:
                    end_date = end_date.tz_localize(self.default_timezone)
                else:
                    end_date = end_date.tz_convert(self.default_timezone)
```


### Columns
There are a lot of options here, since we have `Fuel Type` (e.g. `Gas`, `Hydro`) and `Sub Fuel Type` (e.g. `Simple Cycle`), as well as outage types (`Operational Outage`, what we care about by fuel type, `Mothball Outage`, what we care about summed across fuel types). The subfuel types are all related to the `Gas` Fuel type, so I mostly ignore them, combining all the `Gas` subtypes into the simple `Gas` fuel type. The Daily Report also combines all the Mothball Outage (MBO) into a single column, so I do that here as well, and lastly create a `Total Outage` column that sums the operational outages. 

I could separate out the `Gas` subtypes, like `Gas - Simple Cycle`, `Gas - Cogeneration`, etc (I had this at one point but nixed it). Given that we are doing column headers as Fuel Types, this simpler naming seemed like the way to go. We might just have to explain this in the description of the dataset. @cwaldoch et al if you want to weight in here that would be good.

### "Publish Time"
I've gone back and forth on whether or not this is a forecast that needs a publish time and I'm currently operating on the thought that yes it is, and therefore needs a publish time. A user may want to see how future outages evolve over time. Technically these are updated quite frequently though, and there is no explicit publish time from the API (only in the ETS system). So I set the publish time to be 1 hour before each past interval, since it is an hourly dataset (though the outages are updated quite frequently, they are often unchanging) and the current time floored to the nearest hour for future intervals. This will result in a good middle ground of tracked changes but not constant (e.g. every 5 minutes) forecasts for the next 24 months. 