### PR TITLE
Update column name in PJM data

### DIFF
--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -1071,7 +1071,7 @@ class PJM(ISOBase):
             "Withdrawal Date": "Withdrawn Date",
             "Withdrawn Remarks": "Withdrawal Comment",
             "Status": "Status",
-            "Revised In Service Date": "Proposed Completion Date",
+            "Projected In Service Date": "Proposed Completion Date",
             "Actual In Service Date": "Actual Completion Date",
             "Fuel": "Generation Type",
             "MW Capacity": "Summer Capacity (MW)",


### PR DESCRIPTION
## Summary
The PJM column rename dictionary was out of date and had a column that has since been renamed in the raw PJM data. This PR changes the "Revised In Service Date" key in the rename dictionary to the new column name in the raw data, "Proposed Completion Date".

### Details