### PR TITLE
Fix CAISO Fuel Regions

### DIFF
--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -364,7 +364,7 @@ class CAISO(ISOBase):
 
         retry_num = 0
         while retry_num < max_retries:
-            r = requests.get(url, verify=False)
+            r = requests.get(url, verify=True)
 
             if r.status_code == 200:
                 break
@@ -1648,8 +1648,14 @@ class CAISO(ISOBase):
 
         logger.info(f"Fetching {url}")
 
+        response = requests.get(url)
+        response.raise_for_status()
+
         # Only want the "GPI_Fuel_Region" sheet
-        return pd.read_excel(url, sheet_name="GPI_Fuel_Region").rename(
+        return pd.read_excel(
+            io.BytesIO(response.content),
+            sheet_name="GPI_Fuel_Region",
+        ).rename(
             columns={
                 "Fuel Region": "Fuel Region Id",
                 "Cap & Trade Credit": "Cap and Trade Credit",


### PR DESCRIPTION
## Summary

- Fixes CAISO().get_fuel_regions() by switching to `requests.get` for the URL to solve SSL verification problems
- Restores SSL verification for all CAISO requests as this was supposed to be a temporary patch: https://github.com/gridstatus/gridstatus/pull/772

### Validation

- Run tests with `VCR_RECORD_MODE=all uv run pytest -s -vv gridstatus/tests/source_specific/test_caiso.py` 
  - We need to run all the tests because the SSL verification we added back in affects most CAISO datasets
- Run `CAISO().get_fuel_regions()` and assure it fetches the data 
