### PR TITLE
Tighten /code-guard output and require PR-context weighing

### DIFF
--- a/.claude/commands/code-guard.md
+++ b/.claude/commands/code-guard.md
@@ -25,6 +25,7 @@ Follow the steps below and only output the final Report Out section.
      - **Public API surface**: renamed/removed methods are breaking changes for library users
 
 4. **Review the Diff**
+   - Before flagging a concern, weigh it against the PR's stated context — description, commit messages, inline comments. If the author's reasoning already addresses the concern, drop it.
    - Go file by file
    - Verify correctness and intent
    - Look for bugs, logic errors, regressions, and common AI-generated mistakes (unused abstractions, inconsistent naming, unnecessary complexity, over-broad `except Exception`)
@@ -39,8 +40,8 @@ Follow the steps below and only output the final Report Out section.
    - Cite the relevant guideline / convention for each issue when applicable
 
 6. **Report Out**
-   - List all issues directly. NEVER add a higher-level summary of the review
-   - Pair each issue with a clear, actionable fix
-   - Order issues with sections by priority (blocking, important, nit) with global numbering so each issue can unambiguously be referenced
+   - Only include actual issues — omit anything the PR's description, commit messages, or inline comments already justify. No higher-level summary, no recap of what the PR does, no positive acknowledgments.
+   - Keep each issue to one or two sentences: the problem, then the fix.
+   - Order issues with sections by priority (blocking, important, nit) with global numbering so each issue can unambiguously be referenced. Omit any priority tier with no issues.
    - At the end, list out each issue one by one with a concise (no more than 20 words) description, so the user can reply with numbers. Call this section "Next Steps". The last line should say "Which issue(s) do you want to fix first?".
    - Propose architectural changes only if they materially improve maintainability


### PR DESCRIPTION
## Summary

Addresses reviewer feedback given on sibling PRs (gs-etl #1180, gs-infra #14, gridstatusio #105):

> "I find it overly verbose and lacking context that explains why some of the decisions made in the PR are not an issue. I would prefer a more succinct message that highlights actual issues."

Two surgical edits to `.claude/commands/code-guard.md`:

- Step 4 now requires the reviewer-agent to weigh each potential issue against the PR's stated context (description, commits, inline comments) and skip anything the author's reasoning already addresses.
- Step 6 is tightened: no summary, no positive acknowledgments, 1-2 sentences per issue, empty priority tiers omitted.

Repo-specific risk zones (VCR cassettes, Python 3.10-3.12 compat, ISO API breakage, timezone handling, retries/rate limits, public API surface) are preserved unchanged.

## Test plan

- [x] Diff review — only the two targeted sections change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes to the `code-guard` reviewer-agent instructions with no runtime code impact.
> 
> **Overview**
> Updates `.claude/commands/code-guard.md` to require weighing potential review concerns against PR-provided context (description/commits/inline comments) before reporting them.
> 
> Tightens the “Report Out” instructions to **only list actual issues**, avoid summaries/positive acknowledgments, keep each issue to 1–2 sentences, and omit empty priority tiers while preserving the existing “Next Steps” numbering format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a3bc925bb47b8a2aa93768932d975f9872be6d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->