### PR TITLE
Add /code-review Claude Code slash command

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -1,0 +1,46 @@
+## Review code changes against CLAUDE.md guidelines to catch issues and ensure maintainability
+
+Follow the steps below and only output the final Report Out section.
+
+1. **Collect Inputs**
+   - Review changes in this branch only
+   - Base branch for the diff: `$ARGUMENTS` (default to `main` if empty)
+   - Use `git diff <base>...HEAD` to show all changes
+   - Note any context the user provided (goal, constraints, known tradeoffs)
+
+2. **Load Guidelines**
+   - Read the workspace `../CLAUDE.md` for monorepo-wide rules
+   - Read any repo-level `AGENTS.md` / `CONTRIBUTING.md` if touched areas need it
+   - No repo-local `CLAUDE.md` exists here — rely on conventions evident in nearby code
+
+3. **Build a Mental Model**
+   - Identify what the change is trying to accomplish
+   - Map what's touched: ISO parser (`gridstatus/<iso>.py`), base classes, HTTP helpers, tests, fixtures
+   - Flag risk zones:
+     - **VCR cassettes**: new tests must use fixed recent dates (not `today`/`latest`), cassettes must not contain 4xx/5xx responses, and must be uploaded via `make fixtures-upload iso=<iso>` — they are NOT committed to git
+     - **Python version compat**: library supports Python 3.10–3.12; no 3.13-only syntax (no `type` statement aliases, etc.)
+     - **ISO API breakage**: parsers that silently return empty DataFrames on schema changes
+     - **Timezone handling**: every ISO has its own local tz; confirm tz-aware timestamps
+     - **Network retries and rate limits**
+     - **Public API surface**: renamed/removed methods are breaking changes for library users
+
+4. **Review the Diff**
+   - Go file by file
+   - Verify correctness and intent
+   - Look for bugs, logic errors, regressions, and common AI-generated mistakes (unused abstractions, inconsistent naming, unnecessary complexity, over-broad `except Exception`)
+   - For parser changes: confirm returned DataFrame columns/dtypes match sibling ISOs
+   - For new tests: confirm `api_vcr.use_cassette(...)` is used with a fixed recent date; confirm cassette recording plan is explicit
+   - For `@pytest.mark.integration` / `@pytest.mark.slow` usage: confirm tests that hit live APIs are marked so CI can skip them
+
+5. **Validate Against CLAUDE.md + Best Practices**
+   - Run `make lint` and surface any failures
+   - For changed parser files, confirm `make test-<iso>` is runnable (don't execute unless the user asks)
+   - Flag important best-practice issues not covered by guidelines
+   - Cite the relevant guideline / convention for each issue when applicable
+
+6. **Report Out**
+   - List all issues directly. NEVER add a higher-level summary of the review
+   - Pair each issue with a clear, actionable fix
+   - Order issues with sections by priority (blocking, important, nit) with global numbering so each issue can unambiguously be referenced
+   - At the end, list out each issue one by one with a concise (no more than 20 words) description, so the user can reply with numbers. Call this section "Next Steps". The last line should say "Which issue(s) do you want to fix first?".
+   - Propose architectural changes only if they materially improve maintainability


### PR DESCRIPTION
## Summary

Adds a `/code-review` Claude Code slash command tailored to this library's conventions.

The command walks a 6-step flow (collect inputs → load guidelines → build a mental model → review the diff → validate against best practices → report out) and flags risk zones specific to this repo:

- **VCR cassettes**: fixed recent dates (not `today`/`latest`), no 4xx/5xx responses in cassettes, S3 sync via `make fixtures-upload iso=<iso>` (cassettes are not committed to git)
- **Python 3.10–3.12 compatibility**: no syntax that requires newer versions
- **Public API stability**: renamed/removed methods are breaking changes for library users
- **ISO parser consistency**: returned DataFrame columns/dtypes/timezones stay aligned across ISOs
- **Test markers**: `@pytest.mark.integration` / `@pytest.mark.slow` applied to live-API tests

Runs `make lint` as part of validation and outputs a numbered **Next Steps** list so reviewers can reply with issue numbers.

## Test plan

- [x] Open a Claude Code session on a branch with a non-trivial diff and run `/code-review`; confirm output follows the 6-step flow and ends with a numbered Next Steps list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new markdown command definition only, with no runtime code or behavior changes.
> 
> **Overview**
> Introduces a new Claude Code slash command definition at `.claude/commands/code-review.md` that prescribes a 6-step review workflow (diff collection, guideline loading, risk-zone checks, validation, and a structured report).
> 
> The instructions emphasize repo-specific review pitfalls (VCR cassette handling, Python 3.10–3.12 compatibility, parser/timezone consistency, API stability) and require output to end with a numbered "Next Steps" list for easy follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf5e7fa5688f2509f95f8e86302087dd9318863c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->