### PR TITLE
feat(ENG 1853): Add PJM Transfer Limits, Tie Flows, Scheduled Tie Flows, and more

### DIFF
--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -3010,6 +3010,3 @@ class PJM(ISOBase):
                 "Scheduled Tie Flow",
             ]
         ]
-
-    # @support_date_range(frequency=None)
-    # def get_actual_and_scheduled_interchange_summary() -> pd.DataFrame:

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -2621,3 +2621,186 @@ class TestPJM(BaseTestISO):
 
             # Maximum interval start should be within 15 seconds of the end date
             assert end - pd.Timedelta(seconds=15) <= df["Interval Start"].max() <= end
+
+    def _check_hourly_net_exports_by_state(self, df):
+        assert isinstance(df, pd.DataFrame)
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "State",
+            "Net Interchange",
+        ]
+        assert not df.empty
+        assert df["Interval Start"].is_monotonic_increasing
+
+    def test_get_hourly_net_exports_by_state_latest(self):
+        with pjm_vcr.use_cassette("test_get_hourly_net_exports_by_state_latest.yaml"):
+            df = self.iso.get_hourly_net_exports_by_state("latest")
+            self._check_hourly_net_exports_by_state(df)
+
+    @pytest.mark.parametrize("date, end", test_dates)
+    def test_get_hourly_net_exports_by_state_historical_date_range(self, date, end):
+        with pjm_vcr.use_cassette(
+            f"test_get_hourly_net_exports_by_state_{date}_{end}.yaml",
+        ):
+            df = self.iso.get_hourly_net_exports_by_state(date, end)
+            self._check_hourly_net_exports_by_state(df)
+            assert df["Interval Start"].min().date() == pd.Timestamp(date).date()
+            assert df["Interval End"].max().date() <= pd.Timestamp(
+                end,
+            ).date() + pd.Timedelta(days=1)
+
+    def _check_hourly_transfer_limits_and_flows(self, df):
+        assert isinstance(df, pd.DataFrame)
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "Transfer Limit Area",
+            "Average Transfers",
+            "Average Transfer Limit",
+        ]
+        assert not df.empty
+
+    def test_get_hourly_transfer_limits_and_flows_latest(self):
+        with pjm_vcr.use_cassette(
+            "test_get_hourly_transfer_limits_and_flows_latest.yaml",
+        ):
+            df = self.iso.get_hourly_transfer_limits_and_flows("latest")
+            self._check_hourly_transfer_limits_and_flows(df)
+
+    @pytest.mark.parametrize("date, end", test_dates)
+    def test_get_hourly_transfer_limits_and_flows_historical_date_range(
+        self,
+        date,
+        end,
+    ):
+        with pjm_vcr.use_cassette(
+            f"test_get_hourly_transfer_limits_and_flows_{date}_{end}.yaml",
+        ):
+            df = self.iso.get_hourly_transfer_limits_and_flows(date, end)
+            self._check_hourly_transfer_limits_and_flows(df)
+            assert df["Interval Start"].min().date() == pd.Timestamp(date).date()
+            assert df["Interval End"].max().date() <= pd.Timestamp(end).date()
+
+    def _check_actual_and_scheduled_interchange_summary(self, df):
+        assert isinstance(df, pd.DataFrame)
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "Tie Line",
+            "Actual Flow",
+            "Scheduled Flow",
+            "Inadvertent Flow",
+        ]
+        assert not df.empty
+
+    def test_get_actual_and_scheduled_interchange_summary_latest(self):
+        with pjm_vcr.use_cassette(
+            "test_get_actual_and_scheduled_interchange_summary_latest.yaml",
+        ):
+            df = self.iso.get_actual_and_scheduled_interchange_summary("latest")
+            self._check_actual_and_scheduled_interchange_summary(df)
+
+    @pytest.mark.parametrize("date, end", test_dates)
+    def test_get_actual_and_scheduled_interchange_summary_historical_date_range(
+        self,
+        date,
+        end,
+    ):
+        with pjm_vcr.use_cassette(
+            f"test_get_actual_and_scheduled_interchange_summary_{date}_{end}.yaml",
+        ):
+            df = self.iso.get_actual_and_scheduled_interchange_summary(date, end)
+            self._check_actual_and_scheduled_interchange_summary(df)
+            assert df["Interval Start"].min().date() == pd.Timestamp(date).date()
+            assert df["Interval End"].max().date() <= pd.Timestamp(
+                end,
+            ).date() + pd.Timedelta(days=1)
+
+    def _check_scheduled_interchange_real_time(self, df):
+        assert isinstance(df, pd.DataFrame)
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "Tie Line",
+            "Hourly Net Tie Schedule",
+        ]
+        assert not df.empty
+        assert df["Interval Start"].is_monotonic_increasing
+
+    def test_get_scheduled_interchange_real_time_latest(self):
+        with pjm_vcr.use_cassette(
+            "test_get_scheduled_interchange_real_time_latest.yaml",
+        ):
+            df = self.iso.get_scheduled_interchange_real_time("latest")
+            self._check_scheduled_interchange_real_time(df)
+
+    @pytest.mark.parametrize("date, end", test_dates)
+    def test_get_scheduled_interchange_real_time_historical_date_range(self, date, end):
+        with pjm_vcr.use_cassette(
+            f"test_get_scheduled_interchange_real_time_{date}_{end}.yaml",
+        ):
+            df = self.iso.get_scheduled_interchange_real_time(date, end)
+            self._check_scheduled_interchange_real_time(df)
+            assert df["Interval Start"].min().date() == pd.Timestamp(date).date()
+            assert df["Interval End"].max().date() <= pd.Timestamp(
+                end,
+            ).date() + pd.Timedelta(days=1)
+
+    def _check_interface_flows_and_limit_day_ahead(self, df):
+        assert isinstance(df, pd.DataFrame)
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "Interface Limit Name",
+            "Flow",
+            "Limit",
+        ]
+        assert not df.empty
+
+    def test_get_interface_flows_and_limit_day_ahead_latest(self):
+        with pjm_vcr.use_cassette(
+            "test_get_interface_flows_and_limit_day_ahead_latest.yaml",
+        ):
+            df = self.iso.get_interface_flows_and_limit_day_ahead("latest")
+            self._check_interface_flows_and_limit_day_ahead(df)
+
+    @pytest.mark.parametrize("date, end", test_dates)
+    def test_get_interface_flows_and_limit_day_ahead_historical_date_range(
+        self,
+        date,
+        end,
+    ):
+        with pjm_vcr.use_cassette(
+            f"test_get_interface_flows_and_limit_day_ahead_{date}_{end}.yaml",
+        ):
+            df = self.iso.get_interface_flows_and_limit_day_ahead(date, end)
+            self._check_interface_flows_and_limit_day_ahead(df)
+            assert df["Interval Start"].min().date() == pd.Timestamp(date).date()
+            assert df["Interval End"].max().date() <= pd.Timestamp(
+                end,
+            ).date() + pd.Timedelta(days=1)
+
+    def _check_projected_peak_tie_flow(self, df):
+        assert isinstance(df, pd.DataFrame)
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "Generated At",
+            "Interface",
+            "Scheduled Tie Flow",
+        ]
+        assert not df.empty
+
+    def test_get_projected_peak_tie_flow_latest(self):
+        with pjm_vcr.use_cassette("test_get_projected_peak_tie_flow_latest.yaml"):
+            df = self.iso.get_projected_peak_tie_flow("latest")
+            self._check_projected_peak_tie_flow(df)
+
+    @pytest.mark.parametrize("date, end", test_dates)
+    def test_get_projected_peak_tie_flow_historical_date_range(self, date, end):
+        with pjm_vcr.use_cassette(
+            f"test_get_projected_peak_tie_flow_{date}_{end}.yaml",
+        ):
+            df = self.iso.get_projected_peak_tie_flow(date, end)
+            self._check_projected_peak_tie_flow(df)

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -2747,7 +2747,7 @@ class TestPJM(BaseTestISO):
                 end,
             ).date() + pd.Timedelta(days=1)
 
-    def _check_interface_flows_and_limit_day_ahead(self, df):
+    def _check_interface_flows_and_limits_day_ahead(self, df):
         assert isinstance(df, pd.DataFrame)
         assert df.columns.tolist() == [
             "Interval Start",
@@ -2758,24 +2758,24 @@ class TestPJM(BaseTestISO):
         ]
         assert not df.empty
 
-    def test_get_interface_flows_and_limit_day_ahead_latest(self):
+    def test_get_interface_flows_and_limits_day_ahead_latest(self):
         with pjm_vcr.use_cassette(
-            "test_get_interface_flows_and_limit_day_ahead_latest.yaml",
+            "test_get_interface_flows_and_limits_day_ahead_latest.yaml",
         ):
-            df = self.iso.get_interface_flows_and_limit_day_ahead("latest")
-            self._check_interface_flows_and_limit_day_ahead(df)
+            df = self.iso.get_interface_flows_and_limits_day_ahead("latest")
+            self._check_interface_flows_and_limits_day_ahead(df)
 
     @pytest.mark.parametrize("date, end", test_dates)
-    def test_get_interface_flows_and_limit_day_ahead_historical_date_range(
+    def test_get_interface_flows_and_limits_day_ahead_historical_date_range(
         self,
         date,
         end,
     ):
         with pjm_vcr.use_cassette(
-            f"test_get_interface_flows_and_limit_day_ahead_{date}_{end}.yaml",
+            f"test_get_interface_flows_and_limits_day_ahead_{date}_{end}.yaml",
         ):
-            df = self.iso.get_interface_flows_and_limit_day_ahead(date, end)
-            self._check_interface_flows_and_limit_day_ahead(df)
+            df = self.iso.get_interface_flows_and_limits_day_ahead(date, end)
+            self._check_interface_flows_and_limits_day_ahead(df)
             assert df["Interval Start"].min().date() == pd.Timestamp(date).date()
             assert df["Interval End"].max().date() <= pd.Timestamp(
                 end,


### PR DESCRIPTION
## Summary
Adds `pjm_hourly_net_exports_by_state`, `pjm_hourly_transfer_limits_and_flows`, `pjm_actual_and_scheduled_interchange_summary`, `pjm_scheduled_interchange_real_time`, `pjm_interface_flows_and_limit_day_ahead`, and `pjm_projected_peak_tie_flow` datasets.

All of these datasets are similar timeseries with similar content, so doing them all as one PR. 

```
from gridstatus import PJM

pjm = PJM()
df1 = pjm.get_hourly_net_exports_by_state(
    date="latest"
)
df2 = pjm.get_hourly_net_exports_by_state(
    date="2025-07-01",
    end="2025-07-09"
)
df3 = pjm.get_hourly_transfer_limits_and_flows(
    date="latest"
)
df4 = pjm.get_hourly_transfer_limits_and_flows(
    date="2025-06-01",
    end="2025-07-01"
)
df5 = pjm.get_actual_and_scheduled_interchange_summary(
    date="latest"
)
df6 = pjm.get_actual_and_scheduled_interchange_summary(
    date="2025-07-01",
    end="2025-07-09"
)
df7 = pjm.get_scheduled_interchange_real_time(
    date="latest"
)
df8 = pjm.get_scheduled_interchange_real_time(
    date="2025-07-01",
    end="2025-07-09"
)
df9 = pjm.get_interface_flows_and_limit_day_ahead(
    date="latest"
)
df10 = pjm.get_interface_flows_and_limit_day_ahead(
    date="2025-07-01",
    end="2025-07-09"
)
df11 = pjm.get_projected_peak_tie_flow(
    date="latest"
)
df12 = pjm.get_projected_peak_tie_flow(
    date="2025-07-01",
    end="2025-07-09"
)

print(df1)
print(df2)
print(df3)
print(df4)
print(df5)
print(df6)
print(df7)
print(df8)
print(df9)
print(df10)
print(df11)
```

### Details
All of these are hourly timeseries that relate to interchange and tie flows, so mostly straightforward. 