### PR TITLE
[ENG-3152] MISO Multiday Operating Margin Methods

### DIFF
--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -1980,16 +1980,27 @@ class MISO(ISOBase):
                     else:
                         row_data[new_name] = None
 
-            # Handle "Additional Emergency Headroom" which appears 3 times
-            # We identify them by finding all rows and using their position
+            # Handle "Additional Emergency Headroom" which appears 3 times:
+            # 1. After RESOURCE COMMITTED -> "Committed Additional Emergency Headroom"
+            # 2. After RESOURCE UNCOMMITTED -> "Uncommitted Additional Emergency Headroom"
+            # 3. After EMERGENCY RESOURCES -> "Emergency Resources Additional Headroom"
             emergency_headroom_rows = data[
                 data.iloc[:, 0].astype(str).str.strip()
                 == "Additional Emergency Headroom"
             ]
             if len(emergency_headroom_rows) >= 1:
-                # First one: after RESOURCE COMMITTED
                 val = emergency_headroom_rows.iloc[0][col]
-                row_data["Additional Emergency Headroom"] = (
+                row_data["Committed Additional Emergency Headroom"] = (
+                    float(val) if pd.notna(val) else None
+                )
+            if len(emergency_headroom_rows) >= 2:
+                val = emergency_headroom_rows.iloc[1][col]
+                row_data["Uncommitted Additional Emergency Headroom"] = (
+                    float(val) if pd.notna(val) else None
+                )
+            if len(emergency_headroom_rows) >= 3:
+                val = emergency_headroom_rows.iloc[2][col]
+                row_data["Emergency Resources Additional Headroom"] = (
                     float(val) if pd.notna(val) else None
                 )
 
@@ -2051,13 +2062,15 @@ class MISO(ISOBase):
                     "Peak Hour",
                     "Region",
                     "Resource Committed",
-                    "Additional Emergency Headroom",
+                    "Committed Additional Emergency Headroom",
                     "Resource Uncommitted",
                     "Uncommitted Greater than 16 Hours",
                     "Uncommitted 12 to 16 Hours",
                     "Uncommitted 8 to 12 Hours",
                     "Uncommitted 4 to 8 Hours",
                     "Uncommitted Less than 4 Hours",
+                    "Uncommitted Additional Emergency Headroom",
+                    "Emergency Resources Additional Headroom",
                     "Renewable Forecast",
                     "Wind Forecast",
                     "Solar Forecast",
@@ -2075,13 +2088,15 @@ class MISO(ISOBase):
                     "Peak Hour",
                     "Region",
                     "Resource Committed",
-                    "Additional Emergency Headroom",
+                    "Committed Additional Emergency Headroom",
                     "Resource Uncommitted",
                     "Uncommitted Greater than 16 Hours",
                     "Uncommitted 12 to 16 Hours",
                     "Uncommitted 8 to 12 Hours",
                     "Uncommitted 4 to 8 Hours",
                     "Uncommitted Less than 4 Hours",
+                    "Uncommitted Additional Emergency Headroom",
+                    "Emergency Resources Additional Headroom",
                     "Renewable Forecast",
                     "Wind Forecast",
                     "Solar Forecast",

--- a/gridstatus/tests/source_specific/test_miso.py
+++ b/gridstatus/tests/source_specific/test_miso.py
@@ -1137,13 +1137,15 @@ class TestMISO(BaseTestISO):
         assert df["Peak Hour"].dtype == "datetime64[ns, EST]"
         assert df["Region"].dtype == object
         assert df["Resource Committed"].dtype == np.float64
-        assert df["Additional Emergency Headroom"].dtype == np.float64
+        assert df["Committed Additional Emergency Headroom"].dtype == np.float64
         assert df["Resource Uncommitted"].dtype == np.float64
         assert df["Uncommitted Greater than 16 Hours"].dtype == np.float64
         assert df["Uncommitted 12 to 16 Hours"].dtype == np.float64
         assert df["Uncommitted 8 to 12 Hours"].dtype == np.float64
         assert df["Uncommitted 4 to 8 Hours"].dtype == np.float64
         assert df["Uncommitted Less than 4 Hours"].dtype == np.float64
+        assert df["Uncommitted Additional Emergency Headroom"].dtype == np.float64
+        assert df["Emergency Resources Additional Headroom"].dtype == np.float64
         assert df["Renewable Forecast"].dtype == np.float64
         assert df["Wind Forecast"].dtype == np.float64
         assert df["Solar Forecast"].dtype == np.float64
@@ -1191,13 +1193,15 @@ class TestMISO(BaseTestISO):
         assert df["Peak Hour"].dtype == "datetime64[ns, EST]"
         assert df["Region"].dtype == object
         assert df["Resource Committed"].dtype == np.float64
-        assert df["Additional Emergency Headroom"].dtype == np.float64
+        assert df["Committed Additional Emergency Headroom"].dtype == np.float64
         assert df["Resource Uncommitted"].dtype == np.float64
         assert df["Uncommitted Greater than 16 Hours"].dtype == np.float64
         assert df["Uncommitted 12 to 16 Hours"].dtype == np.float64
         assert df["Uncommitted 8 to 12 Hours"].dtype == np.float64
         assert df["Uncommitted 4 to 8 Hours"].dtype == np.float64
         assert df["Uncommitted Less than 4 Hours"].dtype == np.float64
+        assert df["Uncommitted Additional Emergency Headroom"].dtype == np.float64
+        assert df["Emergency Resources Additional Headroom"].dtype == np.float64
         assert df["Renewable Forecast"].dtype == np.float64
         assert df["Wind Forecast"].dtype == np.float64
         assert df["Solar Forecast"].dtype == np.float64


### PR DESCRIPTION

## Summary


- Adds `MISO().get_multiday_operating_margin` which retrieves data for MISO as a whole
- Adds `MISO().get_multiday_operating_margin_regional` which retrieves data for each region in one dataset

### Validation

- Run specific tests with `VCR_RECORD_MODE=all uv run pytest gridstatus/tests/source_specific/test_miso.py -k multiday`
