### PR TITLE
Add pricing nodes in MISO api

### DIFF
--- a/gridstatus/miso_api.py
+++ b/gridstatus/miso_api.py
@@ -1994,7 +1994,9 @@ class MISOAPI:
 
         return df_pivot
 
-    def _miso_quarterly_days(self, start, end):
+    def _miso_quarterly_days(
+        self, start: pd.Timestamp, end: pd.Timestamp
+    ) -> List[pd.Timestamp]:
         """
         MISO pricing nodes are updated quarterly on March 1st, June 1st, September 1st, and December 1st.
         This function generates a list of these dates within the specified start and end range.
@@ -2035,10 +2037,7 @@ class MISOAPI:
                  quarterly updates between date and end.
             verbose: If True, prints additional information during data retrieval.
         """
-        if date is None:
-            date = "latest"
-
-        if date == "latest":
+        if date == "latest" or date is None:
             date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
         end = (

--- a/gridstatus/tests/source_specific/test_miso_api.py
+++ b/gridstatus/tests/source_specific/test_miso_api.py
@@ -1149,7 +1149,6 @@ class TestMISOAPI(TestHelperMixin):
         with pytest.raises(NotSupported, match="only available for future dates"):
             self.iso.get_look_ahead_hourly(yesterday)
 
-    @pytest.mark.integration
     def test_get_pricing_nodes(self):
         today = pd.Timestamp(self.local_today())
 
@@ -1164,7 +1163,6 @@ class TestMISOAPI(TestHelperMixin):
             if col not in ["Node", "Location Type"]:
                 assert df[col].dtype == "str"
 
-    @pytest.mark.integration
     def test_get_pricing_nodes_by_date(self):
         today = pd.Timestamp(self.local_today())
         date = "latest"
@@ -1182,7 +1180,6 @@ class TestMISOAPI(TestHelperMixin):
             if col not in ["Node", "Location Type"]:
                 assert df[col].dtype == "str"
 
-    @pytest.mark.integration
     def test_get_pricing_nodes_by_date_range(self):
         today = pd.Timestamp(self.local_today())
         date = today - pd.Timedelta(days=100)


### PR DESCRIPTION
## Summary
This pull request adds new functionality to retrieve and process MISO pricing node data, enhances internal mapping logic, and introduces comprehensive integration tests for the new API methods. The main changes are grouped into API enhancements, internal logic improvements, and testing.

Fix #682 

**API Enhancements:**

* Added a new `get_pricing_nodes` method to the `miso_api.py` module, which retrieves MISO pricing node data for a specific date or date range, handling quarterly updates and returning a DataFrame with standardized columns (`Node`, `Location Type`).

* Added the `_miso_quarterly_days` helper function to compute quarterly anchor dates (March 1, June 1, September 1, December 1) within a given date range for accurate data retrieval.

**Internal Logic Improvements:**

* Updated `_get_node_to_type_mapping` to use the new `get_pricing_nodes` method, ensuring the mapping between nodes and location types is always current and based on the correct date range.

**Testing:**

* Introduced integration tests for `get_pricing_nodes`, covering retrieval for the latest date, a specific date, and a date range, with assertions on data shape and column types to ensure API correctness.


