### PR TITLE
Fix Integer Parsing in MISO Binding Constraints Intraday

### DIFF
--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -1629,7 +1629,7 @@ class MISO(ISOBase):
         # Shadow price is a float, all others are integers
         df["Shadow Price"] = pd.to_numeric(df["Shadow Price"], errors="coerce")
         for col in ["Override", "BP1", "PC1", "BP2", "PC2"]:
-            df[col] = df[col].astype(int)
+            df[col] = df[col].replace({"": None}).astype("Int64")
 
         df["Interval Start"] = df["Interval End"] - pd.Timedelta(minutes=5)
 

--- a/gridstatus/tests/source_specific/test_miso.py
+++ b/gridstatus/tests/source_specific/test_miso.py
@@ -1140,11 +1140,11 @@ class TestMISO(BaseTestISO):
 
         assert df.dtypes["Constraint Name"] == "object"
         assert df.dtypes["Shadow Price"] == "float64"
-        assert df.dtypes["Override"] == "int64"
-        assert df.dtypes["BP1"] == "int64"
-        assert df.dtypes["PC1"] == "int64"
-        assert df.dtypes["BP2"] == "int64"
-        assert df.dtypes["PC2"] == "int64"
+        assert df.dtypes["Override"] == "Int64"
+        assert df.dtypes["BP1"] == "Int64"
+        assert df.dtypes["PC1"] == "Int64"
+        assert df.dtypes["BP2"] == "Int64"
+        assert df.dtypes["PC2"] == "Int64"
 
         assert (df["Constraint Name"] != "None").all()
 


### PR DESCRIPTION
## Summary

- Standard `np.int64` do not support `None` in integer columns. Instead, we have to use Pandas `Int64` data type
- Applies to column in MISO binding constraints real time intraday

### Validation

- Run tests with `VCR_RECORD_MODE=all uv run pytest gridstatus/tests/source_specific/test_miso.py -k binding_constraints_real_time_intraday`
