### PR TITLE
feat(ENG 2613): Additional PJM datasets

### DIFF
--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -3465,10 +3465,16 @@ class PJM(ISOBase):
         https://dataminer2.pjm.com/feed/day_gen_capacity/definition
         """
         if date == "latest":
-            ten_days_ago = pd.Timestamp.now(tz=self.default_timezone) - pd.DateOffset(
-                days=10,
-            )
-            return self.get_generation_capacity_daily(ten_days_ago.date())
+            try:
+                return self.get_generation_capacity_daily("today")
+            except NoDataFoundException:
+                yesterday = (
+                    pd.Timestamp.now(tz=self.default_timezone).normalize()
+                    - pd.Timedelta(days=1)
+                ).date()
+                return self.get_generation_capacity_daily(
+                    pd.Timestamp(yesterday, tz=self.default_timezone),
+                )
 
         df = self._get_pjm_json(
             "day_gen_capacity",

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -3167,8 +3167,8 @@ class TestPJM(BaseTestISO):
         with pjm_vcr.use_cassette("test_get_generation_capacity_daily_latest.yaml"):
             df = self.iso.get_generation_capacity_daily("latest")
             self._check_generation_capacity_daily(df)
-            ten_days_ago = self.local_today() - pd.Timedelta(days=10)
-            assert df["Interval Start"].min() >= self.local_start_of_day(ten_days_ago)
+            yesterday = self.local_today() - pd.Timedelta(days=1)
+            assert df["Interval Start"].min() >= self.local_start_of_day(yesterday)
 
     def test_get_generation_capacity_daily_historical_range(self):
         past_date = self.local_today() - pd.Timedelta(days=10)


### PR DESCRIPTION
## Summary
Adds:

- `pjm_generation_capacity_daily`
- `pjm_cleared_virtuals_daily`
- `pjm_inc_and_dec_bids_day_ahead_hourly`
- `pjm_sync_reserve_events`

### Details
Lots of paper cuts in these.

The `filter_timestamp_name` in `_get_pjm_json` assumes a `_ept` suffix, so it doesn't work for `cleared_virtuals_daily`. I have to go manual there. Probably not perfect but I don't trust modifying `_get_pjm_json` give its prevalence and the state of the tests. 

Sync reserves is a list not date-filterable from the API, and there are only ~1000 records going back to 2002, so I just return the whole list each time. 