### PR TITLE
[ENG-2208] CAISO System Load and Resource Schedules

### DIFF
--- a/gridstatus/caiso/caiso_constants.py
+++ b/gridstatus/caiso/caiso_constants.py
@@ -389,6 +389,58 @@ OASIS_DATASET_CONFIG = {
         },
         "params": {},
     },
+    "system_load_and_resource_schedules_day_ahead": {
+        "query": {
+            "path": "SingleZip",
+            "resultformat": 6,
+            "queryname": "ENE_SLRS",
+            "version": 1,
+        },
+        "params": {
+            "market_run_id": ["DAM"],
+            "tac_zone_name": "ALL",
+            "schedule": "ALL",
+        },
+    },
+    "system_load_and_resource_schedules_day_hasp": {
+        "query": {
+            "path": "SingleZip",
+            "resultformat": 6,
+            "queryname": "ENE_SLRS",
+            "version": 1,
+        },
+        "params": {
+            "market_run_id": ["HASP"],
+            "tac_zone_name": "ALL",
+            "schedule": "ALL",
+        },
+    },
+    "system_load_and_resource_schedules_real_time": {
+        "query": {
+            "path": "SingleZip",
+            "resultformat": 6,
+            "queryname": "ENE_SLRS",
+            "version": 1,
+        },
+        "params": {
+            "market_run_id": ["RTM"],
+            "tac_zone_name": "ALL",
+            "schedule": "ALL",
+        },
+    },
+    "system_load_and_resource_schedules_ruc": {
+        "query": {
+            "path": "SingleZip",
+            "resultformat": 6,
+            "queryname": "ENE_SLRS",
+            "version": 1,
+        },
+        "params": {
+            "market_run_id": ["RUC"],
+            "tac_zone_name": "ALL",
+            "schedule": "ALL",
+        },
+    },
 }
 
 

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -1404,3 +1404,191 @@ class TestCAISO(BaseTestISO):
                 end,
                 tz=self.iso.default_timezone,
             )
+
+    """get_caiso_system_load_and_resource_schedules"""
+
+    def _check_system_load_and_resource_schedules(self, df):
+        """Helper to check system load and resource schedules dataframe."""
+        assert df.shape[0] > 0
+
+        # Check base columns that should always be present
+        required_columns = ["Interval Start", "Interval End", "TAC Name"]
+        for col in required_columns:
+            assert col in df.columns, f"Missing required column: {col}"
+
+        # Check that interval timestamps are valid
+        assert pd.api.types.is_datetime64_any_dtype(df["Interval Start"])
+        assert pd.api.types.is_datetime64_any_dtype(df["Interval End"])
+
+        # Check TAC Name is string
+        assert pd.api.types.is_string_dtype(df["TAC Name"])
+
+        # Check that there are schedule columns (after pivoting)
+        # These could be columns like "LOAD", "GENERATION", "IMPORT", "EXPORT", etc.
+        schedule_columns = [col for col in df.columns if col not in required_columns]
+        assert len(schedule_columns) > 0, "No schedule columns found after pivoting"
+
+        # Check that schedule columns contain numeric data
+        for col in schedule_columns:
+            assert pd.api.types.is_numeric_dtype(df[col]), (
+                f"Column {col} should be numeric"
+            )
+
+    def test_get_caiso_system_load_and_resource_schedules_day_ahead_latest(self):
+        with caiso_vcr.use_cassette(
+            "test_get_caiso_system_load_and_resource_schedules_day_ahead_latest.yaml",
+        ):
+            df = self.iso.get_caiso_system_load_and_resource_schedules_day_ahead(
+                "latest",
+            )
+            self._check_system_load_and_resource_schedules(df)
+
+            # For day-ahead, should have future data
+            assert df["Interval Start"].max() > self.local_now()
+
+    @pytest.mark.parametrize(
+        "date, end",
+        [
+            ("2024-01-15", "2024-01-17"),
+            ("2024-06-01", "2024-06-03"),
+        ],
+    )
+    def test_get_caiso_system_load_and_resource_schedules_day_ahead_date_range(
+        self,
+        date,
+        end,
+    ):
+        with caiso_vcr.use_cassette(
+            f"test_get_caiso_system_load_and_resource_schedules_day_ahead_{date}_{end}.yaml",
+        ):
+            df = self.iso.get_caiso_system_load_and_resource_schedules_day_ahead(
+                date,
+                end=end,
+            )
+            self._check_system_load_and_resource_schedules(df)
+
+            # Check date range
+            assert df["Interval Start"].min() >= pd.Timestamp(
+                date,
+                tz=self.iso.default_timezone,
+            )
+            assert df["Interval End"].max() <= pd.Timestamp(
+                end,
+                tz=self.iso.default_timezone,
+            ) + pd.Timedelta(days=1)
+
+    def test_get_caiso_system_load_and_resource_schedules_hasp_latest(self):
+        with caiso_vcr.use_cassette(
+            "test_get_caiso_system_load_and_resource_schedules_hasp_latest.yaml",
+        ):
+            df = self.iso.get_caiso_system_load_and_resource_schedules_hasp("latest")
+            self._check_system_load_and_resource_schedules(df)
+
+    @pytest.mark.parametrize(
+        "date, end",
+        [
+            ("2024-01-15", "2024-01-17"),
+            ("2024-06-01", "2024-06-03"),
+        ],
+    )
+    def test_get_caiso_system_load_and_resource_schedules_hasp_date_range(
+        self,
+        date,
+        end,
+    ):
+        with caiso_vcr.use_cassette(
+            f"test_get_caiso_system_load_and_resource_schedules_hasp_{date}_{end}.yaml",
+        ):
+            df = self.iso.get_caiso_system_load_and_resource_schedules_hasp(
+                date,
+                end=end,
+            )
+            self._check_system_load_and_resource_schedules(df)
+
+            # Check date range
+            assert df["Interval Start"].min() >= pd.Timestamp(
+                date,
+                tz=self.iso.default_timezone,
+            )
+            assert df["Interval End"].max() <= pd.Timestamp(
+                end,
+                tz=self.iso.default_timezone,
+            ) + pd.Timedelta(days=1)
+
+    def test_get_caiso_system_load_and_resource_schedules_real_time_latest(self):
+        with caiso_vcr.use_cassette(
+            "test_get_caiso_system_load_and_resource_schedules_real_time_latest.yaml",
+        ):
+            df = self.iso.get_caiso_system_load_and_resource_schedules_real_time(
+                "latest",
+            )
+            self._check_system_load_and_resource_schedules(df)
+
+    @pytest.mark.parametrize(
+        "date, end",
+        [
+            ("2024-01-15", "2024-01-17"),
+            ("2024-06-01", "2024-06-03"),
+        ],
+    )
+    def test_get_caiso_system_load_and_resource_schedules_real_time_date_range(
+        self,
+        date,
+        end,
+    ):
+        with caiso_vcr.use_cassette(
+            f"test_get_caiso_system_load_and_resource_schedules_real_time_{date}_{end}.yaml",
+        ):
+            df = self.iso.get_caiso_system_load_and_resource_schedules_real_time(
+                date,
+                end=end,
+            )
+            self._check_system_load_and_resource_schedules(df)
+
+            # Check date range
+            assert df["Interval Start"].min() >= pd.Timestamp(
+                date,
+                tz=self.iso.default_timezone,
+            )
+            assert df["Interval End"].max() <= pd.Timestamp(
+                end,
+                tz=self.iso.default_timezone,
+            ) + pd.Timedelta(days=1)
+
+    def test_get_caiso_system_load_and_resource_schedules_ruc_latest(self):
+        with caiso_vcr.use_cassette(
+            "test_get_caiso_system_load_and_resource_schedules_ruc_latest.yaml",
+        ):
+            df = self.iso.get_caiso_system_load_and_resource_schedules_ruc("latest")
+            self._check_system_load_and_resource_schedules(df)
+
+    @pytest.mark.parametrize(
+        "date, end",
+        [
+            ("2024-01-15", "2024-01-17"),
+            ("2024-06-01", "2024-06-03"),
+        ],
+    )
+    def test_get_caiso_system_load_and_resource_schedules_ruc_date_range(
+        self,
+        date,
+        end,
+    ):
+        with caiso_vcr.use_cassette(
+            f"test_get_caiso_system_load_and_resource_schedules_ruc_{date}_{end}.yaml",
+        ):
+            df = self.iso.get_caiso_system_load_and_resource_schedules_ruc(
+                date,
+                end=end,
+            )
+            self._check_system_load_and_resource_schedules(df)
+
+            # Check date range
+            assert df["Interval Start"].min() >= pd.Timestamp(
+                date,
+                tz=self.iso.default_timezone,
+            )
+            assert df["Interval End"].max() <= pd.Timestamp(
+                end,
+                tz=self.iso.default_timezone,
+            ) + pd.Timedelta(days=1)


### PR DESCRIPTION
## Summary

- Adds four CAISO system load and resource schedules datasets, one for each market:
  - `get_caiso_system_load_and_resource_schedules_day_ahead`
  - `get_caiso_system_load_and_resource_schedules_real_hasp`
  - `get_caiso_system_load_and_resource_schedules_real_time`
  - `get_caiso_system_load_and_resource_schedules_ruc`

### Details
