### PR TITLE
(fix) No Verify SSL for CAISO OASIS

### DIFF
--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -351,7 +351,7 @@ class CAISO(ISOBase):
 
         retry_num = 0
         while retry_num < max_retries:
-            r = requests.get(url)
+            r = requests.get(url, verify=False)
 
             if r.status_code == 200:
                 break


### PR DESCRIPTION
## Summary

- SSL verification seems to be currently broken on OASIS for CAISO so this disables SSL verification
- This is intended to be temporary


### Details
