### PR TITLE
feat(ENG 3787): Add CAISO EDAM Wind and Solar Forecast scraper

### DIFF
--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -1331,6 +1331,69 @@ class CAISO(ISOBase):
             publish_time_offset=pd.Timedelta(minutes=22.5),
         )
 
+    def get_edam_wind_solar_forecast(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        params: dict | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Day-ahead, hourly, BAA-level wind and solar forecasts for balancing
+        areas participating in the extended day-ahead market (EDAM).
+
+        Data at: http://oasis.caiso.com/mrioasis/logon.do at System Demand >
+        Wind and Solar Forecast (EDAM).
+
+        Args:
+            date (str | pd.Timestamp): date to return data
+            end (str | pd.Timestamp | None, optional): last date of range to return data.
+            params (dict | None, optional): overrides for OASIS query parameters
+                (e.g. ``{"baa_grp_id": None}`` omits ``baa_grp_id`` from the URL).
+            verbose (bool, optional): print out url being fetched. Defaults to False.
+
+        Returns:
+            pandas.DataFrame: hourly EDAM wind and solar forecasts by BAA
+        """
+        data = self.get_oasis_dataset(
+            dataset="edam_wind_solar_forecast",
+            date=date,
+            end=end,
+            params=params,
+            verbose=verbose,
+            raw_data=False,
+        )
+
+        df = data.rename(
+            columns={
+                "BAA_GRP_ID": "BAA",
+                "SOLAR": "Solar",
+                "WIND": "Wind",
+            },
+        )
+
+        df["Solar"] = pd.to_numeric(df["Solar"], errors="coerce")
+        df["Wind"] = pd.to_numeric(df["Wind"], errors="coerce")
+
+        df["Publish Date"] = (
+            df["Interval Start"].dt.tz_convert(self.default_timezone).dt.normalize()
+            - pd.Timedelta(days=1)
+        ).dt.tz_convert("UTC")
+
+        return (
+            df[
+                [
+                    "Interval Start",
+                    "Interval End",
+                    "Publish Date",
+                    "BAA",
+                    "Solar",
+                    "Wind",
+                ]
+            ]
+            .sort_values(["Interval Start", "BAA"])
+            .reset_index(drop=True)
+        )
+
     def get_pnodes(self, verbose: bool = False) -> pd.DataFrame:
         start = utils._handle_date("today")
 

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -1381,7 +1381,7 @@ class CAISO(ISOBase):
             publish_time_offset_from_day_start=pd.Timedelta(
                 hours=11,
                 minutes=5,
-            ),  # NOTE: only one day of data to go off.  We can adjust
+            ),
         )
 
         return (

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -1341,8 +1341,8 @@ class CAISO(ISOBase):
         """Day-ahead, hourly, BAA-level wind and solar forecasts for balancing
         areas participating in the extended day-ahead market (EDAM).
 
-        Data at: http://oasis.caiso.com/mrioasis/logon.do at System Demand >
-        Wind and Solar Forecast (EDAM).
+        Data at: http://oasis.caiso.com/mrioasis/logon.do at Energy >
+        EDAM > Wind and Solar Forecast.
 
         Args:
             date (str | pd.Timestamp): date to return data

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -1393,16 +1393,11 @@ class CAISO(ISOBase):
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
-        sleep: int = 5,
-        max_retries: int = 3,
         verbose: bool = False,
     ) -> list[dict]:
         """Fetch the OASIS XML version of the EDAM Wind and Solar Forecast
         and return a list of row dicts that include the publish timestamp
         from each daily file's ``MessageHeader.TimeDate``.
-
-        Mirrors the retry-on-429 pattern of ``_get_oasis``; OASIS rate-limits
-        back-to-back requests so back-to-back daily chunks must back off.
         """
         start = utils._handle_date(date, self.default_timezone)
         if end is not None:
@@ -1416,18 +1411,10 @@ class CAISO(ISOBase):
         )
         logger.info(f"Fetching URL: {url}")
 
-        # NOTE: Rate limit gets hit quickly if pulling multiple days
-        retry_num = 0
-        while retry_num < max_retries:
-            r = requests.get(url, verify=True)
-            if r.status_code == 200:
-                break
-            retry_num += 1
-            logger.info(
-                f"Failed to get data from CAISO. Error: {r.status_code}. Retrying...{retry_num} / {max_retries}",
-            )
-            time.sleep(sleep)
-            sleep *= retry_num
+        # NOTE: OASIS rate-limits ~1 request per 5s; pace daily chunks to stay under it.
+        # Matches the _get_oasis retry-on-429 pattern
+        time.sleep(5)
+        r = requests.get(url, verify=True)
         r.raise_for_status()
 
         rows: list[dict] = []

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -1378,7 +1378,10 @@ class CAISO(ISOBase):
         df = self._add_forecast_publish_time(
             df,
             current_time=current_time,
-            publish_time_offset_from_day_start=pd.Timedelta(hours=7),
+            publish_time_offset_from_day_start=pd.Timedelta(
+                hours=11,
+                minutes=5,
+            ),  # NOTE: only one day of data to go off.  We can adjust
         )
 
         return (

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -1354,6 +1354,8 @@ class CAISO(ISOBase):
         Returns:
             pandas.DataFrame: hourly EDAM wind and solar forecasts by BAA
         """
+        current_time = pd.Timestamp.now(tz=self.default_timezone)
+
         data = self.get_oasis_dataset(
             dataset="edam_wind_solar_forecast",
             date=date,
@@ -1362,7 +1364,6 @@ class CAISO(ISOBase):
             verbose=verbose,
             raw_data=False,
         )
-
         df = data.rename(
             columns={
                 "BAA_GRP_ID": "BAA",
@@ -1374,17 +1375,18 @@ class CAISO(ISOBase):
         df["Solar"] = pd.to_numeric(df["Solar"], errors="coerce")
         df["Wind"] = pd.to_numeric(df["Wind"], errors="coerce")
 
-        df["Publish Date"] = (
-            df["Interval Start"].dt.tz_convert(self.default_timezone).dt.normalize()
-            - pd.Timedelta(days=1)
-        ).dt.tz_convert("UTC")
+        df = self._add_forecast_publish_time(
+            df,
+            current_time=current_time,
+            publish_time_offset_from_day_start=pd.Timedelta(hours=7),
+        )
 
         return (
             df[
                 [
                     "Interval Start",
                     "Interval End",
-                    "Publish Date",
+                    "Publish Time",
                     "BAA",
                     "Solar",
                     "Wind",

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -3,6 +3,7 @@ import io
 import re
 import time
 import warnings
+import xml.etree.ElementTree as ElementTree
 from typing import Literal
 from zipfile import ZipFile
 
@@ -1331,11 +1332,11 @@ class CAISO(ISOBase):
             publish_time_offset=pd.Timedelta(minutes=22.5),
         )
 
+    @support_date_range(frequency="DAY_START")
     def get_edam_wind_solar_forecast(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
-        params: dict | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
         """Day-ahead, hourly, BAA-level wind and solar forecasts for balancing
@@ -1344,44 +1345,33 @@ class CAISO(ISOBase):
         Data at: http://oasis.caiso.com/mrioasis/logon.do at Energy >
         EDAM > Wind and Solar Forecast.
 
+        Per the OASIS Publications Schedule, the report is published every
+        30 minutes between 6:00 and 10:00 AM Pacific. The Publish Time on
+        each row is the actual publish timestamp pulled from the
+        ``MessageHeader.TimeDate`` of the corresponding XML report, not a
+        derived offset.
+
         Args:
             date (str | pd.Timestamp): date to return data
             end (str | pd.Timestamp | None, optional): last date of range to return data.
-            params (dict | None, optional): overrides for OASIS query parameters
-                (e.g. ``{"baa_grp_id": None}`` omits ``baa_grp_id`` from the URL).
             verbose (bool, optional): print out url being fetched. Defaults to False.
 
         Returns:
             pandas.DataFrame: hourly EDAM wind and solar forecasts by BAA
         """
-        current_time = pd.Timestamp.now(tz=self.default_timezone)
-
-        data = self.get_oasis_dataset(
-            dataset="edam_wind_solar_forecast",
+        rows = self._fetch_edam_wind_solar_forecast_xml(
             date=date,
             end=end,
-            params=params,
             verbose=verbose,
-            raw_data=False,
         )
-        df = data.rename(
-            columns={
-                "BAA_GRP_ID": "BAA",
-                "SOLAR": "Solar",
-                "WIND": "Wind",
-            },
+        df = pd.DataFrame(rows)
+        df["Solar"] = pd.to_numeric(df["Solar"])
+        df["Wind"] = pd.to_numeric(df["Wind"])
+        df["Interval Start"] = df["Interval Start"].dt.tz_convert(
+            self.default_timezone,
         )
-
-        df["Solar"] = pd.to_numeric(df["Solar"], errors="coerce")
-        df["Wind"] = pd.to_numeric(df["Wind"], errors="coerce")
-
-        df = self._add_forecast_publish_time(
-            df,
-            current_time=current_time,
-            publish_time_offset_from_day_start=pd.Timedelta(
-                hours=11,
-                minutes=5,
-            ),
+        df["Interval End"] = df["Interval End"].dt.tz_convert(
+            self.default_timezone,
         )
 
         return (
@@ -1398,6 +1388,78 @@ class CAISO(ISOBase):
             .sort_values(["Interval Start", "BAA"])
             .reset_index(drop=True)
         )
+
+    def _fetch_edam_wind_solar_forecast_xml(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        sleep: int = 5,
+        max_retries: int = 3,
+        verbose: bool = False,
+    ) -> list[dict]:
+        """Fetch the OASIS XML version of the EDAM Wind and Solar Forecast
+        and return a list of row dicts that include the publish timestamp
+        from each daily file's ``MessageHeader.TimeDate``.
+
+        Mirrors the retry-on-429 pattern of ``_get_oasis``; OASIS rate-limits
+        back-to-back requests so back-to-back daily chunks must back off.
+        """
+        start = utils._handle_date(date, self.default_timezone)
+        if end is not None:
+            end = utils._handle_date(end, self.default_timezone)
+        start_str, end_str = _caiso_handle_start_end(start, end)
+
+        url = (
+            "http://oasis.caiso.com/oasisapi/GroupZip"
+            f"?resultformat=5&version=1&groupid=EDAM_WND_SLR_FORECAST_GRP"
+            f"&startdatetime={start_str}&enddatetime={end_str}"
+        )
+        logger.info(f"Fetching URL: {url}")
+
+        # NOTE: Rate limit gets hit quickly if pulling multiple days
+        retry_num = 0
+        while retry_num < max_retries:
+            r = requests.get(url, verify=True)
+            if r.status_code == 200:
+                break
+            retry_num += 1
+            logger.info(
+                f"Failed to get data from CAISO. Error: {r.status_code}. Retrying...{retry_num} / {max_retries}",
+            )
+            time.sleep(sleep)
+            sleep *= retry_num
+        r.raise_for_status()
+
+        rows: list[dict] = []
+        ns = "{http://www.caiso.com/soa/EDAMWindAndSolarForecast_v1.xsd}"
+        with ZipFile(io.BytesIO(r.content)) as z:
+            for fname in z.namelist():
+                with z.open(fname) as fh:
+                    tree = ElementTree.parse(fh)
+                root = tree.getroot()
+                publish_time = pd.Timestamp(
+                    root.find(f"./{ns}MessageHeader/{ns}TimeDate").text,
+                )
+                for record in root.iter(f"{ns}REPORT_DATA"):
+                    fields = {child.tag.replace(ns, ""): child.text for child in record}
+                    rows.append(
+                        {
+                            "Interval Start": pd.to_datetime(
+                                fields["INTERVAL_START_GMT"],
+                                utc=True,
+                            ),
+                            "Interval End": pd.to_datetime(
+                                fields["INTERVAL_END_GMT"],
+                                utc=True,
+                            ),
+                            "Publish Time": publish_time,
+                            "BAA": fields["BAA_GRP_ID"],
+                            "Solar": fields["SOLAR"],
+                            "Wind": fields["WIND"],
+                        },
+                    )
+
+        return rows
 
     def get_pnodes(self, verbose: bool = False) -> pd.DataFrame:
         start = utils._handle_date("today")

--- a/gridstatus/caiso/caiso_constants.py
+++ b/gridstatus/caiso/caiso_constants.py
@@ -162,16 +162,6 @@ OASIS_DATASET_CONFIG = {
             "max_query_frequency": "1d",
         },
     },
-    "edam_wind_solar_forecast": {
-        "query": {
-            "path": "GroupZip",
-            "resultformat": 6,
-            "version": 1,
-        },
-        "params": {
-            "groupid": "EDAM_WND_SLR_FORECAST_GRP",
-        },
-    },
     "pnode_map": {
         "query": {
             "path": "SingleZip",

--- a/gridstatus/caiso/caiso_constants.py
+++ b/gridstatus/caiso/caiso_constants.py
@@ -162,6 +162,16 @@ OASIS_DATASET_CONFIG = {
             "max_query_frequency": "1d",
         },
     },
+    "edam_wind_solar_forecast": {
+        "query": {
+            "path": "GroupZip",
+            "resultformat": 6,
+            "version": 1,
+        },
+        "params": {
+            "groupid": "EDAM_WND_SLR_FORECAST_GRP",
+        },
+    },
     "pnode_map": {
         "query": {
             "path": "SingleZip",

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -315,6 +315,37 @@ class TestCAISO(BaseTestISO):
         assert df["Publish Time"].max() < self.local_now()
         assert df["Publish Time"].nunique() == expected_count_unique_publish_times
 
+    def _check_edam_wind_solar_forecast(self, df: pd.DataFrame) -> None:
+        assert df.shape[0] > 0
+
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "Publish Date",
+            "BAA",
+            "Solar",
+            "Wind",
+        ]
+
+        self._check_time_columns(
+            df,
+            instant_or_interval="interval",
+            skip_column_named_time=True,
+        )
+
+        assert isinstance(df.loc[0]["Publish Date"], pd.Timestamp)
+        assert df.loc[0]["Publish Date"].tz is not None
+
+        assert pd.api.types.is_numeric_dtype(df["Solar"])
+        assert pd.api.types.is_numeric_dtype(df["Wind"])
+
+        assert df["BAA"].notna().all()
+        assert not df.duplicated(subset=["Interval Start", "BAA"]).any()
+
+        assert (
+            df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
+        ).all()
+
     def test_get_renewables_forecast_dam_today(self):
         with caiso_vcr.use_cassette(
             "test_get_renewables_forecast_dam_today.yaml",
@@ -378,6 +409,33 @@ class TestCAISO(BaseTestISO):
             df = self.iso.get_renewables_forecast_dam(start, end=end)
 
             self._check_solar_and_wind_forecast(df, 1)
+
+    """get_edam_wind_solar_forecast"""
+
+    def test_get_edam_wind_solar_forecast_today(self):
+        with caiso_vcr.use_cassette(
+            "test_get_edam_wind_solar_forecast_today.yaml",
+        ):
+            df = self.iso.get_edam_wind_solar_forecast("today")
+        self._check_edam_wind_solar_forecast(df)
+
+        assert df["Interval Start"].min() == self.local_start_of_today()
+        assert df["Interval Start"].max() == self.local_start_of_today() + pd.Timedelta(
+            hours=23,
+        )
+
+    @pytest.mark.parametrize("date", ["2026-05-01"])
+    def test_get_edam_wind_solar_forecast_historical_date(self, date):
+        with caiso_vcr.use_cassette(
+            f"test_get_edam_wind_solar_forecast_{date}.yaml",
+        ):
+            df = self.iso.get_edam_wind_solar_forecast(date)
+        self._check_edam_wind_solar_forecast(df)
+
+        assert df["Interval Start"].min() == self.local_start_of_day(date)
+        assert df["Interval Start"].max() == self.local_start_of_day(
+            date,
+        ) + pd.Timedelta(hours=23)
 
     def test_get_renewables_forecast_hasp_latest(self):
         with caiso_vcr.use_cassette(

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -321,7 +321,7 @@ class TestCAISO(BaseTestISO):
         assert df.columns.tolist() == [
             "Interval Start",
             "Interval End",
-            "Publish Date",
+            "Publish Time",
             "BAA",
             "Solar",
             "Wind",
@@ -333,8 +333,8 @@ class TestCAISO(BaseTestISO):
             skip_column_named_time=True,
         )
 
-        assert isinstance(df.loc[0]["Publish Date"], pd.Timestamp)
-        assert df.loc[0]["Publish Date"].tz is not None
+        assert isinstance(df.loc[0]["Publish Time"], pd.Timestamp)
+        assert df.loc[0]["Publish Time"].tz is not None
 
         assert pd.api.types.is_numeric_dtype(df["Solar"])
         assert pd.api.types.is_numeric_dtype(df["Wind"])


### PR DESCRIPTION
## Summary
- Adds `CAISO.get_edam_wind_solar_forecast`, a scraper for the new CAISO OASIS `EDAM_WND_SLR_FORECAST_GRP` GroupZip report (day-ahead, hourly wind and solar forecasts by BAA for balancing areas participating in the extended day-ahead market).
- Registers `edam_wind_solar_forecast` in `OASIS_DATASET_CONFIG` with the `GroupZip` path, `version=1`, `resultformat=6`, and `groupid=EDAM_WND_SLR_FORECAST_GRP`.
- VCR-fixturized tests covering `today` and a recorded historical date (May 1, 2026 — the first market day with available data).

Output columns: `Interval Start`, `Interval End`, `Publish Time`, `BAA`, `Solar`, `Wind`.

I add publish time with our existing `_add_forecast_publish_time` helper method based on the datetime given in the one file available, since it isn't provided with the CSV result. Worth a look.
<img width="1164" height="300" alt="CleanShot 2026-05-01 at 14 00 47@2x" src="https://github.com/user-attachments/assets/27292dd9-1151-4323-a927-14fc5af943c2" />


## Test plan
- [x] `uv run pytest gridstatus/tests/source_specific/test_caiso.py -k edam_wind_solar_forecast`

```
from gridstatus.caiso import CAISO

iso = CAISO()

df = iso.get_edam_wind_solar_forecast(date="2026-05-01", end="2026-05-02")
print(df.head())
print(df.dtypes)
```