### PR TITLE
[ENG-2585] Fix ERCOT Temperature Forecast by Weather Zone for DST End 2025

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -3507,14 +3507,31 @@ class Ercot(ISOBase):
         # Process files in a loop to add the publish time for each doc
         df = pd.concat(
             [
-                self.read_doc(
-                    doc,
-                    verbose=verbose,
-                    parse_doc_kwargs={"keep_dst_flag": True},
-                ).assign(**{"Publish Time": doc.publish_date})
+                self.read_doc(doc, verbose=verbose, parse=False).assign(
+                    **{"Publish Time": doc.publish_date},
+                )
                 for doc in docs
             ],
         )
+
+        # For the 2025 DST end transition, the raw data looks like
+        # DeliveryDate,HourEnding,Coast,East,FarWest,North,NorthCentral,SouthCentral,Southern,West,DSTFlag
+        # 11/02/2025,01:00,63.3, 58, 60, 57, 60, 63.5, 71.4, 59,N
+        # 11/02/2025,02:00,124.3, 113, 114, 111, 116.25, 120.5, 140.6, 112.8,N
+        # 11/02/2025,03:00,60.9, 55, 54, 54, 56.25, 58, 68.8, 54.2,Y
+        # 11/02/2025,03:00,60.9, 55, 54, 54, 56.25, 58, 68.8, 54.2,N
+        # The 3:00 ending hour is duplicated when it should be the 2:00 ending hour
+        # (We will not correct the obviously wrong temperature values)
+        dst_transition_date_2025 = "11/02/2025"
+        if dst_transition_date_2025 in df["DeliveryDate"].unique():
+            mask = (
+                (df["DeliveryDate"] == "11/02/2025")
+                & (df["HourEnding"] == "03:00")
+                & (df["DSTFlag"] == "Y")
+            )
+            df.loc[mask, "HourEnding"] = "2:00"
+
+        df = self.parse_doc(df)
 
         df = df.drop(columns=["Time"]).rename(
             columns=self._weather_zone_column_name_mapping(),
@@ -3546,23 +3563,7 @@ class Ercot(ISOBase):
             # after the correction, the straight duplicate intervals remain, so we remove them
             df = df.drop_duplicates(subset=["Interval Start", "Publish Time"])
 
-        # Raw data looks like
-        # DeliveryDate,HourEnding,Coast,East,FarWest,North,NorthCentral,SouthCentral,Southern,West,DSTFlag
-        # 11/02/2025,01:00,63.3, 58, 60, 57, 60, 63.5, 71.4, 59,N
-        # 11/02/2025,02:00,124.3, 113, 114, 111, 116.25, 120.5, 140.6, 112.8,N
-        # 11/02/2025,03:00,60.9, 55, 54, 54, 56.25, 58, 68.8, 54.2,Y
-        # 11/02/2025,03:00,60.9, 55, 54, 54, 56.25, 58, 68.8, 54.2,N
-        # The 3:00 ending hour is duplicated when it should be the 2:00 ending hour
-        # (We will not correct the obviously wrong temperature values)
-        dst_transition_date_2025 = pd.Timestamp("2025-11-02")
-        if dst_transition_date_2025.date() in df["Interval Start"].dt.date.values:
-            mask = (df["Interval End"] == "2025-11-02 03:00:00 -0600") & (
-                df["DSTFlag"] == "Y"
-            )
-            df.loc[mask, "Interval End"] = pd.Timestamp("2025-11-02 02:00:00 -0600")
-            df.loc[mask, "Interval Start"] = pd.Timestamp("2025-11-02 01:00:00 -0600")
-
-        return df.sort_values("Interval Start").drop(columns=["DSTFlag"])
+        return df.sort_values("Interval Start")
 
     def _get_document(
         self,
@@ -3806,7 +3807,6 @@ class Ercot(ISOBase):
         verbose: bool = False,
         request_kwargs: dict | None = None,
         read_csv_kwargs: dict | None = None,
-        parse_doc_kwargs: dict | None = None,
     ) -> pd.DataFrame:
         logger.debug(f"Reading {doc.url}")
 
@@ -3821,7 +3821,7 @@ class Ercot(ISOBase):
             df = pd.read_csv(doc.url, compression="zip", **(read_csv_kwargs or {}))
 
         if parse:
-            df = self.parse_doc(df, verbose=verbose, **(parse_doc_kwargs or {}))
+            df = self.parse_doc(df, verbose=verbose)
         return df
 
     def read_docs(
@@ -3868,7 +3868,6 @@ class Ercot(ISOBase):
         dst_ambiguous_default: str = "infer",
         verbose: bool = False,
         nonexistent: str = "raise",
-        keep_dst_flag: bool = False,
     ) -> pd.DataFrame:
         # files sometimes have different naming conventions
         # a more elegant solution would be nice
@@ -4000,8 +3999,6 @@ class Ercot(ISOBase):
 
         for col in optional_drop:
             if col in doc.columns:
-                if col == "DSTFlag" and keep_dst_flag:
-                    continue
                 doc = doc.drop(columns=[col])
 
         return doc

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -1743,10 +1743,12 @@ class TestErcot(BaseTestISO):
 
         self._check_temperature_forecast_by_weather_zone(df)
 
-    @pytest.mark.integration
     def test_get_temperature_forecast_by_weather_zone_dst_end_2025(self):
         # This forecast date includes 2025-11-02, DST end
-        df = self.iso.get_temperature_forecast_by_weather_zone("2025-10-26")
+        with api_vcr.use_cassette(
+            "test_get_temperature_forecast_by_weather_zone_dst_end_2025.yaml",
+        ):
+            df = self.iso.get_temperature_forecast_by_weather_zone("2025-10-26")
 
         self._check_temperature_forecast_by_weather_zone(df)
 


### PR DESCRIPTION
## Summary

- Fixes the issue with `Ercot().get_temperature_forecast_by_weather_zone()` for DST end 2025
- ERCOT publishes data with a repeated hour ending 03:00 instead of a repeated hour ending 02:00 (since the 1-2 hour is repeated)

### Details
