### PR TITLE
Update utils.py

### DIFF
--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -343,7 +343,13 @@ def get_interconnection_queues() -> pd.DataFrame:
     for iso in tqdm.tqdm(all_isos):
         iso = iso()
         # only shared columns
-        queue = iso.get_interconnection_queue()[_interconnection_columns]
+        # add error handling for IESO
+        
+        try:
+          queue = iso.get_interconnection_queue()[_interconnection_columns]
+        except NotImplementedError:
+          queue = pd.DataFrame()
+        
         queue.insert(0, "ISO", iso.name)
         queue.reset_index(drop=True, inplace=True)
         all_queues.append(queue)


### PR DESCRIPTION
Error handling for get_interconnection_queues()

## Summary
Fix for Issue #649 
Currently, get_interconnection_queues() fails on IESO, as the region has no implementation for interconnection queues.
Added basic error handling to return a blank DataFrame in event of NotImplementedError.