### PR TITLE
feat(ENG 1686): AESO Tx Outages

### DIFF
--- a/gridstatus/aeso/aeso.py
+++ b/gridstatus/aeso/aeso.py
@@ -1,9 +1,11 @@
 import json
 import os
+import re
 from typing import Any, Literal
 
 import pandas as pd
 import requests
+from bs4 import BeautifulSoup
 from requests.exceptions import HTTPError, RequestException
 
 from gridstatus import utils
@@ -14,6 +16,9 @@ from gridstatus.aeso.aeso_constants import (
 )
 from gridstatus.base import NotSupported
 from gridstatus.decorators import support_date_range
+from gridstatus.gs_logging import setup_gs_logger
+
+logger = setup_gs_logger("aeso")
 
 
 class AESO:
@@ -831,3 +836,203 @@ class AESO:
                 df_pivot[col] = 0
 
         return df_pivot[expected_columns]
+
+    def get_transmission_outages(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+    ) -> pd.DataFrame:
+        """
+        Get transmission outages data.
+
+        Args:
+            date: Start date for the data. Can be "latest" to get current data.
+            end: End date for the data. If not provided, will get data for the specified date.
+
+        Returns:
+            DataFrame containing transmission outage data
+        """
+        if date == "latest":
+            url = "http://ets.aeso.ca/outage_reports/qryOpPlanTransmissionTable_1.html"
+            response = requests.get(url)
+            response.raise_for_status()
+
+            soup = BeautifulSoup(response.text, "html.parser")
+            csv_link = soup.find("a", href=lambda x: x and "csvData" in x)
+            csv_href = csv_link["href"].replace("\\", "/")
+            csv_url = f"http://ets.aeso.ca/outage_reports/{csv_href}"
+
+            publish_match = re.search(
+                r"(\d{4}-\d{2}-\d{2})_(\d{2}-\d{2}-\d{2})",
+                csv_href,
+            )
+            if publish_match:
+                publish_date = publish_match.group(1)
+                publish_time = publish_match.group(2).replace("-", ":")
+                publish_datetime = pd.to_datetime(f"{publish_date} {publish_time}")
+                publish_datetime = publish_datetime.tz_localize(self.default_timezone)
+
+            df = pd.read_csv(csv_url)
+
+            df["Interval Start"] = pd.to_datetime(df["From"], format="%d-%b-%y %H:%M")
+            df["Interval End"] = pd.to_datetime(df["To"], format="%d-%b-%y %H:%M")
+            df["Publish Time"] = publish_datetime
+
+            df = df.rename(
+                columns={
+                    "Owner": "Transmission Owner",
+                    "Date/Time Comments": "Date Time Comments",
+                },
+            )
+
+            df = df[
+                [
+                    "Interval Start",
+                    "Interval End",
+                    "Publish Time",
+                    "Transmission Owner",
+                    "Type",
+                    "Element",
+                    "Scheduled Activity",
+                    "Date Time Comments",
+                    "Interconnection",
+                ]
+            ]
+
+            return df
+
+        else:
+            # NB: For historical data, we need to navigate backwards through Previous Version links
+            # as there doesn't seem to be a better way to do it.
+            start_date = pd.Timestamp(date)
+            end_date = pd.Timestamp(end) if end else start_date
+
+            # NB: Start from the latest file and navigate backwards
+            current_url = (
+                "http://ets.aeso.ca/outage_reports/qryOpPlanTransmissionTable_1.html"
+            )
+            historical_files = []
+
+            for _ in range(100):  # NB: Limit iterations to prevent infinite loops
+                try:
+                    response = requests.get(current_url)
+                    response.raise_for_status()
+
+                    soup = BeautifulSoup(response.text, "html.parser")
+
+                    csv_link = soup.find("a", href=lambda x: x and "csvData" in x)
+                    if csv_link:
+                        csv_href = csv_link["href"].replace("\\", "/")
+
+                        publish_match = re.search(
+                            r"(\d{4}-\d{2}-\d{2})_(\d{2}-\d{2}-\d{2})",
+                            csv_href,
+                        )
+                        if publish_match:
+                            publish_date = publish_match.group(1)
+                            publish_time = publish_match.group(2).replace("-", ":")
+                            publish_datetime = pd.to_datetime(
+                                f"{publish_date} {publish_time}",
+                            )
+                            publish_datetime = publish_datetime.tz_localize(
+                                self.default_timezone,
+                            )
+
+                            if start_date <= publish_datetime.date() <= end_date.date():
+                                csv_url = (
+                                    f"http://ets.aeso.ca/outage_reports/{csv_href}"
+                                )
+                                historical_files.append((csv_url, publish_datetime))
+
+                            if publish_datetime.date() < start_date.date():
+                                break
+
+                    prev_link = soup.find(
+                        "a",
+                        string=lambda text: text and "Previous Version" in text,
+                    )
+                    if not prev_link:
+                        break
+
+                    prev_href = prev_link.get("href")
+
+                    if prev_href.startswith("http"):
+                        current_url = prev_href
+                    elif prev_href.startswith("file:///"):
+                        # NOTE: There's a few that link to an engineer's local file path, so we navigate around that
+                        filename = os.path.basename(prev_href)
+                        current_url = (
+                            f"http://ets.aeso.ca/outage_reports/archives/{filename}"
+                        )
+                    else:
+                        prev_href_clean = prev_href.replace("\\", "/")
+                        if prev_href_clean.startswith("archives/"):
+                            current_url = (
+                                f"http://ets.aeso.ca/outage_reports/{prev_href_clean}"
+                            )
+                        else:
+                            current_url = f"http://ets.aeso.ca/outage_reports/archives/{prev_href_clean}"
+
+                except Exception as e:
+                    logger.error(f"Error accessing {current_url}: {e}")
+                    break
+
+            if not historical_files:
+                return pd.DataFrame(
+                    columns=[
+                        "Interval Start",
+                        "Interval End",
+                        "Publish Time",
+                        "Transmission Owner",
+                        "Type",
+                        "Element",
+                        "Scheduled Activity",
+                        "Date Time Comments",
+                        "Interconnection",
+                    ],
+                )
+
+            all_dfs = []
+            for csv_url, publish_datetime in historical_files:
+                try:
+                    df_hist = pd.read_csv(csv_url)
+                    df_hist["Interval Start"] = pd.to_datetime(
+                        df_hist["From"],
+                        format="%d-%b-%y %H:%M",
+                    )
+                    df_hist["Interval End"] = pd.to_datetime(
+                        df_hist["To"],
+                        format="%d-%b-%y %H:%M",
+                    )
+                    df_hist["Publish Time"] = publish_datetime
+
+                    df_hist = df_hist.rename(
+                        columns={
+                            "Owner": "Transmission Owner",
+                            "Date/Time Comments": "Date Time Comments",
+                        },
+                    )
+
+                    df_hist = df_hist[
+                        [
+                            "Interval Start",
+                            "Interval End",
+                            "Publish Time",
+                            "Transmission Owner",
+                            "Type",
+                            "Element",
+                            "Scheduled Activity",
+                            "Date Time Comments",
+                            "Interconnection",
+                        ]
+                    ]
+
+                    all_dfs.append(df_hist)
+                except Exception as e:
+                    logger.error(f"Error accessing {csv_url}: {e}")
+                    continue
+
+            if all_dfs:
+                df = pd.concat(all_dfs, ignore_index=True)
+                df = df.sort_values("Publish Time", ascending=False)
+                return df

--- a/gridstatus/aeso/aeso.py
+++ b/gridstatus/aeso/aeso.py
@@ -876,8 +876,14 @@ class AESO:
 
             df = pd.read_csv(csv_url)
 
-            df["Interval Start"] = pd.to_datetime(df["From"], format="%d-%b-%y %H:%M")
-            df["Interval End"] = pd.to_datetime(df["To"], format="%d-%b-%y %H:%M")
+            df["Interval Start"] = pd.to_datetime(
+                df["From"],
+                format="%d-%b-%y %H:%M",
+            ).dt.tz_localize(self.default_timezone)
+            df["Interval End"] = pd.to_datetime(
+                df["To"],
+                format="%d-%b-%y %H:%M",
+            ).dt.tz_localize(self.default_timezone)
             df["Publish Time"] = publish_datetime
 
             df = df.rename(
@@ -1020,16 +1026,15 @@ class AESO:
             all_dfs = []
             for csv_url, publish_datetime in historical_files:
                 try:
-                    # Read CSV with error handling for inconsistent field counts
                     df_hist = pd.read_csv(csv_url, on_bad_lines="skip")
                     df_hist["Interval Start"] = pd.to_datetime(
                         df_hist["From"],
                         format="%d-%b-%y %H:%M",
-                    )
+                    ).dt.tz_localize(self.default_timezone)
                     df_hist["Interval End"] = pd.to_datetime(
                         df_hist["To"],
                         format="%d-%b-%y %H:%M",
-                    )
+                    ).dt.tz_localize(self.default_timezone)
                     df_hist["Publish Time"] = publish_datetime
 
                     df_hist = df_hist.rename(

--- a/gridstatus/aeso/aeso.py
+++ b/gridstatus/aeso/aeso.py
@@ -915,6 +915,25 @@ class AESO:
             # as there doesn't seem to be a better way to do it.
             start_date = pd.Timestamp(date)
             end_date = pd.Timestamp(end) if end else start_date
+            # NB: Data is only available from 2024-01-31 onwards is seems
+            earliest_available = pd.Timestamp("2024-01-31")
+
+            if end_date.date() < earliest_available.date() or (
+                start_date.date() < earliest_available.date() and end_date is None
+            ):
+                raise ValueError(
+                    f"Requested date range is before available data. "
+                    f"Transmission outage data is only available from {earliest_available.date()} onwards. "
+                    f"Requested: {start_date.date()} to {end_date.date()}",
+                )
+            elif start_date.date() < earliest_available.date():
+                logger.warning(
+                    f"Requested start date {start_date.date()} is before available data. "
+                    f"Data is only available from {earliest_available.date()} onwards. "
+                    f"Adjusting start date to {earliest_available.date()}",
+                )
+                start_date = earliest_available
+
             logger.info(
                 f"Fetching historical transmission outages from {start_date.date()} to {end_date.date()}",
             )

--- a/gridstatus/aeso/aeso.py
+++ b/gridstatus/aeso/aeso.py
@@ -929,10 +929,8 @@ class AESO:
             elif start_date.date() < earliest_available.date():
                 logger.warning(
                     f"Requested start date {start_date.date()} is before available data. "
-                    f"Data is only available from {earliest_available.date()} onwards. "
-                    f"Adjusting start date to {earliest_available.date()}",
+                    f"Data is only available from {earliest_available.date()} onwards. ",
                 )
-                start_date = earliest_available
 
             logger.info(
                 f"Fetching historical transmission outages from {start_date.date()} to {end_date.date()}",

--- a/gridstatus/tests/source_specific/test_aeso.py
+++ b/gridstatus/tests/source_specific/test_aeso.py
@@ -693,3 +693,26 @@ class TestAESO(TestHelperMixin):
             assert df["Publish Time"].nunique() > 1
             assert df["Publish Time"].min().date() >= start_date.date()
             assert df["Publish Time"].max().date() <= end_date.date()
+
+    @pytest.mark.parametrize(
+        "target_date",
+        [
+            pd.Timestamp("2025-01-17"),
+        ],
+    )
+    def test_get_transmission_outages_single_date(
+        self,
+        target_date: pd.Timestamp,
+    ) -> None:
+        """Test getting transmission outages for a single date (most recent file before target date)."""
+        with api_vcr.use_cassette(
+            f"test_get_transmission_outages_single_date_{target_date.strftime('%Y-%m-%d')}.yaml",
+        ):
+            df = self.iso.get_transmission_outages(date=target_date)
+            self._check_transmission_outages(df)
+            assert len(df) > 0
+            assert df["Publish Time"].nunique() == 1
+            publish_time = df["Publish Time"].iloc[0]
+            assert publish_time.date() < target_date.date(), (
+                f"Publish time {publish_time.date()} should be before target date {target_date.date()}"
+            )

--- a/gridstatus/tests/source_specific/test_aeso.py
+++ b/gridstatus/tests/source_specific/test_aeso.py
@@ -619,3 +619,77 @@ class TestAESO(TestHelperMixin):
             assert df["Interval Start"].max() <= end_date.tz_localize(
                 self.iso.default_timezone,
             )
+
+    def _check_transmission_outages(self, df: pd.DataFrame) -> None:
+        """Check transmission outages DataFrame structure and types."""
+        expected_columns = [
+            "Interval Start",
+            "Interval End",
+            "Publish Time",
+            "Transmission Owner",
+            "Type",
+            "Element",
+            "Scheduled Activity",
+            "Date Time Comments",
+            "Interconnection",
+        ]
+        assert df.columns.tolist() == expected_columns
+        assert (
+            df.dtypes["Interval Start"]
+            == f"datetime64[ns, {self.iso.default_timezone}]"
+        )
+        assert (
+            df.dtypes["Interval End"] == f"datetime64[ns, {self.iso.default_timezone}]"
+        )
+        assert (
+            df.dtypes["Publish Time"] == f"datetime64[ns, {self.iso.default_timezone}]"
+        )
+        string_columns = [
+            "Transmission Owner",
+            "Type",
+            "Element",
+            "Scheduled Activity",
+            "Date Time Comments",
+            "Interconnection",
+        ]
+        for col in string_columns:
+            assert df[col].dtype == "object", (
+                f"Column {col} should be object/string type"
+            )
+
+        assert (df["Interval End"] >= df["Interval Start"]).all()
+
+    def test_get_transmission_outages_latest(self):
+        """Test getting latest transmission outages data."""
+        with api_vcr.use_cassette("test_get_transmission_outages_latest.yaml"):
+            df = self.iso.get_transmission_outages(date="latest")
+            self._check_transmission_outages(df)
+            assert len(df) > 0
+            assert df["Publish Time"].nunique() == 1
+
+    @pytest.mark.parametrize(
+        "start_date,end_date",
+        [
+            (
+                pd.Timestamp("2025-05-01"),
+                pd.Timestamp("2025-06-15"),
+            ),
+        ],
+    )
+    def test_get_transmission_outages_historical_range(
+        self,
+        start_date: pd.Timestamp,
+        end_date: pd.Timestamp,
+    ) -> None:
+        """Test getting historical transmission outages data."""
+        with api_vcr.use_cassette(
+            f"test_get_transmission_outages_historical_range_{start_date.strftime('%Y-%m-%d')}_{end_date.strftime('%Y-%m-%d')}.yaml",
+        ):
+            df = self.iso.get_transmission_outages(
+                date=start_date,
+                end=end_date,
+            )
+            self._check_transmission_outages(df)
+            assert df["Publish Time"].nunique() > 1
+            assert df["Publish Time"].min().date() >= start_date.date()
+            assert df["Publish Time"].max().date() <= end_date.date()


### PR DESCRIPTION
## Summary
Adds the `aeso_transmission_outage` dataset. I can already tell this is going to be a fun one to maintain...

```
from gridstatus import AESO
aeso = AESO()
df = aeso.get_transmission_outages(date="latest")
df2 = aeso.get_transmission_outages(date="2025-01-17", end="2025-06-17")
print(df)
print(df.columns)
print(df2)
print(df2.columns)
```

### Details
Lots of fun quirks in this one. `latest` is pretty straighforward since we can navigate to the unchanging link.

Historical data is much more suspect, in that the only way I've found to get historical reports is to navigate to the latest report link and work backwards via the "Previous Version" link in the report. Since the archived reports have links (both html and csv) based on the semi-random publish time, we cannot navigate directly to them and thus much search them backward. This is made more complicated by the fact that some of the links are broken, either pointing to local machine links or to links that are not valid. For the local machine links, I've had some success substituting the normal URL scheme to find files. However, the trail runs cold at `2025-01-22 15:41:59` since the previous version link there doesn't work (likely a typo). So we have historical data back to then. 

The report isn't always consistent and has some problematic rows of one flavor or another. I try to handle these as best I can (but given the variable state of the source, my guess is these files are not heavily used).

I iterate through the files sequentially to find the links we want, and then iterate through them to grab the data. I could probably combine these tasks, but the break logic gets harder to manage then and overall the current approach is fairly efficient.

Also adds logging to AESO.