### PR TITLE
[ENG-3660]  [ENG-3661] feat(ERCOT): Add DAM Aggregated ASDC + 3-Day Highest Price SCED datasets

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -238,6 +238,10 @@ RTD_INDICATIVE_REAL_TIME_MCPC_RTID = 24889
 # https://www.ercot.com/mp/data-products/data-product-details?id=NP6-328-CD
 TOTAL_CAPABILITY_OF_RESOURCES_AS_RTID = 24887
 
+# DAM Aggregated Ancillary Service Offer Curve
+# https://www.ercot.com/mp/data-products/data-product-details?id=np4-19-cd
+DAM_AGGREGATED_AS_OFFER_CURVE_RTID = 12330
+
 
 class ERCOTSevenDayLoadForecastReport(Enum):
     """
@@ -6415,6 +6419,67 @@ class Ercot(ISOBase):
             .sort_values(
                 ["Interval Start", "Publish Time", "AS Type", "Demand Curve Point"],
             )
+            .reset_index(drop=True)
+        )
+
+    # Published once per DAM run (daily, ~12-2 PM Central) for the next day's
+    # delivery date. Covers the AS types REGDN, REGUP, RRSPF, RRSFF, RRSUF,
+    # ECRSS, and ECRSM.
+    @support_date_range(frequency=None)
+    def get_dam_asdc_aggregated(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Get DAM Aggregated Ancillary Service Offer Curve (NP4-19-CD).
+
+        The DAM Aggregated Ancillary Service Demand/Offer Curve contains the
+        aggregated offer curve (price/quantity pairs) per ancillary service
+        type for each hour of the next day's delivery, published once per DAM
+        run. ``date`` and ``end`` are interpreted as delivery dates; the DAM
+        runs the day before, so the underlying file is located by shifting the
+        posted-date filter back by one day.
+
+        https://www.ercot.com/mp/data-products/data-product-details?id=np4-19-cd
+        """
+        if date == "latest":
+            docs = self._get_documents(
+                report_type_id=DAM_AGGREGATED_AS_OFFER_CURVE_RTID,
+                extension="csv",
+                date=date,
+                verbose=verbose,
+            )
+        else:
+            if end is None:
+                end = date + pd.DateOffset(days=1)
+
+            docs = self._get_documents(
+                report_type_id=DAM_AGGREGATED_AS_OFFER_CURVE_RTID,
+                extension="csv",
+                published_after=date - pd.Timedelta(days=1),
+                published_before=end - pd.Timedelta(days=1),
+                verbose=verbose,
+            )
+
+        df = self.read_docs(docs, parse=False, verbose=verbose)
+        return self._handle_dam_asdc_aggregated(df)
+
+    def _handle_dam_asdc_aggregated(self, df: pd.DataFrame) -> pd.DataFrame:
+        df = df.rename(
+            columns={
+                "AncillaryType": "AS Type",
+                "RepeatedHourFlag": "DSTFlag",
+            },
+        )
+        df = self.parse_doc(df)
+
+        for col in ["Price", "Quantity"]:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+
+        return (
+            df[["Interval Start", "Interval End", "AS Type", "Price", "Quantity"]]
+            .sort_values(["Interval Start", "AS Type", "Price"])
             .reset_index(drop=True)
         )
 

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -242,6 +242,10 @@ TOTAL_CAPABILITY_OF_RESOURCES_AS_RTID = 24887
 # https://www.ercot.com/mp/data-products/data-product-details?id=np4-19-cd
 DAM_AGGREGATED_AS_OFFER_CURVE_RTID = 12330
 
+# 3-Day Highest Price Bids Selected or Dispatched in SCED
+# https://www.ercot.com/mp/data-products/data-product-details?id=np3-257-ex
+THREE_DAY_HIGHEST_PRICE_BIDS_SCED_RTID = 13230
+
 
 class ERCOTSevenDayLoadForecastReport(Enum):
     """
@@ -4802,6 +4806,73 @@ class Ercot(ISOBase):
                 ]
             ]
             .sort_values(["SCED Timestamp", "AS Type", "Resource Name"])
+            .reset_index(drop=True)
+        )
+
+    @support_date_range("DAY_START")
+    def get_3_day_highest_price_sced(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Get the bid price and name of the Load Resource submitting the
+        highest-priced bid selected or dispatched by SCED for the given
+        operating day.
+
+        Published daily, three days after the applicable operating day.
+
+        https://www.ercot.com/mp/data-products/data-product-details?id=np3-257-ex
+
+        Arguments:
+            date: operating day to fetch data for.
+            end: optional end operating day for date range queries.
+            verbose: print verbose output.
+
+        Returns:
+            pandas.DataFrame with columns: Interval Start, Interval End,
+            SCED Timestamp, QSE, DME, Load Resource,
+            Highest Price Dispatched by SCED, Proxy Extension.
+        """
+        report_date = date.normalize() + pd.DateOffset(days=3)
+
+        doc = self._get_document(
+            report_type_id=THREE_DAY_HIGHEST_PRICE_BIDS_SCED_RTID,
+            date=report_date,
+            verbose=verbose,
+        )
+
+        df = self.read_doc(doc, parse=False, verbose=verbose)
+        return self._handle_3_day_highest_price_sced(df)
+
+    def _handle_3_day_highest_price_sced(self, df: pd.DataFrame) -> pd.DataFrame:
+        df = df.rename(
+            columns={
+                "SCED Time Stamp": "SCED Timestamp",
+                "Repeated Hour Flag": "RepeatedHourFlag",
+            },
+        )
+        df = self._handle_sced_timestamp(df)
+
+        df["Highest Price Dispatched by SCED"] = pd.to_numeric(
+            df["Highest Price Dispatched by SCED"],
+            errors="coerce",
+        )
+
+        return (
+            df[
+                [
+                    "Interval Start",
+                    "Interval End",
+                    "SCED Timestamp",
+                    "QSE",
+                    "DME",
+                    "Load Resource",
+                    "Highest Price Dispatched by SCED",
+                    "Proxy Extension",
+                ]
+            ]
+            .sort_values(["SCED Timestamp", "QSE", "DME", "Load Resource"])
             .reset_index(drop=True)
         )
 

--- a/gridstatus/ercot_api/ercot_api.py
+++ b/gridstatus/ercot_api/ercot_api.py
@@ -160,6 +160,12 @@ INDICATIVE_LMP_BY_SETTLEMENT_POINT_ENDPOINT = "/np6-970-cd/rtd_lmp_node_zone_hub
 # https://data.ercot.com/data-product-archive/NP1-301
 COP_ADJUSTMENT_PERIOD_SNAPSHOT_ENDPOINT = "/np1-301/60_cop_adj_period_snapshot"
 
+# DAM Aggregated Ancillary Service Offer Curve
+# https://data.ercot.com/data-product-archive/NP4-19-CD
+# Not exposed as a delivery-date filterable public API endpoint; archive only.
+DAM_ASDC_AGGREGATED_EMIL_ID = "np4-19-cd"
+DAM_ASDC_AGGREGATED_ENDPOINT = f"/{DAM_ASDC_AGGREGATED_EMIL_ID}"
+
 ESR_ENDPOINT = "/rptesr-m/4_sec_esr_charging_mw"
 
 
@@ -793,6 +799,50 @@ class ErcotAPI:
     ) -> pd.DataFrame:
         data = self.ercot.parse_doc(data, verbose=verbose)
         return self.ercot._handle_mcpc_dam_df(data)
+
+    @support_date_range(frequency=None)
+    def get_dam_asdc_aggregated(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Get DAM Aggregated Ancillary Service Offer Curve (NP4-19-CD).
+
+        Contains the aggregated offer curve (price/quantity pairs) per
+        ancillary service type for each hour of the next day's delivery,
+        published once per DAM run. Covers REGDN, REGUP, RRSPF, RRSFF, RRSUF,
+        ECRSS, and ECRSM.
+
+        This dataset is only available via the ERCOT data archive (not as a
+        delivery-date filterable public API endpoint), so the archive is
+        filtered by the DAM posted date, which runs the day before delivery.
+
+        Arguments:
+            date (str): the delivery date to fetch offer curves for. Can be
+                "latest" to fetch the next day's curves.
+            end (str, optional): the end delivery date. Defaults to None.
+            verbose (bool, optional): print verbose output. Defaults to False.
+
+        Returns:
+            pandas.DataFrame: A DataFrame with columns Interval Start,
+            Interval End, AS Type, Price, and Quantity.
+        """
+        if date == "latest":
+            return self.get_dam_asdc_aggregated("today", verbose=verbose)
+
+        end = self._handle_end_date(date, end, days_to_add_if_no_end=1)
+
+        # The archive filters by posted datetime, which is the day before the
+        # delivery date (DAM runs the day before), so shift back by one day.
+        data = self.get_historical_data(
+            endpoint=DAM_ASDC_AGGREGATED_ENDPOINT,
+            start_date=date - pd.Timedelta(days=1),
+            end_date=end - pd.Timedelta(days=1),
+            verbose=verbose,
+        )
+
+        return self.ercot._handle_dam_asdc_aggregated(data)
 
     @support_date_range(frequency=None)
     def get_as_reports(self, date, end=None, verbose=False):

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -3231,6 +3231,66 @@ class TestErcot(BaseTestISO):
             end + pd.DateOffset(days=1) - pd.Timedelta(hours=1)
         ).tz_localize(self.iso.default_timezone)
 
+    """get_dam_asdc_aggregated"""
+
+    # Per NP4-19-CD documentation, the dataset advertises REGDN, REGUP, RRSPF,
+    # RRSFF, RRSUF, ECRSS, and ECRSM; in practice the published files also
+    # include the pre-ECRS NSPIN and NSPNM products.
+    allowed_dam_asdc_aggregated_as_types = {
+        "REGDN",
+        "REGUP",
+        "RRSPF",
+        "RRSFF",
+        "RRSUF",
+        "ECRSS",
+        "ECRSM",
+        "NSPIN",
+        "NSPNM",
+    }
+
+    def _check_get_dam_asdc_aggregated(self, df: pd.DataFrame):
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "AS Type",
+            "Price",
+            "Quantity",
+        ]
+        assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
+        assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
+        assert df.dtypes["AS Type"] == "object"
+        assert df.dtypes["Price"] == "float64"
+        assert df.dtypes["Quantity"] == "float64"
+        assert (
+            (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(hours=1)
+        ).all()
+        assert set(df["AS Type"].unique()).issubset(
+            self.allowed_dam_asdc_aggregated_as_types,
+        )
+
+    def test_get_dam_asdc_aggregated_latest(self):
+        with api_vcr.use_cassette("test_get_dam_asdc_aggregated_latest.yaml"):
+            df = self.iso.get_dam_asdc_aggregated("latest")
+        self._check_get_dam_asdc_aggregated(df)
+
+    def test_get_dam_asdc_aggregated_date_range(self):
+        date = pd.Timestamp.now().normalize() - pd.Timedelta(days=2)
+        end = date + pd.Timedelta(days=1)
+
+        with api_vcr.use_cassette(
+            f"test_get_dam_asdc_aggregated_date_range_{date}_{end}.yaml",
+        ):
+            df = self.iso.get_dam_asdc_aggregated(date, end)
+
+        self._check_get_dam_asdc_aggregated(df)
+
+        assert df["Interval Start"].min() == date.tz_localize(
+            self.iso.default_timezone,
+        )
+        assert df["Interval End"].max() == end.tz_localize(
+            self.iso.default_timezone,
+        )
+
     """get_as_deployment_factors_projected"""
 
     def _check_as_deployment_factors_projected(self, df: pd.DataFrame):

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -1536,6 +1536,41 @@ class TestErcot(BaseTestISO):
 
         self._check_highest_price_as_offer_selected_sced(df)
 
+    """get_3_day_highest_price_sced"""
+
+    def _check_3_day_highest_price_sced(self, df: pd.DataFrame):
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "SCED Timestamp",
+            "QSE",
+            "DME",
+            "Load Resource",
+            "Highest Price Dispatched by SCED",
+            "Proxy Extension",
+        ]
+        assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
+        assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
+        assert df.dtypes["SCED Timestamp"] == "datetime64[ns, US/Central]"
+        for col in ["QSE", "DME", "Load Resource", "Proxy Extension"]:
+            assert df.dtypes[col] == "object"
+        assert df.dtypes["Highest Price Dispatched by SCED"] == "float64"
+        assert (
+            (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(minutes=5)
+        ).all()
+        assert set(df["Proxy Extension"].unique()).issubset({"Yes", "No"})
+
+    def test_get_3_day_highest_price_sced(self):
+        date = self.local_start_of_today() - pd.DateOffset(days=4)
+
+        with api_vcr.use_cassette(
+            f"test_get_3_day_highest_price_sced_{date}.yaml",
+        ):
+            df = self.iso.get_3_day_highest_price_sced(date)
+
+        self._check_3_day_highest_price_sced(df)
+        assert df["SCED Timestamp"].dt.date.unique() == [date.date()]
+
     """test get_as_reports"""
 
     def test_get_as_reports(self):

--- a/gridstatus/tests/source_specific/test_ercot_api.py
+++ b/gridstatus/tests/source_specific/test_ercot_api.py
@@ -446,6 +446,50 @@ class TestErcotAPI(TestHelperMixin):
             end,
         )
 
+    """get_dam_asdc_aggregated"""
+
+    # Per NP4-19-CD documentation, the dataset advertises REGDN, REGUP, RRSPF,
+    # RRSFF, RRSUF, ECRSS, and ECRSM; in practice the published files also
+    # include the pre-ECRS NSPIN and NSPNM products.
+    allowed_dam_asdc_aggregated_as_types = {
+        "REGDN",
+        "REGUP",
+        "RRSPF",
+        "RRSFF",
+        "RRSUF",
+        "ECRSS",
+        "ECRSM",
+        "NSPIN",
+        "NSPNM",
+    }
+
+    def _check_get_dam_asdc_aggregated(self, df: pd.DataFrame):
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "AS Type",
+            "Price",
+            "Quantity",
+        ]
+        assert (
+            (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(hours=1)
+        ).all()
+        assert set(df["AS Type"].unique()).issubset(
+            self.allowed_dam_asdc_aggregated_as_types,
+        )
+
+    def test_get_dam_asdc_aggregated_historical(self):
+        date = self.local_today() - pd.Timedelta(days=10)
+        end = date + pd.Timedelta(days=1)
+
+        with api_vcr.use_cassette(
+            f"test_get_dam_asdc_aggregated_historical_{date}.yaml",
+        ):
+            df = self.iso.get_dam_asdc_aggregated(date, end)
+        self._check_get_dam_asdc_aggregated(df)
+        assert df["Interval Start"].min() == self.local_start_of_day(date)
+        assert df["Interval End"].max() == self.local_start_of_day(end)
+
     """get_as_reports"""
 
     def _check_as_reports(self, df, before_full_columns=False):


### PR DESCRIPTION
## Summary

Adds two ERCOT datasets:

- **NP4-19-CD — DAM Aggregated Ancillary Service Offer Curve** (ENG-3661)
  - `Ercot.get_dam_asdc_aggregated(date, end, verbose)` — MIS scraper (RTID 12330).
  - `ErcotAPI.get_dam_asdc_aggregated(date, end, verbose)` — archive-only (no public-API delivery-date endpoint exists).
  - Both paths treat ``date`` as the **delivery date** and return the same schema: `Interval Start, Interval End, AS Type, Price, Quantity`. The DAM publishes the day before delivery, so both implementations shift the posted-date filter back by one day internally.

- **NP3-257-EX — 3-Day Highest Price Bids Selected or Dispatched in SCED** (ENG-3660)
  - `Ercot.get_3_day_highest_price_sced(date, end, verbose)` — MIS scraper (RTID 13230).
  - Published ~3-4 AM Central, 3 days after the applicable operating day; the scraper converts the operating day into `report_date = date + 3 days` to locate the publish date.
  - Columns: `Interval Start, Interval End, SCED Timestamp, QSE, DME, Load Resource, Highest Price Dispatched by SCED, Proxy Extension`.
  - No `ErcotAPI` counterpart — the dataset is not exposed via api.ercot.com.

## How reviewers can test these methods

### 1) Run the new tests (cassettes replayed, no network)

All new tests use VCR cassettes. From the repo root:

```bash
# DAM Aggregated ASDC — both Ercot and ErcotAPI
uv run pytest -vv gridstatus/tests/source_specific/test_ercot.py -k "test_get_dam_asdc_aggregated"
uv run pytest -vv gridstatus/tests/source_specific/test_ercot_api.py -k "test_get_dam_asdc_aggregated"

# 3-Day Highest Price SCED — Ercot only
uv run pytest -vv gridstatus/tests/source_specific/test_ercot.py -k "test_get_3_day_highest_price_sced"

# Or run all new tests at once
uv run pytest -vv gridstatus/tests/source_specific/test_ercot.py gridstatus/tests/source_specific/test_ercot_api.py -k "test_get_dam_asdc_aggregated or test_get_3_day_highest_price_sced"
```

To re-record cassettes against the live endpoints (requires ``ERCOT_API_USERNAME`` / ``ERCOT_API_PASSWORD`` / ``ERCOT_PUBLIC_API_SUBSCRIPTION_KEY`` for the ErcotAPI test):

```bash
VCR_RECORD_MODE=all uv run pytest -vv gridstatus/tests/source_specific/test_ercot.py gridstatus/tests/source_specific/test_ercot_api.py -k "test_get_dam_asdc_aggregated or test_get_3_day_highest_price_sced"
```

### 2) Exercise the methods by hand

Drop any of these snippets into ``uv run python`` to hit the live ERCOT MIS / API. Each one-liner should finish in a few seconds.

**DAM Aggregated ASDC via the MIS scraper:**

```python
import pandas as pd
from gridstatus.ercot import Ercot

iso = Ercot()

# Delivery date ``date`` (inclusive); the scraper looks up the DAM run from the
# day before internally. Try yesterday and a few days back.
yesterday = pd.Timestamp.now(tz=iso.default_timezone).normalize() - pd.Timedelta(days=1)
df = iso.get_dam_asdc_aggregated(yesterday)
print(df["Interval Start"].min(), df["Interval End"].max(), len(df))
print(df.head())
```

**DAM Aggregated ASDC via the ErcotAPI (requires credentials):**

```python
import pandas as pd
from gridstatus.ercot_api.ercot_api import ErcotAPI

api = ErcotAPI()

# ``date`` and ``end`` are delivery dates (inclusive / exclusive).
start = pd.Timestamp.now(tz=api.default_timezone).normalize() - pd.Timedelta(days=10)
end = start + pd.Timedelta(days=1)
df = api.get_dam_asdc_aggregated(start, end)
print(df["Interval Start"].min(), df["Interval End"].max(), len(df))
print(df.head())
```

**Verify the two paths agree for the same date:**

```python
import pandas as pd
from gridstatus.ercot import Ercot
from gridstatus.ercot_api.ercot_api import ErcotAPI

target = pd.Timestamp("2026-04-01", tz="US/Central")

df_mis = Ercot().get_dam_asdc_aggregated(target)
df_api = ErcotAPI().get_dam_asdc_aggregated(target)

# Same delivery range from both
assert df_mis["Interval Start"].min() == df_api["Interval Start"].min()
assert df_mis["Interval End"].max()   == df_api["Interval End"].max()
```

**3-Day Highest Price SCED (operating day must be at least 3 days in the past):**

```python
import pandas as pd
from gridstatus.ercot import Ercot

iso = Ercot()

operating_day = pd.Timestamp.now(tz=iso.default_timezone).normalize() - pd.Timedelta(days=4)
df = iso.get_3_day_highest_price_sced(operating_day)

print(df.dtypes)
print(df.head())
# Data should be entirely on the requested operating day, on 5-minute intervals
assert (df["Interval End"] - df["Interval Start"] == pd.Timedelta(minutes=5)).all()
assert df["SCED Timestamp"].dt.date.unique().tolist() == [operating_day.date()]
```