### PR TITLE
fix: correct type annotation for date parameter in _get_document(s)

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -3,7 +3,7 @@ import io
 import time
 from dataclasses import dataclass
 from enum import Enum
-from typing import BinaryIO, Callable, List
+from typing import BinaryIO, Callable, List, Literal
 from zipfile import ZipFile
 
 import pandas as pd
@@ -4320,7 +4320,7 @@ class Ercot(ISOBase):
     def _get_document(
         self,
         report_type_id: int,
-        date: str | None = None,
+        date: Literal["latest"] | datetime.datetime | None = None,
         published_after: str | None = None,
         published_before: str | None = None,
         constructed_name_contains: str | None = None,
@@ -4360,7 +4360,7 @@ class Ercot(ISOBase):
     def _get_documents(
         self,
         report_type_id: int,
-        date: str | None = None,
+        date: Literal["latest"] | datetime.datetime | None = None,
         published_after: str | None = None,
         published_before: str | None = None,
         friendly_name_timestamp_after: str | None = None,


### PR DESCRIPTION
The date parameter was annotated as str | None but the code calls date.date(), which requires a datetime object. Updated to Literal["latest"] | datetime.datetime | None to match actual usage.