### PR TITLE
feat(ENG 1692): AESO Daily Average Price

### DIFF
--- a/gridstatus/aeso/aeso.py
+++ b/gridstatus/aeso/aeso.py
@@ -513,6 +513,99 @@ class AESO:
             ]
 
     @support_date_range(frequency=None)
+    def get_daily_average_price(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """
+        Get daily average pool price data with on-peak and off-peak breakdowns.
+
+        On-peak hours are defined as hours ending 8 through 23 (inclusive).
+        Off-peak hours are all other hours.
+
+        Returns:
+            DataFrame containing daily average price data
+        """
+        if date == "latest":
+            return self.get_daily_average_price(date="today")
+
+        hourly_df = self._get_pool_price_data(date, end, actual_or_forecast="actual")
+
+        hourly_df["Hour Ending"] = hourly_df["Interval Start"].dt.hour
+        hourly_df["Is On Peak"] = hourly_df["Hour Ending"].isin(range(8, 24))
+
+        daily_df = (
+            hourly_df.groupby(hourly_df["Interval Start"].dt.date)
+            .agg(
+                {
+                    "Pool Price": "mean",
+                    "Rolling 30 Day Average Pool Price": "mean",
+                    "Is On Peak": lambda x: x.sum(),
+                },
+            )
+            .reset_index()
+        )
+
+        daily_averages = []
+        for _, day_row in daily_df.iterrows():
+            day_date = day_row["Interval Start"]
+            day_hourly = hourly_df[hourly_df["Interval Start"].dt.date == day_date]
+
+            on_peak_prices = day_hourly[day_hourly["Is On Peak"]]["Pool Price"]
+            daily_on_peak_avg = (
+                on_peak_prices.mean() if not on_peak_prices.empty else None
+            )
+
+            off_peak_prices = day_hourly[~day_hourly["Is On Peak"]]["Pool Price"]
+            daily_off_peak_avg = (
+                off_peak_prices.mean() if not off_peak_prices.empty else None
+            )
+
+            daily_averages.append(
+                {
+                    "date": day_date,
+                    "Daily On Peak Average": daily_on_peak_avg,
+                    "Daily Off Peak Average": daily_off_peak_avg,
+                },
+            )
+
+        daily_avg_df = pd.DataFrame(daily_averages)
+
+        result_df = daily_df.merge(
+            daily_avg_df,
+            left_on="Interval Start",
+            right_on="date",
+            how="left",
+        )
+
+        result_df["Interval Start"] = pd.to_datetime(
+            result_df["Interval Start"],
+        ).dt.tz_localize(self.default_timezone)
+        result_df["Interval End"] = result_df["Interval Start"] + pd.Timedelta(days=1)
+
+        result_df = result_df.rename(
+            columns={
+                "Pool Price": "Daily Average",
+                "Rolling 30 Day Average Pool Price": "30 Day Average",
+            },
+        )
+
+        result_df = result_df[
+            [
+                "Interval Start",
+                "Interval End",
+                "Daily Average",
+                "Daily On Peak Average",
+                "Daily Off Peak Average",
+                "30 Day Average",
+            ]
+        ]
+
+        return result_df.sort_values("Interval Start").reset_index(drop=True)
+
+    @support_date_range(frequency=None)
     def get_system_marginal_price(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],

--- a/gridstatus/aeso/aeso.py
+++ b/gridstatus/aeso/aeso.py
@@ -604,6 +604,9 @@ class AESO:
             how="left",
         )
 
+        result_df["Interval Start"] = pd.to_datetime(
+            result_df["Interval Start"],
+        ).dt.tz_localize(self.default_timezone)
         result_df["Interval End"] = result_df["Interval Start"] + pd.Timedelta(days=1)
 
         result_df = result_df.rename(

--- a/gridstatus/tests/source_specific/test_aeso.py
+++ b/gridstatus/tests/source_specific/test_aeso.py
@@ -232,7 +232,7 @@ class TestAESO(TestHelperMixin):
     ) -> None:
         """Test getting historical forecast pool price data."""
         with api_vcr.use_cassette(
-            f"test_get_forecast_pool_price_historical_range_{start_date.strftime('%Y-%m-%d')}.yaml",
+            f"test_get_forecast_pool_price_historical_range_{start_date.date()}_{end_date.date()}.yaml",
         ):
             df = self.iso.get_forecast_pool_price(
                 date=start_date,
@@ -863,3 +863,66 @@ class TestAESO(TestHelperMixin):
             assert len(df) > 0
             assert df["Interval Start"].min().date() >= start_date.date()
             assert df["Interval Start"].max().date() <= end_date.date()
+
+    def _check_daily_average_price(self, df: pd.DataFrame) -> None:
+        """Check daily average price DataFrame structure and types."""
+        expected_columns = [
+            "Interval Start",
+            "Interval End",
+            "Daily Average",
+            "Daily On Peak Average",
+            "Daily Off Peak Average",
+            "30 Day Average",
+        ]
+        assert df.columns.tolist() == expected_columns
+        assert (
+            df.dtypes["Interval Start"]
+            == f"datetime64[ns, {self.iso.default_timezone}]"
+        )
+        assert (
+            df.dtypes["Interval End"] == f"datetime64[ns, {self.iso.default_timezone}]"
+        )
+
+        assert (df["Interval End"] - df["Interval Start"] == pd.Timedelta(days=1)).all()
+
+        price_columns = [
+            "Daily Average",
+            "Daily On Peak Average",
+            "Daily Off Peak Average",
+            "30 Day Average",
+        ]
+        for col in price_columns:
+            assert pd.api.types.is_numeric_dtype(df[col]), (
+                f"Column {col} should be numeric"
+            )
+
+    def test_get_daily_average_price_latest(self):
+        """Test getting latest daily average price data."""
+        with api_vcr.use_cassette("test_get_daily_average_price_latest.yaml"):
+            df = self.iso.get_daily_average_price(date="latest")
+            self._check_daily_average_price(df)
+            assert len(df) > 0
+
+    @pytest.mark.parametrize(
+        "start_date,end_date,expected_days",
+        [
+            (
+                pd.Timestamp("2024-01-01"),
+                pd.Timestamp("2024-01-04"),
+                4,
+            ),
+        ],
+    )
+    def test_get_daily_average_price_historical_range(
+        self,
+        start_date: pd.Timestamp,
+        end_date: pd.Timestamp,
+        expected_days: int,
+    ) -> None:
+        """Test getting historical daily average price data."""
+        with api_vcr.use_cassette(
+            f"test_get_daily_average_price_historical_range_{start_date.date()}_{end_date.date()}.yaml",
+        ):
+            df = self.iso.get_daily_average_price(date=start_date, end=end_date)
+            self._check_daily_average_price(df)
+            assert len(df) == expected_days


### PR DESCRIPTION
## Summary
Adds the `aeso_daily_average_price` dataset. 

### Details
We normally don't do aggregates, opting to simply provide the most granular values and let the user do their own aggregates in downstream systems of their choosing, but in this case we make an exception. This is a reconstruction of the [ETS system](http://ets.aeso.ca/) `Daily Average Price` report, using data from the API pool price endpoint. Dealing with the API is much easier than dealing with the ETS system for performance and maintainability reasons, but this report might be relevant to people wanting to use Grid Status to see AESO data they are used to. 

Values are matching across the two systems:
**ETS**
![CleanShot 2025-06-24 at 13 06 18@2x](https://github.com/user-attachments/assets/508c00c3-2388-484b-b4ec-58f638b12710)

**Recalculation**
![CleanShot 2025-06-24 at 13 07 02@2x](https://github.com/user-attachments/assets/55073997-3355-426f-9028-8ce03d547861)

Though we punt on the 30 day rolling average peak and off peak prices, since doing that calculation requires pulling 30 days of data each time (the simple 30 day rolling average is provided by the API itself and doesn't need to be recalculated). 

The 30 day rolling average shown in the ETS report is the last value of each day (Interval Start Hour = 23).