### PR TITLE
Add MISO missing Load, Generation, and Interchange APIs

### DIFF
--- a/gridstatus/miso_api.py
+++ b/gridstatus/miso_api.py
@@ -513,7 +513,7 @@ class MISOAPI:
         verbose: bool = False,
     ) -> pd.DataFrame:
         if date == "latest":
-            date = "today"
+            date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
         return self._get_day_ahead_cleared_demand(
             date,
@@ -530,7 +530,7 @@ class MISOAPI:
         verbose: bool = False,
     ) -> pd.DataFrame:
         if date == "latest":
-            date = "today"
+            date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
         return self._get_day_ahead_cleared_demand(
             date,
@@ -591,7 +591,7 @@ class MISOAPI:
         verbose: bool = False,
     ) -> pd.DataFrame:
         if date == "latest":
-            date = "today"
+            date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
         return self._get_day_ahead_cleared_generation_hourly(
             date, end, verbose, generation_type="physical"
@@ -605,7 +605,7 @@ class MISOAPI:
         verbose: bool = False,
     ) -> pd.DataFrame:
         if date == "latest":
-            date = "today"
+            date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
         return self._get_day_ahead_cleared_generation_hourly(
             date, end, verbose, generation_type="virtual"
@@ -619,7 +619,7 @@ class MISOAPI:
         verbose: bool = False,
     ) -> pd.DataFrame:
         if date == "latest":
-            date = "today"
+            date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
         date_str = date.strftime("%Y-%m-%d")
 
@@ -720,7 +720,7 @@ class MISOAPI:
         verbose: bool = False,
     ) -> pd.DataFrame:
         if date == "latest":
-            date = "today"
+            date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
         return self._get_day_ahead_offered_generation_hourly(
             date, end, verbose, ecotype="ecomax"
@@ -734,7 +734,7 @@ class MISOAPI:
         verbose: bool = False,
     ) -> pd.DataFrame:
         if date == "latest":
-            date = "today"
+            date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
         return self._get_day_ahead_offered_generation_hourly(
             date, end, verbose, ecotype="ecomin"
@@ -748,7 +748,7 @@ class MISOAPI:
         verbose: bool = False,
     ) -> pd.DataFrame:
         if date == "latest":
-            date = "today"
+            date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
         date_str = date.strftime("%Y-%m-%d")
 
@@ -864,7 +864,7 @@ class MISOAPI:
         verbose: bool = False,
     ) -> pd.DataFrame:
         if date == "latest":
-            date = "today"
+            date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
         return self._get_real_time_cleared_demand(
             date,
@@ -881,9 +881,9 @@ class MISOAPI:
         verbose: bool = False,
     ) -> pd.DataFrame:
         if date == "latest":
-            date = pd.Timestamp.today(tz=self.default_timezone) - pd.Timedelta(
-                days=1
-            )  # Yesterday
+            date = pd.Timestamp.today(tz=self.default_timezone).floor(
+                "d"
+            ) - pd.Timedelta(days=1)  # Yesterday
 
         return self._get_real_time_cleared_demand(
             date,
@@ -948,9 +948,9 @@ class MISOAPI:
             "get_real_time_cleared_generation_hourly is not ready for use yet."
         )
         if date == "latest":
-            date = pd.Timestamp.today(tz=self.default_timezone) - pd.Timedelta(
-                days=1
-            )  # Yesterday
+            date = pd.Timestamp.today(tz=self.default_timezone).floor(
+                "d"
+            ) - pd.Timedelta(days=1)  # Yesterday
 
         return self._get_real_time_cleared_generation(
             date, end, verbose, time_resolution=HOURLY_RESOLUTION
@@ -964,7 +964,7 @@ class MISOAPI:
         verbose: bool = False,
     ) -> pd.DataFrame:
         if date == "latest":
-            date = "today"
+            date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
         date_str = date.strftime("%Y-%m-%d")
 
@@ -1019,7 +1019,7 @@ class MISOAPI:
         verbose: bool = False,
     ) -> pd.DataFrame:
         if date == "latest":
-            date = "today"
+            date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
         date_str = date.strftime("%Y-%m-%d")
 
@@ -1074,7 +1074,7 @@ class MISOAPI:
         verbose: bool = False,
     ) -> pd.DataFrame:
         if date == "latest":
-            date = "today"
+            date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
         date_str = date.strftime("%Y-%m-%d")
 

--- a/gridstatus/tests/source_specific/test_miso_api.py
+++ b/gridstatus/tests/source_specific/test_miso_api.py
@@ -499,26 +499,30 @@ class TestMISOAPI(TestHelperMixin):
 
     @pytest.mark.integration
     def test_get_day_ahead_cleared_demand_daily_date_range(self):
-        with api_vcr.use_cassette("get_day_ahead_cleared_demand_daily_today"):
-            df = self.iso.get_day_ahead_cleared_demand_daily("today")
+        date = self.local_start_of_today()
+
+        with api_vcr.use_cassette(f"get_day_ahead_cleared_demand_daily_{date.date()}"):
+            df = self.iso.get_day_ahead_cleared_demand_daily(date)
 
         self._check_test_get_day_ahead_cleared_demand(df)
 
-        assert df["Interval Start"].min() == self.local_start_of_today()
-        assert df["Interval Start"].max() == self.local_start_of_today()
-        assert df["Interval End"].max() == self.local_start_of_today() + pd.Timedelta(
+        assert df["Interval Start"].min() == date
+        assert df["Interval Start"].max() == date
+        assert df["Interval End"].max() == date + pd.Timedelta(
             days=1,
         )
 
     @pytest.mark.integration
     def test_get_day_ahead_cleared_demand_hourly_date_range(self):
-        with api_vcr.use_cassette("get_day_ahead_cleared_demand_hourly_today"):
-            df = self.iso.get_day_ahead_cleared_demand_hourly("today")
+        date = self.local_start_of_today()
+
+        with api_vcr.use_cassette(f"get_day_ahead_cleared_demand_hourly_{date.date()}"):
+            df = self.iso.get_day_ahead_cleared_demand_hourly(date)
 
         self._check_test_get_day_ahead_cleared_demand(df)
 
-        assert df["Interval Start"].min() == self.local_start_of_today()
-        assert df["Interval Start"].max() == self.local_start_of_today() + pd.Timedelta(
+        assert df["Interval Start"].min() == date
+        assert df["Interval Start"].max() == date + pd.Timedelta(
             hours=23,
         )
 
@@ -537,50 +541,46 @@ class TestMISOAPI(TestHelperMixin):
             if col not in ["Interval Start", "Interval End", "Region"]:
                 assert df[col].dtype == "float64"
 
-        assert df["Interval Start"].min() == self.local_start_of_today()
-        assert df["Interval Start"].max() == self.local_start_of_today() + pd.Timedelta(
+    @pytest.mark.integration
+    def test_get_day_ahead_cleared_generation_physical_hourly_date_range(self):
+        date = self.local_start_of_today()
+
+        with api_vcr.use_cassette(
+            f"get_day_ahead_cleared_generation_physical_hourly_{date.date()}"
+        ):
+            df = self.iso.get_day_ahead_cleared_generation_physical_hourly(date)
+
+        self._check_day_ahead_cleared_generation_hourly(df)
+
+        assert df["Interval Start"].min() == date
+        assert df["Interval Start"].max() == date + pd.Timedelta(
             hours=23,
         )
 
     @pytest.mark.integration
-    def test_get_day_ahead_cleared_generation_physical_hourly_date_range(self):
-        with api_vcr.use_cassette(
-            "get_day_ahead_cleared_generation_physical_hourly_today"
-        ):
-            df = self.iso.get_day_ahead_cleared_generation_physical_hourly("today")
-
-        self._check_day_ahead_cleared_generation_hourly(df)
-
-    @pytest.mark.integration
     def test_get_day_ahead_cleared_generation_virtual_hourly_date_range(self):
+        date = self.local_start_of_today()
+
         with api_vcr.use_cassette(
-            "get_day_ahead_cleared_generation_virtual_hourly_today"
+            f"get_day_ahead_cleared_generation_virtual_hourly_{date.date()}"
         ):
-            df = self.iso.get_day_ahead_cleared_generation_virtual_hourly("today")
+            df = self.iso.get_day_ahead_cleared_generation_virtual_hourly(date)
 
         self._check_day_ahead_cleared_generation_hourly(df)
 
-    def _check_day_ahead_offered_generation_hourly(self, df, expected_columns):
-        assert df.columns.tolist() == expected_columns
-
-        assert df["Interval Start"].dtype == "datetime64[ns, EST]"
-        assert df["Interval End"].dtype == "datetime64[ns, EST]"
-
-        for col in df.columns:
-            if col not in ["Interval Start", "Interval End", "Region"]:
-                assert df[col].dtype == "float64"
-
-        assert df["Interval Start"].min() == self.local_start_of_today()
-        assert df["Interval Start"].max() == self.local_start_of_today() + pd.Timedelta(
+        assert df["Interval Start"].min() == date
+        assert df["Interval Start"].max() == date + pd.Timedelta(
             hours=23,
         )
 
     @pytest.mark.integration
     def test_get_day_ahead_net_scheduled_interchange_hourly_date_range(self):
+        date = self.local_start_of_today()
+
         with api_vcr.use_cassette(
-            "get_day_ahead_net_scheduled_interchange_hourly_today"
+            f"get_day_ahead_net_scheduled_interchange_hourly_{date.date()}"
         ):
-            df = self.iso.get_day_ahead_net_scheduled_interchange_hourly("today")
+            df = self.iso.get_day_ahead_net_scheduled_interchange_hourly(date)
 
         assert df.columns.tolist() == [
             "Interval Start",
@@ -596,17 +596,55 @@ class TestMISOAPI(TestHelperMixin):
             if col not in ["Interval Start", "Interval End", "Region"]:
                 assert df[col].dtype == "float64"
 
-        assert df["Interval Start"].min() == self.local_start_of_today()
-        assert df["Interval Start"].max() == self.local_start_of_today() + pd.Timedelta(
+        assert df["Interval Start"].min() == date
+        assert df["Interval Start"].max() == date + pd.Timedelta(
+            hours=23,
+        )
+
+    def _check_day_ahead_offered_generation_hourly(self, df, expected_columns):
+        assert df.columns.tolist() == expected_columns
+
+        assert df["Interval Start"].dtype == "datetime64[ns, EST]"
+        assert df["Interval End"].dtype == "datetime64[ns, EST]"
+
+        for col in df.columns:
+            if col not in ["Interval Start", "Interval End", "Region"]:
+                assert df[col].dtype == "float64"
+
+    @pytest.mark.integration
+    def test_get_day_ahead_offered_generation_ecomax_hourly_date_range(self):
+        date = self.local_start_of_today()
+
+        with api_vcr.use_cassette(
+            f"get_day_ahead_offered_generation_ecomax_hourly_{date.date()}"
+        ):
+            df = self.iso.get_day_ahead_offered_generation_ecomax_hourly(date)
+
+        self._check_day_ahead_offered_generation_hourly(
+            df,
+            [
+                "Interval Start",
+                "Interval End",
+                "Region",
+                "Must Run",
+                "Economic",
+                "Emergency",
+            ],
+        )
+
+        assert df["Interval Start"].min() == date
+        assert df["Interval Start"].max() == date + pd.Timedelta(
             hours=23,
         )
 
     @pytest.mark.integration
-    def test_get_day_ahead_offered_generation_ecomax_hourly_date_range(self):
+    def test_get_day_ahead_offered_generation_ecomin_hourly_date_range(self):
+        date = self.local_start_of_today()
+
         with api_vcr.use_cassette(
-            "get_day_ahead_offered_generation_ecomax_hourly_today"
+            f"get_day_ahead_offered_generation_ecomin_hourly_{date.date()}"
         ):
-            df = self.iso.get_day_ahead_offered_generation_ecomax_hourly("today")
+            df = self.iso.get_day_ahead_offered_generation_ecomin_hourly(date)
 
         self._check_day_ahead_offered_generation_hourly(
             df,
@@ -620,29 +658,19 @@ class TestMISOAPI(TestHelperMixin):
             ],
         )
 
-    @pytest.mark.integration
-    def test_get_day_ahead_offered_generation_ecomin_hourly_date_range(self):
-        with api_vcr.use_cassette(
-            "get_day_ahead_offered_generation_ecomin_hourly_today"
-        ):
-            df = self.iso.get_day_ahead_offered_generation_ecomin_hourly("today")
-
-        self._check_day_ahead_offered_generation_hourly(
-            df,
-            [
-                "Interval Start",
-                "Interval End",
-                "Region",
-                "Must Run",
-                "Economic",
-                "Emergency",
-            ],
+        assert df["Interval Start"].min() == date
+        assert df["Interval Start"].max() == date + pd.Timedelta(
+            hours=23,
         )
 
     @pytest.mark.integration
     def test_get_day_ahead_generation_fuel_type_hourly_date_range(self):
-        with api_vcr.use_cassette("get_day_ahead_generation_fuel_type_hourly_today"):
-            df = self.iso.get_day_ahead_generation_fuel_type_hourly("today")
+        date = self.local_start_of_today()
+
+        with api_vcr.use_cassette(
+            f"get_day_ahead_generation_fuel_type_hourly_{date.date()}"
+        ):
+            df = self.iso.get_day_ahead_generation_fuel_type_hourly(date)
 
         assert df.columns.tolist() == [
             "Interval Start",
@@ -665,11 +693,11 @@ class TestMISOAPI(TestHelperMixin):
             if col not in ["Interval Start", "Interval End", "Region"]:
                 assert df[col].dtype == "float64"
 
-        assert df["Interval Start"].min() == self.local_start_of_today()
-        assert df["Interval Start"].max() == self.local_start_of_today() + pd.Timedelta(
+        assert df["Interval Start"].min() == date
+        assert df["Interval Start"].max() == date + pd.Timedelta(
             hours=23,
         )
-        assert df["Interval End"].max() == self.local_start_of_today() + pd.Timedelta(
+        assert df["Interval End"].max() == date + pd.Timedelta(
             days=1,
         )
 
@@ -689,33 +717,33 @@ class TestMISOAPI(TestHelperMixin):
 
     @pytest.mark.integration
     def test_get_real_time_cleared_demand_daily_date_range(self):
-        yesterday = self.local_start_of_today() - pd.Timedelta(days=1)
+        date = self.local_start_of_today() - pd.Timedelta(days=1)
 
-        with api_vcr.use_cassette("get_real_time_cleared_demand_daily_today"):
-            df = self.iso.get_real_time_cleared_demand_daily(yesterday)
+        with api_vcr.use_cassette(f"get_real_time_cleared_demand_daily_{date.date()}"):
+            df = self.iso.get_real_time_cleared_demand_daily(date)
 
         self._check_test_get_real_time_cleared_demand(df)
 
-        assert df["Interval Start"].min() == yesterday
-        assert df["Interval Start"].max() == yesterday
-        assert df["Interval End"].max() == yesterday + pd.Timedelta(
+        assert df["Interval Start"].min() == date
+        assert df["Interval Start"].max() == date
+        assert df["Interval End"].max() == date + pd.Timedelta(
             days=1,
         )
 
     @pytest.mark.integration
     def test_get_real_time_cleared_demand_hourly_date_range(self):
-        yesterday = self.local_start_of_today() - pd.Timedelta(days=1)
+        date = self.local_start_of_today() - pd.Timedelta(days=1)
 
-        with api_vcr.use_cassette("get_real_time_cleared_demand_hourly_yesterday"):
-            df = self.iso.get_real_time_cleared_demand_hourly(yesterday)
+        with api_vcr.use_cassette(f"get_real_time_cleared_demand_hourly_{date.date()}"):
+            df = self.iso.get_real_time_cleared_demand_hourly(date)
 
         self._check_test_get_real_time_cleared_demand(df)
 
-        assert df["Interval Start"].min() == yesterday
-        assert df["Interval Start"].max() == yesterday + pd.Timedelta(
+        assert df["Interval Start"].min() == date
+        assert df["Interval Start"].max() == date + pd.Timedelta(
             hours=23,
         )
-        assert df["Interval End"].max() == yesterday + pd.Timedelta(days=1)
+        assert df["Interval End"].max() == date + pd.Timedelta(days=1)
 
     def _check_real_time_cleared_generation(self, df):
         assert df.columns.tolist() == [
@@ -734,12 +762,12 @@ class TestMISOAPI(TestHelperMixin):
     # @pytest.mark.integration
     @pytest.mark.skip(reason="MISO returns wrong data for a specific date")
     def test_get_real_time_cleared_generation_hourly_date_range(self):
-        start = self.local_start_of_today() - pd.Timedelta(days=2)
+        date = self.local_start_of_today() - pd.Timedelta(days=2)
 
         with api_vcr.use_cassette(
-            f"get_real_time_cleared_generation_hourly_{start.strftime('%Y%m%d')}"
+            f"get_real_time_cleared_generation_hourly_{date.date()}"
         ):
-            df = self.iso.get_real_time_cleared_generation_hourly(start)
+            df = self.iso.get_real_time_cleared_generation_hourly(date)
 
         self._check_real_time_cleared_generation(df)
 
@@ -751,12 +779,12 @@ class TestMISOAPI(TestHelperMixin):
 
     @pytest.mark.integration
     def test_get_real_time_offered_generation_ecomax_hourly_date_range(self):
-        start = self.local_start_of_today() - pd.Timedelta(days=2)
+        date = self.local_start_of_today() - pd.Timedelta(days=1)
 
         with api_vcr.use_cassette(
-            f"get_real_time_offered_generation_ecomax_hourly_{start.strftime('%Y%m%d')}"
+            f"get_real_time_offered_generation_ecomax_hourly_{date.date()}"
         ):
-            df = self.iso.get_real_time_offered_generation_ecomax_hourly(start)
+            df = self.iso.get_real_time_offered_generation_ecomax_hourly(date)
 
         assert df.columns.tolist() == [
             "Interval Start",
@@ -773,22 +801,22 @@ class TestMISOAPI(TestHelperMixin):
             if col not in ["Interval Start", "Interval End"]:
                 assert df[col].dtype == "float64"
 
-        assert df["Interval Start"].min() == start
-        assert df["Interval Start"].max() == start + pd.Timedelta(
+        assert df["Interval Start"].min() == date
+        assert df["Interval Start"].max() == date + pd.Timedelta(
             hours=23,
         )
-        assert df["Interval End"].max() == start + pd.Timedelta(
+        assert df["Interval End"].max() == date + pd.Timedelta(
             days=1,
         )
 
     @pytest.mark.integration
     def test_get_real_time_committed_generation_ecomax_hourly_date_range(self):
-        start = self.local_start_of_today() - pd.Timedelta(days=2)
+        date = self.local_start_of_today() - pd.Timedelta(days=2)
 
         with api_vcr.use_cassette(
-            f"get_real_time_committed_generation_ecomax_hourly_{start.strftime('%Y%m%d')}"
+            f"get_real_time_committed_generation_ecomax_hourly_{date.date()}"
         ):
-            df = self.iso.get_real_time_committed_generation_ecomax_hourly(start)
+            df = self.iso.get_real_time_committed_generation_ecomax_hourly(date)
 
         assert df.columns.tolist() == [
             "Interval Start",
@@ -805,22 +833,22 @@ class TestMISOAPI(TestHelperMixin):
             if col not in ["Interval Start", "Interval End"]:
                 assert df[col].dtype == "float64"
 
-        assert df["Interval Start"].min() == start
-        assert df["Interval Start"].max() == start + pd.Timedelta(
+        assert df["Interval Start"].min() == date
+        assert df["Interval Start"].max() == date + pd.Timedelta(
             hours=23,
         )
-        assert df["Interval End"].max() == start + pd.Timedelta(
+        assert df["Interval End"].max() == date + pd.Timedelta(
             days=1,
         )
 
     @pytest.mark.integration
     def test_get_real_time_generation_fuel_type_hourly_date_range(self):
-        yesterday = self.local_start_of_today() - pd.Timedelta(days=1)
+        date = self.local_start_of_today() - pd.Timedelta(days=1)
 
         with api_vcr.use_cassette(
-            f"get_real_time_generation_fuel_type_hourly_{yesterday.strftime('%Y%m%d')}"
+            f"get_real_time_generation_fuel_type_hourly_{date.date()}"
         ):
-            df = self.iso.get_real_time_generation_fuel_type_hourly(yesterday)
+            df = self.iso.get_real_time_generation_fuel_type_hourly(date)
 
         assert df.columns.tolist() == [
             "Interval Start",
@@ -843,10 +871,10 @@ class TestMISOAPI(TestHelperMixin):
             if col not in ["Interval Start", "Interval End", "Region"]:
                 assert df[col].dtype == "float64"
 
-        assert df["Interval Start"].min() == yesterday
-        assert df["Interval Start"].max() == yesterday + pd.Timedelta(
+        assert df["Interval Start"].min() == date
+        assert df["Interval Start"].max() == date + pd.Timedelta(
             hours=23,
         )
-        assert df["Interval End"].max() == yesterday + pd.Timedelta(
+        assert df["Interval End"].max() == date + pd.Timedelta(
             days=1,
         )


### PR DESCRIPTION
## Summary
This pull request significantly expands the integration test coverage for the MISO API in `test_miso_api.py`. It introduces new tests for various "day ahead" and "real time" cleared and offered demand/generation endpoints, along with robust helper methods to validate DataFrame structure and data types.

The most important changes are:

**New integration tests for MISO API endpoints:**

* Added tests for day-ahead cleared demand (daily and hourly), day-ahead cleared generation (physical and virtual, hourly), and day-ahead offered generation (EcoMax/EcoMin, hourly) endpoints, each verifying correct DataFrame structure and date ranges.
* Added tests for real-time cleared demand (daily and hourly), real-time cleared generation (hourly, currently skipped due to data issues), real-time offered generation EcoMax (hourly), and real-time committed generation EcoMax (hourly), with assertions for columns, types, and date intervals.

**Helper methods for DataFrame validation:**

* Introduced reusable helper methods (e.g., `_check_test_get_day_ahead_cleared_demand`, `_check_day_ahead_cleared_generation_hourly`, etc.) to standardize validation of DataFrame columns and data types across tests.

**Test infrastructure and maintenance:**

* Used `api_vcr` cassettes for all new integration tests to ensure reproducibility and isolation from live API changes.
* Skipped a problematic real-time cleared generation test with a clear comment, documenting an upstream data issue with MISO.


### Details
