### PR TITLE
[ENG-2325], [ENG-2326] SPP Market Clearing Datasets

### DIFF
--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -1642,9 +1642,9 @@ class SPP(ISOBase):
     @support_date_range("DAY_START")
     def get_market_clearing_real_time(
         self,
-        date,
-        end=None,
-        verbose=False,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+        verbose: bool = False,
     ):
         """Get Market Clearing Real Time
 
@@ -1679,9 +1679,9 @@ class SPP(ISOBase):
     @support_date_range("DAY_START")
     def get_market_clearing_day_ahead(
         self,
-        date,
-        end=None,
-        verbose=False,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+        verbose: bool = False,
     ):
         """Get Market Clearing Day Ahead
 
@@ -1711,7 +1711,7 @@ class SPP(ISOBase):
 
         return self._process_market_clearing(df, 60)
 
-    def _process_market_clearing(self, df, interval_minutes: int):
+    def _process_market_clearing(self, df: pd.DataFrame, interval_minutes: int):
         df = self._handle_market_end_to_interval(
             df,
             column="GMTIntervalEnd",

--- a/gridstatus/tests/source_specific/test_spp.py
+++ b/gridstatus/tests/source_specific/test_spp.py
@@ -1352,7 +1352,7 @@ class TestSPP(BaseTestISO):
 
     """get_market_clearing_real_time"""
 
-    def _check_market_clearing_real_time(self, df):
+    def _check_market_clearing_real_time(self, df: pd.DataFrame):
         assert df.columns.tolist() == [
             "Interval Start",
             "Interval End",
@@ -1376,6 +1376,12 @@ class TestSPP(BaseTestISO):
             df["Interval End"] - df["Interval Start"] == pd.Timedelta(minutes=5)
         ).all()
 
+    def test_market_clearing_real_time_latest(self):
+        with api_vcr.use_cassette("test_market_clearing_real_time_latest.yaml"):
+            df = self.iso.get_market_clearing_real_time(date="latest")
+
+        self._check_market_clearing_real_time(df)
+
     def test_market_clearing_real_time_date_range(self):
         start = (self.local_now() - pd.Timedelta(days=5)).normalize()
         end = start + pd.DateOffset(days=3)
@@ -1391,7 +1397,7 @@ class TestSPP(BaseTestISO):
 
     """get_market_clearing_day_ahead"""
 
-    def _check_market_clearing_day_ahead(self, df):
+    def _check_market_clearing_day_ahead(self, df: pd.DataFrame):
         assert df.columns.tolist() == [
             "Interval Start",
             "Interval End",
@@ -1422,6 +1428,12 @@ class TestSPP(BaseTestISO):
         assert (
             df["Interval End"] - df["Interval Start"] == pd.Timedelta(minutes=60)
         ).all()
+
+    def test_market_clearing_day_ahead_latest(self):
+        with api_vcr.use_cassette("test_market_clearing_day_ahead_latest.yaml"):
+            df = self.iso.get_market_clearing_day_ahead(date="latest")
+
+        self._check_market_clearing_day_ahead(df)
 
     def test_market_clearing_day_ahead_date_range(self):
         start = (self.local_now() - pd.Timedelta(days=5)).normalize()

--- a/gridstatus/tests/source_specific/test_spp.py
+++ b/gridstatus/tests/source_specific/test_spp.py
@@ -1349,3 +1349,89 @@ class TestSPP(BaseTestISO):
     def test_get_hourly_load_current_day_not_supported(self, date):
         with pytest.raises(NotSupported):
             self.iso.get_hourly_load(date)
+
+    """get_market_clearing_real_time"""
+
+    def _check_market_clearing_real_time(self, df):
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "Generation",
+            "Cleared DR",
+            "NSI",
+            "SMP",
+            "Min LMP",
+            "Max LMP",
+            "Reg Up",
+            "Reg Dn",
+            "Ramp Up",
+            "Ramp Dn",
+            "Unc Up",
+            "Spin",
+            "Supp",
+            "Capacity Available",
+        ]
+
+        assert (
+            df["Interval End"] - df["Interval Start"] == pd.Timedelta(minutes=5)
+        ).all()
+
+    def test_market_clearing_real_time_date_range(self):
+        start = (self.local_now() - pd.Timedelta(days=5)).normalize()
+        end = start + pd.DateOffset(days=3)
+
+        with api_vcr.use_cassette(
+            f"test_market_clearing_real_time_{start.strftime('%Y%m%d')}_to_{end.strftime('%Y%m%d')}.yaml",
+        ):
+            df = self.iso.get_market_clearing_real_time(start=start, end=end)
+
+        assert df["Interval Start"].min() == start
+        assert df["Interval Start"].max() == end - pd.Timedelta(minutes=5)
+        self._check_market_clearing_real_time(df)
+
+    """get_market_clearing_day_ahead"""
+
+    def _check_market_clearing_day_ahead(self, df):
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "Generation",
+            "Cleared DR",
+            "Cleared Demand Bid",
+            "Cleared Fixed Demand Bid",
+            "Cleared Virtual Bid",
+            "Cleared Virtual Offer",
+            "Total Demand",
+            "NSI",
+            "SMP",
+            "Min LMP",
+            "Max LMP",
+            "Reg Up",
+            "Reg Dn",
+            "Ramp Up",
+            "Ramp Dn",
+            "Unc Up",
+            "Spin",
+            "Supp",
+            "Capacity Available",
+            "Fixed Obligation",
+            "Net Capacity",
+            "Curtailed Fixed Demand Bid",
+        ]
+
+        assert (
+            df["Interval End"] - df["Interval Start"] == pd.Timedelta(minutes=60)
+        ).all()
+
+    def test_market_clearing_day_ahead_date_range(self):
+        start = (self.local_now() - pd.Timedelta(days=5)).normalize()
+        end = start + pd.DateOffset(days=3)
+
+        with api_vcr.use_cassette(
+            f"test_market_clearing_day_ahead_{start.strftime('%Y%m%d')}_to_{end.strftime('%Y%m%d')}.yaml",
+        ):
+            df = self.iso.get_market_clearing_day_ahead(start=start, end=end)
+
+        assert df["Interval Start"].min() == start
+        assert df["Interval Start"].max() == end - pd.Timedelta(hours=1)
+        self._check_market_clearing_day_ahead(df)


### PR DESCRIPTION
## Summary

- Adds `SPP().get_market_clearing_real_time()` for real time 5 minute data (1 day delay)
- Adds `SPP().get_market_clearing_day_ahead()` for day ahead hourly data



### Details
