### PR TITLE
feat(ENG 1854): PJM List Datasets 

### DIFF
--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -3000,7 +3000,7 @@ class PJM(ISOBase):
                 "UTC",
             )
             .dt.tz_convert(self.default_timezone)
-            .date()
+            .dt.date
         )
         df["Interval End"] = df["Interval Start"] + pd.Timedelta(days=1)
         df = df.rename(
@@ -3031,7 +3031,14 @@ class PJM(ISOBase):
         https://dataminer2.pjm.com/feed/ops_sum_prev_period/definition
         """
         if date == "latest":
-            return self.get_actual_operational_statistics("today")
+            now = pd.Timestamp.now(tz=self.default_timezone)
+            if now.hour >= 5:
+                return self.get_actual_operational_statistics("today")
+            else:
+                yesterday = pd.Timestamp.now(
+                    tz=self.default_timezone,
+                ).date() - pd.Timedelta(days=1)
+                return self.get_actual_operational_statistics(yesterday)
 
         df = self._get_pjm_json(
             "ops_sum_prev_period",

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -3279,7 +3279,7 @@ class PJM(ISOBase):
 
         df = self._get_pjm_json(
             "agg_definitions",
-            start=as_of,
+            start=None,
             end=None,
             params={
                 "fields": "effective_date_ept,terminate_date_ept,agg_pnode_id,agg_pnode_name,bus_pnode_id,bus_pnode_name,bus_pnode_factor",

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -3108,6 +3108,7 @@ class PJM(ISOBase):
         Retrieves the pricing nodes data from:
         https://dataminer2.pjm.com/feed/pnode/definition
         """
+        as_of = utils._handle_date(as_of)
         if as_of == "now":
             return self.get_pricing_nodes(
                 as_of=pd.Timestamp.now(tz=self.default_timezone),
@@ -3164,6 +3165,7 @@ class PJM(ISOBase):
         Retrieves the reserve subzone resources data from:
         https://dataminer2.pjm.com/feed/sync_pri_reserves_resources_list/definition
         """
+        as_of = utils._handle_date(as_of)
         if as_of == "now":
             return self.get_reserve_subzone_resources(
                 as_of=pd.Timestamp.now(tz=self.default_timezone),
@@ -3218,6 +3220,7 @@ class PJM(ISOBase):
         Retrieves the reserve subzone buses data from:
         https://dataminer2.pjm.com/feed/sync_pri_reserves_buses_list/definition
         """
+        as_of = utils._handle_date(as_of)
         if as_of == "now":
             return self.get_reserve_subzone_buses(
                 as_of=pd.Timestamp.now(tz=self.default_timezone),
@@ -3269,6 +3272,7 @@ class PJM(ISOBase):
         Retrieves the weight average aggregation definition data from:
         https://dataminer2.pjm.com/feed/agg_definitions/definition
         """
+        as_of = utils._handle_date(as_of)
         if as_of == "now":
             return self.get_weight_average_aggregation_definition(
                 as_of=pd.Timestamp.now(tz=self.default_timezone),

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -2988,7 +2988,7 @@ class PJM(ISOBase):
             },
             interval_duration_min=60,
             verbose=verbose,
-            filter_timestamp_name="generated_at_ept",
+            filter_timestamp_name="generated_at",
         )
 
         df["Publish Time"] = pd.to_datetime(df["generated_at_ept"]).dt.tz_localize(

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -3108,7 +3108,7 @@ class PJM(ISOBase):
         Retrieves the pricing nodes data from:
         https://dataminer2.pjm.com/feed/pnode/definition
         """
-        as_of = utils._handle_date(as_of)
+        as_of = utils._handle_date(as_of, tz=self.default_timezone)
         if as_of == "now":
             return self.get_pricing_nodes(
                 as_of=pd.Timestamp.now(tz=self.default_timezone),
@@ -3165,7 +3165,7 @@ class PJM(ISOBase):
         Retrieves the reserve subzone resources data from:
         https://dataminer2.pjm.com/feed/sync_pri_reserves_resources_list/definition
         """
-        as_of = utils._handle_date(as_of)
+        as_of = utils._handle_date(as_of, tz=self.default_timezone)
         if as_of == "now":
             return self.get_reserve_subzone_resources(
                 as_of=pd.Timestamp.now(tz=self.default_timezone),
@@ -3220,7 +3220,7 @@ class PJM(ISOBase):
         Retrieves the reserve subzone buses data from:
         https://dataminer2.pjm.com/feed/sync_pri_reserves_buses_list/definition
         """
-        as_of = utils._handle_date(as_of)
+        as_of = utils._handle_date(as_of, tz=self.default_timezone)
         if as_of == "now":
             return self.get_reserve_subzone_buses(
                 as_of=pd.Timestamp.now(tz=self.default_timezone),
@@ -3272,7 +3272,7 @@ class PJM(ISOBase):
         Retrieves the weight average aggregation definition data from:
         https://dataminer2.pjm.com/feed/agg_definitions/definition
         """
-        as_of = utils._handle_date(as_of)
+        as_of = utils._handle_date(as_of, tz=self.default_timezone)
         if as_of == "now":
             return self.get_weight_average_aggregation_definition(
                 as_of=pd.Timestamp.now(tz=self.default_timezone),

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -3046,8 +3046,6 @@ class PJM(ISOBase):
 
         df = df.rename(
             columns={
-                "datetime_beginning_utc": "Interval Start",
-                "datetime_ending_utc": "Interval End",
                 "generated_at_ept": "Publish Time",
                 "area": "Area",
                 "area_load_forecast": "Area Load Forecast",

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -2786,7 +2786,7 @@ class TestPJM(BaseTestISO):
         assert df.columns.tolist() == [
             "Interval Start",
             "Interval End",
-            "Generated At",
+            "Publish Time",
             "Interface",
             "Scheduled Tie Flow",
         ]
@@ -2830,8 +2830,7 @@ class TestPJM(BaseTestISO):
             self._check_actual_operational_statistics(df)
             min_start = df["Interval Start"].min().date()
             today = self.local_start_of_today().date()
-            yesterday = today - pd.Timedelta(days=1)
-            assert min_start in [today, yesterday]
+            assert min_start == today
 
     @pytest.mark.parametrize("date, end", test_dates)
     def test_get_actual_operational_statistics_historical_date_range(self, date, end):

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -2804,3 +2804,231 @@ class TestPJM(BaseTestISO):
         ):
             df = self.iso.get_projected_peak_tie_flow(date, end)
             self._check_projected_peak_tie_flow(df)
+
+    """get_actual_operational_statistics"""
+
+    def _check_actual_operational_statistics(self, df):
+        assert isinstance(df, pd.DataFrame)
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "Publish Time",
+            "Area",
+            "Area Load Forecast",
+            "Actual Load",
+            "Dispatch Rate",
+        ]
+        assert not df.empty
+        assert df["Area"].dtype == object
+        assert df["Area Load Forecast"].dtype in [np.float64, np.int64]
+        assert df["Actual Load"].dtype in [np.float64, np.int64]
+        assert df["Dispatch Rate"].dtype in [np.float64, np.int64]
+
+    def test_get_actual_operational_statistics_latest(self):
+        with pjm_vcr.use_cassette("test_get_actual_operational_statistics_latest.yaml"):
+            df = self.iso.get_actual_operational_statistics("latest")
+            self._check_actual_operational_statistics(df)
+            min_start = df["Interval Start"].min().date()
+            today = self.local_start_of_today().date()
+            yesterday = today - pd.Timedelta(days=1)
+            assert min_start in [today, yesterday]
+
+    @pytest.mark.parametrize("date, end", test_dates)
+    def test_get_actual_operational_statistics_historical_date_range(self, date, end):
+        with pjm_vcr.use_cassette(
+            f"test_get_actual_operational_statistics_{date}_{end}.yaml",
+        ):
+            df = self.iso.get_actual_operational_statistics(date, end)
+            self._check_actual_operational_statistics(df)
+            assert df["Interval Start"].min().date() == pd.Timestamp(date).date()
+            assert df["Interval End"].max().date() <= pd.Timestamp(end).date()
+
+    """get_pricing_nodes"""
+
+    def _check_pricing_nodes(self, df):
+        assert isinstance(df, pd.DataFrame)
+        assert df.columns.tolist() == [
+            "Pricing Node ID",
+            "Pricing Node Name",
+            "Pricing Node Type",
+            "Pricing Node SubType",
+            "Zone",
+            "Voltage Level",
+            "Effective Date",
+            "Termination Date",
+        ]
+        assert not df.empty
+        assert df["Pricing Node ID"].dtype in [np.int64, np.float64]
+        assert df["Pricing Node Name"].dtype == object
+        assert df["Pricing Node Type"].dtype == object
+        assert df["Zone"].dtype == object
+
+    @pytest.mark.parametrize("as_of", ["now", None])
+    def test_get_pricing_nodes_as_of(self, as_of):
+        with pjm_vcr.use_cassette(f"test_get_pricing_nodes_as_of_{as_of}.yaml"):
+            df = self.iso.get_pricing_nodes(as_of=as_of)
+            self._check_pricing_nodes(df)
+            if as_of == "now":
+                # Should filter out terminated records
+                assert (
+                    df["Termination Date"].isna()
+                    | (
+                        df["Termination Date"]
+                        > pd.Timestamp.now(tz=self.iso.default_timezone)
+                    )
+                ).all()
+
+    def test_get_pricing_nodes_with_specific_date(self):
+        specific_date = pd.Timestamp("2024-01-01", tz=self.iso.default_timezone)
+        with pjm_vcr.use_cassette(
+            f"test_get_pricing_nodes_specific_date_{specific_date.strftime('%Y-%m-%d')}.yaml",
+        ):
+            df = self.iso.get_pricing_nodes(as_of=specific_date)
+            self._check_pricing_nodes(df)
+            # Should filter out records terminated before the specific date
+            assert (
+                df["Termination Date"].isna() | (df["Termination Date"] > specific_date)
+            ).all()
+
+    """get_reserve_subzone_resources"""
+
+    def _check_reserve_subzone_resources(self, df):
+        assert isinstance(df, pd.DataFrame)
+        assert df.columns.tolist() == [
+            "Effective Date",
+            "Termination Date",
+            "Subzone",
+            "Resource ID",
+            "Resource Name",
+            "Resource Type",
+            "Zone",
+        ]
+        assert not df.empty
+        assert df["Resource ID"].dtype in [object, np.int64, np.float64]
+        assert df["Resource Name"].dtype == object
+        assert df["Resource Type"].dtype == object
+        assert df["Subzone"].dtype == object
+        assert df["Zone"].dtype == object
+
+    @pytest.mark.parametrize("as_of", ["now", None])
+    def test_get_reserve_subzone_resources_as_of(self, as_of):
+        with pjm_vcr.use_cassette(
+            f"test_get_reserve_subzone_resources_as_of_{as_of}.yaml",
+        ):
+            df = self.iso.get_reserve_subzone_resources(as_of=as_of)
+            self._check_reserve_subzone_resources(df)
+            if as_of == "now":
+                # Should filter out terminated records
+                assert (
+                    df["Termination Date"].isna()
+                    | (
+                        df["Termination Date"]
+                        > pd.Timestamp.now(tz=self.iso.default_timezone)
+                    )
+                ).all()
+
+    def test_get_reserve_subzone_resources_with_specific_date(self):
+        specific_date = pd.Timestamp("2024-01-01", tz=self.iso.default_timezone)
+        with pjm_vcr.use_cassette(
+            f"test_get_reserve_subzone_resources_specific_date_{specific_date.strftime('%Y-%m-%d')}.yaml",
+        ):
+            df = self.iso.get_reserve_subzone_resources(as_of=specific_date)
+            self._check_reserve_subzone_resources(df)
+            # Should filter out records terminated before the specific date
+            assert (
+                df["Termination Date"].isna() | (df["Termination Date"] > specific_date)
+            ).all()
+
+    """get_reserve_subzone_buses"""
+
+    def _check_reserve_subzone_buses(self, df):
+        assert isinstance(df, pd.DataFrame)
+        assert df.columns.tolist() == [
+            "Effective Date",
+            "Termination Date",
+            "Subzone",
+            "Pricing Node ID",
+            "Pricing Node Name",
+            "Pricing Node Type",
+        ]
+        assert not df.empty
+        assert df["Pricing Node ID"].dtype in [np.int64, np.float64]
+        assert df["Pricing Node Name"].dtype == object
+        assert df["Pricing Node Type"].dtype == object
+        assert df["Subzone"].dtype == object
+
+    @pytest.mark.parametrize("as_of", ["now", None])
+    def test_get_reserve_subzone_buses_as_of(self, as_of):
+        with pjm_vcr.use_cassette(f"test_get_reserve_subzone_buses_as_of_{as_of}.yaml"):
+            df = self.iso.get_reserve_subzone_buses(as_of=as_of)
+            self._check_reserve_subzone_buses(df)
+            if as_of == "now":
+                # Should filter out terminated records
+                assert (
+                    df["Termination Date"].isna()
+                    | (
+                        df["Termination Date"]
+                        > pd.Timestamp.now(tz=self.iso.default_timezone)
+                    )
+                ).all()
+
+    def test_get_reserve_subzone_buses_with_specific_date(self):
+        specific_date = pd.Timestamp("2024-01-01", tz=self.iso.default_timezone)
+        with pjm_vcr.use_cassette(
+            f"test_get_reserve_subzone_buses_specific_date_{specific_date.strftime('%Y-%m-%d')}.yaml",
+        ):
+            df = self.iso.get_reserve_subzone_buses(as_of=specific_date)
+            self._check_reserve_subzone_buses(df)
+            # Should filter out records terminated before the specific date
+            assert (
+                df["Termination Date"].isna() | (df["Termination Date"] > specific_date)
+            ).all()
+
+    """get_weight_average_aggregation_definition"""
+
+    def _check_weight_average_aggregation_definition(self, df):
+        assert isinstance(df, pd.DataFrame)
+        assert df.columns.tolist() == [
+            "Effective Date",
+            "Termination Date",
+            "Aggregate Node ID",
+            "Aggregate Node Name",
+            "Bus Node ID",
+            "Bus Node Name",
+            "Bus Node Factor",
+        ]
+        assert not df.empty
+        assert df["Aggregate Node ID"].dtype in [np.int64, np.float64]
+        assert df["Aggregate Node Name"].dtype == object
+        assert df["Bus Node ID"].dtype in [np.int64, np.float64]
+        assert df["Bus Node Name"].dtype == object
+        assert df["Bus Node Factor"].dtype in [np.float64, np.int64]
+
+    @pytest.mark.parametrize("as_of", ["now", None])
+    def test_get_weight_average_aggregation_definition_as_of(self, as_of):
+        with pjm_vcr.use_cassette(
+            f"test_get_weight_average_aggregation_definition_as_of_{as_of}.yaml",
+        ):
+            df = self.iso.get_weight_average_aggregation_definition(as_of=as_of)
+            self._check_weight_average_aggregation_definition(df)
+            if as_of == "now":
+                # Should filter out terminated records
+                assert (
+                    df["Termination Date"].isna()
+                    | (
+                        df["Termination Date"]
+                        > pd.Timestamp.now(tz=self.iso.default_timezone)
+                    )
+                ).all()
+
+    def test_get_weight_average_aggregation_definition_with_specific_date(self):
+        specific_date = pd.Timestamp("2024-01-01", tz=self.iso.default_timezone)
+        with pjm_vcr.use_cassette(
+            f"test_get_weight_average_aggregation_definition_specific_date_{specific_date.strftime('%Y-%m-%d')}.yaml",
+        ):
+            df = self.iso.get_weight_average_aggregation_definition(as_of=specific_date)
+            self._check_weight_average_aggregation_definition(df)
+            # Should filter out records terminated before the specific date
+            assert (
+                df["Termination Date"].isna() | (df["Termination Date"] > specific_date)
+            ).all()

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -2830,7 +2830,9 @@ class TestPJM(BaseTestISO):
             self._check_actual_operational_statistics(df)
             min_start = df["Interval Start"].min().date()
             today = self.local_start_of_today().date()
-            assert min_start == today
+            yesterday = today - pd.Timedelta(days=1)
+            # The implementation can return either today's or yesterday's data depending on time
+            assert min_start in [today, yesterday]
 
     @pytest.mark.parametrize("date, end", test_dates)
     def test_get_actual_operational_statistics_historical_date_range(self, date, end):
@@ -2839,8 +2841,11 @@ class TestPJM(BaseTestISO):
         ):
             df = self.iso.get_actual_operational_statistics(date, end)
             self._check_actual_operational_statistics(df)
-            assert df["Interval Start"].min().date() == pd.Timestamp(date).date()
-            assert df["Interval End"].max().date() <= pd.Timestamp(end).date()
+            expected_start_date = pd.Timestamp(date).date() - pd.Timedelta(days=1)
+            assert df["Interval Start"].min().date() == expected_start_date
+            assert df["Interval End"].max().date() <= pd.Timestamp(
+                end,
+            ).date() - pd.Timedelta(days=1)
 
     """get_pricing_nodes"""
 


### PR DESCRIPTION
## Summary
Adds `get_pricing_nodes`, `get_reserve_subzone_resources`, `get_reserve_subzone_buses`, `get_actual_operational_statistics`, `get_weight_average_aggregation_definition`

```
from gridstatus.pjm import PJM
pjm = PJM()

df1 = pjm.get_pricing_nodes()
df2 = pjm.get_reserve_subzone_resources()
df3 = pjm.get_reserve_subzone_buses()
df4 = pjm.get_actual_operational_statistics(date="2025-07-10")
df5 = pjm.get_weight_average_aggregation_definition()

print(df1)
print(df2)
print(df3)
print(df4)
print(df5)
```

Also alters the existing `projected_peak_tie_flow` to operate on `Publish Time`, changing the `Generated At` to `Publish Time` and updating the `filter_timestamp_name`.

### Details
I tried a few approaches with these datasets such as a traditional `date` and `end` with `@support_date_range`, but thought it was weird to have to give a date to something like `get_pricing_nodes()`. Most of them are formulated with an `Effective Date` (the date they become active) and a `Termination Date`, the date the are inactivated. So I add an `as_of` field the these list datasets with those, that effectively lets the user query the active rows given a certain date (it defaults to getting all rows). 

We could incorporate that `as_of` time as a sort of `Publish Time`, if we want to capture the lists as they change over time. For example the [list of nodes](https://dataminer2.pjm.com/feed/pnode/definition) is updated daily. However, we could just grab the list as-is each time and let other systems handle updating data as they wish. My guess is that these list data are updated partially and in-place, such as when a new termination date is added to a node. I lean toward not including a "Publish Time" for these data, since it fans out considerably and there are likely better ways to capture updates and track changes over time. 

More in the comments