### PR TITLE
fix: NYISO Constraints

### DIFF
--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -1426,7 +1426,7 @@ class NYISO(ISOBase):
             ]
         ]
 
-    @support_date_range(frequency="MONTH_START")
+    @support_date_range(frequency="DAY_START")
     def get_limiting_constraints_real_time(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],


### PR DESCRIPTION
## Summary
Technically the `_nyiso_archive` for this datasets returns zip files with daily files, such that it's a bit of `MONTH_START`, `DAY_START`, which can be accomplished with a `DAY_START`.


Test:
```
$ VCR_RECORD_MODE=all make test-one-off market=nyiso test=test_get_limiting_constraints_real_time_historical_range
```
### Details
Month start zip files, giving way to daily csv files
<img width="886" height="1208" alt="CleanShot 2025-12-02 at 11 28 05@2x" src="https://github.com/user-attachments/assets/85f2abc8-5ce8-4081-87b7-05b1dd658272" />

<img width="674" height="120" alt="CleanShot 2025-12-02 at 11 29 14@2x" src="https://github.com/user-attachments/assets/0ab57c5c-a9a3-4948-8bf5-f35a4d126f5a" />
