### PR TITLE
feat(ENG-2023): Add ERCOT operations_messages dataset

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -3278,7 +3278,7 @@ class Ercot(ISOBase):
         url = self.OPERATIONS_MESSAGES_URL
         logger.info(f"Getting operations messages from {url}")
 
-        dfs = pd.read_html(url, header=0)
+        dfs = pd.read_html(url, match="Date & Time")
         df = dfs[0]
 
         df = df.rename(columns={"Date & Time": "Publish Time"})

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -3259,6 +3259,47 @@ class Ercot(ISOBase):
 
         return df
 
+    OPERATIONS_MESSAGES_URL = (
+        "https://www.ercot.com/services/comm/mkt_notices/opsmessages"
+    )
+
+    def get_operations_messages(
+        self,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Get operations messages from the ERCOT control room.
+
+        Scrapes the HTML table at
+        https://www.ercot.com/services/comm/mkt_notices/opsmessages
+
+        Returns one row per message with Publish Time, Notice, Type, and Status.
+        The page shows a rolling window of recent messages (roughly one month).
+        """
+        url = self.OPERATIONS_MESSAGES_URL
+        logger.info(f"Getting operations messages from {url}")
+
+        dfs = pd.read_html(url, header=0)
+        df = dfs[0]
+
+        df = df.rename(columns={"Date & Time": "Publish Time"})
+
+        df["Publish Time"] = pd.to_datetime(df["Publish Time"])
+
+        now = pd.Timestamp.now(tz=self.default_timezone)
+        ambiguous = (now.utcoffset().total_seconds() / 3600) == -5.0
+
+        df["Publish Time"] = df["Publish Time"].dt.tz_localize(
+            self.default_timezone,
+            ambiguous=ambiguous,
+            nonexistent="shift_forward",
+        )
+
+        return (
+            df[["Publish Time", "Notice", "Type", "Status"]]
+            .sort_values("Publish Time")
+            .reset_index(drop=True)
+        )
+
     def get_real_time_system_conditions(
         self,
         date: str = "latest",

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -1,6 +1,7 @@
 import datetime
 from io import StringIO
 from typing import Dict
+from unittest import mock
 
 import numpy as np
 import pandas as pd
@@ -252,6 +253,79 @@ class TestErcot(BaseTestISO):
         df = self.iso.get_real_time_system_conditions()
         assert df.shape == (1, 15)
         assert df.columns[0] == "Time"
+
+    """get_operations_messages"""
+
+    expected_operations_messages_cols = [
+        "Publish Time",
+        "Notice",
+        "Type",
+        "Status",
+    ]
+
+    SAMPLE_OPS_MESSAGES_DF = pd.DataFrame(
+        {
+            "Date & Time": [
+                "Apr 14, 2026 2:23:50 AM",
+                "Apr 14, 2026 12:04:02 AM",
+            ],
+            "Notice": [
+                "ERCOT has cancelled the following notice: Railroad DC Tie derated.",
+                "No sudden loss of generation greater than 450 MW occurred.",
+            ],
+            "Type": [
+                "Operational Information",
+                "Operational Information",
+            ],
+            "Status": [
+                "Cancelled",
+                "Active",
+            ],
+        },
+    )
+
+    def test_get_operations_messages(self):
+        with mock.patch(
+            "gridstatus.ercot.pd.read_html",
+            return_value=[self.SAMPLE_OPS_MESSAGES_DF.copy()],
+        ):
+            df = self.iso.get_operations_messages()
+
+        assert df.columns.tolist() == self.expected_operations_messages_cols
+        assert len(df) == 2
+        assert isinstance(df["Publish Time"].dtype, pd.DatetimeTZDtype)
+        assert str(df["Publish Time"].dt.tz) == str(self.iso.default_timezone)
+        assert df["Notice"].iloc[0] is not None
+        assert df["Type"].iloc[0] == "Operational Information"
+        assert set(df["Status"]) == {"Active", "Cancelled"}
+
+    def test_get_operations_messages_sorted_by_publish_time(self):
+        with mock.patch(
+            "gridstatus.ercot.pd.read_html",
+            return_value=[self.SAMPLE_OPS_MESSAGES_DF.copy()],
+        ):
+            df = self.iso.get_operations_messages()
+
+        assert df["Publish Time"].is_monotonic_increasing
+
+    def test_get_operations_messages_single_row(self):
+        single_row_df = pd.DataFrame(
+            {
+                "Date & Time": ["Mar 10, 2026 9:00:00 AM"],
+                "Notice": ["Advisory issued due to tool unavailability."],
+                "Type": ["Advisory"],
+                "Status": ["Active"],
+            },
+        )
+        with mock.patch(
+            "gridstatus.ercot.pd.read_html",
+            return_value=[single_row_df],
+        ):
+            df = self.iso.get_operations_messages()
+
+        assert len(df) == 1
+        assert df.columns.tolist() == self.expected_operations_messages_cols
+        assert df["Type"].iloc[0] == "Advisory"
 
     @pytest.mark.integration
     def test_get_energy_storage_resources(self):


### PR DESCRIPTION
## Summary
- Adds `get_operations_messages()` to the `Ercot` class in gridstatus
- Scrapes the HTML table at [ercot.com/services/comm/mkt_notices/opsmessages](https://www.ercot.com/services/comm/mkt_notices/opsmessages)
- Returns `Publish Time`, `Notice`, `Type`, and `Status` columns with US/Central timezone handling

### Details
The ERCOT Operations Messages page shows a rolling window (~1 month) of control room messages including operational notices, advisories, and alerts. The scraper uses `pd.read_html(match="Date & Time")` to target the correct table on the page (skipping a calendar widget), parses timestamps into timezone-aware US/Central datetimes, and returns sorted results.

Columns and primary key follow the [ENG-2023 Notion ticket](https://app.notion.com/p/245e835f42aa80438b38c1377cd35a77):
- **Primary Key**: `Publish Time` + `Notice`
- **Time Index**: `Publish Time`
- **Frequency**: Irregular

### Test plan
- [x] Unit tests with mocked `pd.read_html` (3 tests, all passing)
- [ ] Manual verification via `scripts/ercot_ops_messages_tester.py`

Made with [Cursor](https://cursor.com)