### PR TITLE
fix: Add GHG component to CAISO DA LMP

### DIFF
--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -1489,37 +1489,21 @@ class CAISO(ISOBase):
             "Location Type",
         ] = "DLAP"
 
-        if market == Markets.DAY_AHEAD_HOURLY:
-            df = df[
-                [
-                    "Time",
-                    "Interval Start",
-                    "Interval End",
-                    "Market",
-                    "Location",
-                    "Location Type",
-                    "LMP",
-                    "Energy",
-                    "Congestion",
-                    "Loss",
-                ]
+        df = df[
+            [
+                "Time",
+                "Interval Start",
+                "Interval End",
+                "Market",
+                "Location",
+                "Location Type",
+                "LMP",
+                "Energy",
+                "Congestion",
+                "Loss",
+                "GHG",
             ]
-        else:
-            df = df[
-                [
-                    "Time",
-                    "Interval Start",
-                    "Interval End",
-                    "Market",
-                    "Location",
-                    "Location Type",
-                    "LMP",
-                    "Energy",
-                    "Congestion",
-                    "Loss",
-                    "GHG",
-                ]
-            ]
+        ]
 
         # data = utils.filter_lmp_locations(df, locations=location_filter)
         data = df

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -756,6 +756,7 @@ class TestCAISO(BaseTestISO):
         "Energy",
         "Congestion",
         "Loss",
+        "GHG",
     ]
 
     @with_markets(


### PR DESCRIPTION
## Summary
Previously was always `0.0`, now has values. 

### Details
Tests were already failing, attempted a fix but they are fairly entangled so punting on the CAISO test fixes for now (just added the column). 