### PR TITLE
Fix Read the Docs Build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,10 +13,10 @@ build:
       # https://docs.astral.sh/uv/getting-started/installation/
       - pip install uv
     post_install:
-      # Install dependencies with all dependencies
+      # Install dependencies including dev group for docs build
       # VIRTUAL_ENV needs to be set manually for now.
       # See https://github.com/readthedocs/readthedocs.org/pull/11152/
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH uv sync
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH uv sync --group dev
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
## Summary

- Our read the docs build has been failing for over thirty days due to a missing library. This attempts to fix by making sure we install the `dev` group of dependencies

### Details
