### PR TITLE
feat(ENG 2022): Add the PJM Emergency Postings dataset

### DIFF
--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -23,6 +23,7 @@ from gridstatus.gs_logging import logger
 from gridstatus.lmp_config import lmp_config
 from gridstatus.pjm_constants import (
     DEFAULT_RETRIES,
+    EMERGENCY_POSTINGS_GUEST_DASHBOARD_URL,
     HUB_NODE_IDS,
     LOCATION_TYPES,
     PRICE_NODE_IDS,
@@ -72,10 +73,6 @@ class PJM(ISOBase):
     load_forecast_endpoint_name = "load_frcstd_7_day"
     load_forecast_historical_endpoint_name = "load_frcstd_hist"
     load_forecast_5_min_endpoint_name = "very_short_load_frcst"
-
-    EMERGENCY_POSTINGS_GUEST_DASHBOARD_URL = (
-        "https://emergencyprocedures.pjm.com/ep/pages/dashboard.jsf"
-    )
 
     def __init__(
         self,
@@ -3796,108 +3793,22 @@ class PJM(ISOBase):
             .reset_index(drop=True)
         )
 
-    @staticmethod
-    def _emergency_xml_local_name(tag: str) -> str:
-        if "}" in tag:
-            return tag.split("}", 1)[1]
-        return tag
+    def get_emergency_postings(self, url: str | None = None) -> pd.DataFrame:
+        """
+        Retrieves PJM emergency procedure postings by triggering the public
+        "Export To XML" button on the guest dashboard.
 
-    def _emergency_child_text(self, parent: ET.Element, name: str) -> str | None:
-        for child in parent:
-            if self._emergency_xml_local_name(child.tag) == name:
-                return child.text
-        return None
+        Two-step flow (no credentials required):
+          1. GET the guest dashboard to obtain a session cookie and JSF ViewState.
+          2. POST ``frmButtons:lnkDownload`` to download the XML export.
 
-    def _emergency_region_names(self, parent: ET.Element) -> list[str | None]:
-        names: list[str | None] = []
-        for child in parent:
-            if self._emergency_xml_local_name(child.tag) != "Region":
-                continue
-            rn = self._emergency_child_text(child, "regionName")
-            names.append(rn)
-        return names if names else [None]
-
-    def _parse_emergency_procedures_xml(self, xml_bytes: bytes) -> pd.DataFrame:
-        root = ET.fromstring(xml_bytes)
-        rows: list[dict] = []
-        for elem in root.iter():
-            if self._emergency_xml_local_name(elem.tag) != "EmergencyMessage":
-                continue
-
-            mid = self._emergency_child_text(elem, "messageId")
-            if mid is None:
-                continue
-
-            msg_type = self._emergency_child_text(elem, "messageType")
-            priority = self._emergency_child_text(elem, "priority")
-            body = self._emergency_child_text(elem, "message")
-            posted = self._emergency_child_text(elem, "postedTimestamp")
-            canceled = self._emergency_child_text(elem, "canceledTimestamp")
-            eff_start = self._emergency_child_text(elem, "effectiveStartTime")
-            if eff_start is None:
-                eff_start = self._emergency_child_text(elem, "applicableStartTime")
-            if eff_start is None:
-                continue
-            eff_end = self._emergency_child_text(elem, "effectiveEndTime")
-            if eff_end is None:
-                eff_end = self._emergency_child_text(elem, "applicableEndTime")
-
-            region_names = self._emergency_region_names(elem)
-
-            for rn in region_names:
-                rows.append(
-                    {
-                        "Message ID": int(mid.strip()),
-                        "Message Type": msg_type,
-                        "Priority": priority,
-                        "Emergency Message": body,
-                        "Region": rn,
-                        "Interval Start": eff_start,
-                        "Interval End": eff_end,
-                        "Publish Time": posted,
-                        "Canceled Time": canceled,
-                    },
-                )
-
-        if not rows:
-            raise NoDataFoundException("No emergency procedure messages found in XML")
-
-        df = pd.DataFrame(rows)
-
-        df["Interval Start"] = pd.to_datetime(
-            df["Interval Start"],
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
-        df["Interval End"] = pd.to_datetime(
-            df["Interval End"],
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
-        df["Publish Time"] = pd.to_datetime(
-            df["Publish Time"],
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
-        df["Canceled Time"] = pd.to_datetime(
-            df["Canceled Time"],
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
-
-        df = df.sort_values(["Interval Start", "Message ID", "Region"]).reset_index(
-            drop=True,
-        )
-
-        return df[
-            [
-                "Interval Start",
-                "Interval End",
-                "Message ID",
-                "Priority",
-                "Message Type",
-                "Region",
-                "Emergency Message",
-                "Publish Time",
-                "Canceled Time",
-            ]
-        ]
+        The XML contains Publish Time, Canceled Time, proper UTC start/end
+        timestamps, and individual Region elements (one DataFrame row per
+        message-region pair).
+        """
+        fetch_url = url or EMERGENCY_POSTINGS_GUEST_DASHBOARD_URL
+        xml_bytes = self._fetch_emergency_xml(fetch_url)
+        return self._parse_emergency_xml(xml_bytes)
 
     def _fetch_emergency_xml(self, url: str) -> bytes:
         session = requests.Session()
@@ -3940,22 +3851,70 @@ class PJM(ISOBase):
 
         return xml_resp.content
 
-    def get_emergency_postings(self, url: str | None = None) -> pd.DataFrame:
-        """
-        Retrieves PJM emergency procedure postings by triggering the public
-        "Export To XML" button on the guest dashboard.
+    def _parse_emergency_xml(self, xml_bytes: bytes) -> pd.DataFrame:
+        root = ET.fromstring(xml_bytes)
+        rows: list[dict] = []
+        for msg in root.iter("EmergencyMessage"):
+            mid = msg.findtext("messageId")
+            if mid is None:
+                continue
 
-        Two-step flow (no credentials required):
-          1. GET the guest dashboard to obtain a session cookie and JSF ViewState.
-          2. POST ``frmButtons:lnkDownload`` to download the XML export.
+            eff_start = msg.findtext("effectiveStartTime") or msg.findtext(
+                "applicableStartTime",
+            )
+            if eff_start is None:
+                continue
 
-        The XML contains richer data than the HTML table: Publish Time,
-        Canceled Time, proper UTC start/end timestamps, and individual Region
-        elements (one DataFrame row per message-region pair).
-        """
-        fetch_url = url or self.EMERGENCY_POSTINGS_GUEST_DASHBOARD_URL
-        xml_bytes = self._fetch_emergency_xml(fetch_url)
-        return self._parse_emergency_procedures_xml(xml_bytes)
+            eff_end = msg.findtext("effectiveEndTime") or msg.findtext(
+                "applicableEndTime",
+            )
+
+            regions = msg.findall("Region")
+            region_names = (
+                [r.findtext("regionName") for r in regions] if regions else [None]
+            )
+
+            for rn in region_names:
+                rows.append(
+                    {
+                        "Message ID": int(mid.strip()),
+                        "Message Type": msg.findtext("messageType"),
+                        "Priority": msg.findtext("priority"),
+                        "Emergency Message": msg.findtext("message"),
+                        "Region": rn,
+                        "Interval Start": eff_start,
+                        "Interval End": eff_end,
+                        "Publish Time": msg.findtext("postedTimestamp"),
+                        "Canceled Time": msg.findtext("canceledTimestamp"),
+                    },
+                )
+
+        if not rows:
+            raise NoDataFoundException("No emergency procedure messages found in XML")
+
+        df = pd.DataFrame(rows)
+        for col in ("Interval Start", "Interval End", "Publish Time", "Canceled Time"):
+            df[col] = pd.to_datetime(df[col], utc=True).dt.tz_convert(
+                self.default_timezone,
+            )
+
+        return (
+            df[
+                [
+                    "Interval Start",
+                    "Interval End",
+                    "Message ID",
+                    "Priority",
+                    "Message Type",
+                    "Region",
+                    "Emergency Message",
+                    "Publish Time",
+                    "Canceled Time",
+                ]
+            ]
+            .sort_values(["Interval Start", "Message ID", "Region"])
+            .reset_index(drop=True)
+        )
 
     @support_date_range(frequency=None)
     def get_pai_intervals_5_min(

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -3859,16 +3859,6 @@ class PJM(ISOBase):
             if mid is None:
                 continue
 
-            eff_start = msg.findtext("effectiveStartTime") or msg.findtext(
-                "applicableStartTime",
-            )
-            if eff_start is None:
-                continue
-
-            eff_end = msg.findtext("effectiveEndTime") or msg.findtext(
-                "applicableEndTime",
-            )
-
             regions = msg.findall("Region")
             region_names = (
                 [r.findtext("regionName") for r in regions] if regions else [None]
@@ -3882,8 +3872,10 @@ class PJM(ISOBase):
                         "Priority": msg.findtext("priority"),
                         "Emergency Message": msg.findtext("message"),
                         "Region": rn,
-                        "Interval Start": eff_start,
-                        "Interval End": eff_end,
+                        "Effective Start": msg.findtext("effectiveStartTime"),
+                        "Effective End": msg.findtext("effectiveEndTime"),
+                        "Applicable Start": msg.findtext("applicableStartTime"),
+                        "Applicable End": msg.findtext("applicableEndTime"),
                         "Publish Time": msg.findtext("postedTimestamp"),
                         "Canceled Time": msg.findtext("canceledTimestamp"),
                     },
@@ -3893,7 +3885,14 @@ class PJM(ISOBase):
             raise NoDataFoundException("No emergency procedure messages found in XML")
 
         df = pd.DataFrame(rows)
-        for col in ("Interval Start", "Interval End", "Publish Time", "Canceled Time"):
+        for col in (
+            "Effective Start",
+            "Effective End",
+            "Applicable Start",
+            "Applicable End",
+            "Publish Time",
+            "Canceled Time",
+        ):
             df[col] = pd.to_datetime(df[col], utc=True).dt.tz_convert(
                 self.default_timezone,
             )
@@ -3901,18 +3900,20 @@ class PJM(ISOBase):
         return (
             df[
                 [
-                    "Interval Start",
-                    "Interval End",
                     "Message ID",
-                    "Priority",
                     "Message Type",
+                    "Priority",
                     "Region",
-                    "Emergency Message",
+                    "Effective Start",
+                    "Effective End",
+                    "Applicable Start",
+                    "Applicable End",
                     "Publish Time",
                     "Canceled Time",
+                    "Emergency Message",
                 ]
             ]
-            .sort_values(["Interval Start", "Message ID", "Region"])
+            .sort_values(["Effective Start", "Message ID", "Region"])
             .reset_index(drop=True)
         )
 

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -10,6 +10,7 @@ from typing import BinaryIO
 import pandas as pd
 import requests
 import tqdm
+from bs4 import BeautifulSoup
 
 from gridstatus import utils
 from gridstatus.base import ISOBase, Markets, NoDataFoundException, NotSupported
@@ -72,8 +73,8 @@ class PJM(ISOBase):
     load_forecast_historical_endpoint_name = "load_frcstd_hist"
     load_forecast_5_min_endpoint_name = "very_short_load_frcst"
 
-    EMERGENCY_POSTINGS_XML_DEFAULT_URL = (
-        "https://www.pjm.com/-/media/DotCom/etools/emerg-procedures/epsample.xml"
+    EMERGENCY_POSTINGS_GUEST_DASHBOARD_URL = (
+        "https://emergencyprocedures.pjm.com/ep/pages/dashboard.jsf"
     )
 
     def __init__(
@@ -3866,21 +3867,19 @@ class PJM(ISOBase):
         df["Interval Start"] = pd.to_datetime(
             df["Interval Start"],
             utc=True,
-        ).dt.tz_convert(
-            self.default_timezone,
-        )
-        df["Interval End"] = pd.to_datetime(df["Interval End"], utc=True).dt.tz_convert(
-            self.default_timezone,
-        )
-        df["Publish Time"] = pd.to_datetime(df["Publish Time"], utc=True).dt.tz_convert(
-            self.default_timezone,
-        )
+        ).dt.tz_convert(self.default_timezone)
+        df["Interval End"] = pd.to_datetime(
+            df["Interval End"],
+            utc=True,
+        ).dt.tz_convert(self.default_timezone)
+        df["Publish Time"] = pd.to_datetime(
+            df["Publish Time"],
+            utc=True,
+        ).dt.tz_convert(self.default_timezone)
         df["Canceled Time"] = pd.to_datetime(
             df["Canceled Time"],
             utc=True,
-        ).dt.tz_convert(
-            self.default_timezone,
-        )
+        ).dt.tz_convert(self.default_timezone)
 
         df = df.sort_values(["Interval Start", "Message ID", "Region"]).reset_index(
             drop=True,
@@ -3900,34 +3899,63 @@ class PJM(ISOBase):
             ]
         ]
 
-    def parse_emergency_procedures_xml(self, xml_bytes: bytes) -> pd.DataFrame:
-        return self._parse_emergency_procedures_xml(xml_bytes)
+    def _fetch_emergency_xml(self, url: str) -> bytes:
+        session = requests.Session()
+        session.headers["User-Agent"] = "Mozilla/5.0 (compatible; gridstatus)"
 
-    def get_emergency_postings(self, verbose: bool = False) -> pd.DataFrame:
-        """
-        Retrieves PJM emergency procedure postings from the XML feed.
+        logger.info(f"GET emergency postings dashboard from {url}...")
+        page = session.get(url, timeout=REQUEST_TIMEOUT, allow_redirects=True)
+        page.raise_for_status()
 
-        ``PJM_EMERGENCY_POSTINGS_XML_URL`` overrides the default URL (PJM's public
-        sample XML). ``PJM_EMERGENCY_POSTINGS_COOKIE`` may be set to the full
-        ``Cookie`` header value when the feed requires a browser session.
-        """
-        url = (
-            os.getenv("PJM_EMERGENCY_POSTINGS_XML_URL")
-            or self.EMERGENCY_POSTINGS_XML_DEFAULT_URL
-        )
-        headers: dict[str, str] = {}
-        cookie_header = os.getenv("PJM_EMERGENCY_POSTINGS_COOKIE")
-        if cookie_header:
-            headers["Cookie"] = cookie_header
-        logger.info(f"Requesting emergency postings XML from {url}...")
-        response = requests.get(
+        soup = BeautifulSoup(page.content, "lxml")
+        vs_input = soup.select_one('input[name="javax.faces.ViewState"]')
+        if vs_input is None:
+            raise NoDataFoundException(
+                "Could not find javax.faces.ViewState in dashboard HTML.",
+            )
+        view_state: str = vs_input["value"]
+
+        logger.info("POST XML export (frmButtons:lnkDownload)...")
+        xml_resp = session.post(
             url,
-            headers=headers,
+            data={
+                "frmButtons": "frmButtons",
+                "frmButtons:lnkDownload": "frmButtons:lnkDownload",
+                "javax.faces.ViewState": view_state,
+            },
+            headers={
+                "Referer": url,
+                "Origin": "https://emergencyprocedures.pjm.com",
+            },
             timeout=REQUEST_TIMEOUT,
             allow_redirects=True,
         )
-        response.raise_for_status()
-        return self._parse_emergency_procedures_xml(response.content)
+        xml_resp.raise_for_status()
+
+        content_type = xml_resp.headers.get("Content-Type", "")
+        if "xml" not in content_type:
+            raise NoDataFoundException(
+                f"Expected XML response but got Content-Type: {content_type}",
+            )
+
+        return xml_resp.content
+
+    def get_emergency_postings(self, url: str | None = None) -> pd.DataFrame:
+        """
+        Retrieves PJM emergency procedure postings by triggering the public
+        "Export To XML" button on the guest dashboard.
+
+        Two-step flow (no credentials required):
+          1. GET the guest dashboard to obtain a session cookie and JSF ViewState.
+          2. POST ``frmButtons:lnkDownload`` to download the XML export.
+
+        The XML contains richer data than the HTML table: Publish Time,
+        Canceled Time, proper UTC start/end timestamps, and individual Region
+        elements (one DataFrame row per message-region pair).
+        """
+        fetch_url = url or self.EMERGENCY_POSTINGS_GUEST_DASHBOARD_URL
+        xml_bytes = self._fetch_emergency_xml(fetch_url)
+        return self._parse_emergency_procedures_xml(xml_bytes)
 
     @support_date_range(frequency=None)
     def get_pai_intervals_5_min(

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -4,6 +4,7 @@ import os
 import random
 import time
 import warnings
+import xml.etree.ElementTree as ET
 from typing import BinaryIO
 
 import pandas as pd
@@ -70,6 +71,10 @@ class PJM(ISOBase):
     load_forecast_endpoint_name = "load_frcstd_7_day"
     load_forecast_historical_endpoint_name = "load_frcstd_hist"
     load_forecast_5_min_endpoint_name = "very_short_load_frcst"
+
+    EMERGENCY_POSTINGS_XML_DEFAULT_URL = (
+        "https://www.pjm.com/-/media/DotCom/etools/emerg-procedures/epsample.xml"
+    )
 
     def __init__(
         self,
@@ -3789,6 +3794,140 @@ class PJM(ISOBase):
             .sort_values("Interval Start")
             .reset_index(drop=True)
         )
+
+    @staticmethod
+    def _emergency_xml_local_name(tag: str) -> str:
+        if "}" in tag:
+            return tag.split("}", 1)[1]
+        return tag
+
+    def _emergency_child_text(self, parent: ET.Element, name: str) -> str | None:
+        for child in parent:
+            if self._emergency_xml_local_name(child.tag) == name:
+                return child.text
+        return None
+
+    def _emergency_region_names(self, parent: ET.Element) -> list[str | None]:
+        names: list[str | None] = []
+        for child in parent:
+            if self._emergency_xml_local_name(child.tag) != "Region":
+                continue
+            rn = self._emergency_child_text(child, "regionName")
+            names.append(rn)
+        return names if names else [None]
+
+    def _parse_emergency_procedures_xml(self, xml_bytes: bytes) -> pd.DataFrame:
+        root = ET.fromstring(xml_bytes)
+        rows: list[dict] = []
+        for elem in root.iter():
+            if self._emergency_xml_local_name(elem.tag) != "EmergencyMessage":
+                continue
+
+            mid = self._emergency_child_text(elem, "messageId")
+            if mid is None:
+                continue
+
+            msg_type = self._emergency_child_text(elem, "messageType")
+            priority = self._emergency_child_text(elem, "priority")
+            body = self._emergency_child_text(elem, "message")
+            posted = self._emergency_child_text(elem, "postedTimestamp")
+            canceled = self._emergency_child_text(elem, "canceledTimestamp")
+            eff_start = self._emergency_child_text(elem, "effectiveStartTime")
+            if eff_start is None:
+                eff_start = self._emergency_child_text(elem, "applicableStartTime")
+            if eff_start is None:
+                continue
+            eff_end = self._emergency_child_text(elem, "effectiveEndTime")
+            if eff_end is None:
+                eff_end = self._emergency_child_text(elem, "applicableEndTime")
+
+            region_names = self._emergency_region_names(elem)
+
+            for rn in region_names:
+                rows.append(
+                    {
+                        "Message ID": int(mid.strip()),
+                        "Message Type": msg_type,
+                        "Priority": priority,
+                        "Emergency Message": body,
+                        "Region": rn,
+                        "Interval Start": eff_start,
+                        "Interval End": eff_end,
+                        "Publish Time": posted,
+                        "Canceled Time": canceled,
+                    },
+                )
+
+        if not rows:
+            raise NoDataFoundException("No emergency procedure messages found in XML")
+
+        df = pd.DataFrame(rows)
+
+        df["Interval Start"] = pd.to_datetime(
+            df["Interval Start"],
+            utc=True,
+        ).dt.tz_convert(
+            self.default_timezone,
+        )
+        df["Interval End"] = pd.to_datetime(df["Interval End"], utc=True).dt.tz_convert(
+            self.default_timezone,
+        )
+        df["Publish Time"] = pd.to_datetime(df["Publish Time"], utc=True).dt.tz_convert(
+            self.default_timezone,
+        )
+        df["Canceled Time"] = pd.to_datetime(
+            df["Canceled Time"],
+            utc=True,
+        ).dt.tz_convert(
+            self.default_timezone,
+        )
+
+        df = df.sort_values(["Interval Start", "Message ID", "Region"]).reset_index(
+            drop=True,
+        )
+
+        return df[
+            [
+                "Interval Start",
+                "Interval End",
+                "Message ID",
+                "Priority",
+                "Message Type",
+                "Region",
+                "Emergency Message",
+                "Publish Time",
+                "Canceled Time",
+            ]
+        ]
+
+    def parse_emergency_procedures_xml(self, xml_bytes: bytes) -> pd.DataFrame:
+        return self._parse_emergency_procedures_xml(xml_bytes)
+
+    def get_emergency_postings(self, verbose: bool = False) -> pd.DataFrame:
+        """
+        Retrieves PJM emergency procedure postings from the XML feed.
+
+        ``PJM_EMERGENCY_POSTINGS_XML_URL`` overrides the default URL (PJM's public
+        sample XML). ``PJM_EMERGENCY_POSTINGS_COOKIE`` may be set to the full
+        ``Cookie`` header value when the feed requires a browser session.
+        """
+        url = (
+            os.getenv("PJM_EMERGENCY_POSTINGS_XML_URL")
+            or self.EMERGENCY_POSTINGS_XML_DEFAULT_URL
+        )
+        headers: dict[str, str] = {}
+        cookie_header = os.getenv("PJM_EMERGENCY_POSTINGS_COOKIE")
+        if cookie_header:
+            headers["Cookie"] = cookie_header
+        logger.info(f"Requesting emergency postings XML from {url}...")
+        response = requests.get(
+            url,
+            headers=headers,
+            timeout=REQUEST_TIMEOUT,
+            allow_redirects=True,
+        )
+        response.raise_for_status()
+        return self._parse_emergency_procedures_xml(response.content)
 
     @support_date_range(frequency=None)
     def get_pai_intervals_5_min(

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -3901,14 +3901,14 @@ class PJM(ISOBase):
             df[
                 [
                     "Message ID",
+                    "Applicable Start",
+                    "Applicable End",
+                    "Publish Time",
                     "Message Type",
                     "Priority",
                     "Region",
                     "Effective Start",
                     "Effective End",
-                    "Applicable Start",
-                    "Applicable End",
-                    "Publish Time",
                     "Canceled Time",
                     "Emergency Message",
                 ]

--- a/gridstatus/pjm_constants.py
+++ b/gridstatus/pjm_constants.py
@@ -1,6 +1,10 @@
 # PJM requires retries because the API is flaky
 DEFAULT_RETRIES: int = 3
 
+EMERGENCY_POSTINGS_GUEST_DASHBOARD_URL: str = (
+    "https://emergencyprocedures.pjm.com/ep/pages/dashboard.jsf"
+)
+
 # Timeout for API requests in seconds (connect, read)
 CONNECT_TIMEOUT_SECONDS = 10
 READ_TIMEOUT_SECONDS = 15

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -3314,15 +3314,17 @@ class TestPJM(BaseTestISO):
     """get_emergency_postings"""
 
     expected_emergency_postings_cols = [
-        "Interval Start",
-        "Interval End",
         "Message ID",
-        "Priority",
         "Message Type",
+        "Priority",
         "Region",
-        "Emergency Message",
+        "Effective Start",
+        "Effective End",
+        "Applicable Start",
+        "Applicable End",
         "Publish Time",
         "Canceled Time",
+        "Emergency Message",
     ]
 
     SAMPLE_DASHBOARD_HTML = (
@@ -3341,6 +3343,8 @@ class TestPJM(BaseTestISO):
 <message>Hello</message>
 <effectiveStartTime>2016-07-05T19:33Z</effectiveStartTime>
 <effectiveEndTime>2016-07-06T04:18Z</effectiveEndTime>
+<applicableStartTime>2016-07-06T08:00Z</applicableStartTime>
+<applicableEndTime>2016-07-07T03:59Z</applicableEndTime>
 <Region><regionName>AEP</regionName><regionType>Control Area</regionType></Region>
 </EmergencyMessage>
 </ns2:EmergencyProcedures>"""
@@ -3379,9 +3383,11 @@ class TestPJM(BaseTestISO):
         assert df["Region"].iloc[0] == "AEP"
         assert df["Message Type"].iloc[0] == "Test"
         assert df["Priority"].iloc[0] == "Warning"
-        assert isinstance(df["Interval Start"].dtype, pd.DatetimeTZDtype)
-        assert str(df["Interval Start"].dt.tz) == str(self.iso.default_timezone)
-        assert isinstance(df["Interval End"].dtype, pd.DatetimeTZDtype)
+        assert isinstance(df["Effective Start"].dtype, pd.DatetimeTZDtype)
+        assert str(df["Effective Start"].dt.tz) == str(self.iso.default_timezone)
+        assert isinstance(df["Effective End"].dtype, pd.DatetimeTZDtype)
+        assert isinstance(df["Applicable Start"].dtype, pd.DatetimeTZDtype)
+        assert isinstance(df["Applicable End"].dtype, pd.DatetimeTZDtype)
         assert isinstance(df["Publish Time"].dtype, pd.DatetimeTZDtype)
 
     def test_get_emergency_postings_xml_export_multi_region(self):
@@ -3394,6 +3400,8 @@ class TestPJM(BaseTestISO):
 <priority>Alert</priority>
 <message>Body</message>
 <effectiveStartTime>2026-04-13T12:00Z</effectiveStartTime>
+<effectiveEndTime>2026-04-17T03:59Z</effectiveEndTime>
+<applicableStartTime>2026-04-13T14:00Z</applicableStartTime>
 <applicableEndTime>2026-04-17T03:59Z</applicableEndTime>
 <Region><regionName>SOUTHERN</regionName></Region>
 <Region><regionName>MIDATL</regionName></Region>

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -3325,10 +3325,14 @@ class TestPJM(BaseTestISO):
         "Canceled Time",
     ]
 
-    def test_get_emergency_postings_parses_xml(self, monkeypatch):
-        monkeypatch.delenv("PJM_EMERGENCY_POSTINGS_COOKIE", raising=False)
-        xml = b"""<?xml version="1.0" encoding="UTF-8"?>
-<EmergencyProcedures xmlns="http://www.pjm.com/external/schemas/emergencyprocedures/v1">
+    SAMPLE_DASHBOARD_HTML = (
+        b"<html><body><form>"
+        b'<input name="javax.faces.ViewState" value="123:456" />'
+        b"</form></body></html>"
+    )
+
+    SAMPLE_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<ns2:EmergencyProcedures xmlns:ns2="http://www.pjm.com/external/schemas/emergencyprocedures/v1">
 <EmergencyMessage>
 <messageId>1</messageId>
 <messageType>Test</messageType>
@@ -3339,12 +3343,35 @@ class TestPJM(BaseTestISO):
 <effectiveEndTime>2016-07-06T04:18Z</effectiveEndTime>
 <Region><regionName>AEP</regionName><regionType>Control Area</regionType></Region>
 </EmergencyMessage>
-</EmergencyProcedures>"""
-        mock_resp = mock.Mock()
-        mock_resp.content = xml
-        mock_resp.raise_for_status = mock.Mock()
-        with mock.patch("gridstatus.pjm.requests.get", return_value=mock_resp):
-            df = self.iso.get_emergency_postings()
+</ns2:EmergencyProcedures>"""
+
+    def _mock_session_for_xml_export(self, dashboard_html, xml_bytes):
+        mock_page = mock.Mock()
+        mock_page.content = dashboard_html
+        mock_page.status_code = 200
+        mock_page.raise_for_status = mock.Mock()
+
+        mock_xml = mock.Mock()
+        mock_xml.content = xml_bytes
+        mock_xml.status_code = 200
+        mock_xml.headers = {"Content-Type": "application/xml"}
+        mock_xml.raise_for_status = mock.Mock()
+
+        mock_session = mock.Mock()
+        mock_session.headers = {}
+        mock_session.get.return_value = mock_page
+        mock_session.post.return_value = mock_xml
+        return mock_session
+
+    def test_get_emergency_postings_xml_export(self):
+        mock_session = self._mock_session_for_xml_export(
+            self.SAMPLE_DASHBOARD_HTML,
+            self.SAMPLE_XML,
+        )
+        with mock.patch("gridstatus.pjm.requests.Session", return_value=mock_session):
+            df = self.iso.get_emergency_postings(
+                url="https://example.test/dashboard.jsf",
+            )
 
         assert df.columns.tolist() == self.expected_emergency_postings_cols
         assert len(df) == 1
@@ -3354,51 +3381,51 @@ class TestPJM(BaseTestISO):
         assert df["Priority"].iloc[0] == "Warning"
         assert isinstance(df["Interval Start"].dtype, pd.DatetimeTZDtype)
         assert str(df["Interval Start"].dt.tz) == str(self.iso.default_timezone)
+        assert isinstance(df["Interval End"].dtype, pd.DatetimeTZDtype)
+        assert isinstance(df["Publish Time"].dtype, pd.DatetimeTZDtype)
 
-    def test_get_emergency_postings_sends_cookie_header(self, monkeypatch):
-        monkeypatch.setenv("PJM_EMERGENCY_POSTINGS_COOKIE", "JSESSIONID=example")
+    def test_get_emergency_postings_xml_export_multi_region(self):
         xml = b"""<?xml version="1.0" encoding="UTF-8"?>
-<EmergencyProcedures xmlns="http://www.pjm.com/external/schemas/emergencyprocedures/v1">
+<ns2:EmergencyProcedures xmlns:ns2="http://www.pjm.com/external/schemas/emergencyprocedures/v1">
 <EmergencyMessage>
-<messageId>1</messageId>
-<messageType>Test</messageType>
-<postedTimestamp>2016-07-05T19:37Z</postedTimestamp>
-<priority>Warning</priority>
-<message>Hello</message>
-<effectiveStartTime>2016-07-05T19:33Z</effectiveStartTime>
-<Region><regionName>AEP</regionName></Region>
+<messageId>99</messageId>
+<messageType>Hot Weather Alert</messageType>
+<postedTimestamp>2026-04-13T12:00Z</postedTimestamp>
+<priority>Alert</priority>
+<message>Body</message>
+<effectiveStartTime>2026-04-13T12:00Z</effectiveStartTime>
+<applicableEndTime>2026-04-17T03:59Z</applicableEndTime>
+<Region><regionName>SOUTHERN</regionName></Region>
+<Region><regionName>MIDATL</regionName></Region>
 </EmergencyMessage>
-</EmergencyProcedures>"""
-        mock_resp = mock.Mock()
-        mock_resp.content = xml
-        mock_resp.raise_for_status = mock.Mock()
-        with mock.patch(
-            "gridstatus.pjm.requests.get",
-            return_value=mock_resp,
-        ) as mock_get:
-            self.iso.get_emergency_postings()
+</ns2:EmergencyProcedures>"""
+        mock_session = self._mock_session_for_xml_export(
+            self.SAMPLE_DASHBOARD_HTML,
+            xml,
+        )
+        with mock.patch("gridstatus.pjm.requests.Session", return_value=mock_session):
+            df = self.iso.get_emergency_postings(
+                url="https://example.test/dashboard.jsf",
+            )
 
-        assert mock_get.call_args.kwargs["headers"]["Cookie"] == "JSESSIONID=example"
+        assert len(df) == 2
+        assert set(df["Region"]) == {"SOUTHERN", "MIDATL"}
+        assert df["Message ID"].iloc[0] == 99
 
-    def test_parse_emergency_procedures_xml(self):
-        xml = b"""<?xml version="1.0" encoding="UTF-8"?>
-<EmergencyProcedures xmlns="http://www.pjm.com/external/schemas/emergencyprocedures/v1">
-<EmergencyMessage>
-<messageId>1</messageId>
-<messageType>Test</messageType>
-<postedTimestamp>2016-07-05T19:37Z</postedTimestamp>
-<priority>Warning</priority>
-<message>Hello</message>
-<effectiveStartTime>2016-07-05T19:33Z</effectiveStartTime>
-<effectiveEndTime>2016-07-06T04:18Z</effectiveEndTime>
-<Region><regionName>AEP</regionName><regionType>Control Area</regionType></Region>
-</EmergencyMessage>
-</EmergencyProcedures>"""
-        df = self.iso.parse_emergency_procedures_xml(xml)
-        assert df.columns.tolist() == self.expected_emergency_postings_cols
-        assert len(df) == 1
-        assert df["Message ID"].iloc[0] == 1
-        assert df["Region"].iloc[0] == "AEP"
+    def test_get_emergency_postings_posts_viewstate(self):
+        mock_session = self._mock_session_for_xml_export(
+            self.SAMPLE_DASHBOARD_HTML,
+            self.SAMPLE_XML,
+        )
+        with mock.patch("gridstatus.pjm.requests.Session", return_value=mock_session):
+            self.iso.get_emergency_postings(url="https://example.test/dashboard.jsf")
+
+        post_call = mock_session.post.call_args
+        assert post_call.kwargs["data"]["javax.faces.ViewState"] == "123:456"
+        assert (
+            post_call.kwargs["data"]["frmButtons:lnkDownload"]
+            == "frmButtons:lnkDownload"
+        )
 
     """get_voltage_limits"""
 

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -3315,14 +3315,14 @@ class TestPJM(BaseTestISO):
 
     expected_emergency_postings_cols = [
         "Message ID",
+        "Applicable Start",
+        "Applicable End",
+        "Publish Time",
         "Message Type",
         "Priority",
         "Region",
         "Effective Start",
         "Effective End",
-        "Applicable Start",
-        "Applicable End",
-        "Publish Time",
         "Canceled Time",
         "Emergency Message",
     ]

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -3311,6 +3311,95 @@ class TestPJM(BaseTestISO):
             df = self.iso.get_sync_reserve_events()
             self._check_sync_reserve_events(df)
 
+    """get_emergency_postings"""
+
+    expected_emergency_postings_cols = [
+        "Interval Start",
+        "Interval End",
+        "Message ID",
+        "Priority",
+        "Message Type",
+        "Region",
+        "Emergency Message",
+        "Publish Time",
+        "Canceled Time",
+    ]
+
+    def test_get_emergency_postings_parses_xml(self, monkeypatch):
+        monkeypatch.delenv("PJM_EMERGENCY_POSTINGS_COOKIE", raising=False)
+        xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<EmergencyProcedures xmlns="http://www.pjm.com/external/schemas/emergencyprocedures/v1">
+<EmergencyMessage>
+<messageId>1</messageId>
+<messageType>Test</messageType>
+<postedTimestamp>2016-07-05T19:37Z</postedTimestamp>
+<priority>Warning</priority>
+<message>Hello</message>
+<effectiveStartTime>2016-07-05T19:33Z</effectiveStartTime>
+<effectiveEndTime>2016-07-06T04:18Z</effectiveEndTime>
+<Region><regionName>AEP</regionName><regionType>Control Area</regionType></Region>
+</EmergencyMessage>
+</EmergencyProcedures>"""
+        mock_resp = mock.Mock()
+        mock_resp.content = xml
+        mock_resp.raise_for_status = mock.Mock()
+        with mock.patch("gridstatus.pjm.requests.get", return_value=mock_resp):
+            df = self.iso.get_emergency_postings()
+
+        assert df.columns.tolist() == self.expected_emergency_postings_cols
+        assert len(df) == 1
+        assert df["Message ID"].iloc[0] == 1
+        assert df["Region"].iloc[0] == "AEP"
+        assert df["Message Type"].iloc[0] == "Test"
+        assert df["Priority"].iloc[0] == "Warning"
+        assert isinstance(df["Interval Start"].dtype, pd.DatetimeTZDtype)
+        assert str(df["Interval Start"].dt.tz) == str(self.iso.default_timezone)
+
+    def test_get_emergency_postings_sends_cookie_header(self, monkeypatch):
+        monkeypatch.setenv("PJM_EMERGENCY_POSTINGS_COOKIE", "JSESSIONID=example")
+        xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<EmergencyProcedures xmlns="http://www.pjm.com/external/schemas/emergencyprocedures/v1">
+<EmergencyMessage>
+<messageId>1</messageId>
+<messageType>Test</messageType>
+<postedTimestamp>2016-07-05T19:37Z</postedTimestamp>
+<priority>Warning</priority>
+<message>Hello</message>
+<effectiveStartTime>2016-07-05T19:33Z</effectiveStartTime>
+<Region><regionName>AEP</regionName></Region>
+</EmergencyMessage>
+</EmergencyProcedures>"""
+        mock_resp = mock.Mock()
+        mock_resp.content = xml
+        mock_resp.raise_for_status = mock.Mock()
+        with mock.patch(
+            "gridstatus.pjm.requests.get",
+            return_value=mock_resp,
+        ) as mock_get:
+            self.iso.get_emergency_postings()
+
+        assert mock_get.call_args.kwargs["headers"]["Cookie"] == "JSESSIONID=example"
+
+    def test_parse_emergency_procedures_xml(self):
+        xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<EmergencyProcedures xmlns="http://www.pjm.com/external/schemas/emergencyprocedures/v1">
+<EmergencyMessage>
+<messageId>1</messageId>
+<messageType>Test</messageType>
+<postedTimestamp>2016-07-05T19:37Z</postedTimestamp>
+<priority>Warning</priority>
+<message>Hello</message>
+<effectiveStartTime>2016-07-05T19:33Z</effectiveStartTime>
+<effectiveEndTime>2016-07-06T04:18Z</effectiveEndTime>
+<Region><regionName>AEP</regionName><regionType>Control Area</regionType></Region>
+</EmergencyMessage>
+</EmergencyProcedures>"""
+        df = self.iso.parse_emergency_procedures_xml(xml)
+        assert df.columns.tolist() == self.expected_emergency_postings_cols
+        assert len(df) == 1
+        assert df["Message ID"].iloc[0] == 1
+        assert df["Region"].iloc[0] == "AEP"
+
     """get_voltage_limits"""
 
     def _check_voltage_limits(self, df):


### PR DESCRIPTION
## Summary
Adds a method to grab the PJM Emergency Postings from the XML feed.

```
from gridstatus import PJM
pjm = PJM()

df = pjm.get_emergency_postings()
print(df)
print(df.dtypes)
```

### Details
I went back and forth on this one for a while on what route to take. [As the help page indicates](https://www.pjm.com/markets-and-operations/etools/emerg-procedure), there is an XML feed and a PJM CLI. The PJM CLI is a large dependency that I'd rather avoid. And so while there is an XML feed, it does require some involved session management. Cookies stay alive for 30 minutes with inactivity, 8 hours with activity, and passing these around is a bit of a pain. 

However, all of the information is available to GUEST users, so really all of that session management is not needed to access the data. And the HTML doesn't have every piece of information, the XML does. They even provide an XML button on the HTML page that is publicly available. 
<img width="1802" height="446" alt="CleanShot 2026-04-13 at 11 03 10@2x" src="https://github.com/user-attachments/assets/88c0aab1-0c2c-4955-8c8d-0e788e05e6e5" />

So really the most straightforward path is to simply request the page, and then download the XML and parse it. That way we can avoid session management and keep alive tactics, the method works for this opensource scraper, and the XML has all the information we need. So that's what I do here. 

PJM just asks that automated scrapers don't hit more than 1200 requests per minute, which is easily abided by. 
<img width="744" height="112" alt="CleanShot 2026-04-13 at 11 16 56@2x" src="https://github.com/user-attachments/assets/cb41b910-1b7c-4f7e-9b5b-2df79bb5af9b" />


### Tests

```
uv run pytest gridstatus/tests/source_specific/test_pjm.py -k "emergency" -vv
```