### PR TITLE
[ENG-2516] Fix NYISO LMP 15 Minute not on 15 minute intervals

### DIFF
--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -690,10 +690,15 @@ class NYISO(ISOBase):
             df.loc[~mask_15_min, "Market"] = Markets.REAL_TIME_5_MIN.value
             df.loc[mask_15_min, "Market"] = Markets.REAL_TIME_15_MIN.value
 
-            df.loc[mask_15_min, "Interval End"] = df.loc[
+            # For 15-min data, the original "Interval End" column contains the correct
+            # end time (since the raw data has timestamps as interval END). However,
+            # "Interval Start" was calculated assuming a 5-minute interval, so we need
+            # to recalculate it for 15-minute intervals.
+            # Interval Start = Interval End - 15 minutes
+            df.loc[mask_15_min, "Interval Start"] = df.loc[
                 mask_15_min,
-                "Interval Start",
-            ] + pd.Timedelta(
+                "Interval End",
+            ] - pd.Timedelta(
                 minutes=15,
             )
 


### PR DESCRIPTION
## Summary

- `NYISO().get_lmp(market=Markets.REAL_TIME_15_MIN)` was returning data not on 15 minute intervals (i.e. :10, :25, :40, :55). This was caused by upstream processing that treats the mixed data as all 5-minute data.
- This PR addresses the issue and adds a test to ensure the 15 minute data is on 15 minute intervals (:00, :15, :30, :45). The test fails on main and passes on this branch

### Details
