### PR TITLE
[ENG-3684] [ENG-3688] feat(ERCOT): Add DAM AS Only Awards + Offers 60 Day datasets

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -25,6 +25,8 @@ from gridstatus.base import (
 )
 from gridstatus.decorators import support_date_range
 from gridstatus.ercot_60d_utils import (
+    DAM_AS_ONLY_AWARDS_KEY,
+    DAM_AS_ONLY_OFFERS_KEY,
     DAM_ENERGY_BID_AWARDS_KEY,
     DAM_ENERGY_BIDS_KEY,
     DAM_ENERGY_ONLY_OFFER_AWARDS_KEY,
@@ -46,6 +48,8 @@ from gridstatus.ercot_60d_utils import (
     SCED_RESOURCE_AS_OFFERS_KEY,
     SCED_SMNE_KEY,
     CurveOutputFormat,
+    process_dam_as_only_awards,
+    process_dam_as_only_offers,
     process_dam_energy_bid_awards,
     process_dam_energy_bids,
     process_dam_energy_only_offer_awards,
@@ -2886,6 +2890,8 @@ class Ercot(ISOBase):
         - "dam_ptp_obligation_option_awards"
         - "dam_esr" (when available, starting 2025-12-06)
         - "dam_esr_as_offers" (when available, starting 2025-12-06)
+        - "dam_as_only_awards" (when available, starting 2025-12-06)
+        - "dam_as_only_offers" (when available, starting 2025-12-06)
 
         and values as pandas.DataFrame objects
 
@@ -2951,10 +2957,13 @@ class Ercot(ISOBase):
                 DAM_PTP_OBLIGATION_OPTION_AWARDS_KEY: "60d_DAM_PTP_Obligation_OptionAwards-",  # noqa
             }
 
-        # ESR files are optional (only available starting 2025-12-06)
+        # Optional files added to the disclosure bundle starting operating day
+        # 2025-12-06 (posted 2026-02-04).
         optional_files_prefix = {
             DAM_ESR_KEY: "60d_DAM_ESR_Data-",
             DAM_ESR_AS_OFFERS_KEY: "60d_DAM_ESR_ASOffers-",
+            DAM_AS_ONLY_AWARDS_KEY: "60d_DAM_AS_Only_Awards-",
+            DAM_AS_ONLY_OFFERS_KEY: "60d_DAM_AS_Only_Offers-",
         }
 
         files = {}
@@ -2998,6 +3007,8 @@ class Ercot(ISOBase):
                 DAM_PTP_OBLIGATION_OPTION_AWARDS_KEY: process_dam_ptp_obligation_option_awards,  # noqa
                 DAM_ESR_KEY: process_dam_esr,
                 DAM_ESR_AS_OFFERS_KEY: process_dam_esr_as_offers,
+                DAM_AS_ONLY_AWARDS_KEY: process_dam_as_only_awards,
+                DAM_AS_ONLY_OFFERS_KEY: process_dam_as_only_offers,
             }
 
             # These process functions accept output_format for curve extraction
@@ -3009,6 +3020,7 @@ class Ercot(ISOBase):
                 DAM_GEN_RESOURCE_AS_OFFERS_KEY,
                 DAM_LOAD_RESOURCE_AS_OFFERS_KEY,
                 DAM_ESR_AS_OFFERS_KEY,
+                DAM_AS_ONLY_OFFERS_KEY,
             }
 
             for file_name, process_func in file_to_function.items():

--- a/gridstatus/ercot_60d_utils.py
+++ b/gridstatus/ercot_60d_utils.py
@@ -34,6 +34,8 @@ DAM_PTP_OBLIGATION_OPTION_KEY = "dam_ptp_obligation_option"
 DAM_PTP_OBLIGATION_OPTION_AWARDS_KEY = "dam_ptp_obligation_option_awards"
 DAM_ESR_KEY = "dam_esr"
 DAM_ESR_AS_OFFERS_KEY = "dam_esr_as_offers"
+DAM_AS_ONLY_AWARDS_KEY = "dam_as_only_awards"
+DAM_AS_ONLY_OFFERS_KEY = "dam_as_only_offers"
 
 SCED_LOAD_RESOURCE_KEY = "sced_load_resource"
 SCED_GEN_RESOURCE_KEY = "sced_gen_resource"
@@ -233,6 +235,30 @@ DAM_ESR_COLUMNS = [
 
 # Same columns as gen/load resource AS offers
 DAM_ESR_AS_OFFERS_COLUMNS = DAM_RESOURCE_AS_OFFERS_COLUMNS[:]
+
+DAM_AS_ONLY_AWARDS_COLUMNS = [
+    "Interval Start",
+    "Interval End",
+    "QSE",
+    "AS Type",
+    "Offer ID",
+    "Quantity1 Award",
+    "Quantity2 Award",
+    "Quantity3 Award",
+    "Quantity4 Award",
+    "Quantity5 Award",
+    "Total Award",
+    "MCPC",
+]
+
+DAM_AS_ONLY_OFFERS_COLUMNS = [
+    "Interval Start",
+    "Interval End",
+    "QSE",
+    "AS Type",
+    "Offer ID",
+    "Offer Curve",
+]
 
 SCED_GEN_RESOURCE_COLUMNS = [
     "SCED Timestamp",
@@ -1079,6 +1105,55 @@ def process_dam_ptp_obligation_option_awards(df):
 
     df = df[DAM_PTP_OBLIGATION_OPTION_AWARDS_COLUMNS].sort_values(
         ["Interval Start", "QSE"],
+    )
+    df = _categorize_strings(df)
+    return df
+
+
+def process_dam_as_only_awards(df):
+    df = df.rename(
+        columns={
+            "QSE Name": "QSE",
+            "Quantity1_Award": "Quantity1 Award",
+            "Quantity2_Award": "Quantity2 Award",
+            "Quantity3_Award": "Quantity3 Award",
+            "Quantity4_Award": "Quantity4 Award",
+            "Quantity5_Award": "Quantity5 Award",
+            "Total_Award": "Total Award",
+        },
+    )
+
+    for col in DAM_AS_ONLY_AWARDS_COLUMNS:
+        if col not in df.columns:
+            df[col] = np.nan
+
+    df = df[DAM_AS_ONLY_AWARDS_COLUMNS].sort_values(
+        ["Interval Start", "QSE", "AS Type", "Offer ID"],
+    )
+    df = _categorize_strings(df)
+    return df
+
+
+def process_dam_as_only_offers(
+    df,
+    output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
+):
+    df = df.rename(columns={"QSE Name": "QSE"})
+
+    df["Offer Curve"] = extract_curve(
+        df,
+        "AS Only Offer",
+        mw_suffix=" MW",
+        price_suffix=" Price",
+        output_format=output_format,
+    )
+
+    for col in DAM_AS_ONLY_OFFERS_COLUMNS:
+        if col not in df.columns:
+            df[col] = np.nan
+
+    df = df[DAM_AS_ONLY_OFFERS_COLUMNS].sort_values(
+        ["Interval Start", "QSE", "AS Type", "Offer ID"],
     )
     df = _categorize_strings(df)
     return df

--- a/gridstatus/ercot_api/ercot_api.py
+++ b/gridstatus/ercot_api/ercot_api.py
@@ -1500,6 +1500,8 @@ class ErcotAPI:
                 - "dam_ptp_obligation_option_awards"
                 - "dam_esr" (when available, starting 2025-12-06)
                 - "dam_esr_as_offers" (when available, starting 2025-12-06)
+                - "dam_as_only_awards" (when available, starting 2025-12-06)
+                - "dam_as_only_offers" (when available, starting 2025-12-06)
 
         NOTE: because data is delayed by 60 days, requesting data in the past 60 days
         will return no data.

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -15,6 +15,10 @@ from gridstatus.ercot import (
     parse_timestamp_from_friendly_name,
 )
 from gridstatus.ercot_60d_utils import (
+    DAM_AS_ONLY_AWARDS_COLUMNS,
+    DAM_AS_ONLY_AWARDS_KEY,
+    DAM_AS_ONLY_OFFERS_COLUMNS,
+    DAM_AS_ONLY_OFFERS_KEY,
     DAM_ENERGY_BID_AWARDS_COLUMNS,
     DAM_ENERGY_BID_AWARDS_KEY,
     DAM_ENERGY_BIDS_COLUMNS,
@@ -1214,6 +1218,14 @@ class TestErcot(BaseTestISO):
                 "Resource Name",
             ],
         ).any()
+
+        # AS Only Awards/Offers (ENG-3684/ENG-3688) landed in the bundle on the
+        # same 2025-12-06 operating day as ESR, so we check them here too.
+        assert DAM_AS_ONLY_AWARDS_KEY in df_dict
+        assert DAM_AS_ONLY_OFFERS_KEY in df_dict
+
+        _check_dam_as_only_awards(df_dict[DAM_AS_ONLY_AWARDS_KEY])
+        _check_dam_as_only_offers(df_dict[DAM_AS_ONLY_OFFERS_KEY])
 
         # Also check the other datasets are still present
         check_60_day_dam_disclosure(df_dict)
@@ -4484,6 +4496,63 @@ def check_60_day_dam_disclosure(df_dict):
     assert not dam_load_resource_as_offers.duplicated(
         subset=["Interval Start", "Interval End", "QSE", "DME", "Resource Name"],
     ).any()
+
+
+_AS_ONLY_PK = ["Interval Start", "QSE", "AS Type", "Offer ID"]
+
+
+def _check_dam_as_only_awards(df):
+    assert df.columns.tolist() == DAM_AS_ONLY_AWARDS_COLUMNS
+    assert len(df) > 0
+
+    # Hour Ending - 1 hour => exactly 1-hour intervals
+    assert ((df["Interval End"] - df["Interval Start"]) == pd.Timedelta(hours=1)).all()
+
+    # Primary-key components non-null and unique
+    for pk_col in _AS_ONLY_PK:
+        assert df[pk_col].notna().all(), f"{pk_col} has nulls"
+    assert not df.duplicated(subset=_AS_ONLY_PK).any()
+
+    # All quantity/price columns parse as numeric
+    for col in [
+        "Quantity1 Award",
+        "Quantity2 Award",
+        "Quantity3 Award",
+        "Quantity4 Award",
+        "Quantity5 Award",
+        "Total Award",
+        "MCPC",
+    ]:
+        assert pd.api.types.is_numeric_dtype(df[col]), f"{col} is not numeric"
+
+    # Total Award should equal the sum of Quantity1..5 Award per row
+    quantity_cols = [f"Quantity{i} Award" for i in range(1, 6)]
+    assert np.allclose(
+        df[quantity_cols].sum(axis=1).astype(float),
+        df["Total Award"].astype(float),
+    )
+
+
+def _check_dam_as_only_offers(df):
+    assert df.columns.tolist() == DAM_AS_ONLY_OFFERS_COLUMNS
+    assert len(df) > 0
+
+    assert ((df["Interval End"] - df["Interval Start"]) == pd.Timedelta(hours=1)).all()
+
+    for pk_col in _AS_ONLY_PK:
+        assert df[pk_col].notna().all(), f"{pk_col} has nulls"
+    assert not df.duplicated(subset=_AS_ONLY_PK).any()
+
+    # Every non-null Offer Curve must be a non-empty list of [mw, price] pairs
+    non_null = df["Offer Curve"].dropna()
+    assert len(non_null) > 0
+    for curve in non_null:
+        assert isinstance(curve, list) and len(curve) > 0
+        for point in curve:
+            assert len(point) == 2
+            mw, price = point
+            assert isinstance(mw, (int, float))
+            assert isinstance(price, (int, float))
 
 
 def _list_to_pg_string(lst):

--- a/gridstatus/tests/source_specific/test_ercot_api.py
+++ b/gridstatus/tests/source_specific/test_ercot_api.py
@@ -6,6 +6,8 @@ import pytest
 from gridstatus.base import Markets, NoDataFoundException
 from gridstatus.ercot import ELECTRICAL_BUS_LOCATION_TYPE
 from gridstatus.ercot_60d_utils import (
+    DAM_AS_ONLY_AWARDS_KEY,
+    DAM_AS_ONLY_OFFERS_KEY,
     DAM_ESR_AS_OFFERS_COLUMNS,
     DAM_ESR_AS_OFFERS_KEY,
     DAM_ESR_COLUMNS,
@@ -25,7 +27,11 @@ from gridstatus.ercot_constants import (
 )
 from gridstatus.tests.base_test_iso import TestHelperMixin
 from gridstatus.tests.source_specific.test_ercot import (
-    TestErcot,
+    TestErcot as _ErcotChecks,
+)
+from gridstatus.tests.source_specific.test_ercot import (
+    _check_dam_as_only_awards,
+    _check_dam_as_only_offers,
     check_60_day_dam_disclosure,
     check_60_day_sced_disclosure,
     check_load_forecast_by_model,
@@ -625,7 +631,7 @@ class TestErcotAPI(TestHelperMixin):
         with api_vcr.use_cassette(f"test_get_as_reports_dam_{date}.yaml"):
             df = self.iso.get_as_reports_dam(date, verbose=True)
 
-        TestErcot()._check_as_reports_dam(df)
+        _ErcotChecks()._check_as_reports_dam(df)
 
         assert df["Interval Start"].dt.date.unique() == date.date()
 
@@ -639,7 +645,7 @@ class TestErcotAPI(TestHelperMixin):
         with api_vcr.use_cassette(f"test_get_as_reports_sced_{date}.yaml"):
             df = self.iso.get_as_reports_sced(date, verbose=True)
 
-        TestErcot()._check_as_reports_sced(df)
+        _ErcotChecks()._check_as_reports_sced(df)
 
         assert df["SCED Timestamp"].dt.date.unique() == date.date()
 
@@ -1444,6 +1450,14 @@ class TestErcotAPI(TestHelperMixin):
         dam_esr_as_offers = df_dict[DAM_ESR_AS_OFFERS_KEY]
         assert dam_esr_as_offers.columns.tolist() == DAM_ESR_AS_OFFERS_COLUMNS
         assert len(dam_esr_as_offers) > 0
+
+        # AS Only Awards/Offers (ENG-3684/ENG-3688) landed in the bundle on the
+        # same 2025-12-06 operating day as ESR, so we check them here too.
+        assert DAM_AS_ONLY_AWARDS_KEY in df_dict
+        assert DAM_AS_ONLY_OFFERS_KEY in df_dict
+
+        _check_dam_as_only_awards(df_dict[DAM_AS_ONLY_AWARDS_KEY])
+        _check_dam_as_only_offers(df_dict[DAM_AS_ONLY_OFFERS_KEY])
 
         # Also check the other datasets are still present
         check_60_day_dam_disclosure(df_dict)


### PR DESCRIPTION
## Summary

Adds two new datasets to the 60-day DAM disclosure dict returned by both `Ercot` and `ErcotAPI`:

- `dam_as_only_awards` (ENG-3684) — per-block awarded quantities, Total Award, MCPC
- `dam_as_only_offers` (ENG-3688) — 5 MW/Price offer pairs collapsed into an `Offer Curve` list-of-[mw,price]

Both source files (`60d_DAM_AS_Only_Awards-*.csv`, `60d_DAM_AS_Only_Offers-*.csv`) were added to the NP3-966-ER bundle on **operating day 2025-12-06** (same release as ESR), so they are registered as optional files and silently skipped for older dates.

AS-Only validation is folded into the existing `test_get_60_day_dam_disclosure_esr` tests (which already run at a post-cutover date). No net new tests — the two new shared helpers (`_check_dam_as_only_awards`, `_check_dam_as_only_offers`) are colocated with `check_60_day_dam_disclosure` and cross-validate `Total Award == sum(Quantity1..5 Award)` plus per-row offer-curve shape.

Also aliases the `TestErcot` import in `test_ercot_api.py` as `_ErcotChecks` to stop pytest from re-collecting it there (pre-existing collection duplication, 185 duplicate items removed).

## Test plan

- [ ] `VCR_RECORD_MODE=all uv run pytest -vv -n 0 gridstatus/tests/source_specific/test_ercot.py::TestErcot::test_get_60_day_dam_disclosure_esr` passes against current ERCOT MIS (post-2025-12-06 date, validates AS-Only presence + structure)
- [ ] `VCR_RECORD_MODE=all uv run pytest -vv -n 0 gridstatus/tests/source_specific/test_ercot_api.py::TestErcotAPI::test_get_60_day_dam_disclosure_esr` passes against ErcotAPI (same assertions via shared helpers)
- [ ] `VCR_RECORD_MODE=all uv run pytest -vv -n 0 gridstatus/tests/source_specific/test_ercot_api.py::TestErcotAPI::test_get_60_day_dam_disclosure_repeated_offers` passes on 2024-09-04 (pre-cutover date, confirms optional files don't break older zips)
- [ ] `uv run pytest --collect-only -q gridstatus/tests/source_specific/test_ercot_api.py` shows 71 items collected (was 256 pre-fix; confirms the `TestErcot` re-collection is gone)
- [ ] `make lint` is clean
- [ ] Spot-check: `Ercot().get_60_day_dam_disclosure(date=pd.Timestamp(\"2026-01-15\"), process=True)[\"dam_as_only_offers\"][\"Offer Curve\"].dropna().iloc[0]` returns a list of `[mw, price]` pairs

🤖 Generated with [Claude Code](https://claude.com/claude-code)