### PR TITLE
(fix) Update AS Price Corrections to MCPC DAM Price Corrections

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -3990,12 +3990,12 @@ class Ercot(ISOBase):
 
         return df
 
-    def get_dam_as_price_corrections(
+    def get_mcpc_dam_price_corrections(
         self,
         verbose: bool = False,
     ) -> pd.DataFrame:
         """
-        Get DAM Ancillary Service (AS) Price Corrections (MCPC).
+        Get Market Clearing Price for Capacity (MCPC) corrections for DAM.
 
         MCPC (Market Clearing Price for Capacity) corrections contain
         ancillary service prices at the system level.

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -1569,9 +1569,9 @@ class TestErcot(BaseTestISO):
         assert df.columns.tolist() == cols
 
     @pytest.mark.integration
-    def test_get_dam_as_price_corrections(self):
+    def test_get_mcpc_dam_price_corrections(self):
         """Test DAM AS Price Corrections (MCPC)."""
-        df = self.iso.get_dam_as_price_corrections()
+        df = self.iso.get_mcpc_dam_price_corrections()
 
         cols = [
             "Price Correction Time",


### PR DESCRIPTION
## Summary

- Changes `Ercot().get_dam_as_price_corrections` to `Ercot().get_mcpc_dam_price_corrections`
- Run specific tests with `VCR_RECORD_MODE=all uv run pytest gridstatus/tests/source_specific/test_ercot.py -k test_get_mcpc_dam_price_corrections`

### Details
