### PR TITLE
[ENG-2394], [ENG-2395], [ENG-2666], [ENG-2396], [ENG-2397] ERCOT RTC+B Market Trials Part One

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -4458,7 +4458,14 @@ class Ercot(ISOBase):
             verbose=verbose,
         )
 
-        df = self.read_docs(docs, parse=False, verbose=verbose)
+        df = pd.concat(
+            [
+                self.read_doc(doc, parse=False, verbose=verbose).assign(
+                    **{"Publish Time": doc.publish_date},
+                )
+                for doc in docs
+            ],
+        )
 
         return self._handle_as_demand_curves_rtc_b_trial(df)
 
@@ -4480,13 +4487,16 @@ class Ercot(ISOBase):
                 [
                     "Interval Start",
                     "Interval End",
+                    "Publish Time",
                     "AS Type",
                     "Demand Curve Point",
                     "Quantity",
                     "Price",
                 ]
             ]
-            .sort_values(["Interval Start", "AS Type", "Demand Curve Point"])
+            .sort_values(
+                ["Interval Start", "Publish Time", "AS Type", "Demand Curve Point"],
+            )
             .reset_index(drop=True)
         )
 

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -2385,6 +2385,7 @@ class TestErcot(BaseTestISO):
         assert df.columns.tolist() == [
             "Interval Start",
             "Interval End",
+            "Publish Time",
             "AS Type",
             "Demand Curve Point",
             "Quantity",
@@ -2392,6 +2393,7 @@ class TestErcot(BaseTestISO):
         ]
         assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
         assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
+        assert df.dtypes["Publish Time"] == "datetime64[s, US/Central]"
         assert df.dtypes["AS Type"] == "object"
         assert df.dtypes["Demand Curve Point"] == "int64"
         assert df.dtypes["Quantity"] == "int64"


### PR DESCRIPTION
## Summary

- Adds first five new dataset for RTC+B
- `Ercot().get_as_deployment_factors_projected_rtc_b_trial`
- `Ercot().get_as_demand_curves_rtc_b_trial`
- `Ercot().get_mcpc_real_time_15_min_rtc_b_trial`
- `Ercot().get_mcpc_sced_rtc_b_trial`
- `Ercot().get_lmp_by_settlement_point_rtc_b_trial`

### Details
