### PR TITLE
[ENG-2977] ERCOT DAM AS Price Corrections

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -4005,7 +4005,7 @@ class Ercot(ISOBase):
                 - Price Correction Time
                 - Interval Start
                 - Interval End
-                - Ancillary Service Type
+                - AS Type
                 - MCPC Original
                 - MCPC Corrected
         """
@@ -4074,7 +4074,7 @@ class Ercot(ISOBase):
         # Rename columns to match gridstatus conventions
         df = df.rename(
             columns={
-                "ASType": "Ancillary Service Type",
+                "ASType": "AS Type",
                 "MCPCOriginal": "MCPC Original",
                 "MCPCCorrected": "MCPC Corrected",
                 "PriceCorrectionTime": "Price Correction Time",
@@ -4092,7 +4092,7 @@ class Ercot(ISOBase):
                 "Price Correction Time",
                 "Interval Start",
                 "Interval End",
-                "Ancillary Service Type",
+                "AS Type",
                 "MCPC Original",
                 "MCPC Corrected",
             ]

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -1577,7 +1577,7 @@ class TestErcot(BaseTestISO):
             "Price Correction Time",
             "Interval Start",
             "Interval End",
-            "Ancillary Service Type",
+            "AS Type",
             "MCPC Original",
             "MCPC Corrected",
         ]
@@ -1588,7 +1588,7 @@ class TestErcot(BaseTestISO):
         assert pd.api.types.is_datetime64_any_dtype(df["Price Correction Time"])
         assert pd.api.types.is_datetime64_any_dtype(df["Interval Start"])
         assert pd.api.types.is_datetime64_any_dtype(df["Interval End"])
-        assert pd.api.types.is_object_dtype(df["Ancillary Service Type"])
+        assert pd.api.types.is_object_dtype(df["AS Type"])
         assert pd.api.types.is_float_dtype(df["MCPC Original"])
         assert pd.api.types.is_float_dtype(df["MCPC Corrected"])
 


### PR DESCRIPTION
## Summary

- Adds `Ercot().get_dam_as_price_corrections`
- Run specific tests with `VCR_RECORD_MODE=all uv run pytest gridstatus/tests/source_specific/test_ercot.py -k test_get_dam_as_price_corrections`
