### PR TITLE
Fix ERCOT COP Adjustment for DST End (2025)

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -4713,6 +4713,17 @@ class Ercot(ISOBase):
                     ambiguous=ambiguous,
                 ) - pd.Timedelta(hours=1)
             except pytz.AmbiguousTimeError as e:
+                # Handle datasets where HourEnding is like 01:00
+                if doc["HourEnding"].min() == "01:00":
+                    doc["HourEnding"] = (
+                        doc["HourEnding"]
+                        .astype(str)
+                        .str.split(
+                            ":",
+                        )
+                        .str[0]
+                        .astype(int)
+                    )
                 # Sometimes ERCOT handles DST end by putting 25 hours in HourEnding
                 # which makes IntervalStart where HourEnding >= 3 an hour later than
                 # they should be. We correct this by subtracting an hour.


### PR DESCRIPTION
## Summary

- Fixes ERCOT COP Adjustment 60 day for DST End 2025
- Make sure `Ercot().get_cop_adjustment_period_snapshot_60_day('2025-11-02')` runs

### Details
