### PR TITLE
Use HTTPS for CAISO OASIS requests

### DIFF
--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -354,7 +354,7 @@ class CAISO(ISOBase):
         config["startdatetime"] = start
         config["enddatetime"] = end
 
-        base_url = f"http://oasis.caiso.com/oasisapi/{config.pop('path')}?"
+        base_url = f"https://oasis.caiso.com/oasisapi/{config.pop('path')}?"
 
         url = base_url + "&".join(
             [f"{k}={v}" for k, v in config.items()],


### PR DESCRIPTION
## Summary
- switch CAISO OASIS requests from `http://` to `https://`
- keep the existing verified TLS request path intact

## Why
CAISO OASIS is reachable over HTTPS with valid certificate verification, so these requests should not use plaintext HTTP.