### PR TITLE
Add Publish Time to ERCOT AS Total Capability

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -5462,7 +5462,16 @@ class Ercot(ISOBase):
                 verbose=verbose,
             )
 
-        df = self.read_docs(docs, parse=False, verbose=verbose)
+        # Add the publish time to deal with duplicates downstream
+        df = pd.concat(
+            [
+                self.read_doc(doc, parse=False, verbose=verbose).assign(
+                    **{"Publish Time": doc.publish_date},
+                )
+                for doc in docs
+            ],
+        )
+
         return self._handle_as_total_capability(df)
 
     def _handle_as_total_capability(self, df: pd.DataFrame) -> pd.DataFrame:
@@ -5499,8 +5508,8 @@ class Ercot(ISOBase):
             df[col] = df[col].astype(float)
 
         return (
-            df[["SCED Timestamp"] + cap_cols]
-            .sort_values("SCED Timestamp")
+            df[["SCED Timestamp", "Publish Time"] + cap_cols]
+            .sort_values(["SCED Timestamp", "Publish Time"])
             .reset_index(drop=True)
         )
 

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -2887,6 +2887,7 @@ class TestErcot(BaseTestISO):
     def _check_get_as_total_capability(self, df: pd.DataFrame):
         assert df.columns.tolist() == [
             "SCED Timestamp",
+            "Publish Time",
             "Cap RegUp Total",
             "Cap RegDn Total",
             "Cap RRS Total",
@@ -2921,6 +2922,7 @@ class TestErcot(BaseTestISO):
 
         # Each file has 5 SCED intervals
         assert df["SCED Timestamp"].nunique() == 5
+        assert df["Publish Time"].nunique() == 1
 
     def test_get_as_total_capability_date_range(self):
         # Choose a date range that spans two days to test we handle day transitions
@@ -2943,6 +2945,7 @@ class TestErcot(BaseTestISO):
         # and 4 previous). This means the number of unique SCED intervals in 2 hours is
         # (2 hours / 5 minutes/interval) + 4 extra intervals = 28 intervals
         assert df["SCED Timestamp"].nunique() == 28
+        assert df["Publish Time"].nunique() == 24
 
     """get_real_time_adders"""
 


### PR DESCRIPTION
## Summary

- Adds a `Publish Time` column to the `Ercot().get_as_total_capability()`
- This is required so we can keep the latest published values when there are duplicate SCED Timestamps
- Run tests with `VCR_RECORD_MODE=all uv run pytest gridstatus/tests/source_specific/test_ercot.py -k as_total_capability`

### Details
