### PR TITLE
Remove Interval Start and End from ERCOT SCED ESR

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -2188,7 +2188,12 @@ class Ercot(ISOBase):
             esr = esr.rename(
                 columns={"SCED Time Stamp": "SCED Timestamp"},
             )
-            esr = handle_time(esr, time_col="SCED Timestamp")
+            # Localize timestamp but don't add Interval Start/End
+            esr["SCED Timestamp"] = pd.to_datetime(esr["SCED Timestamp"])
+            esr["SCED Timestamp"] = esr["SCED Timestamp"].dt.tz_localize(
+                self.default_timezone,
+                ambiguous=esr["Repeated Hour Flag"] == "N",
+            )
 
         if process:
             logger.info("Processing 60 day SCED disclosure data")

--- a/gridstatus/ercot_60d_utils.py
+++ b/gridstatus/ercot_60d_utils.py
@@ -277,8 +277,6 @@ SCED_SMNE_COLUMNS = [
 ]
 
 SCED_ESR_COLUMNS = [
-    "Interval Start",
-    "Interval End",
     "SCED Timestamp",
     "QSE",
     "DME",
@@ -989,8 +987,6 @@ def process_sced_load(df):
 
 def process_sced_esr(df):
     time_cols = [
-        "Interval Start",
-        "Interval End",
         "SCED Timestamp",
     ]
 


### PR DESCRIPTION
## Summary

- Removes "Interval Start" and "Interval End" columns from ERCOT SCED ESR 60 day because this dataset is released per SCED run

### Details
