### PR TITLE
(fix) Set Frequency to None for ERCOT AS Demand Curves DAM and SCED

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -5126,8 +5126,10 @@ class Ercot(ISOBase):
             .reset_index(drop=True)
         )
 
-    # Published once per day for today and tomorrow in the same file
-    @support_date_range(frequency="DAY_START")
+    # Should be published once per day for today and tomorrow in the same file
+    # NOTE: occassionally ERCOT will publish multiple copies of the same data
+    # on the same day.
+    @support_date_range(frequency=None)
     def get_as_demand_curves_dam_and_sced(
         self,
         date: str | pd.Timestamp,


### PR DESCRIPTION
## Summary

- Sets `frequency=None` in the `@support_date_range` decorator for `Ercot().get_as_demand_curves_dam_and_sced()`
- Since the function is directly filtering for documents by date and end, we don't need a frequency to iterate over days and the `"DAY_START"` frequency can result in fetching the same file multiple times
- Make sure the tests still pass: `VCR_RECORD_MODE=all uv run pytest gridstatus/tests/source_specific/test_ercot.py -k "as_demand_curves_dam_and_sced"`

### Details
