### PR TITLE
Add Battery Storage to MISO Fuel Mix

### DIFF
--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -129,6 +129,7 @@ class MISO(ISOBase):
         df_pivoted = add_interval_end(df_pivoted, 5)
         df_pivoted.columns.name = None
         for col in [
+            "Battery Storage",
             "Coal",
             "Imports",
             "Natural Gas",

--- a/gridstatus/tests/source_specific/test_miso.py
+++ b/gridstatus/tests/source_specific/test_miso.py
@@ -55,6 +55,7 @@ class TestMISO(BaseTestISO):
             "Time",
             "Interval Start",
             "Interval End",
+            "Battery Storage",
             "Coal",
             "Imports",
             "Natural Gas",


### PR DESCRIPTION
## Summary

- Adds "Battery Storage" to MISO().get_fuel_mix()
- Run specific testse with `VCR_RECORD_MODE=all uv run pytest gridstatus/tests/source_specific/test_miso.py -k fuel_mix`
  - NOTE: the test for "today" fails because there's no data. The test for yesterday is failing because there's no imports
  - These failures are expected because the "today" and "yesterday" endpoints are not reliable, only the latest endpoint is reliable

### Details
