### PR TITLE
fix(ENG 1813): IESO Predispatch

### DIFF
--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -1941,7 +1941,6 @@ class IESO(ISOBase):
                 file_name_prefix=f"PUB_{directory_path}",
             )
 
-            # If no end provided, use a default of 1 hour
             end = end or (date + pd.Timedelta(hours=1))
 
             urls = [
@@ -1975,7 +1974,7 @@ class IESO(ISOBase):
                 tz=self.default_timezone,
             )
 
-            # Now get the date the file is FOR to use  as the base date
+            # Get the date the file is FOR to use as the base date
             match = re.search(r"FOR (\d{4}/\d{2}/\d{2})", first_line)
             delivery_date = pd.Timestamp(match.group(1), tz=self.default_timezone)
 
@@ -2015,7 +2014,6 @@ class IESO(ISOBase):
             .reset_index(drop=True)
         )
 
-        # Remove :LMP from the location
         data["Location"] = data["Location"].str.replace(":LMP", "")
 
         return data
@@ -2040,7 +2038,6 @@ class IESO(ISOBase):
         if verbose:
             logger.info(f"Fetching LMP data from {url}")
 
-        # Skip first line of the csv which contains the file created time
         data = pd.read_csv(url, skiprows=1)
 
         if minutes_per_interval == 5:
@@ -2054,19 +2051,16 @@ class IESO(ISOBase):
                     unit="minute",
                 ),
             )
-        elif minutes_per_interval == 60:
+        else:
             data["Interval Start"] = pd.to_datetime(
                 base_date.normalize()
                 + pd.to_timedelta(data["Delivery Hour"] - 1, unit="hour"),
             )
-        else:
-            raise ValueError("Invalid minutes_per_interval. Must be 5 or 60.")
 
         data["Interval End"] = data["Interval Start"] + pd.Timedelta(
             minutes=minutes_per_interval,
         )
 
-        # Standardize column names
         data = data.rename(
             columns={
                 "Energy Loss Price": "Loss",
@@ -2075,7 +2069,6 @@ class IESO(ISOBase):
             },
         )
 
-        # Calculate energy from definition of LMP
         data["Energy"] = data["LMP"] - data["Loss"] - data["Congestion"]
 
         columns = [
@@ -2094,7 +2087,6 @@ class IESO(ISOBase):
             .reset_index(drop=True)
         )
 
-        # Remove :LMP from the location
         data["Location"] = data["Location"].str.replace(":LMP", "")
 
         return data

--- a/gridstatus/tests/source_specific/test_ieso.py
+++ b/gridstatus/tests/source_specific/test_ieso.py
@@ -1915,11 +1915,13 @@ class TestIESO(BaseTestISO):
         today = pd.Timestamp.now(tz=self.default_timezone).normalize()
         assert (data["Interval Start"].dt.date == today.date()).all()
 
-    def test_get_real_time_totals_historical_date_range(self):
-        # Only date for which data is available
-        start_date = "2025-05-01T09:00:00Z"
-        end_date = "2025-05-01T12:00:00Z"
-
+    @pytest.mark.parametrize(
+        "start_date, end_date",
+        [
+            ("2025-06-01T09:00:00Z", "2025-06-01T12:00:00Z"),
+        ],
+    )
+    def test_get_real_time_totals_historical_date_range(self, start_date, end_date):
         with file_vcr.use_cassette(
             f"test_get_real_time_totals_historical_date_range_{start_date}_{end_date}.yaml",
         ):
@@ -2084,7 +2086,10 @@ class TestIESO(BaseTestISO):
     @pytest.mark.parametrize(
         "date, end",
         [
-            ("2025-05-01", "2025-05-03"),
+            (
+                pd.Timestamp.now().normalize() - pd.Timedelta(days=12),
+                pd.Timestamp.now().normalize() - pd.Timedelta(days=10),
+            ),
         ],
     )
     def test_get_shadow_prices_real_time_5_min_historical_range(self, date, end):
@@ -2104,7 +2109,10 @@ class TestIESO(BaseTestISO):
     @pytest.mark.parametrize(
         "date, end",
         [
-            ("2025-05-05", "2025-05-07"),
+            (
+                pd.Timestamp.now().normalize() - pd.Timedelta(days=12),
+                pd.Timestamp.now().normalize() - pd.Timedelta(days=10),
+            ),
         ],
     )
     def test_get_shadow_prices_day_ahead_hourly_historical_range(self, date, end):


### PR DESCRIPTION
## Summary
Enforce types and parallelize URL getting for IESO predispatch LMP methods where needed.

Examples to try:
```
df = ieso.get_lmp_predispatch_hourly("2025-06-01 04:00:00", end="2025-06-4 04:05:00")
df2 = ieso.get_lmp_predispatch_hourly_ontario_zonal("2025-06-01 04:00:00", end="2025-06-4 04:05:00")
df3 = ieso.get_lmp_predispatch_hourly_intertie("2025-06-01 04:00:00", end="2025-06-4 04:05:00")
```

### Details
Parallelization speeds these methods up by ~50%-80%. Since the dataframe cleanup code for the 3 predispatch submethods (`virtual_zonal`, `ontario_zonal`, `intertie`) is the same, I pull this parallelization and cleanup code out into a single helper function. 

I also fix some IESO tests that were failing. Since data eventually rolls off the back at the source, it makes these relative historical dates rather than fixed dates. All IESO tests should be back to passing now.