### PR TITLE
fix(ENG 1892): Add back peak time

### DIFF
--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -2998,6 +2998,11 @@ class PJM(ISOBase):
         df["Publish Time"] = pd.to_datetime(df["generated_at_ept"]).dt.tz_localize(
             self.default_timezone,
         )
+        df["Projected Peak Time"] = pd.to_datetime(
+            df["projected_peak_datetime_utc"],
+            format="ISO8601",
+        ).dt.tz_localize("UTC")
+
         df["Interval Start"] = (
             pd.to_datetime(df["projected_peak_datetime_utc"], format="ISO8601")
             .dt.tz_localize(
@@ -3018,6 +3023,7 @@ class PJM(ISOBase):
                 "Interval Start",
                 "Interval End",
                 "Publish Time",
+                "Projected Peak Time",
                 "Interface",
                 "Scheduled Tie Flow",
             ]

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -2998,19 +2998,17 @@ class PJM(ISOBase):
         df["Publish Time"] = pd.to_datetime(df["generated_at_ept"]).dt.tz_localize(
             self.default_timezone,
         )
-        df["Projected Peak Time"] = pd.to_datetime(
-            df["projected_peak_datetime_utc"],
-            format="ISO8601",
-        ).dt.tz_localize("UTC")
 
-        df["Interval Start"] = (
-            pd.to_datetime(df["projected_peak_datetime_utc"], format="ISO8601")
-            .dt.tz_localize(
-                "UTC",
+        df["Projected Peak Time"] = (
+            pd.to_datetime(
+                df["projected_peak_datetime_utc"],
+                format="ISO8601",
             )
+            .dt.tz_localize("UTC")
             .dt.tz_convert(self.default_timezone)
-            .dt.floor("D")
         )
+
+        df["Interval Start"] = df["Projected Peak Time"].dt.floor("D")
         df["Interval End"] = df["Interval Start"] + pd.Timedelta(days=1)
         df = df.rename(
             columns={

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -2787,6 +2787,7 @@ class TestPJM(BaseTestISO):
             "Interval Start",
             "Interval End",
             "Publish Time",
+            "Projected Peak Time",
             "Interface",
             "Scheduled Tie Flow",
         ]


### PR DESCRIPTION
## Summary
In the initial addition of this scraper the Interval Start and End were the peak time hour. So I switched to day that to be the full day, like in other `projected` datasets. But I didn’t add back a separate column for peak time. This corrects that for the final correct columns.

Example existing dataset: https://www.gridstatus.io/datasets/pjm_projected_rto_statistics_at_peak
Current Projected Peak Time (missing peak time column): https://www.gridstatus.io/datasets/pjm_projected_peak_tie_flow
