### PR TITLE
Remove interval padding with zero '0'.

### DIFF
--- a/gridstatus/miso_api.py
+++ b/gridstatus/miso_api.py
@@ -205,8 +205,7 @@ class MISOAPI:
         version: str = EX_POST,
         verbose: bool = False,
     ) -> List[Dict[str, Any]]:
-        # 0-padded hour. 00 doesn't exist so add 1 to the hour
-        interval = str(date.hour + 1).zfill(2)
+        interval = str(date.hour + 1)
         date_str = date.strftime("%Y-%m-%d")
 
         url = (
@@ -225,8 +224,7 @@ class MISOAPI:
         prelim_or_final: str = PRELIMINARY_STRING,
         verbose: bool = False,
     ) -> List[Dict[str, Any]]:
-        # 0-padded hour. 00 doesn't exist so add 1 to the hour
-        interval = str(date.hour + 1).zfill(2)
+        interval = str(date.hour + 1)
         date_str = date.strftime("%Y-%m-%d")
         version = EX_POST
         resolution = HOURLY_RESOLUTION
@@ -732,7 +730,7 @@ class MISOAPI:
         version: str = EX_POST,
         verbose: bool = False,
     ) -> List[Dict[str, Any]]:
-        interval = str(date.hour + 1).zfill(2)
+        interval = str(date.hour + 1)
         date_str = date.strftime("%Y-%m-%d")
 
         url = (
@@ -789,7 +787,7 @@ class MISOAPI:
         prelim_or_final: str = PRELIMINARY_STRING,
         verbose: bool = False,
     ) -> List[Dict[str, Any]]:
-        interval = str(date.hour + 1).zfill(2)
+        interval = str(date.hour + 1)
         date_str = date.strftime("%Y-%m-%d")
         version = EX_POST
         time_resolution = HOURLY_RESOLUTION


### PR DESCRIPTION
## Summary
MISO’s Pricing API incorrectly returns a 404 - Empty data returned for date error when the **interval** parameter is zero-padded (e.g., **interval=01**). While this appears to be a defect in the API, zero-padding is not required for valid requests. To ensure consistent results, we should remove leading zeros from the interval parameter in all MISO Pricing API calls.

### Details

**Issue:**
When requesting data for interval 01, the API responds with a 404 error despite valid data being available for interval 1.

**Example – Failing Request:**

```
curl -v -X GET "https://apim.misoenergy.org/pricing/v1/real-time/2025-10-03/lmp-expost?interval=01&preliminaryFinal=Final&timeResolution=hourly&pageNumber=1" -H "Cache-Control: no-cache" -H "Ocp-Apim-Subscription-Key: ••••••••••••••••••••••••••••••••"
```

Response:
```
HTTP response
HTTP/1.1 404 Not Found

connection: keep-alive
content-length: 54
content-type: application/json;charset=UTF-8
date: Tue, 07 Oct 2025 13:30:31 GMT
strict-transport-security: max-age=31536000; includeSubDomains

{
    "status": 404,
    "reason": "Empty data returned for date"
}
```

---

**Example – Successful Request:**

Removing the zero padding from the interval parameter (interval=1) returns valid data as expected.

```
curl -v -X GET "https://apim.misoenergy.org/pricing/v1/real-time/2025-10-03/lmp-expost?interval=1&preliminaryFinal=Final&timeResolution=hourly&pageNumber=1" -H "Cache-Control: no-cache" -H "Ocp-Apim-Subscription-Key: ••••••••••••••••••••••••••••••••"
```

Response:
```
HTTP response
HTTP/1.1 200 OK

connection: keep-alive
content-encoding: gzip
content-type: application/json;charset=UTF-8
date: Tue, 07 Oct 2025 13:28:19 GMT
strict-transport-security: max-age=31536000; includeSubDomains
transfer-encoding: chunked

{
    "data": [{
        "timeInterval": {
            "resolution": "hourly",
            "start": "2025-10-03T00:00:00",
            "end": "2025-10-03T01:00:00",
            "value": "1"
        },
        "preliminaryFinal": "Final",
        "node": "AECI",
        "lmp": 21.030000,
        "mcc": -2.180000,
        "mec": 24.860000,
        "mlc": -1.650000
    }, {
        "timeInterval": {
            "resolution": "hourly",
            "start": "2025-10-03T00:00:00",
            "end": "2025-10-03T01:00:00",
            "value": "1"
        },
        "preliminaryFinal": "Final",
        "node": "AECI.ALTW",
        "lmp": 22.140000,
        "mcc": -1.490000,
        "mec": 24.860000,
        "mlc": -1.230000
    },...
```

**Recommendation**

Avoid zero-padding the interval parameter in all MISO Pricing API requests.
This ensures reliable data retrieval and mitigates exposure to this apparent API defect.