### PR TITLE
Fix IESO Shadow Prices

### DIFF
--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -4219,6 +4219,9 @@ class IESO(ISOBase):
         doc_header = json_data["Document"]["DocHeader"]
         doc_body = json_data["Document"]["DocBody"]
         shadow_prices = doc_body["HourlyPrice"]
+        # Handle case with only one constraint
+        if isinstance(shadow_prices, dict):
+            shadow_prices = [shadow_prices]
         publish_time = pd.Timestamp(doc_header["CreatedAt"], tz=self.default_timezone)
         delivery_date = pd.Timestamp(doc_body["DELIVERYDATE"], tz=self.default_timezone)
 
@@ -4262,7 +4265,12 @@ class IESO(ISOBase):
                 },
             )
 
-        for hourly in doc_body["HourlyPrice"]:
+        # Handle case with one constraint
+        hourly_prices = doc_body["HourlyPrice"]
+        if isinstance(hourly_prices, dict):
+            hourly_prices = [hourly_prices]
+
+        for hourly in hourly_prices:
             constraint = " ".join(hourly["ConstraintName"].split())
             hour = int(hourly["DeliveryHour"])
             intervals = hourly["IntervalShadowPrices"]["Interval"]


### PR DESCRIPTION
## Summary

- Fixes `IESO().get_shadow_prices_real_time_5_min()` and `IESO().get_shadow_prices_day_ahead_hourly()` for shadow price reports with only a single constraint
- Examples
  - https://reports-public.ieso.ca/public/DAConstrShadowPrices/PUB_DAConstrShadowPrices_20251113.xml
  - https://reports-public.ieso.ca/public/RealtimeConstrShadowPrices/PUB_RealtimeConstrShadowPrices_20251112.xml

- Run `IESO().get_shadow_prices_day_ahead_hourly('2025-11-13')` on `main`. This will fail. Run again on this branch and it will succeed.
- Run `IESO().get_shadow_prices_real_time_5_min('2025-11-12')` on `main`. This will fail. Run again on this branch and it will succeed.

### Details
