### PR TITLE
Support Sikeston Board of Municipal Utilities for EIA Grid Monitor

### DIFF
--- a/gridstatus/eia_data/grid_monitor_files.json
+++ b/gridstatus/eia_data/grid_monitor_files.json
@@ -490,5 +490,11 @@
       "Type": "BA",
       "Name": "Western Area Power Administration - Upper Great Plains West",
       "URL": "https://www.eia.gov/electricity/gridmonitor/knownissues/xls/WAUW.xlsx"
+    },
+    "SIKE": {
+      "ID": "SIKE",
+      "Type": "BA",
+      "Name": "Sikeston Board of Municipal Utilities",
+      "URL": "https://www.eia.gov/electricity/gridmonitor/knownissues/xls/SIKE.xlsx"
     }
   }


### PR DESCRIPTION
## Summary

- EIA started reporting data for Sikeston Board of Municipal Utilities at the beginning of November. Since this BA wasn't in `grid_monitor_files.json`, it wasn't supported via `EIA().get_grid_monitor`. This PR adds support for the BA
- Run with `EIA().get_grid_monitor(area_id="SIKE")`.

### Details
