### PR TITLE
[ENG-2777] Remove Slack Link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ There are several ways you can contribute:
 
 * Participating in discussions or providing feedback
 
-Before contributing, please read this guide. If you have any questions, feel free to ask in our [Slack](https://join.slack.com/t/gridstatus/shared_invite/zt-1jk6vlzt2-Lzz4pdpjkJYVUJkynOiIvQ) or open a GitHub issue.
+Before contributing, please read this guide. If you have any questions, feel free to open a GitHub issue.
 
 ## Submitting Bug Reports and Feature Requests
 


### PR DESCRIPTION
## Summary

- Removes the Slack link from CONTRIBUTING.md since we no longer have a public Slack

### Details
