### PR TITLE
fix: NYISO Day Ahead Limiting Constraints

### DIFF
--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -1472,7 +1472,7 @@ class NYISO(ISOBase):
 
         return data
 
-    @support_date_range(frequency=None)
+    @support_date_range(frequency="DAY_START")
     def get_limiting_constraints_day_ahead(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],


### PR DESCRIPTION
## Summary
Similar issue that we experiencing with NYISO Real Time Limiting Constraints in the way the data is published and looked for. 

