### PR TITLE
feat(ENG 1744): Add CAISO Wind and Solar RTD, RTPD Forecasts and Actuals

### DIFF
--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -1160,7 +1160,7 @@ class CAISO(ISOBase):
         )
         return self._handle_renewable_forecast(
             df,
-            publish_time_offset=pd.Timedelta(minutes=90),
+            publish_time_offset=pd.Timedelta(minutes=10),
         )
 
     def get_rtpd_renewable_forecast(
@@ -1193,7 +1193,7 @@ class CAISO(ISOBase):
         )
         return self._handle_renewable_forecast(
             df,
-            publish_time_offset=pd.Timedelta(minutes=90),
+            publish_time_offset=pd.Timedelta(minutes=45),
         )
 
     def get_pnodes(self, verbose: bool = False) -> pd.DataFrame:

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -867,7 +867,7 @@ class CAISO(ISOBase):
 
         return df
 
-    def get_renewable_hourly(
+    def get_renewables_hourly(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
@@ -884,18 +884,18 @@ class CAISO(ISOBase):
             pandas.DataFrame: A DataFrame of wind and solar hourly actuals
         """
         if date == "latest":
-            return self.get_actual_renewable_hourly("today")
+            return self.get_renewables_hourly("today")
 
         df = self.get_oasis_dataset(
-            dataset="renewable",
+            dataset="renewables",
             date=date,
             end=end,
             verbose=verbose,
             raw_data=False,
         )
-        return self._process_renewable_hourly(df)
+        return self._process_renewables_hourly(df)
 
-    def get_renewable_forecast_dam(
+    def get_renewables_forecast_dam(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
@@ -907,19 +907,19 @@ class CAISO(ISOBase):
         DAM Renewable Forecast
         """
         if date == "latest":
-            return self.get_dam_renewable_forecast_hourly("today", verbose=verbose)
+            return self.get_renewables_forecast_dam("today", verbose=verbose)
 
         current_time = pd.Timestamp.now(tz=self.default_timezone)
 
         data = self.get_oasis_dataset(
-            dataset="renewable_forecast_dam",
+            dataset="renewables_forecast_dam",
             date=date,
             end=end,
             verbose=verbose,
             raw_data=False,
         )
 
-        return self._process_renewable_hourly(
+        return self._process_renewables_hourly(
             data,
             current_time,
             # Day-ahead hourly wind and solar forecast is published at 7:00 AM according
@@ -927,7 +927,7 @@ class CAISO(ISOBase):
             publish_time_offset_from_day_start=pd.Timedelta(hours=7),
         )
 
-    def _process_renewable_hourly(
+    def _process_renewables_hourly(
         self,
         data: pd.DataFrame,
         current_time: pd.Timestamp | None = None,
@@ -1055,7 +1055,7 @@ class CAISO(ISOBase):
 
         return data
 
-    def _handle_renewable_forecast(
+    def _handle_renewables_forecast(
         self,
         df: pd.DataFrame,
         publish_time_offset: pd.Timedelta,
@@ -1091,7 +1091,7 @@ class CAISO(ISOBase):
             ]
         ]
 
-    def get_renewable_forecast_hasp(
+    def get_renewables_forecast_hasp(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
@@ -1110,27 +1110,27 @@ class CAISO(ISOBase):
         """
         if date == "latest":
             try:
-                return self.get_hasp_renewable_forecast_hourly(
+                return self.get_renewables_forecast_hasp(
                     pd.Timestamp.now(tz=self.default_timezone) + pd.Timedelta(hours=2),
                 )  # NB: This is a hack to get the latest forecast
             except KeyError:
-                return self.get_hasp_renewable_forecast_hourly(
+                return self.get_renewables_forecast_hasp(
                     pd.Timestamp.now(tz=self.default_timezone) + pd.Timedelta(hours=1),
                 )
 
         df = self.get_oasis_dataset(
-            dataset="renewable_forecast_hasp",
+            dataset="renewables_forecast_hasp",
             date=date,
             end=end,
             verbose=verbose,
             raw_data=False,
         )
-        return self._handle_renewable_forecast(
+        return self._handle_renewables_forecast(
             df,
             publish_time_offset=pd.Timedelta(minutes=90),
         )
 
-    def get_renewable_forecast_rtd(
+    def get_renewables_forecast_rtd(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
@@ -1147,23 +1147,23 @@ class CAISO(ISOBase):
             pandas.DataFrame: A DataFrame of RTD renewable forecast
         """
         if date == "latest":
-            return self.get_rtd_renewable_forecast(
+            return self.get_renewables_forecast_rtd(
                 pd.Timestamp.now(tz=self.default_timezone),
             )
 
         df = self.get_oasis_dataset(
-            dataset="renewable_forecast_rtd",
+            dataset="renewables_forecast_rtd",
             date=date,
             end=end,
             verbose=verbose,
             raw_data=False,
         )
-        return self._handle_renewable_forecast(
+        return self._handle_renewables_forecast(
             df,
             publish_time_offset=pd.Timedelta(minutes=2.5),
         )
 
-    def get_renewable_forecast_rtpd(
+    def get_renewables_forecast_rtpd(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
@@ -1180,18 +1180,18 @@ class CAISO(ISOBase):
             pandas.DataFrame: A DataFrame of RTPD renewable forecast
         """
         if date == "latest":
-            return self.get_rtpd_renewable_forecast(
+            return self.get_renewables_forecast_rtpd(
                 pd.Timestamp.now(tz=self.default_timezone),
             )
 
         df = self.get_oasis_dataset(
-            dataset="renewable_forecast_rtpd",
+            dataset="renewables_forecast_rtpd",
             date=date,
             end=end,
             verbose=verbose,
             raw_data=False,
         )
-        return self._handle_renewable_forecast(
+        return self._handle_renewables_forecast(
             df,
             publish_time_offset=pd.Timedelta(minutes=22.5),
         )

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -867,31 +867,59 @@ class CAISO(ISOBase):
 
         return df
 
-    def get_solar_and_wind_forecast_dam(
+    def get_actual_renewable_hourly(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
-        """Return wind and solar forecast in hourly intervals
+        """Get wind and solar hourly actuals from CAISO.
 
-        Data at: http://oasis.caiso.com/mrioasis/logon.do  at System Demand >
-        Wind and Solar Forecast
+        Args:
+            date (str | pd.Timestamp): date to return data
+            end (str | pd.Timestamp | None, optional): last date of range to return data.
+            verbose (bool, optional): print out url being fetched. Defaults to False.
+
+        Returns:
+            pandas.DataFrame: A DataFrame of wind and solar hourly actuals
         """
         if date == "latest":
-            return self.get_solar_and_wind_forecast_dam("today", verbose=verbose)
+            return self.get_actual_renewable_hourly("today")
+
+        df = self.get_oasis_dataset(
+            dataset="actual_renewable_hourly",
+            date=date,
+            end=end,
+            verbose=verbose,
+            raw_data=False,
+        )
+        return self._process_renewable_hourly(df)
+
+    def get_dam_renewable_forecast_hourly(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Return DAM renewable forecast in hourly intervals
+
+        Data at: http://oasis.caiso.com/mrioasis/logon.do  at System Demand >
+        DAM Renewable Forecast
+        """
+        if date == "latest":
+            return self.get_dam_renewable_forecast_hourly("today", verbose=verbose)
 
         current_time = pd.Timestamp.now(tz=self.default_timezone)
 
         data = self.get_oasis_dataset(
-            dataset="wind_and_solar_forecast",
+            dataset="dam_renewable_forecast_hourly",
             date=date,
             end=end,
             verbose=verbose,
             raw_data=False,
         )
 
-        return self._process_solar_and_wind_forecast_dam(
+        return self._process_renewable_hourly(
             data,
             current_time,
             # Day-ahead hourly wind and solar forecast is published at 7:00 AM according
@@ -899,11 +927,11 @@ class CAISO(ISOBase):
             publish_time_offset_from_day_start=pd.Timedelta(hours=7),
         )
 
-    def _process_solar_and_wind_forecast_dam(
+    def _process_renewable_hourly(
         self,
         data: pd.DataFrame,
-        current_time: pd.Timestamp,
-        publish_time_offset_from_day_start: pd.Timedelta,
+        current_time: pd.Timestamp | None = None,
+        publish_time_offset_from_day_start: pd.Timedelta | None = None,
     ):
         df = data[
             [
@@ -934,30 +962,47 @@ class CAISO(ISOBase):
             values="MW",
         ).reset_index()
 
-        df = self._add_forecast_publish_time(
-            df,
-            current_time,
-            # Day-ahead hourly wind and solar forecast is published at 7:00 AM according
-            # to OASIS.
-            publish_time_offset_from_day_start=publish_time_offset_from_day_start,
-        )
+        if publish_time_offset_from_day_start:
+            df = self._add_forecast_publish_time(
+                df,
+                current_time=current_time,
+                # Day-ahead hourly wind and solar forecast is published at 7:00 AM according
+                # to OASIS.
+                publish_time_offset_from_day_start=publish_time_offset_from_day_start,
+            )
 
-        df = utils.move_cols_to_front(
-            df.rename(
-                columns={
-                    "TRADING_HUB": "Location",
-                    "Solar": "Solar MW",
-                    "Wind": "Wind MW",
-                },
-            ),
-            ["Interval Start", "Interval End", "Publish Time", "Location"],
-        )
+            df = utils.move_cols_to_front(
+                df.rename(
+                    columns={
+                        "TRADING_HUB": "Location",
+                        "Solar": "Solar MW",
+                        "Wind": "Wind MW",
+                    },
+                ),
+                ["Interval Start", "Interval End", "Publish Time", "Location"],
+            )
 
-        df.columns.name = None
+            df.columns.name = None
 
-        return df.sort_values(
-            ["Interval Start", "Publish Time", "Location"],
-        ).reset_index(drop=True)
+            return df.sort_values(
+                ["Interval Start", "Publish Time", "Location"],
+            ).reset_index(drop=True)
+
+        else:
+            df = utils.move_cols_to_front(
+                df.rename(
+                    columns={
+                        "TRADING_HUB": "Location",
+                    },
+                ),
+                ["Interval Start", "Interval End", "Location"],
+            )
+
+            df.columns.name = None
+
+            return df.sort_values(
+                ["Interval Start", "Location"],
+            ).reset_index(drop=True)
 
     def _add_forecast_publish_time(
         self,
@@ -1009,6 +1054,147 @@ class CAISO(ISOBase):
         )
 
         return data
+
+    def _handle_renewable_forecast(
+        self,
+        df: pd.DataFrame,
+        publish_time_offset: pd.Timedelta,
+    ) -> pd.DataFrame:
+        df = df.rename(
+            columns={
+                "TRADING_HUB": "Location",
+                "RENEWABLE_TYPE": "Renewable Type",
+            },
+        )
+
+        df = df.pivot_table(
+            index=[
+                "Interval Start",
+                "Interval End",
+                "Location",
+            ],
+            columns="Renewable Type",
+            values="MW",
+            aggfunc="first",
+        ).reset_index()
+
+        df.columns.name = None
+        df["Publish Time"] = df["Interval Start"] - publish_time_offset
+        return df[
+            [
+                "Interval Start",
+                "Interval End",
+                "Publish Time",
+                "Location",
+                "Solar",
+                "Wind",
+            ]
+        ]
+
+    def get_hasp_renewable_forecast_hourly(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Get solar and wind generation HASP hourly data from CAISO.
+
+        Args:
+            date (str | pd.Timestamp): date to return data
+            end (str | pd.Timestamp | None, optional): last date of range to return data.
+                If None, returns only date. Defaults to None.
+            verbose (bool, optional): print out url being fetched. Defaults to False.
+
+        Returns:
+            pandas.DataFrame: A DataFrame of solar and wind generation HASP hourly data
+        """
+        if date == "latest":
+            try:
+                return self.get_hasp_renewable_forecast_hourly(
+                    pd.Timestamp.now(tz=self.default_timezone) + pd.Timedelta(hours=2),
+                )  # NB: This is a hack to get the latest forecast
+            except KeyError:
+                return self.get_hasp_renewable_forecast_hourly(
+                    pd.Timestamp.now(tz=self.default_timezone) + pd.Timedelta(hours=1),
+                )
+
+        df = self.get_oasis_dataset(
+            dataset="hasp_renewable_forecast_hourly",
+            date=date,
+            end=end,
+            verbose=verbose,
+            raw_data=False,
+        )
+        return self._handle_renewable_forecast(
+            df,
+            publish_time_offset=pd.Timedelta(minutes=90),
+        )
+
+    def get_rtd_renewable_forecast(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Get RTD renewable forecast from CAISO.
+
+        Args:
+            date (str | pd.Timestamp): date to return data
+            end (str | pd.Timestamp | None, optional): last date of range to return data.
+            verbose (bool, optional): print out url being fetched. Defaults to False.
+
+        Returns:
+            pandas.DataFrame: A DataFrame of RTD renewable forecast
+        """
+        if date == "latest":
+            return self.get_rtd_renewable_forecast(
+                pd.Timestamp.now(tz=self.default_timezone),
+            )
+
+        df = self.get_oasis_dataset(
+            dataset="rtd_renewable_forecast",
+            date=date,
+            end=end,
+            verbose=verbose,
+            raw_data=False,
+        )
+        return self._handle_renewable_forecast(
+            df,
+            publish_time_offset=pd.Timedelta(minutes=90),
+        )
+
+    def get_rtpd_renewable_forecast(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Get RTPD renewable forecast from CAISO.
+
+        Args:
+            date (str | pd.Timestamp): date to return data
+            end (str | pd.Timestamp | None, optional): last date of range to return data.
+            verbose (bool, optional): print out url being fetched. Defaults to False.
+
+        Returns:
+            pandas.DataFrame: A DataFrame of RTPD renewable forecast
+        """
+        if date == "latest":
+            return self.get_rtpd_renewable_forecast(
+                pd.Timestamp.now(tz=self.default_timezone),
+            )
+
+        df = self.get_oasis_dataset(
+            dataset="rtpd_renewable_forecast",
+            date=date,
+            end=end,
+            verbose=verbose,
+            raw_data=False,
+        )
+        return self._handle_renewable_forecast(
+            df,
+            publish_time_offset=pd.Timedelta(minutes=90),
+        )
 
     def get_pnodes(self, verbose: bool = False) -> pd.DataFrame:
         start = utils._handle_date("today")
@@ -2208,74 +2394,6 @@ class CAISO(ISOBase):
             ]
         ]
 
-    def get_hasp_renewable_forecast_hourly(
-        self,
-        date: str | pd.Timestamp,
-        end: str | pd.Timestamp | None = None,
-        verbose: bool = False,
-    ) -> pd.DataFrame:
-        """Get solar and wind generation HASP hourly data from CAISO.
-
-        Args:
-            date (str | pd.Timestamp): date to return data
-            end (str | pd.Timestamp | None, optional): last date of range to return data.
-                If None, returns only date. Defaults to None.
-            verbose (bool, optional): print out url being fetched. Defaults to False.
-
-        Returns:
-            pandas.DataFrame: A DataFrame of solar and wind generation HASP hourly data
-        """
-        if date == "latest":
-            try:
-                return self.get_hasp_renewable_forecast_hourly(
-                    pd.Timestamp.now(tz=self.default_timezone) + pd.Timedelta(hours=2),
-                )  # NB: This is a hack to get the latest forecast
-            except KeyError:
-                return self.get_hasp_renewable_forecast_hourly(
-                    pd.Timestamp.now(tz=self.default_timezone) + pd.Timedelta(hours=1),
-                )
-
-        df = self.get_oasis_dataset(
-            dataset="hasp_renewable_forecast_hourly",
-            date=date,
-            end=end,
-            verbose=verbose,
-            raw_data=False,
-        )
-        return self._handle_hasp_renewable_forecast_hourly(df)
-
-    def _handle_hasp_renewable_forecast_hourly(self, df: pd.DataFrame) -> pd.DataFrame:
-        df = df.rename(
-            columns={
-                "TRADING_HUB": "Location",
-                "RENEWABLE_TYPE": "Renewable Type",
-            },
-        )
-
-        df = df.pivot_table(
-            index=[
-                "Interval Start",
-                "Interval End",
-                "Location",
-            ],
-            columns="Renewable Type",
-            values="MW",
-            aggfunc="first",
-        ).reset_index()
-
-        df.columns.name = None
-        df["Publish Time"] = df["Interval Start"] - pd.Timedelta(minutes=90)
-        return df[
-            [
-                "Interval Start",
-                "Interval End",
-                "Publish Time",
-                "Location",
-                "Solar",
-                "Wind",
-            ]
-        ]
-
     @support_date_range(frequency="31D")
     def get_nomogram_branch_shadow_prices_day_ahead_hourly(
         self,
@@ -2296,7 +2414,7 @@ class CAISO(ISOBase):
         """
         if date == "latest":
             return self.get_nomogram_branch_shadow_prices_day_ahead_hourly(
-                pd.Timestamp.now(tz=self.default_timezone)
+                pd.Timestamp.now(tz=self.default_timezone),
             )
 
         df = self.get_oasis_dataset(
@@ -2336,7 +2454,7 @@ class CAISO(ISOBase):
         """
         if date == "latest":
             return self.get_nomogram_branch_shadow_prices_hasp_hourly(
-                pd.Timestamp.now(tz=self.default_timezone)
+                pd.Timestamp.now(tz=self.default_timezone),
             )
 
         df = self.get_oasis_dataset(
@@ -2376,7 +2494,7 @@ class CAISO(ISOBase):
         """
         if date == "latest":
             return self.get_nomogram_branch_shadow_price_forecast_15_min(
-                pd.Timestamp.now(tz=self.default_timezone)
+                pd.Timestamp.now(tz=self.default_timezone),
             )
 
         df = self.get_oasis_dataset(
@@ -2416,7 +2534,7 @@ class CAISO(ISOBase):
         """
         if date == "latest":
             return self.get_interval_nomogram_branch_shadow_prices_real_time_5_min(
-                pd.Timestamp.now(tz=self.default_timezone)
+                pd.Timestamp.now(tz=self.default_timezone),
             )
 
         df = self.get_oasis_dataset(

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -1160,7 +1160,7 @@ class CAISO(ISOBase):
         )
         return self._handle_renewable_forecast(
             df,
-            publish_time_offset=pd.Timedelta(minutes=10),
+            publish_time_offset=pd.Timedelta(minutes=2.5),
         )
 
     def get_rtpd_renewable_forecast(
@@ -1193,7 +1193,7 @@ class CAISO(ISOBase):
         )
         return self._handle_renewable_forecast(
             df,
-            publish_time_offset=pd.Timedelta(minutes=45),
+            publish_time_offset=pd.Timedelta(minutes=22.5),
         )
 
     def get_pnodes(self, verbose: bool = False) -> pd.DataFrame:

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -867,7 +867,7 @@ class CAISO(ISOBase):
 
         return df
 
-    def get_actual_renewable_hourly(
+    def get_renewable_hourly(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
@@ -887,7 +887,7 @@ class CAISO(ISOBase):
             return self.get_actual_renewable_hourly("today")
 
         df = self.get_oasis_dataset(
-            dataset="actual_renewable_hourly",
+            dataset="renewable",
             date=date,
             end=end,
             verbose=verbose,
@@ -895,7 +895,7 @@ class CAISO(ISOBase):
         )
         return self._process_renewable_hourly(df)
 
-    def get_dam_renewable_forecast_hourly(
+    def get_renewable_forecast_dam(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
@@ -912,7 +912,7 @@ class CAISO(ISOBase):
         current_time = pd.Timestamp.now(tz=self.default_timezone)
 
         data = self.get_oasis_dataset(
-            dataset="dam_renewable_forecast_hourly",
+            dataset="renewable_forecast_dam",
             date=date,
             end=end,
             verbose=verbose,
@@ -1091,7 +1091,7 @@ class CAISO(ISOBase):
             ]
         ]
 
-    def get_hasp_renewable_forecast_hourly(
+    def get_renewable_forecast_hasp(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
@@ -1119,7 +1119,7 @@ class CAISO(ISOBase):
                 )
 
         df = self.get_oasis_dataset(
-            dataset="hasp_renewable_forecast_hourly",
+            dataset="renewable_forecast_hasp",
             date=date,
             end=end,
             verbose=verbose,
@@ -1130,7 +1130,7 @@ class CAISO(ISOBase):
             publish_time_offset=pd.Timedelta(minutes=90),
         )
 
-    def get_rtd_renewable_forecast(
+    def get_renewable_forecast_rtd(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
@@ -1152,7 +1152,7 @@ class CAISO(ISOBase):
             )
 
         df = self.get_oasis_dataset(
-            dataset="rtd_renewable_forecast",
+            dataset="renewable_forecast_rtd",
             date=date,
             end=end,
             verbose=verbose,
@@ -1163,7 +1163,7 @@ class CAISO(ISOBase):
             publish_time_offset=pd.Timedelta(minutes=2.5),
         )
 
-    def get_rtpd_renewable_forecast(
+    def get_renewable_forecast_rtpd(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
@@ -1185,7 +1185,7 @@ class CAISO(ISOBase):
             )
 
         df = self.get_oasis_dataset(
-            dataset="rtpd_renewable_forecast",
+            dataset="renewable_forecast_rtpd",
             date=date,
             end=end,
             verbose=verbose,

--- a/gridstatus/caiso/caiso_constants.py
+++ b/gridstatus/caiso/caiso_constants.py
@@ -100,7 +100,16 @@ OASIS_DATASET_CONFIG = {
         },
         "params": {},
     },
-    "wind_and_solar_forecast": {
+    "actual_renewable_hourly": {
+        "query": {
+            "path": "SingleZip",
+            "resultformat": 6,
+            "queryname": "SLD_REN_FCST",
+            "version": 1,
+        },
+        "params": {"market_run_id": "ACTUAL"},
+    },
+    "dam_renewable_forecast_hourly": {
         "query": {
             "path": "SingleZip",
             "resultformat": 6,
@@ -108,6 +117,48 @@ OASIS_DATASET_CONFIG = {
             "version": 1,
         },
         "params": {"market_run_id": "DAM"},
+    },
+    "hasp_renewable_forecast_hourly": {
+        "query": {
+            "path": "SingleZip",
+            "resultformat": 6,
+            "queryname": "SLD_REN_FCST",
+            "version": 1,
+        },
+        "params": {
+            "market_run_id": "HASP",
+        },
+        "meta": {
+            "max_query_frequency": "1d",
+        },
+    },
+    "rtd_renewable_forecast": {
+        "query": {
+            "path": "SingleZip",
+            "resultformat": 6,
+            "queryname": "SLD_REN_FCST",
+            "version": 1,
+        },
+        "params": {
+            "market_run_id": "RTD",
+        },
+        "meta": {
+            "max_query_frequency": "1h",
+        },
+    },
+    "rtpd_renewable_forecast": {
+        "query": {
+            "path": "SingleZip",
+            "resultformat": 6,
+            "queryname": "SLD_REN_FCST",
+            "version": 1,
+        },
+        "params": {
+            "market_run_id": "RTPD",
+        },
+        "meta": {
+            "max_query_frequency": "1h",
+        },
     },
     "pnode_map": {
         "query": {
@@ -314,20 +365,6 @@ OASIS_DATASET_CONFIG = {
         "params": {
             "groupid": ["DAM_ENE_SCH_BY_TIE_GRP"],
             "market_run_id": DAY_AHEAD_MARKET_MARKET_RUN_ID,
-        },
-    },
-    "hasp_renewable_forecast_hourly": {
-        "query": {
-            "path": "SingleZip",
-            "resultformat": 6,
-            "queryname": "SLD_REN_FCST",
-            "version": 1,
-        },
-        "params": {
-            "market_run_id": "HASP",
-        },
-        "meta": {
-            "max_query_frequency": "1d",
         },
     },
     "nomogram_branch_shadow_prices": {

--- a/gridstatus/caiso/caiso_constants.py
+++ b/gridstatus/caiso/caiso_constants.py
@@ -100,7 +100,7 @@ OASIS_DATASET_CONFIG = {
         },
         "params": {},
     },
-    "actual_renewable_hourly": {
+    "renewable": {
         "query": {
             "path": "SingleZip",
             "resultformat": 6,
@@ -109,7 +109,7 @@ OASIS_DATASET_CONFIG = {
         },
         "params": {"market_run_id": "ACTUAL"},
     },
-    "dam_renewable_forecast_hourly": {
+    "renewable_forecast_dam": {
         "query": {
             "path": "SingleZip",
             "resultformat": 6,
@@ -118,7 +118,7 @@ OASIS_DATASET_CONFIG = {
         },
         "params": {"market_run_id": "DAM"},
     },
-    "hasp_renewable_forecast_hourly": {
+    "renewable_forecast_hasp": {
         "query": {
             "path": "SingleZip",
             "resultformat": 6,
@@ -132,7 +132,7 @@ OASIS_DATASET_CONFIG = {
             "max_query_frequency": "1d",
         },
     },
-    "rtd_renewable_forecast": {
+    "renewable_forecast_rtd": {
         "query": {
             "path": "SingleZip",
             "resultformat": 6,
@@ -146,7 +146,7 @@ OASIS_DATASET_CONFIG = {
             "max_query_frequency": "1d",
         },
     },
-    "rtpd_renewable_forecast": {
+    "renewable_forecast_rtpd": {
         "query": {
             "path": "SingleZip",
             "resultformat": 6,

--- a/gridstatus/caiso/caiso_constants.py
+++ b/gridstatus/caiso/caiso_constants.py
@@ -100,7 +100,7 @@ OASIS_DATASET_CONFIG = {
         },
         "params": {},
     },
-    "renewable": {
+    "renewables": {
         "query": {
             "path": "SingleZip",
             "resultformat": 6,
@@ -109,7 +109,7 @@ OASIS_DATASET_CONFIG = {
         },
         "params": {"market_run_id": "ACTUAL"},
     },
-    "renewable_forecast_dam": {
+    "renewables_forecast_dam": {
         "query": {
             "path": "SingleZip",
             "resultformat": 6,
@@ -118,7 +118,7 @@ OASIS_DATASET_CONFIG = {
         },
         "params": {"market_run_id": "DAM"},
     },
-    "renewable_forecast_hasp": {
+    "renewables_forecast_hasp": {
         "query": {
             "path": "SingleZip",
             "resultformat": 6,
@@ -132,7 +132,7 @@ OASIS_DATASET_CONFIG = {
             "max_query_frequency": "1d",
         },
     },
-    "renewable_forecast_rtd": {
+    "renewables_forecast_rtd": {
         "query": {
             "path": "SingleZip",
             "resultformat": 6,
@@ -146,7 +146,7 @@ OASIS_DATASET_CONFIG = {
             "max_query_frequency": "1d",
         },
     },
-    "renewable_forecast_rtpd": {
+    "renewables_forecast_rtpd": {
         "query": {
             "path": "SingleZip",
             "resultformat": 6,

--- a/gridstatus/caiso/caiso_constants.py
+++ b/gridstatus/caiso/caiso_constants.py
@@ -143,7 +143,7 @@ OASIS_DATASET_CONFIG = {
             "market_run_id": "RTD",
         },
         "meta": {
-            "max_query_frequency": "1h",
+            "max_query_frequency": "1d",
         },
     },
     "rtpd_renewable_forecast": {
@@ -157,7 +157,7 @@ OASIS_DATASET_CONFIG = {
             "market_run_id": "RTPD",
         },
         "meta": {
-            "max_query_frequency": "1h",
+            "max_query_frequency": "1d",
         },
     },
     "pnode_map": {

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -225,11 +225,11 @@ class TestCAISO(BaseTestISO):
         assert df["Publish Time"].max() < self.local_now()
         assert df["Publish Time"].nunique() == expected_count_unique_publish_times
 
-    def test_get_dam_renewable_forecast_hourly_today(self):
+    def test_get_renewables_forecast_dam_today(self):
         with caiso_vcr.use_cassette(
-            "test_get_dam_renewable_forecast_hourly_today.yaml",
+            "test_get_renewables_forecast_dam_today.yaml",
         ):
-            df = self.iso.get_dam_renewable_forecast_hourly("today")
+            df = self.iso.get_renewables_forecast_dam("today")
             self._check_solar_and_wind_forecast(df, 1)
 
             assert df["Interval Start"].min() == self.local_start_of_today()
@@ -239,20 +239,20 @@ class TestCAISO(BaseTestISO):
                 hours=23,
             )
 
-    def test_get_dam_renewable_forecast_hourly_latest(self):
+    def test_get_renewables_forecast_dam_latest(self):
         with caiso_vcr.use_cassette(
-            "test_get_dam_renewable_forecast_hourly_latest.yaml",
+            "test_get_renewables_forecast_dam_latest.yaml",
         ):
-            assert self.iso.get_dam_renewable_forecast_hourly("latest").equals(
-                self.iso.get_dam_renewable_forecast_hourly("today"),
+            assert self.iso.get_renewables_forecast_dam("latest").equals(
+                self.iso.get_renewables_forecast_dam("today"),
             )
 
     @pytest.mark.parametrize("date", ["2024-02-20"])
-    def test_get_dam_renewable_forecast_hourly_historical_date(self, date):
+    def test_get_renewables_forecast_dam_historical_date(self, date):
         with caiso_vcr.use_cassette(
-            f"test_get_dam_renewable_forecast_hourly_{date}.yaml",
+            f"test_get_renewables_forecast_dam_{date}.yaml",
         ):
-            df = self.iso.get_dam_renewable_forecast_hourly(date)
+            df = self.iso.get_renewables_forecast_dam(date)
             self._check_solar_and_wind_forecast(df, 1)
 
             assert df["Interval Start"].min() == self.local_start_of_day(date)
@@ -261,14 +261,14 @@ class TestCAISO(BaseTestISO):
             ) + pd.Timedelta(hours=23)
 
     @pytest.mark.parametrize("start, end", [("2023-08-15", "2023-08-21")])
-    def test_get_dam_renewable_forecast_hourly_historical_range(self, start, end):
+    def test_get_renewables_forecast_dam_historical_range(self, start, end):
         with caiso_vcr.use_cassette(
-            f"test_get_dam_renewable_forecast_hourly_{start}_{end}.yaml",
+            f"test_get_renewables_forecast_dam_{start}_{end}.yaml",
         ):
             start = pd.Timestamp(start)
             end = pd.Timestamp(end)
 
-            df = self.iso.get_dam_renewable_forecast_hourly(start, end=end)
+            df = self.iso.get_renewables_forecast_dam(start, end=end)
 
             # Only 6 days of data because the end date is exclusive
             self._check_solar_and_wind_forecast(df, 6)
@@ -278,22 +278,22 @@ class TestCAISO(BaseTestISO):
                 end,
             ) - pd.Timedelta(hours=1)
 
-    def test_get_dam_renewable_forecast_hourly_future_date_range(self):
+    def test_get_renewables_forecast_dam_future_date_range(self):
         with caiso_vcr.use_cassette(
-            "test_get_dam_renewable_forecast_hourly_future_date_range.yaml",
+            "test_get_renewables_forecast_dam_future_date_range.yaml",
         ):
             start = self.local_today() + pd.Timedelta(days=1)
             end = start + pd.Timedelta(days=2)
 
-            df = self.iso.get_dam_renewable_forecast_hourly(start, end=end)
+            df = self.iso.get_renewables_forecast_dam(start, end=end)
 
             self._check_solar_and_wind_forecast(df, 1)
 
-    def test_get_hasp_renewable_forecast_hourly_latest(self):
+    def test_get_renewables_forecast_hasp_latest(self):
         with caiso_vcr.use_cassette(
-            "test_get_hasp_renewable_forecast_hourly_latest.yaml",
+            "test_get_renewables_forecast_hasp_latest.yaml",
         ):
-            df = self.iso.get_hasp_renewable_forecast_hourly("latest")
+            df = self.iso.get_renewables_forecast_hasp("latest")
             assert df.shape[0] > 0
             assert df.columns.tolist() == [
                 "Interval Start",
@@ -316,11 +316,11 @@ class TestCAISO(BaseTestISO):
             ),
         ],
     )
-    def test_get_hasp_renewable_forecast_hourly_date_range(self, date, end):
+    def test_get_renewables_forecast_hasp_date_range(self, date, end):
         with caiso_vcr.use_cassette(
-            f"test_get_hasp_renewable_forecast_hourly_date_range_{date}_{end}.yaml",
+            f"test_get_renewables_forecast_hasp_date_range_{date}_{end}.yaml",
         ):
-            df = self.iso.get_hasp_renewable_forecast_hourly(date, end=end)
+            df = self.iso.get_renewables_forecast_hasp(date, end=end)
             assert df.shape[0] > 0
             assert df.columns.tolist() == [
                 "Interval Start",
@@ -342,11 +342,11 @@ class TestCAISO(BaseTestISO):
                 (df["Interval Start"] - df["Publish Time"]) == pd.Timedelta(minutes=90)
             ).all()
 
-    def test_get_actual_renewable_hourly_latest(self):
+    def test_get_renewables_hourly_latest(self):
         with caiso_vcr.use_cassette(
-            "test_get_actual_renewable_hourly_latest.yaml",
+            "test_get_renewables_hourly_latest.yaml",
         ):
-            df = self.iso.get_actual_renewable_hourly("latest")
+            df = self.iso.get_renewables_hourly("latest")
             assert df.shape[0] > 0
             assert df.columns.tolist() == [
                 "Interval Start",
@@ -363,11 +363,11 @@ class TestCAISO(BaseTestISO):
             ("2025-03-20", "2025-03-22"),
         ],
     )
-    def test_get_actual_renewable_hourly_date_range(self, date, end):
+    def test_get_renewables_hourly_date_range(self, date, end):
         with caiso_vcr.use_cassette(
-            f"test_get_actual_renewable_hourly_date_range_{date}_{end}.yaml",
+            f"test_get_renewables_hourly_date_range_{date}_{end}.yaml",
         ):
-            df = self.iso.get_actual_renewable_hourly(date, end=end)
+            df = self.iso.get_renewables_hourly(date, end=end)
             assert df.shape[0] > 0
             assert df.columns.tolist() == [
                 "Interval Start",
@@ -385,11 +385,11 @@ class TestCAISO(BaseTestISO):
                 tz=self.iso.default_timezone,
             )
 
-    def test_get_rtd_renewable_forecast_latest(self):
+    def test_get_renewables_forecast_rtd_latest(self):
         with caiso_vcr.use_cassette(
-            "test_get_rtd_renewable_forecast_latest.yaml",
+            "test_get_renewables_forecast_rtd_latest.yaml",
         ):
-            df = self.iso.get_rtd_renewable_forecast("latest")
+            df = self.iso.get_renewables_forecast_rtd("latest")
             assert df.shape[0] > 0
             assert df.columns.tolist() == [
                 "Interval Start",
@@ -407,11 +407,11 @@ class TestCAISO(BaseTestISO):
             ("2025-03-20", "2025-03-22"),
         ],
     )
-    def test_get_rtd_renewable_forecast_date_range(self, date, end):
+    def test_get_renewables_forecast_rtd_date_range(self, date, end):
         with caiso_vcr.use_cassette(
-            f"test_get_rtd_renewable_forecast_date_range_{date}_{end}.yaml",
+            f"test_get_renewables_forecast_rtd_date_range_{date}_{end}.yaml",
         ):
-            df = self.iso.get_rtd_renewable_forecast(date, end=end)
+            df = self.iso.get_renewables_forecast_rtd(date, end=end)
             assert df.shape[0] > 0
             assert df.columns.tolist() == [
                 "Interval Start",
@@ -430,11 +430,11 @@ class TestCAISO(BaseTestISO):
                 tz=self.iso.default_timezone,
             )
 
-    def test_get_rtpd_renewable_forecast_latest(self):
+    def test_get_renewables_forecast_rtpd_latest(self):
         with caiso_vcr.use_cassette(
-            "test_get_rtpd_renewable_forecast_latest.yaml",
+            "test_get_renewables_forecast_rtpd_latest.yaml",
         ):
-            df = self.iso.get_rtpd_renewable_forecast("latest")
+            df = self.iso.get_renewables_forecast_rtpd("latest")
             assert df.shape[0] > 0
             assert df.columns.tolist() == [
                 "Interval Start",
@@ -452,11 +452,11 @@ class TestCAISO(BaseTestISO):
             ("2025-03-20", "2025-03-22"),
         ],
     )
-    def test_get_rtpd_renewable_forecast_date_range(self, date, end):
+    def test_get_renewables_forecast_rtpd_date_range(self, date, end):
         with caiso_vcr.use_cassette(
-            f"test_get_rtpd_renewable_forecast_date_range_{date}_{end}.yaml",
+            f"test_get_renewables_forecast_rtpd_date_range_{date}_{end}.yaml",
         ):
-            df = self.iso.get_rtpd_renewable_forecast(date, end=end)
+            df = self.iso.get_renewables_forecast_rtpd(date, end=end)
             assert df.shape[0] > 0
             assert df.columns.tolist() == [
                 "Interval Start",


### PR DESCRIPTION
## Summary
Adds the CAISO `get_rtd_renewable_forecast`, `get_rtpd_renewable_forecast` and `get_actual_renewables_hourly` methods to `CAISO()` and simplifies the handler methods and naming convention a bit across similar reports. 

Open questions:
- Renaming of existing `solar_and_wind_forecast_dam`
- ~Publish Time Offset correctness~

## Details
### Organization and Naming
Add the methods for the new datasets, as well as their source report constants and parameters, and places the existing `hasp_renewable_forecast_hourly` method up with the existing `solar_and_wind_forecast_dam` (which has been renamed to reflect the naming convention of this report to `dam_renewable_forecast_hourly` - more below). Also puts their tests together in the test file. Finally, expands but simplifies some of the helper methods, to simply `_process_renewable_hourly()` for the Actuals and DAM, and `_handle_renewable_forecast()` for the others (HASP, RTD, RTPD). Obviously these could probably be simplified further down to a single method since they are all the same response schema, but this is a step in the right direction. Open question on this PR if we want to do that final simplification. 

### Publish Times
Still ironing these out given what I can observe in OASIS, but should be an easily tunable parameter given the helper methods. From what I can tell:

**- RTD Published ~10 minutes ahead of time**
![CleanShot 2025-06-15 at 21 47 12@2x](https://github.com/user-attachments/assets/f6cdf37d-b85d-4d6c-8c57-b77c4fede208)

**- RTPD Published ~45 minutes ahead of time**
![CleanShot 2025-06-15 at 21 50 02@2x](https://github.com/user-attachments/assets/b97ce2e8-ede8-4a5b-af45-3df5bcc8d963)

Actuals don't need a publish time. 