### PR TITLE
[ENG-3753] feat(ERCOT): Add 3-Day Highest Price Offered in SCED dataset

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -250,6 +250,10 @@ DAM_AGGREGATED_AS_OFFER_CURVE_RTID = 12330
 # https://www.ercot.com/mp/data-products/data-product-details?id=np3-257-ex
 THREE_DAY_HIGHEST_PRICE_BIDS_SCED_RTID = 13230
 
+# 3-Day Highest Price Offered in SCED
+# https://www.ercot.com/mp/data-products/data-product-details?id=np3-916-ex
+THREE_DAY_HIGHEST_PRICE_OFFERED_SCED_RTID = 13029
+
 
 class ERCOTSevenDayLoadForecastReport(Enum):
     """
@@ -4822,7 +4826,7 @@ class Ercot(ISOBase):
         )
 
     @support_date_range("DAY_START")
-    def get_3_day_highest_price_sced(
+    def get_3_day_highest_price_bids_selected_sced(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
@@ -4855,9 +4859,12 @@ class Ercot(ISOBase):
         )
 
         df = self.read_doc(doc, parse=False, verbose=verbose)
-        return self._handle_3_day_highest_price_sced(df)
+        return self._handle_3_day_highest_price_bids_selected_sced(df)
 
-    def _handle_3_day_highest_price_sced(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _handle_3_day_highest_price_bids_selected_sced(
+        self,
+        df: pd.DataFrame,
+    ) -> pd.DataFrame:
         df = df.rename(
             columns={
                 "SCED Time Stamp": "SCED Timestamp",
@@ -4885,6 +4892,73 @@ class Ercot(ISOBase):
                 ]
             ]
             .sort_values(["SCED Timestamp", "QSE", "DME", "Load Resource"])
+            .reset_index(drop=True)
+        )
+
+    @support_date_range("DAY_START")
+    def get_3_day_highest_price_offered_sced(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Get the offer price and name of the Generation Resource submitting
+        the highest-priced offer selected by SCED for the given operating day.
+
+        Published daily, three days after the applicable operating day.
+
+        https://www.ercot.com/mp/data-products/data-product-details?id=np3-916-ex
+
+        Arguments:
+            date: operating day to fetch data for.
+            end: optional end operating day for date range queries.
+            verbose: print verbose output.
+
+        Returns:
+            pandas.DataFrame with columns: Interval Start, Interval End,
+            SCED Timestamp, QSE, DME, Generation Resource, LMP,
+            Proxy Extension, Power Balance Penalty Flag.
+        """
+        report_date = date.normalize() + pd.DateOffset(days=3)
+
+        doc = self._get_document(
+            report_type_id=THREE_DAY_HIGHEST_PRICE_OFFERED_SCED_RTID,
+            date=report_date,
+            verbose=verbose,
+        )
+
+        df = self.read_doc(doc, parse=False, verbose=verbose)
+        return self._handle_3_day_highest_price_offered_sced(df)
+
+    def _handle_3_day_highest_price_offered_sced(
+        self,
+        df: pd.DataFrame,
+    ) -> pd.DataFrame:
+        df = df.rename(
+            columns={
+                "SCED Time Stamp": "SCED Timestamp",
+                "Repeated Hour Flag": "RepeatedHourFlag",
+            },
+        )
+        df = self._handle_sced_timestamp(df)
+
+        df["LMP"] = pd.to_numeric(df["LMP"], errors="coerce")
+
+        return (
+            df[
+                [
+                    "Interval Start",
+                    "Interval End",
+                    "SCED Timestamp",
+                    "QSE",
+                    "DME",
+                    "Generation Resource",
+                    "LMP",
+                    "Proxy Extension",
+                    "Power Balance Penalty Flag",
+                ]
+            ]
+            .sort_values(["SCED Timestamp", "QSE", "DME", "Generation Resource"])
             .reset_index(drop=True)
         )
 

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -1548,9 +1548,9 @@ class TestErcot(BaseTestISO):
 
         self._check_highest_price_as_offer_selected_sced(df)
 
-    """get_3_day_highest_price_sced"""
+    """get_3_day_highest_price_bids_selected_sced"""
 
-    def _check_3_day_highest_price_sced(self, df: pd.DataFrame):
+    def _check_3_day_highest_price_bids_selected_sced(self, df: pd.DataFrame):
         assert df.columns.tolist() == [
             "Interval Start",
             "Interval End",
@@ -1572,15 +1572,58 @@ class TestErcot(BaseTestISO):
         ).all()
         assert set(df["Proxy Extension"].unique()).issubset({"Yes", "No"})
 
-    def test_get_3_day_highest_price_sced(self):
+    def test_get_3_day_highest_price_bids_selected_sced(self):
         date = self.local_start_of_today() - pd.DateOffset(days=4)
 
         with api_vcr.use_cassette(
-            f"test_get_3_day_highest_price_sced_{date}.yaml",
+            f"test_get_3_day_highest_price_bids_selected_sced_{date}.yaml",
         ):
-            df = self.iso.get_3_day_highest_price_sced(date)
+            df = self.iso.get_3_day_highest_price_bids_selected_sced(date)
 
-        self._check_3_day_highest_price_sced(df)
+        self._check_3_day_highest_price_bids_selected_sced(df)
+        assert df["SCED Timestamp"].dt.date.unique() == [date.date()]
+
+    """get_3_day_highest_price_offered_sced"""
+
+    def _check_3_day_highest_price_offered_sced(self, df: pd.DataFrame):
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "SCED Timestamp",
+            "QSE",
+            "DME",
+            "Generation Resource",
+            "LMP",
+            "Proxy Extension",
+            "Power Balance Penalty Flag",
+        ]
+        assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
+        assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
+        assert df.dtypes["SCED Timestamp"] == "datetime64[ns, US/Central]"
+        for col in [
+            "QSE",
+            "DME",
+            "Generation Resource",
+            "Proxy Extension",
+            "Power Balance Penalty Flag",
+        ]:
+            assert df.dtypes[col] == "object"
+        assert df.dtypes["LMP"] == "float64"
+        assert (
+            (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(minutes=5)
+        ).all()
+        assert set(df["Proxy Extension"].unique()).issubset({"Yes", "No"})
+        assert set(df["Power Balance Penalty Flag"].unique()).issubset({"Yes", "No"})
+
+    def test_get_3_day_highest_price_offered_sced(self):
+        date = self.local_start_of_today() - pd.DateOffset(days=4)
+
+        with api_vcr.use_cassette(
+            f"test_get_3_day_highest_price_offered_sced_{date}.yaml",
+        ):
+            df = self.iso.get_3_day_highest_price_offered_sced(date)
+
+        self._check_3_day_highest_price_offered_sced(df)
         assert df["SCED Timestamp"].dt.date.unique() == [date.date()]
 
     """test get_as_reports"""


### PR DESCRIPTION
## Summary
- Adds `Ercot.get_3_day_highest_price_offered_sced` for NP3-916-EX (RTID 13029). Published ~3-4 AM Central three days after the applicable operating day, so the scraper shifts the user's operating day forward by three days to locate the publish date.
- Renames the sibling method `get_3_day_highest_price_sced` → `get_3_day_highest_price_bids_selected_sced` to distinguish load-side bids from the new supply-side offers dataset.

Notion: https://www.notion.so/gridstatus/ERCOT-3-Day-Highest-Price-Offered-in-SCED-34ae835f42aa80bfba17c6ca9544afae

## Test plan
- [x] `VCR_RECORD_MODE=all uv run pytest gridstatus/tests/source_specific/test_ercot.py::TestErcot::test_get_3_day_highest_price_offered_sced`
- [x] `VCR_RECORD_MODE=all uv run pytest gridstatus/tests/source_specific/test_ercot.py::TestErcot::test_get_3_day_highest_price_bids_selected_sced` (renamed)