### PR TITLE
feat(ENG 2023): Add ERCOT operations messages dataset

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -3262,28 +3262,101 @@ class Ercot(ISOBase):
     OPERATIONS_MESSAGES_URL = (
         "https://www.ercot.com/services/comm/mkt_notices/opsmessages"
     )
+    WAYBACK_CDX_URL = "https://web.archive.org/cdx/search/cdx"
+    WAYBACK_SNAP_URL = "https://web.archive.org/web/{timestamp}/{url}"
 
     def get_operations_messages(
         self,
+        date: str | pd.Timestamp | None = None,
+        end: str | pd.Timestamp | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
         """Get operations messages from the ERCOT control room.
 
-        Scrapes the HTML table at
+        When called without date arguments, scrapes the live page at
         https://www.ercot.com/services/comm/mkt_notices/opsmessages
+        which shows a rolling window of recent messages (~one month).
 
-        Returns one row per message with Time, Notice, Type, and Status.
-        The page shows a rolling window of recent messages (roughly one month).
+        When called with a date (and optional end), fetches historical
+        snapshots from the Wayback Machine covering the requested range,
+        deduplicates, and filters to the requested window.
+
+        Arguments:
+            date: Start date for historical query, or None for latest.
+            end: End date for historical query. Defaults to date + 1 month.
+            verbose: Print verbose output.
+
+        Returns:
+            pandas.DataFrame with columns Time, Notice, Type, Status.
         """
-        url = self.OPERATIONS_MESSAGES_URL
+        if date is None:
+            return self._fetch_operations_messages_from_url(
+                self.OPERATIONS_MESSAGES_URL,
+                verbose=verbose,
+            )
+
+        date = utils._handle_date(date, tz=self.default_timezone)
+        if end is None:
+            end = date + pd.DateOffset(months=1)
+        else:
+            end = utils._handle_date(end, tz=self.default_timezone)
+
+        snapshots = self._get_wayback_snapshots(
+            start=date - pd.DateOffset(months=1),
+            end=end + pd.DateOffset(months=1),
+            verbose=verbose,
+        )
+
+        if not snapshots:
+            raise NoDataFoundException(
+                f"No Wayback Machine snapshots found for {date} to {end}",
+            )
+
+        frames: list[pd.DataFrame] = []
+        for ts in snapshots:
+            snap_url = self.WAYBACK_SNAP_URL.format(
+                timestamp=ts,
+                url=self.OPERATIONS_MESSAGES_URL,
+            )
+            try:
+                df = self._fetch_operations_messages_from_url(
+                    snap_url,
+                    verbose=verbose,
+                )
+                frames.append(df)
+            except Exception as e:
+                logger.warning(f"Skipping snapshot {ts}: {e}")
+
+        if not frames:
+            raise NoDataFoundException(
+                f"Could not parse any snapshots for {date} to {end}",
+            )
+
+        combined = pd.concat(frames, ignore_index=True)
+        combined = combined.drop_duplicates(
+            subset=["Time", "Notice"],
+        )
+        combined = combined[(combined["Time"] >= date) & (combined["Time"] < end)]
+
+        return (
+            combined[["Time", "Notice", "Type", "Status"]]
+            .sort_values("Time")
+            .reset_index(drop=True)
+        )
+
+    def _fetch_operations_messages_from_url(
+        self,
+        url: str,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Parse the operations messages HTML table from a URL (live or Wayback)."""
         logger.info(f"Getting operations messages from {url}")
 
         dfs = pd.read_html(url, match="Date & Time")
         df = dfs[0]
 
         df = df.rename(columns={"Date & Time": "Time"})
-
-        df["Time"] = pd.to_datetime(df["Time"])
+        df["Time"] = pd.to_datetime(df["Time"], format="%b %d, %Y %I:%M:%S %p")
 
         now = pd.Timestamp.now(tz=self.default_timezone)
         ambiguous = (now.utcoffset().total_seconds() / 3600) == -5.0
@@ -3299,6 +3372,40 @@ class Ercot(ISOBase):
             .sort_values("Time")
             .reset_index(drop=True)
         )
+
+    def _get_wayback_snapshots(
+        self,
+        start: pd.Timestamp,
+        end: pd.Timestamp,
+        verbose: bool = False,
+    ) -> list[str]:
+        """Query the Wayback Machine CDX API for snapshot timestamps."""
+        from_ts = start.strftime("%Y%m%d")
+        to_ts = end.strftime("%Y%m%d")
+
+        params = {
+            "url": self.OPERATIONS_MESSAGES_URL,
+            "output": "json",
+            "fl": "timestamp,statuscode",
+            "filter": "statuscode:200",
+            "collapse": "timestamp:8",
+            "from": from_ts,
+            "to": to_ts,
+        }
+
+        logger.info(
+            f"Querying Wayback Machine CDX for snapshots from {from_ts} to {to_ts}",
+        )
+        resp = requests.get(self.WAYBACK_CDX_URL, params=params, timeout=30)
+        resp.raise_for_status()
+
+        data = resp.json()
+        if len(data) <= 1:
+            return []
+
+        timestamps = [row[0] for row in data[1:]]
+        logger.info(f"Found {len(timestamps)} Wayback snapshots")
+        return timestamps
 
     def get_real_time_system_conditions(
         self,

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -3396,7 +3396,7 @@ class Ercot(ISOBase):
         logger.info(
             f"Querying Wayback Machine CDX for snapshots from {from_ts} to {to_ts}",
         )
-        resp = requests.get(self.WAYBACK_CDX_URL, params=params, timeout=30)
+        resp = requests.get(self.WAYBACK_CDX_URL, params=params, timeout=60)
         resp.raise_for_status()
 
         data = resp.json()

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -3278,7 +3278,7 @@ class Ercot(ISOBase):
         url = self.OPERATIONS_MESSAGES_URL
         logger.info(f"Getting operations messages from {url}")
 
-        dfs = pd.read_html(url, header=0)
+        dfs = pd.read_html(url, match="Date & Time")
         df = dfs[0]
 
         df = df.rename(columns={"Date & Time": "Publish Time"})

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -3259,6 +3259,47 @@ class Ercot(ISOBase):
 
         return df
 
+    OPERATIONS_MESSAGES_URL = (
+        "https://www.ercot.com/services/comm/mkt_notices/opsmessages"
+    )
+
+    def get_operations_messages(
+        self,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Get operations messages from the ERCOT control room.
+
+        Scrapes the HTML table at
+        https://www.ercot.com/services/comm/mkt_notices/opsmessages
+
+        Returns one row per message with Publish Time, Notice, Type, and Status.
+        The page shows a rolling window of recent messages (roughly one month).
+        """
+        url = self.OPERATIONS_MESSAGES_URL
+        logger.info(f"Getting operations messages from {url}")
+
+        dfs = pd.read_html(url, header=0)
+        df = dfs[0]
+
+        df = df.rename(columns={"Date & Time": "Publish Time"})
+
+        df["Publish Time"] = pd.to_datetime(df["Publish Time"])
+
+        now = pd.Timestamp.now(tz=self.default_timezone)
+        ambiguous = (now.utcoffset().total_seconds() / 3600) == -5.0
+
+        df["Publish Time"] = df["Publish Time"].dt.tz_localize(
+            self.default_timezone,
+            ambiguous=ambiguous,
+            nonexistent="shift_forward",
+        )
+
+        return (
+            df[["Publish Time", "Notice", "Type", "Status"]]
+            .sort_values("Publish Time")
+            .reset_index(drop=True)
+        )
+
     def get_real_time_system_conditions(
         self,
         date: str = "latest",

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -3272,7 +3272,7 @@ class Ercot(ISOBase):
         Scrapes the HTML table at
         https://www.ercot.com/services/comm/mkt_notices/opsmessages
 
-        Returns one row per message with Publish Time, Notice, Type, and Status.
+        Returns one row per message with Time, Notice, Type, and Status.
         The page shows a rolling window of recent messages (roughly one month).
         """
         url = self.OPERATIONS_MESSAGES_URL
@@ -3281,22 +3281,22 @@ class Ercot(ISOBase):
         dfs = pd.read_html(url, match="Date & Time")
         df = dfs[0]
 
-        df = df.rename(columns={"Date & Time": "Publish Time"})
+        df = df.rename(columns={"Date & Time": "Time"})
 
-        df["Publish Time"] = pd.to_datetime(df["Publish Time"])
+        df["Time"] = pd.to_datetime(df["Time"])
 
         now = pd.Timestamp.now(tz=self.default_timezone)
         ambiguous = (now.utcoffset().total_seconds() / 3600) == -5.0
 
-        df["Publish Time"] = df["Publish Time"].dt.tz_localize(
+        df["Time"] = df["Time"].dt.tz_localize(
             self.default_timezone,
             ambiguous=ambiguous,
             nonexistent="shift_forward",
         )
 
         return (
-            df[["Publish Time", "Notice", "Type", "Status"]]
-            .sort_values("Publish Time")
+            df[["Time", "Notice", "Type", "Status"]]
+            .sort_values("Time")
             .reset_index(drop=True)
         )
 

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -327,6 +327,91 @@ class TestErcot(BaseTestISO):
         assert df.columns.tolist() == self.expected_operations_messages_cols
         assert df["Type"].iloc[0] == "Advisory"
 
+    def test_get_operations_messages_historical_deduplicates(self):
+        snap1 = pd.DataFrame(
+            {
+                "Date & Time": [
+                    "Jan 10, 2026 2:00:00 PM",
+                    "Jan 9, 2026 12:00:00 AM",
+                ],
+                "Notice": ["Msg A", "Msg B"],
+                "Type": ["Operational Information", "Operational Information"],
+                "Status": ["Active", "Active"],
+            },
+        )
+        snap2 = pd.DataFrame(
+            {
+                "Date & Time": [
+                    "Jan 15, 2026 8:00:00 AM",
+                    "Jan 10, 2026 2:00:00 PM",
+                ],
+                "Notice": ["Msg C", "Msg A"],
+                "Type": ["Advisory", "Operational Information"],
+                "Status": ["Active", "Active"],
+            },
+        )
+
+        with mock.patch(
+            "gridstatus.ercot.requests.get",
+        ) as mock_requests_get:
+            mock_cdx_resp = mock.Mock()
+            mock_cdx_resp.json.return_value = [
+                ["timestamp", "statuscode"],
+                ["20260110000000", "200"],
+                ["20260115000000", "200"],
+            ]
+            mock_cdx_resp.raise_for_status = mock.Mock()
+            mock_requests_get.return_value = mock_cdx_resp
+
+            with mock.patch(
+                "gridstatus.ercot.pd.read_html",
+                side_effect=[[snap1], [snap2]],
+            ):
+                df = self.iso.get_operations_messages(
+                    date="2026-01-01",
+                    end="2026-02-01",
+                )
+
+        assert len(df) == 3
+        assert df["Notice"].tolist() == ["Msg B", "Msg A", "Msg C"]
+        assert df["Time"].is_monotonic_increasing
+
+    def test_get_operations_messages_historical_filters_to_range(self):
+        snap = pd.DataFrame(
+            {
+                "Date & Time": [
+                    "Jan 15, 2026 8:00:00 AM",
+                    "Dec 28, 2025 3:00:00 PM",
+                ],
+                "Notice": ["In range", "Out of range"],
+                "Type": ["Operational Information", "Operational Information"],
+                "Status": ["Active", "Active"],
+            },
+        )
+
+        with mock.patch(
+            "gridstatus.ercot.requests.get",
+        ) as mock_requests_get:
+            mock_cdx_resp = mock.Mock()
+            mock_cdx_resp.json.return_value = [
+                ["timestamp", "statuscode"],
+                ["20260115000000", "200"],
+            ]
+            mock_cdx_resp.raise_for_status = mock.Mock()
+            mock_requests_get.return_value = mock_cdx_resp
+
+            with mock.patch(
+                "gridstatus.ercot.pd.read_html",
+                return_value=[snap],
+            ):
+                df = self.iso.get_operations_messages(
+                    date="2026-01-01",
+                    end="2026-02-01",
+                )
+
+        assert len(df) == 1
+        assert df["Notice"].iloc[0] == "In range"
+
     @pytest.mark.integration
     def test_get_energy_storage_resources(self):
         df = self.iso.get_energy_storage_resources()

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -1,6 +1,7 @@
 import datetime
 from io import StringIO
 from typing import Dict
+from unittest import mock
 
 import numpy as np
 import pandas as pd
@@ -252,6 +253,79 @@ class TestErcot(BaseTestISO):
         df = self.iso.get_real_time_system_conditions()
         assert df.shape == (1, 15)
         assert df.columns[0] == "Time"
+
+    """get_operations_messages"""
+
+    expected_operations_messages_cols = [
+        "Publish Time",
+        "Notice",
+        "Type",
+        "Status",
+    ]
+
+    SAMPLE_OPS_MESSAGES_DF = pd.DataFrame(
+        {
+            "Date & Time": [
+                "Apr 14, 2026 2:23:50 AM",
+                "Apr 14, 2026 12:04:02 AM",
+            ],
+            "Notice": [
+                "ERCOT has cancelled the following notice: Railroad DC Tie derated.",
+                "No sudden loss of generation greater than 450 MW occurred.",
+            ],
+            "Type": [
+                "Operational Information",
+                "Operational Information",
+            ],
+            "Status": [
+                "Cancelled",
+                "Active",
+            ],
+        },
+    )
+
+    def test_get_operations_messages(self):
+        with mock.patch(
+            "gridstatus.ercot.pd.read_html",
+            return_value=[self.SAMPLE_OPS_MESSAGES_DF.copy()],
+        ):
+            df = self.iso.get_operations_messages()
+
+        assert df.columns.tolist() == self.expected_operations_messages_cols
+        assert len(df) == 2
+        assert isinstance(df["Publish Time"].dtype, pd.DatetimeTZDtype)
+        assert str(df["Publish Time"].dt.tz) == str(self.iso.default_timezone)
+        assert df["Notice"].iloc[0] is not None
+        assert df["Type"].iloc[0] == "Operational Information"
+        assert set(df["Status"]) == {"Active", "Cancelled"}
+
+    def test_get_operations_messages_sorted_by_publish_time(self):
+        with mock.patch(
+            "gridstatus.ercot.pd.read_html",
+            return_value=[self.SAMPLE_OPS_MESSAGES_DF.copy()],
+        ):
+            df = self.iso.get_operations_messages()
+
+        assert df["Publish Time"].is_monotonic_increasing
+
+    def test_get_operations_messages_single_row(self):
+        single_row_df = pd.DataFrame(
+            {
+                "Date & Time": ["Mar 10, 2026 9:00:00 AM"],
+                "Notice": ["Advisory issued due to tool unavailability."],
+                "Type": ["Advisory"],
+                "Status": ["Active"],
+            },
+        )
+        with mock.patch(
+            "gridstatus.ercot.pd.read_html",
+            return_value=[single_row_df],
+        ):
+            df = self.iso.get_operations_messages()
+
+        assert len(df) == 1
+        assert df.columns.tolist() == self.expected_operations_messages_cols
+        assert df["Type"].iloc[0] == "Advisory"
 
     @pytest.mark.integration
     def test_get_energy_storage_resources(self):

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -257,7 +257,7 @@ class TestErcot(BaseTestISO):
     """get_operations_messages"""
 
     expected_operations_messages_cols = [
-        "Publish Time",
+        "Time",
         "Notice",
         "Type",
         "Status",
@@ -293,20 +293,20 @@ class TestErcot(BaseTestISO):
 
         assert df.columns.tolist() == self.expected_operations_messages_cols
         assert len(df) == 2
-        assert isinstance(df["Publish Time"].dtype, pd.DatetimeTZDtype)
-        assert str(df["Publish Time"].dt.tz) == str(self.iso.default_timezone)
+        assert isinstance(df["Time"].dtype, pd.DatetimeTZDtype)
+        assert str(df["Time"].dt.tz) == str(self.iso.default_timezone)
         assert df["Notice"].iloc[0] is not None
         assert df["Type"].iloc[0] == "Operational Information"
         assert set(df["Status"]) == {"Active", "Cancelled"}
 
-    def test_get_operations_messages_sorted_by_publish_time(self):
+    def test_get_operations_messages_sorted_by_time(self):
         with mock.patch(
             "gridstatus.ercot.pd.read_html",
             return_value=[self.SAMPLE_OPS_MESSAGES_DF.copy()],
         ):
             df = self.iso.get_operations_messages()
 
-        assert df["Publish Time"].is_monotonic_increasing
+        assert df["Time"].is_monotonic_increasing
 
     def test_get_operations_messages_single_row(self):
         single_row_df = pd.DataFrame(

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -412,6 +412,22 @@ class TestErcot(BaseTestISO):
         assert len(df) == 1
         assert df["Notice"].iloc[0] == "In range"
 
+    def test_get_operations_messages_historical_wayback(self):
+        with api_vcr.use_cassette(
+            "test_get_operations_messages_historical_wayback.yaml",
+        ):
+            df = self.iso.get_operations_messages(
+                date="2026-01-01",
+                end="2026-01-15",
+            )
+        assert df.columns.tolist() == self.expected_operations_messages_cols
+        assert len(df) > 0
+        assert isinstance(df["Time"].dtype, pd.DatetimeTZDtype)
+        assert df["Time"].min() >= pd.Timestamp("2026-01-01", tz="US/Central")
+        assert df["Time"].max() < pd.Timestamp("2026-01-15", tz="US/Central")
+        assert df["Time"].is_monotonic_increasing
+        assert df.duplicated(subset=["Time", "Notice"]).sum() == 0
+
     @pytest.mark.integration
     def test_get_energy_storage_resources(self):
         df = self.iso.get_energy_storage_resources()


### PR DESCRIPTION
## Summary
- Adds `get_operations_messages()`

```
from gridstatus import Ercot
ercot = Ercot()

print("=== Latest (live page) ===")
df = ercot.get_operations_messages()
print(df)
print(df.dtypes)
print()

print("=== Historical (Wayback Machine, Jan 2026) ===")
df_hist = ercot.get_operations_messages(date="2026-01-01", end="2026-02-01")
print(df_hist)
print(df_hist.dtypes)
```

### Details
The ERCOT Operations Messages page shows a rolling window (~1 month) of control room messages including operational notices, advisories, and alerts. The scraper uses `pd.read_html(match="Date & Time")` to target the correct table on the page (skipping a calendar widget), parses timestamps into timezone-aware US/Central datetimes, and returns sorted results.

- Scrapes the HTML table at [ercot.com/services/comm/mkt_notices/opsmessages](https://www.ercot.com/services/comm/mkt_notices/opsmessages)
- Returns `Time`, `Notice`, `Type`, and `Status` columns with US/Central timezone handling

It also uses the Wayback machine to get historical (before the current month) messages for backfilling.

```
uv run pytest -vvv gridstatus/tests/ -k "ercot" -k "messages"
```

Made with [Cursor](https://cursor.com)