### PR TITLE
support static types getting inferred from functions that are decorated with `support_date_range`

### DIFF
--- a/gridstatus/decorators.py
+++ b/gridstatus/decorators.py
@@ -12,6 +12,7 @@ from gridstatus.base import Markets
 P = ParamSpec("P")
 T = TypeVar("T")
 
+
 def _get_args_dict(
     fn: Callable[..., Any],
     args: tuple[Any, ...],


### PR DESCRIPTION
This PR enhances the `support_date_range` decorator by using `ParamSpec` and `TypeVar` for better type safety and flexibility. It ensures that the decorated function preserves its original signature and return type, while maintaining backward compatibility.

LSP and type checker tools will now be able to infer the correct types on methods decorated with this decorator.

The internal function reference is now properly typed to support dynamic argument manipulation without losing type information.

LSP Inference before: 
<img width="562" height="124" alt="Screenshot 2026-02-15 at 3 59 02 PM" src="https://github.com/user-attachments/assets/0dd61ccb-5d5c-43b7-b214-72a114cd043b" />

LSP inference after:
<img width="679" height="147" alt="Screenshot 2026-02-15 at 3 58 24 PM" src="https://github.com/user-attachments/assets/64c7e766-a77e-4384-99d7-9c45fc935a1d" />
