### PR TITLE
[ENG-3431] Update IESO Ontario Zonal LMP for New XML Schema

### DIFF
--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -3116,55 +3116,44 @@ class IESO(ISOBase):
 
         delivery_date_text = root.find(".//DeliveryDate", ns).text
 
-        # Extract date and hour from the text (e.g., "For 2025-04-23 - Hour 12")
-        delivery_date = pd.Timestamp(
-            delivery_date_text.split(" - ")[0].replace("For ", ""),
-        )
-        delivery_hour = int(delivery_date_text.split(" - ")[1].replace("Hour ", ""))
+        if " - " in delivery_date_text:
+            # Format: "For 2025-04-23 - Hour 12"
+            delivery_date = pd.Timestamp(
+                delivery_date_text.split(" - ")[0].replace("For ", ""),
+            )
+            delivery_hour = int(
+                delivery_date_text.split(" - ")[1].replace("Hour ", ""),
+            )
+        else:
+            # Format: <DeliveryDate>2026-03-05</DeliveryDate>
+            #         <DeliveryHour>10</DeliveryHour>
+            delivery_date = pd.Timestamp(delivery_date_text)
+            delivery_hour = int(root.find(".//DeliveryHour", ns).text)
 
         base_datetime = (
             pd.to_datetime(delivery_date) + pd.Timedelta(hours=delivery_hour - 1)
         ).tz_localize(self.default_timezone)
 
-        price_components = root.findall(".//RealTimePriceComponents", ns)
+        zonal_prices = root.findall(".//ZonalPrice", ns)
 
-        zonal_prices = {}
-        loss_prices = {}
-        congestion_prices = {}
-
-        for component in price_components:
-            component_type = component.find("OntarioZonalPrice", ns).text
-
-            # Intervals are 1-indexed, so we loop from 1 to 12
-            for interval in range(1, 13):
-                interval_element_name = f"OntarioZonalPriceInterval{interval}"
-                interval_value_name = f"Interval{interval}"
-
-                interval_element = component.find(interval_element_name, ns)
-                if interval_element is not None:
-                    interval_value_elem = interval_element.find(interval_value_name, ns)
-                    if interval_value_elem is not None and interval_value_elem.text:
-                        value = float(interval_value_elem.text)
-
-                        if component_type == "Zonal Price":
-                            zonal_prices[interval] = value
-                        elif component_type == "Energy Loss Price":
-                            loss_prices[interval] = value
-                        elif component_type == "Energy Congestion Price":
-                            congestion_prices[interval] = value
         data_rows = []
 
-        for interval in range(1, 13):
-            if interval in zonal_prices:
+        if zonal_prices:
+            # New XML schema (r2): flat ZonalPrice elements with
+            # LmpCap, LossPriceCap, CongPriceCap
+            for zp in zonal_prices:
+                interval = int(zp.find("Interval", ns).text)
+                lmp_elem = zp.find("LmpCap", ns)
+                if lmp_elem is None or not lmp_elem.text:
+                    continue
+                lmp = float(lmp_elem.text)
+                loss = float(zp.find("LossPriceCap", ns).text or 0)
+                congestion = float(zp.find("CongPriceCap", ns).text or 0)
+                energy = lmp - congestion - loss
+
                 minutes_offset = (interval - 1) * 5
                 interval_start = base_datetime + pd.Timedelta(minutes=minutes_offset)
                 interval_end = interval_start + pd.Timedelta(minutes=5)
-
-                lmp = zonal_prices.get(interval, 0)
-                loss = loss_prices.get(interval, 0)
-                congestion = congestion_prices.get(interval, 0)
-
-                energy = lmp - congestion - loss
 
                 data_rows.append(
                     {
@@ -3177,6 +3166,62 @@ class IESO(ISOBase):
                         "Loss": loss,
                     },
                 )
+        else:
+            # Old XML schema (r1): RealTimePriceComponents with separate
+            # sections for Zonal Price, Energy Loss Price, Energy Congestion Price
+            price_components = root.findall(".//RealTimePriceComponents", ns)
+
+            lmp_prices = {}
+            loss_prices = {}
+            congestion_prices = {}
+
+            for component in price_components:
+                component_type = component.find("OntarioZonalPrice", ns).text
+
+                for interval in range(1, 13):
+                    interval_element_name = f"OntarioZonalPriceInterval{interval}"
+                    interval_value_name = f"Interval{interval}"
+
+                    interval_element = component.find(interval_element_name, ns)
+                    if interval_element is not None:
+                        interval_value_elem = interval_element.find(
+                            interval_value_name,
+                            ns,
+                        )
+                        if interval_value_elem is not None and interval_value_elem.text:
+                            value = float(interval_value_elem.text)
+
+                            if component_type == "Zonal Price":
+                                lmp_prices[interval] = value
+                            elif component_type == "Energy Loss Price":
+                                loss_prices[interval] = value
+                            elif component_type == "Energy Congestion Price":
+                                congestion_prices[interval] = value
+
+            for interval in range(1, 13):
+                if interval in lmp_prices:
+                    minutes_offset = (interval - 1) * 5
+                    interval_start = base_datetime + pd.Timedelta(
+                        minutes=minutes_offset,
+                    )
+                    interval_end = interval_start + pd.Timedelta(minutes=5)
+
+                    lmp = lmp_prices.get(interval, 0)
+                    loss = loss_prices.get(interval, 0)
+                    congestion = congestion_prices.get(interval, 0)
+                    energy = lmp - congestion - loss
+
+                    data_rows.append(
+                        {
+                            "Interval Start": interval_start,
+                            "Interval End": interval_end,
+                            "Location": ONTARIO_LOCATION,
+                            "LMP": lmp,
+                            "Energy": energy,
+                            "Congestion": congestion,
+                            "Loss": loss,
+                        },
+                    )
 
         df = (
             pd.DataFrame(data_rows)

--- a/gridstatus/tests/source_specific/test_ieso.py
+++ b/gridstatus/tests/source_specific/test_ieso.py
@@ -1711,6 +1711,37 @@ class TestIESO(BaseTestISO):
         assert data[TIME_COLUMN].min() == start
         assert data[TIME_COLUMN].max() == end - pd.Timedelta(minutes=5)
 
+    def test_get_lmp_real_time_5_min_ontario_zonal_today(self):
+        """Test with today's data which uses the new XML schema (r2) with
+        separate DeliveryDate/DeliveryHour elements and flat ZonalPrice
+        elements."""
+        start = pd.Timestamp.now(tz=self.default_timezone).normalize()
+        end = start + pd.Timedelta(hours=1)
+
+        with file_vcr.use_cassette(
+            f"test_get_lmp_real_time_5_min_ontario_zonal_today_{start.date()}.yaml",
+        ):
+            data = self.iso.get_lmp_real_time_5_min_ontario_zonal(start, end=end)
+
+        self._check_lmp_ontario_zonal_data(data, interval_minutes=5)
+        assert (data[TIME_COLUMN].dt.date == start.date()).all()
+
+    def test_get_lmp_real_time_5_min_ontario_zonal_old_format(self):
+        """Test with a date that uses the old XML schema (r1) with combined
+        DeliveryDate text and RealTimePriceComponents elements."""
+        # March 4, 2026 uses the old format
+        start = pd.Timestamp("2026-03-04", tz=self.default_timezone)
+        end = start + pd.Timedelta(hours=1)
+
+        with file_vcr.use_cassette(
+            "test_get_lmp_real_time_5_min_ontario_zonal_old_format.yaml",
+        ):
+            data = self.iso.get_lmp_real_time_5_min_ontario_zonal(start, end=end)
+
+        self._check_lmp_ontario_zonal_data(data, interval_minutes=5)
+        assert (data[TIME_COLUMN].dt.date == start.date()).all()
+        assert len(data) == 12  # 1 hour = 12 five-minute intervals
+
     """get_lmp_day_ahead_hourly_ontario_zonal"""
 
     def test_get_lmp_day_ahead_hourly_ontario_zonal_latest(self):


### PR DESCRIPTION
## Summary

- Updates `IESO().get_lmp_real_time_5_min_ontario_zonal` for the new XML schema starting on 2026-03-05

### Validation

- Run specific tests with `VCR_RECORD_MODE=all uv run pytest -s -vvv gridstatus/tests/source_specific/test_ieso.py -k "lmp_real_time_5_min_ontario_zonal"`
