### PR TITLE
feat(ENG 1761): AESO Renewables Forecasts

### DIFF
--- a/gridstatus/aeso/aeso.py
+++ b/gridstatus/aeso/aeso.py
@@ -1283,7 +1283,10 @@ class AESO:
             format="%Y-%m-%d %H:%M",
         ).dt.tz_localize(self.default_timezone)
 
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(minutes=10)
+        interval_length = (
+            pd.Timedelta(minutes=10) if term == "shortterm" else pd.Timedelta(hours=1)
+        )
+        df["Interval End"] = df["Interval Start"] + interval_length
 
         # NB: Since the forecasts are published every 10 minutes for shortterm and every 1 hour for longterm,
         # we can calculate the publish time based on the presence of actuals values.

--- a/gridstatus/aeso/aeso.py
+++ b/gridstatus/aeso/aeso.py
@@ -1294,11 +1294,6 @@ class AESO:
 
         df["Interval End"] = df["Interval Start"] + pd.Timedelta(minutes=10)
 
-        if date != "latest":
-            raise NotSupported(
-                "Historical data is not supported for wind/solar forecasts at this time.",
-            )
-
         # NB: Since the forecasts are published every 10 minutes for shortterm and every 1 hour for longterm,
         # we can calculate the publish time based on the presence of actuals values.
         # For past forecasted intervals (intervals with an actual value), we know the most recent forecast was published just before each interval.

--- a/gridstatus/aeso/aeso.py
+++ b/gridstatus/aeso/aeso.py
@@ -1293,9 +1293,6 @@ class AESO:
         # For past forecasted intervals (intervals with an actual value), we know the most recent forecast was published just before each interval.
         # For future forecasted values, the publish time for all of them is set to the first interval that has no actual value, since
         # that's when the forecast was last published.
-        publish_time_offset = (
-            pd.Timedelta(minutes=10) if term == "shortterm" else pd.Timedelta(hours=1)
-        )
         first_interval_without_actual = df[df["Actual"].isna()]
         if not first_interval_without_actual.empty:
             forecast_publish_time = first_interval_without_actual[
@@ -1305,12 +1302,12 @@ class AESO:
                 lambda row: (
                     forecast_publish_time
                     if pd.isna(row["Actual"])
-                    else row["Interval Start"] - publish_time_offset
+                    else row["Interval Start"] - interval_length
                 ),
                 axis=1,
             )
         else:
-            df["Publish Time"] = df["Interval Start"] - publish_time_offset
+            df["Publish Time"] = df["Interval Start"] - interval_length
 
         df = df.rename(
             columns={

--- a/gridstatus/aeso/aeso.py
+++ b/gridstatus/aeso/aeso.py
@@ -1154,8 +1154,21 @@ class AESO:
             start_date = pd.Timestamp(date)
             end_date = pd.Timestamp(end) if end else start_date
 
-            earliest_supported = pd.Timestamp("2023-03-01")
-            latest_supported = pd.Timestamp("2025-04-01")
+            if start_date.tz is None:
+                start_date = start_date.tz_localize(self.default_timezone)
+            else:
+                start_date = start_date.tz_convert(self.default_timezone)
+            if end_date.tz is None:
+                end_date = end_date.tz_localize(self.default_timezone)
+            else:
+                end_date = end_date.tz_convert(self.default_timezone)
+
+            earliest_supported = pd.Timestamp("2023-03-01").tz_localize(
+                self.default_timezone,
+            )
+            latest_supported = pd.Timestamp("2025-04-01").tz_localize(
+                self.default_timezone,
+            )
 
             if start_date < earliest_supported or end_date > latest_supported:
                 raise NotSupported(
@@ -1218,8 +1231,21 @@ class AESO:
             start_date = pd.Timestamp(date)
             end_date = pd.Timestamp(end) if end else start_date
 
-            earliest_supported = pd.Timestamp("2023-03-01")
-            latest_supported = pd.Timestamp("2025-04-01")
+            if start_date.tz is None:
+                start_date = start_date.tz_localize(self.default_timezone)
+            else:
+                start_date = start_date.tz_convert(self.default_timezone)
+            if end_date.tz is None:
+                end_date = end_date.tz_localize(self.default_timezone)
+            else:
+                end_date = end_date.tz_convert(self.default_timezone)
+
+            earliest_supported = pd.Timestamp("2023-03-01").tz_localize(
+                self.default_timezone,
+            )
+            latest_supported = pd.Timestamp("2025-04-01").tz_localize(
+                self.default_timezone,
+            )
 
             if start_date < earliest_supported or end_date > latest_supported:
                 raise NotSupported(
@@ -1370,8 +1396,8 @@ class AESO:
         forecast_prefix = forecast_type.upper()
         df["Interval Start"] = pd.to_datetime(
             df["FORECAST_DATE_MPT"],
-            format="%-m/%-d/%Y %-H:%M",
-        ).dt.tz_localize(self.default_timezone)
+            format="mixed",
+        ).dt.tz_localize(self.default_timezone, ambiguous="infer")
 
         df["Interval End"] = df["Interval Start"] + pd.Timedelta(hours=1)
         df["Publish Time"] = df["Interval Start"] - pd.Timedelta(hours=24)


### PR DESCRIPTION
## Summary
Adds the `aeso_wind_forecast_7_day`, `aeso_wind_forecast_12_hour`, `aeso_solar_forecast_7_day`, and `aeso_solar_forecast_12_hour`.

```
from gridstatus.aeso import AESO
aeso = AESO()
df = aeso.get_wind_forecast_12_hour(date="latest")
df2 = aeso.get_solar_forecast_12_hour(date="latest")
df3 = aeso.get_wind_forecast_7_day(date="latest")
df4 = aeso.get_solar_forecast_7_day(date="latest")
df5 = aeso.get_wind_forecast_7_day(date="2023-03-01")
df6 = aeso.get_solar_forecast_7_day(date="2023-03-01")
```

Currently the forecasts and actuals seem to be lagging a bit, so not entirely sure how this will perform. [Source here](https://www.aeso.ca/grid/grid-planning/forecasting/wind-and-solar-power-forecasting).

## Details
### Latest and Historical
The short term forecasts are only available as a `latest` implementation. 

The long term forecasts have historical data available, but only for the range of March 2023 through March 2025. The schema for the historical values are slightly different in that they need to calculate some values that the latest have already calculated, but this is straightforward.

### Publish Times
The shortterm forecasts are published every 10 minutes (currently they seem to be lagging a bit?). The long term forecasts are published every hour. Thus we can calculate the `Publish Time` for: 
- Past forecasted intervals, as the 10 minutes (short term) or 60 minutes (long term) before the `Interval Start` 
- Future forecasted intervals, as the first `Interval Start` timestamp where there is no `Actual` value. 

