### PR TITLE
Add Columns for SCED 60 day datasets

### DIFF
--- a/gridstatus/ercot_60d_utils.py
+++ b/gridstatus/ercot_60d_utils.py
@@ -212,17 +212,17 @@ SCED_GEN_RESOURCE_COLUMNS = [
     "SCED TPO Offer Curve",
     "Ramp Rate Up",
     "Ramp Rate Down",
-    "AS Capability REGUP",
-    "AS Capability REGDN",
+    "AS Capability RegUp",
+    "AS Capability RegDown",
     "AS Capability ECRS",
-    "AS Capability NSPIN",
-    "AS Awards NSPIN",
+    "AS Capability NonSpin",
+    "AS Awards NonSpin",
     "AS Awards RRSFFR",
     "AS Awards RRSPFR",
     "AS Awards RRSUFR",
     "AS Awards ECRS",
-    "AS Awards REGUP",
-    "AS Awards REGDN",
+    "AS Awards RegUp",
+    "AS Awards RegDown",
 ]
 
 SCED_LOAD_RESOURCE_COLUMNS = [
@@ -248,22 +248,22 @@ SCED_LOAD_RESOURCE_COLUMNS = [
     "AS Responsibility for RegDown",
     "AS Responsibility for ECRS",
     "SCED Bid to Buy Curve",
-    "AS Awards NSPIN",
+    "Ramp Rate Up",
+    "Ramp Rate Down",
+    "AS Capability RegUp",
+    "AS Capability RegDown",
+    "AS Capability ECRS",
+    "AS Capability NonSpin",
+    "AS Awards NonSpin",
     "AS Awards RRSFFR",
     "AS Awards RRSPFR",
     "AS Awards RRSUFR",
     "AS Awards ECRS",
-    "AS Awards REGUP",
-    "AS Awards REGDN",
+    "AS Awards RegUp",
+    "AS Awards RegDown",
     "Self Provided RRSFFR",
     "Self Provided RRSUFR",
     "Self Provided ECRS",
-    "Ramp Rate Up",
-    "Ramp Rate Down",
-    "AS Capability NSPIN",
-    "AS Capability ECRS",
-    "AS Capability REGUP",
-    "AS Capability REGDN",
 ]
 
 SCED_SMNE_COLUMNS = [
@@ -861,6 +861,13 @@ def process_sced_gen(df):
             "Ancillary Service ECRS": "AS Responsibility for ECRS",
             # remove space
             "Telemetered Net Output ": "Telemetered Net Output",
+            # Rename REGUP -> RegUp, REGDN -> RegDown, NSPIN -> NonSpin
+            "AS Capability REGUP": "AS Capability RegUp",
+            "AS Capability REGDN": "AS Capability RegDown",
+            "AS Capability NSPIN": "AS Capability NonSpin",
+            "AS Awards REGUP": "AS Awards RegUp",
+            "AS Awards REGDN": "AS Awards RegDown",
+            "AS Awards NSPIN": "AS Awards NonSpin",
         },
     )
 
@@ -923,6 +930,18 @@ def process_sced_load(df):
             df[col] = np.nan
 
     df = df[time_cols + all_cols]
+
+    df = df.rename(
+        columns={
+            # Rename REGUP -> RegUp, REGDN -> RegDown, NSPIN -> NonSpin
+            "AS Capability REGUP": "AS Capability RegUp",
+            "AS Capability REGDN": "AS Capability RegDown",
+            "AS Capability NSPIN": "AS Capability NonSpin",
+            "AS Awards REGUP": "AS Awards RegUp",
+            "AS Awards REGDN": "AS Awards RegDown",
+            "AS Awards NSPIN": "AS Awards NonSpin",
+        },
+    )
 
     return df[SCED_LOAD_RESOURCE_COLUMNS]
 

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -824,7 +824,7 @@ class TestErcot(BaseTestISO):
         gen_resource = df_dict[SCED_GEN_RESOURCE_KEY]
         smne = df_dict[SCED_SMNE_KEY]
 
-        self._check_60_day_sced_disclosure(df_dict)
+        check_60_day_sced_disclosure(df_dict)
 
         assert load_resource["SCED Timestamp"].dt.date.unique().tolist() == [
             days_ago_66,


### PR DESCRIPTION
## Summary

- Adds new columns for ERCOT 60 Day SCED Load Resource and Gen Resource datasets
- New columns were added starting with data for 2025-12-05
- Note: some columns were removed from the source. We keep these as all nulls. Similarly, the new columns will be null for previous days.

### Verification

- Run specific tests with `VCR_RECORD_MODE=all uv run pytest gridstatus/tests/source_specific/test_ercot_api.py -k 60_day_sced_disclosure`
