### PR TITLE
feat(ENG 3784): Add CAISO Imbalance Reserve and Reliability Capacity Prices scraper

### DIFF
--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -2110,6 +2110,76 @@ class CAISO(ISOBase):
         return df
 
     @support_date_range(frequency="DAY_START")
+    def get_ir_rc_prices(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        sleep: int = 4,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Return day-ahead nodal Imbalance Reserve and Reliability Capacity prices.
+
+        The Marginal Clearing Price for Reliability Capacity (RCU/RCD) is comprised
+        of Capacity, Congestion, and Loss components, while Imbalance Reserves
+        (IRU/IRD) only have Capacity and Congestion components (Loss is NaN).
+
+        Arguments:
+            date (datetime.date, str): date to return data
+
+            end (datetime.date, str): last date of range to return data.
+                If None, returns only date. Defaults to None.
+
+            verbose (bool, optional): print out url being fetched. Defaults to False.
+
+        Returns:
+            pandas.DataFrame: A DataFrame of IR/RC prices with one row per
+            (Interval Start, Location, Product). Earliest available date is
+            May 1, 2026.
+        """
+        df = self.get_oasis_dataset(
+            dataset="ir_rc_prices_day_ahead_hourly",
+            start=date,
+            end=end,
+            sleep=sleep,
+            verbose=verbose,
+            raw_data=False,
+        )
+
+        columns = [
+            "Time",
+            "Interval Start",
+            "Interval End",
+            "Location",
+            "Product",
+            "MCP",
+            "Capacity",
+            "Congestion",
+            "Loss",
+        ]
+
+        if df.empty:
+            return pd.DataFrame(columns=columns)
+
+        df = df.rename(
+            columns={
+                "NODE": "Location",
+                "PRODUCT": "Product",
+                "MARGINAL_CLEARING_PRICE": "MCP",
+                "CAPACITY_PRICE": "Capacity",
+                "CONGESTION_PRICE": "Congestion",
+                "LOSS_PRICE": "Loss",
+            },
+        )
+
+        df = df[columns]
+
+        df = df.sort_values(
+            ["Interval Start", "Location", "Product"],
+        ).reset_index(drop=True)
+
+        return df
+
+    @support_date_range(frequency="DAY_START")
     def get_curtailed_non_operational_generator_report(
         self,
         date: str | pd.Timestamp,

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -2146,7 +2146,6 @@ class CAISO(ISOBase):
         )
 
         columns = [
-            "Time",
             "Interval Start",
             "Interval End",
             "Location",
@@ -2156,9 +2155,6 @@ class CAISO(ISOBase):
             "Congestion",
             "Loss",
         ]
-
-        if df.empty:
-            return pd.DataFrame(columns=columns)
 
         df = df.rename(
             columns={

--- a/gridstatus/caiso/caiso_constants.py
+++ b/gridstatus/caiso/caiso_constants.py
@@ -82,6 +82,19 @@ OASIS_DATASET_CONFIG = {
             ],
         },
     },
+    "ir_rc_prices_day_ahead_hourly": {
+        "query": {
+            "path": "GroupZip",
+            "resultformat": 6,
+            "version": 1,
+        },
+        "params": {
+            "groupid": "DAM_CAP_PRC_GRP",
+        },
+        "meta": {
+            "max_query_frequency": "1d",
+        },
+    },
     "fuel_prices": {
         "query": {
             "path": "SingleZip",

--- a/gridstatus/tests/conftest.py
+++ b/gridstatus/tests/conftest.py
@@ -4,12 +4,21 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def disable_exponential_backoff_sleep():
+def disable_exponential_backoff_sleep(request):
     """Disable time.sleep in all modules that use exponential backoff.
 
     This prevents tests from waiting during retry logic, making them run faster.
     The fixture is autouse=True so it applies to all tests automatically.
+
+    Tests marked with ``@pytest.mark.real_sleep`` opt out and use the real
+    ``time.sleep``. Use this for tests that need actual delays between
+    retries/requests (e.g. when re-recording VCR cassettes against
+    rate-limited upstream APIs).
     """
+    if request.node.get_closest_marker("real_sleep"):
+        yield
+        return
+
     modules_with_backoff = [
         "gridstatus.pjm",
         "gridstatus.ercot_api.ercot_api",

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -56,7 +56,6 @@ class TestCAISO(BaseTestISO):
     """get_ir_rc_prices"""
 
     IR_RC_PRICES_COLUMNS = [
-        "Time",
         "Interval Start",
         "Interval End",
         "Location",
@@ -81,7 +80,7 @@ class TestCAISO(BaseTestISO):
         ir_loss_null = df.loc[df["Product"].isin(["IRU", "IRD"]), "Loss"].isna().all()
         assert ir_loss_null
 
-    @pytest.mark.parametrize("date", ["2026-05-01", "2026-05-02"])
+    @pytest.mark.parametrize("date", ["2026-05-01"])
     def test_get_ir_rc_prices(self, date):
         with caiso_vcr.use_cassette(f"test_get_ir_rc_prices_{date}.yaml"):
             df = self.iso.get_ir_rc_prices(date=date)
@@ -91,6 +90,7 @@ class TestCAISO(BaseTestISO):
                 date,
             ) + pd.Timedelta(hours=23)
 
+    @pytest.mark.real_sleep
     @pytest.mark.parametrize(
         "start, end",
         [("2026-05-01", "2026-05-03")],

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -1,5 +1,4 @@
 import math
-from unittest import mock
 
 import numpy as np
 import pandas as pd
@@ -82,26 +81,8 @@ class TestCAISO(BaseTestISO):
         ir_loss_null = df.loc[df["Product"].isin(["IRU", "IRD"]), "Loss"].isna().all()
         assert ir_loss_null
 
-    @pytest.fixture
-    def caiso_real_sleep(self, disable_exponential_backoff_sleep):
-        if RECORD_MODE != "all":
-            yield
-            return
-        mock.patch.stopall()
-        yield
-        for module in [
-            "gridstatus.pjm",
-            "gridstatus.ercot_api.ercot_api",
-            "gridstatus.miso_api",
-            "gridstatus.ieso",
-            "gridstatus.isone_api.isone_api",
-            "gridstatus.caiso.caiso",
-        ]:
-            patcher = mock.patch(f"{module}.time.sleep", return_value=None)
-            patcher.start()
-
     @pytest.mark.parametrize("date", ["2026-05-01", "2026-05-02"])
-    def test_get_ir_rc_prices(self, date, caiso_real_sleep):
+    def test_get_ir_rc_prices(self, date):
         with caiso_vcr.use_cassette(f"test_get_ir_rc_prices_{date}.yaml"):
             df = self.iso.get_ir_rc_prices(date=date)
             self._check_ir_rc_prices(df)
@@ -114,7 +95,7 @@ class TestCAISO(BaseTestISO):
         "start, end",
         [("2026-05-01", "2026-05-03")],
     )
-    def test_get_ir_rc_prices_date_range(self, start, end, caiso_real_sleep):
+    def test_get_ir_rc_prices_date_range(self, start, end):
         with caiso_vcr.use_cassette(
             f"test_get_ir_rc_prices_{start}_{end}.yaml",
         ):
@@ -124,13 +105,6 @@ class TestCAISO(BaseTestISO):
             assert df["Interval Start"].max() == self.local_start_of_day(
                 end,
             ) - pd.Timedelta(hours=1)
-
-    def test_get_ir_rc_prices_before_publication(self, caiso_real_sleep):
-        with caiso_vcr.use_cassette(
-            "test_get_ir_rc_prices_before_publication.yaml",
-        ):
-            df = self.iso.get_ir_rc_prices(date="2026-04-15")
-            assert df.empty
 
     """get_fuel_mix"""
 

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -1,4 +1,5 @@
 import math
+from unittest import mock
 
 import numpy as np
 import pandas as pd
@@ -52,6 +53,84 @@ class TestCAISO(BaseTestISO):
             for market in ["DAM", "RTM"]:
                 df = self.iso.get_as_procurement(date, market=market)
                 self._check_as_data(df, market)
+
+    """get_ir_rc_prices"""
+
+    IR_RC_PRICES_COLUMNS = [
+        "Time",
+        "Interval Start",
+        "Interval End",
+        "Location",
+        "Product",
+        "MCP",
+        "Capacity",
+        "Congestion",
+        "Loss",
+    ]
+
+    def _check_ir_rc_prices(self, df: pd.DataFrame) -> None:
+        assert df.columns.tolist() == self.IR_RC_PRICES_COLUMNS
+        assert df.shape[0] > 0
+        assert set(df["Product"].unique()) == {"IRU", "IRD", "RCU", "RCD"}
+        interval_minutes = (
+            df["Interval End"] - df["Interval Start"]
+        ).dt.total_seconds() / 60
+        assert (interval_minutes == 60).all()
+        assert not df.duplicated(
+            subset=["Interval Start", "Location", "Product"],
+        ).any()
+        ir_loss_null = df.loc[df["Product"].isin(["IRU", "IRD"]), "Loss"].isna().all()
+        assert ir_loss_null
+
+    @pytest.fixture
+    def caiso_real_sleep(self, disable_exponential_backoff_sleep):
+        if RECORD_MODE != "all":
+            yield
+            return
+        mock.patch.stopall()
+        yield
+        for module in [
+            "gridstatus.pjm",
+            "gridstatus.ercot_api.ercot_api",
+            "gridstatus.miso_api",
+            "gridstatus.ieso",
+            "gridstatus.isone_api.isone_api",
+            "gridstatus.caiso.caiso",
+        ]:
+            patcher = mock.patch(f"{module}.time.sleep", return_value=None)
+            patcher.start()
+
+    @pytest.mark.parametrize("date", ["2026-05-01", "2026-05-02"])
+    def test_get_ir_rc_prices(self, date, caiso_real_sleep):
+        with caiso_vcr.use_cassette(f"test_get_ir_rc_prices_{date}.yaml"):
+            df = self.iso.get_ir_rc_prices(date=date)
+            self._check_ir_rc_prices(df)
+            assert df["Interval Start"].min() == self.local_start_of_day(date)
+            assert df["Interval Start"].max() == self.local_start_of_day(
+                date,
+            ) + pd.Timedelta(hours=23)
+
+    @pytest.mark.parametrize(
+        "start, end",
+        [("2026-05-01", "2026-05-03")],
+    )
+    def test_get_ir_rc_prices_date_range(self, start, end, caiso_real_sleep):
+        with caiso_vcr.use_cassette(
+            f"test_get_ir_rc_prices_{start}_{end}.yaml",
+        ):
+            df = self.iso.get_ir_rc_prices(date=start, end=end, sleep=15)
+            self._check_ir_rc_prices(df)
+            assert df["Interval Start"].min() == self.local_start_of_day(start)
+            assert df["Interval Start"].max() == self.local_start_of_day(
+                end,
+            ) - pd.Timedelta(hours=1)
+
+    def test_get_ir_rc_prices_before_publication(self, caiso_real_sleep):
+        with caiso_vcr.use_cassette(
+            "test_get_ir_rc_prices_before_publication.yaml",
+        ):
+            df = self.iso.get_ir_rc_prices(date="2026-04-15")
+            assert df.empty
 
     """get_fuel_mix"""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ testpaths = ["gridstatus/tests/*"]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests as integration tests that pull from an external API (deselect with '-m \"not integration\"')",
+    "real_sleep: do not mock time.sleep for retries/throttling (use when re-recording VCR cassettes against rate-limited APIs)",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary
- Adds `get_ir_rc_prices` for CAISO day-ahead hourly nodal Imbalance Reserve and Reliability Capacity prices via the OASIS `DAM_CAP_PRC_GRP` report.

### Details
Products are `IRU` (Imbalance Reserves Up), `IRD` (Imbalance Reserves Down), `RCU` (Reliability Capacity Up), and `RCD` (Reliability Capacity Down). 

The Marginal Clearing Price for Reliability Capacity is comprised of Capacity, Congestion, and Loss components, while Imbalance Reserves only have Capacity and Congestion components (Loss is `NaN` by source design). 

Earliest available data is May 1, 2026 — this dataset was first published April 30, 2026 as part of CAISO's DAME release for the May 1, 2026 market day.

This also adds some functionality to avoid the sleep skipping we do for tests when running to record new fixtures. To run the new tests:

```bash
VCR_RECORD_MODE=all uv run pytest -vvv gridstatus/tests/ -k "caiso" -k "ir_rc_prices"
```



Made with [Cursor](https://cursor.com)