### PR TITLE
ERCOT SCED 60 Day ESR

### DIFF
--- a/gridstatus/ercot_api/ercot_api.py
+++ b/gridstatus/ercot_api/ercot_api.py
@@ -1586,6 +1586,7 @@ class ErcotAPI:
                 - "sced_gen_resource"
                 - "sced_load_resource"
                 - "sced_smne"
+                - "sced_esr" (when available)
 
         NOTE: because data is delayed by 60 days, requesting data in the past 60 days
         will return no data.

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -35,6 +35,8 @@ from gridstatus.ercot_60d_utils import (
     DAM_PTP_OBLIGATION_OPTION_COLUMNS,
     DAM_PTP_OBLIGATION_OPTION_KEY,
     DAM_RESOURCE_AS_OFFERS_COLUMNS,
+    SCED_ESR_COLUMNS,
+    SCED_ESR_KEY,
     SCED_GEN_RESOURCE_COLUMNS,
     SCED_GEN_RESOURCE_KEY,
     SCED_LOAD_RESOURCE_COLUMNS,
@@ -840,6 +842,49 @@ class TestErcot(BaseTestISO):
             days_ago_66,
             days_ago_65,
         ]
+
+    @pytest.mark.integration
+    def test_get_60_day_sced_disclosure_esr(self):
+        # ESR data is available starting 2025-12-05
+        esr_start = pd.Timestamp("2025-12-05").date()
+        days_ago_65 = pd.Timestamp.now(
+            tz=self.iso.default_timezone,
+        ).date() - pd.Timedelta(
+            days=65,
+        )
+
+        # Use the later of 65 days ago or ESR start date
+        date = max(days_ago_65, esr_start)
+
+        with api_vcr.use_cassette(
+            f"test_get_60_day_sced_disclosure_esr_{date}",
+        ):
+            try:
+                df_dict = self.iso.get_60_day_sced_disclosure(
+                    date=date,
+                    process=True,
+                )
+            except NoDataFoundException:
+                pytest.skip(
+                    f"No data found for date {date} - "
+                    "ESR report may not be published yet",
+                )
+
+        assert SCED_ESR_KEY in df_dict
+        esr = df_dict[SCED_ESR_KEY]
+
+        assert esr.columns.tolist() == SCED_ESR_COLUMNS
+        assert len(esr) > 0
+        assert esr["Resource Type"].unique().tolist() == ["ESR"]
+        assert esr["SCED Timestamp"].dt.date.unique()[0] == date
+
+        # Verify offer curves are parsed
+        assert esr["SCED1 Offer Curve"].apply(lambda x: isinstance(x, list)).any()
+        assert esr["SCED2 Offer Curve"].apply(lambda x: isinstance(x, list)).any()
+        assert esr["SCED TPO Offer Curve"].apply(lambda x: isinstance(x, list)).any()
+
+        # Also check the other datasets are still present
+        check_60_day_sced_disclosure(df_dict)
 
     """get_60_day_dam_disclosure"""
 
@@ -3338,6 +3383,12 @@ def check_60_day_sced_disclosure(df_dict: Dict[str, pd.DataFrame]) -> None:
     assert load_resource.columns.tolist() == SCED_LOAD_RESOURCE_COLUMNS
     assert gen_resource.columns.tolist() == SCED_GEN_RESOURCE_COLUMNS
     assert smne.columns.tolist() == SCED_SMNE_COLUMNS
+
+    if SCED_ESR_KEY in df_dict:
+        esr = df_dict[SCED_ESR_KEY]
+        assert esr.columns.tolist() == SCED_ESR_COLUMNS
+        assert len(esr) > 0
+        assert esr["Resource Type"].unique().tolist() == ["ESR"]
 
 
 def check_60_day_dam_disclosure(df_dict):


### PR DESCRIPTION
## Summary

- Adds ESR data to the ERCOT SCED 60 day datasets. Available starting 2025-12-05

### Validation

```python
from gridstatus.ercot import Ercot
sced = Ercot().get_60_day_sced_disclosure('2025-12-05', process=True)
esr = sced['sced_esr']
esr.head()
```

- Run tests with `VCR_RECORD_MODE=all uv run pytest gridstatus/tests/source_specific/test_ercot_api.py -k 60_day_sced_disclosure`
