### PR TITLE
[ENG-3385] MISO Binding Constraints Intraday Fixes

### DIFF
--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -1626,8 +1626,10 @@ class MISO(ISOBase):
             },
         )
 
-        for col in ["Shadow Price", "Override", "BP1", "PC1", "BP2", "PC2"]:
-            df[col] = pd.to_numeric(df[col], errors="coerce")
+        # Shadow price is a float, all others are integers
+        df["Shadow Price"] = pd.to_numeric(df["Shadow Price"], errors="coerce")
+        for col in ["Override", "BP1", "PC1", "BP2", "PC2"]:
+            df[col] = df[col].astype(int)
 
         df["Interval Start"] = df["Interval End"] - pd.Timedelta(minutes=5)
 

--- a/gridstatus/tests/source_specific/test_miso.py
+++ b/gridstatus/tests/source_specific/test_miso.py
@@ -1140,11 +1140,11 @@ class TestMISO(BaseTestISO):
 
         assert df.dtypes["Constraint Name"] == "object"
         assert df.dtypes["Shadow Price"] == "float64"
-        assert df.dtypes["Override"] == "float64"
-        assert df.dtypes["BP1"] == "float64"
-        assert df.dtypes["PC1"] == "float64"
-        assert df.dtypes["BP2"] == "float64"
-        assert df.dtypes["PC2"] == "float64"
+        assert df.dtypes["Override"] == "int64"
+        assert df.dtypes["BP1"] == "int64"
+        assert df.dtypes["PC1"] == "int64"
+        assert df.dtypes["BP2"] == "int64"
+        assert df.dtypes["PC2"] == "int64"
 
         assert (df["Constraint Name"] != "None").all()
 


### PR DESCRIPTION
## Summary

- When there are no active constraints, MISO publishes placeholder constraints where all the strings are "None" and the values are 0. These are not real constraints so we should raise a NoDataFoundException in these cases.
- The "Period" provided in the data should be "Interval End", not "Interval Start" as currently implemented
- Correct data types for values other than "Shadow Price" which is a float. Other numeric values are ints

### Validation

- Run specific tests with `VCR_RECORD_MODE=all uv run pytest gridstatus/tests/source_specific/test_miso.py -k binding_constraints_real_time_intraday`
