### PR TITLE
Remove Interval Start and Interval End from ERCOT SCED 60 Day Datasets

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -2171,29 +2171,25 @@ class Ercot(ISOBase):
 
             return df
 
-        load_resource = load_resource.rename(
-            columns={"SCED Time Stamp": "SCED Timestamp"},
-        )
-        gen_resource = gen_resource.rename(
-            columns={"SCED Time Stamp": "SCED Timestamp"},
-        )
+        def localize_sced_timestamp(df: pd.DataFrame) -> pd.DataFrame:
+            """Localize SCED Timestamp without adding Interval Start/End."""
+            df = df.rename(columns={"SCED Time Stamp": "SCED Timestamp"})
+            df["SCED Timestamp"] = pd.to_datetime(df["SCED Timestamp"])
+            df["SCED Timestamp"] = df["SCED Timestamp"].dt.tz_localize(
+                self.default_timezone,
+                ambiguous=df["Repeated Hour Flag"] == "N",
+            )
+            return df
 
-        load_resource = handle_time(load_resource, time_col="SCED Timestamp")
-        gen_resource = handle_time(gen_resource, time_col="SCED Timestamp")
+        load_resource = localize_sced_timestamp(load_resource)
+        gen_resource = localize_sced_timestamp(gen_resource)
+
         # no repeated hour flag like other ERCOT data
         # likely will error on DST change
         smne = handle_time(smne, time_col="Interval Time", is_interval_end=True)
 
         if esr is not None:
-            esr = esr.rename(
-                columns={"SCED Time Stamp": "SCED Timestamp"},
-            )
-            # Localize timestamp but don't add Interval Start/End
-            esr["SCED Timestamp"] = pd.to_datetime(esr["SCED Timestamp"])
-            esr["SCED Timestamp"] = esr["SCED Timestamp"].dt.tz_localize(
-                self.default_timezone,
-                ambiguous=esr["Repeated Hour Flag"] == "N",
-            )
+            esr = localize_sced_timestamp(esr)
 
         if process:
             logger.info("Processing 60 day SCED disclosure data")

--- a/gridstatus/ercot_60d_utils.py
+++ b/gridstatus/ercot_60d_utils.py
@@ -181,8 +181,6 @@ DAM_PTP_OBLIGATION_OPTION_COLUMNS = [
 DAM_PTP_OBLIGATION_OPTION_AWARDS_COLUMNS = DAM_PTP_OBLIGATION_OPTION_COLUMNS[:-1]
 
 SCED_GEN_RESOURCE_COLUMNS = [
-    "Interval Start",
-    "Interval End",
     "SCED Timestamp",
     "QSE",
     "DME",
@@ -227,8 +225,6 @@ SCED_GEN_RESOURCE_COLUMNS = [
 ]
 
 SCED_LOAD_RESOURCE_COLUMNS = [
-    "Interval Start",
-    "Interval End",
     "SCED Timestamp",
     "QSE",
     "DME",
@@ -817,8 +813,6 @@ def process_dam_ptp_obligation_option_awards(df):
 
 def process_sced_gen(df):
     time_cols = [
-        "Interval Start",
-        "Interval End",
         "SCED Timestamp",
     ]
 
@@ -915,8 +909,6 @@ def process_sced_gen(df):
 
 def process_sced_load(df):
     time_cols = [
-        "Interval Start",
-        "Interval End",
         "SCED Timestamp",
     ]
 


### PR DESCRIPTION
## Summary

- Removes "Interval Start" and "Interval End" from ERCOT SCED Gen and Load Resource 60 day
- We are removing these columns because these are SCED datasets and we can rely on the SCED Timestamp column

### Validation

- Run tests with `VCR_RECORD_MODE=all uv run pytest gridstatus/tests/source_specific/test_ercot_api.py -k 60_day_sced_disclosure`
