### PR TITLE
Fix missing NYISO ICAP market report for December 2023

### DIFF
--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -1247,11 +1247,14 @@ class NYISO(ISOBase):
             # todo: it looks like the "27447313" component of the base URL changes
             # every year but I'm not sure what the link between that and the year
             # is...
-        capacity_market_base_url = (
-            f"https://www.nyiso.com/documents/20142/{year_code}/ICAP-Market-Report"
-        )
+        capacity_market_base_url = f"https://www.nyiso.com/documents/20142/{year_code}"
 
-        url = f"{capacity_market_base_url}-{date.month_name()}-{date.year}.xlsx"
+        url = f"{capacity_market_base_url}/ICAP-Market-Report-{date.month_name()}-{date.year}.xlsx"
+
+        # Special case
+        if date.month_name() == "December" and date.year == 2023:
+            url = f"{capacity_market_base_url}/ICAP%20Market%20Report%20-%20{date.month_name()}%20{date.year}.xlsx"
+
         logger.info(f"Requesting {url}")
 
         df = pd.read_excel(url, sheet_name="MCP Table", header=[0, 1])

--- a/gridstatus/tests/source_specific/test_nyiso.py
+++ b/gridstatus/tests/source_specific/test_nyiso.py
@@ -22,7 +22,14 @@ class TestNYISO(BaseTestISO):
 
     @pytest.mark.parametrize(
         "date",
-        ["Dec 1, 2022", "Jan 1, 2023", "Jan 1, 2024", "Jan 1, 2025", "today"],
+        [
+            "Dec 1, 2022",
+            "Jan 1, 2023",
+            "Dec 1, 2023",
+            "Jan 1, 2024",
+            "Jan 1, 2025",
+            "today",
+        ],
     )
     def test_get_capacity_prices(self, date):
         with nyiso_vcr.use_cassette(


### PR DESCRIPTION
## Summary
Closes #309

### Details
```
>>> from gridstatus import NYISO
>>> nyiso = NYISO()
>>> nyiso.get_capacity_prices("Dec 1, 2023", verbose=True)
2025-06-23 20:00:12 - INFO - Requesting https://www.nyiso.com/documents/20142/35397361/ICAP%20Market%20Report%20-%20December%202023.xlsx
            NYCA                ...    LI
           Strip Monthly  Spot  ... Strip Monthly  Spot
                                ...
2023-12-01  3.86    1.85  3.23  ...  3.86    2.00  3.23
```

Since CI is broken, confirmation that the extra test case is passing locally:
```
gridstatus/tests/source_specific/test_nyiso.py ......  [100%]

===================== 6 passed in 0.59s ======================
```