### PR TITLE
fix(ENG 2613): PJM DST transitions

### DIFF
--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -3649,6 +3649,12 @@ class PJM(ISOBase):
             },
         )
 
+        df["Publish Time"] = (
+            pd.to_datetime(df["Publish Time"], format="ISO8601")
+            .dt.tz_localize("UTC")
+            .dt.tz_convert(self.default_timezone)
+        )
+
         return (
             df[
                 [

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -3239,7 +3239,7 @@ class TestPJM(BaseTestISO):
             df.columns.tolist() == self.expected_inc_and_dec_bids_day_ahead_hourly_cols
         )
         assert not df.empty
-        assert df["Publish Time"].dtype == object
+        assert pd.api.types.is_datetime64tz_dtype(df["Publish Time"])
         assert df["Price Point"].dtype in [np.float64, np.int64]
         assert df["Inc MW"].dtype in [np.float64, np.int64]
         assert df["Dec MW"].dtype in [np.float64, np.int64]


### PR DESCRIPTION
## Summary
Actually using the utc output from the API seems to handle DST transitions much better. EPT seems to fall down in various ways. 

Correct for various DST transitions discovered in looking at historical data. 

