### PR TITLE
Fix Filtering for ERCOT AS Demand Curves

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -3882,9 +3882,10 @@ class Ercot(ISOBase):
         if is_sced_format:
             # SCED format: Parse SCED Timestamp directly
             # SCED Timestamp format is like "12/07/2025 00:00:17"
+            # TODO: this dataset doesn't have a DSTFlag so we may have issues with
+            # DST transitions
             df["SCED Timestamp"] = pd.to_datetime(df["SCED Timestamp"]).dt.tz_localize(
                 self.default_timezone,
-                ambiguous=self.ambiguous_based_on_dst_flag(df["SCED Timestamp"]),
             )
 
             # Group by SCED Timestamp and resource identifiers only
@@ -3900,6 +3901,8 @@ class Ercot(ISOBase):
             # DAM format: Parse Hour Ending and Delivery Date
             is_dst_end = 25 in df["Hour Ending"].values
 
+            # TODO: we haven't been able to test this with an actual DST transition
+            # so we may have to update this logic
             if not is_dst_end:
                 df = self.parse_doc(df)
             else:


### PR DESCRIPTION
## Summary

- Updates the source filtering for `Ercot().get_as_demand_curves_dam_and_sced` to use publish time
- Run tests with `VCR_RECORD_MODE=all uv run pytest gridstatus/tests/source_specific/test_ercot.py -k "as_demand_curves_dam_and_sced"`
- Also fixes a timestamp parsing issue with `Ercot().get_highest_price_as_offer_selected_sced` 

### Details
