### PR TITLE
fix(ENG 3843): SPP RT binding constraint timeliness

### DIFF
--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -156,6 +156,27 @@ def fill_baa_column(df, load_col):
     return df
 
 
+def _binding_constraints_real_time_5_min_frequency(args_dict: dict) -> str:
+    """support_date_range frequency for SPP real-time binding constraints.
+
+    Splits at 5-min boundaries only for same-day recent windows so the
+    caller's explicit end is preserved through decorator chunking. Otherwise
+    splits per day, matching the source's daily-file granularity.
+    """
+    iso = args_dict["self"]
+    end = args_dict.get("end")
+    if end is None:
+        return "DAY_START"
+
+    start = utils._handle_date(args_dict["date"], iso.default_timezone)
+    end = utils._handle_date(end, iso.default_timezone)
+    if start.normalize() != end.normalize():
+        return "DAY_START"
+    if not utils.is_within_last_days(start, 1, iso.default_timezone):
+        return "DAY_START"
+    return "5_MIN"
+
+
 class SPP(ISOBase):
     """Southwest Power Pool (SPP)"""
 
@@ -2531,132 +2552,12 @@ class SPP(ISOBase):
 
         return df[cols_to_keep].sort_values(["Interval Start", "Constraint Name"])
 
-    # NB: For the SPP Real Time Binding Constraints,
-    # Daily files are more performant for older historical dates than interval files.
-    # Use interval files for today and yesterday so recent data matches RTBM interval
-    # publishing (daily By_Day files can lag). The decorator splits by day.
-    # Daily files contain the first 2.25 hours of the next day, so interval files for
-    # today don't start until ~02:15.
-    def _normalize_binding_constraints_window(
-        self,
-        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
-        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None,
-    ) -> tuple[pd.Timestamp, pd.Timestamp | None]:
-        start = utils._handle_date(date, self.default_timezone)
-        window_end = (
-            utils._handle_date(end, self.default_timezone) if end is not None else None
-        )
-        return start, window_end
-
-    # NB: This controls support_date_range splitting for this dataset only.
-    # We keep day-level splitting by default for historical efficiency, and
-    # switch to 5-minute splitting only for same-day recent windows so the
-    # requested end bound is preserved during incremental catch-up.
-    def _binding_constraints_real_time_5_min_frequency(
-        self,
-        args_dict: dict[str, object],
-    ) -> str:
-        end = args_dict.get("end")
-        if end is None:
-            return "DAY_START"
-
-        start_date = utils._handle_date(args_dict["date"], self.default_timezone)
-        end_date = utils._handle_date(end, self.default_timezone)
-        if (
-            start_date.normalize() == end_date.normalize()
-            and self._is_recent_binding_constraints_window(start_date, end_date)
-        ):
-            return "5_MIN"
-        return "DAY_START"
-
-    # NB: "Recent" means the interval window overlaps today or yesterday
-    # in SPP local time, where interval files are preferred over daily files.
-    def _is_recent_binding_constraints_window(
-        self,
-        start: pd.Timestamp,
-        end: pd.Timestamp | None,
-    ) -> bool:
-        if utils.is_within_last_days(start, 1, self.default_timezone):
-            return True
-        if end is None:
-            return False
-        return utils.is_within_last_days(
-            end - pd.Timedelta(minutes=5),
-            1,
-            self.default_timezone,
-        )
-
-    # NB: Central router for source choice. This keeps route policy in one
-    # place so callers only dispatch to "intervals" or "daily".
-    def _route_binding_constraints_source(
-        self,
-        start: pd.Timestamp,
-        end: pd.Timestamp | None,
-    ) -> str:
-        if utils.is_today(start, self.default_timezone):
-            return "intervals"
-        if utils.is_yesterday(start, self.default_timezone) and (
-            start == start.normalize()
-        ):
-            return "intervals"
-        if (
-            end is not None
-            and start.normalize() == end.normalize()
-            and self._is_recent_binding_constraints_window(start, end)
-        ):
-            return "intervals"
-        return "daily"
-
-    # NB: Today requires an interval floor (~02:10 local) because early
-    # intervals are represented in the prior day's daily file.
-    def _adjust_today_interval_window(
-        self,
-        start: pd.Timestamp,
-        end: pd.Timestamp | None,
-    ) -> tuple[pd.Timestamp, pd.Timestamp]:
-        day_floor = start.normalize()
-        adjusted_start = max(
-            start,
-            day_floor + pd.Timedelta(hours=2, minutes=10),
-        )
-        adjusted_end = end
-        if adjusted_end is None:
-            if start == day_floor:
-                now_ceiled = pd.Timestamp.now(
-                    tz=self.default_timezone,
-                ).ceil("5min")
-                adjusted_end = min(
-                    now_ceiled,
-                    day_floor + pd.Timedelta(days=1),
-                )
-            else:
-                adjusted_end = start + pd.Timedelta(minutes=5)
-        if adjusted_end <= adjusted_start:
-            adjusted_end = adjusted_start + pd.Timedelta(minutes=5)
-        return adjusted_start, adjusted_end
-
-    # NB: Final interval window builder used after routing to interval files.
-    # It normalizes defaults for non-today windows while keeping explicit end.
-    def _get_binding_constraints_interval_window(
-        self,
-        start: pd.Timestamp,
-        end: pd.Timestamp | None,
-    ) -> tuple[pd.Timestamp, pd.Timestamp]:
-        if utils.is_today(start, self.default_timezone):
-            return self._adjust_today_interval_window(start, end)
-        if end is None:
-            if start == start.normalize():
-                return start, start + pd.Timedelta(days=1)
-            return start, start + pd.Timedelta(minutes=5)
-        return start, end
-
-    @support_date_range(
-        lambda args_dict: args_dict[
-            "self"
-        ]._binding_constraints_real_time_5_min_frequency(
-            args_dict,
-        ),
-    )
+    # NB: SPP RTBM publishes per-interval CSVs and daily aggregates. Daily files
+    # are faster (one request per day) but lag publication, so we use interval
+    # files for today/yesterday and daily files for older history. Today's first
+    # ~2.25 hours don't have interval files yet (they live in yesterday's daily
+    # file), so today's interval start is floored to 02:10 local.
+    @support_date_range(_binding_constraints_real_time_5_min_frequency)
     def get_binding_constraints_real_time_5_min(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
@@ -2680,27 +2581,54 @@ class SPP(ISOBase):
                 verbose=verbose,
             )
 
-        start, window_end = self._normalize_binding_constraints_window(date, end)
-        source = self._route_binding_constraints_source(start, window_end)
-
-        if source == "intervals":
-            interval_start, interval_end = (
-                self._get_binding_constraints_interval_window(
-                    start,
-                    window_end,
-                )
-            )
-            return self._get_binding_constraints_real_time_5_min_from_intervals(
-                interval_start,
-                end=interval_end,
+        start = utils._handle_date(date, self.default_timezone)
+        if not utils.is_within_last_days(start, 1, self.default_timezone):
+            return self._get_binding_constraints_real_time_5_min_from_daily_files(
+                start,
+                end=end,
                 verbose=verbose,
             )
 
-        return self._get_binding_constraints_real_time_5_min_from_daily_files(
+        interval_start, interval_end = self._resolve_recent_interval_window(
             start,
-            end=window_end,
+            end,
+        )
+        return self._get_binding_constraints_real_time_5_min_from_intervals(
+            interval_start,
+            end=interval_end,
             verbose=verbose,
         )
+
+    def _resolve_recent_interval_window(
+        self,
+        start: pd.Timestamp,
+        end: pd.Timestamp | None,
+    ) -> tuple[pd.Timestamp, pd.Timestamp]:
+        """Window for today/yesterday interval fetches.
+
+        Today's first ~2.25 hours live in yesterday's daily file, so start
+        is floored to 02:10. When end is omitted (DAY_START chunk), fetch
+        through end-of-local-day, capping today at the most recent 5-min
+        boundary so we don't request future intervals.
+        """
+        is_today = utils.is_today(start, self.default_timezone)
+        day_floor = start.normalize()
+
+        if is_today:
+            start = max(start, day_floor + pd.Timedelta(hours=2, minutes=10))
+
+        if end is None:
+            end = day_floor + pd.Timedelta(days=1)
+            if is_today:
+                end = min(
+                    end,
+                    pd.Timestamp.now(tz=self.default_timezone).ceil("5min"),
+                )
+
+        if end <= start:
+            end = start + pd.Timedelta(minutes=5)
+
+        return start, end
 
     def _get_binding_constraints_real_time_5_min_from_daily_files(
         self,

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -2548,6 +2548,10 @@ class SPP(ISOBase):
         )
         return start, window_end
 
+    # NB: This controls support_date_range splitting for this dataset only.
+    # We keep day-level splitting by default for historical efficiency, and
+    # switch to 5-minute splitting only for same-day recent windows so the
+    # requested end bound is preserved during incremental catch-up.
     def _binding_constraints_real_time_5_min_frequency(
         self,
         args_dict: dict[str, object],
@@ -2565,6 +2569,8 @@ class SPP(ISOBase):
             return "5_MIN"
         return "DAY_START"
 
+    # NB: "Recent" means the interval window overlaps today or yesterday
+    # in SPP local time, where interval files are preferred over daily files.
     def _is_recent_binding_constraints_window(
         self,
         start: pd.Timestamp,
@@ -2580,6 +2586,8 @@ class SPP(ISOBase):
             self.default_timezone,
         )
 
+    # NB: Central router for source choice. This keeps route policy in one
+    # place so callers only dispatch to "intervals" or "daily".
     def _route_binding_constraints_source(
         self,
         start: pd.Timestamp,
@@ -2599,6 +2607,8 @@ class SPP(ISOBase):
             return "intervals"
         return "daily"
 
+    # NB: Today requires an interval floor (~02:10 local) because early
+    # intervals are represented in the prior day's daily file.
     def _adjust_today_interval_window(
         self,
         start: pd.Timestamp,
@@ -2625,6 +2635,8 @@ class SPP(ISOBase):
             adjusted_end = adjusted_start + pd.Timedelta(minutes=5)
         return adjusted_start, adjusted_end
 
+    # NB: Final interval window builder used after routing to interval files.
+    # It normalizes defaults for non-today windows while keeping explicit end.
     def _get_binding_constraints_interval_window(
         self,
         start: pd.Timestamp,

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -2531,7 +2531,120 @@ class SPP(ISOBase):
 
         return df[cols_to_keep].sort_values(["Interval Start", "Constraint Name"])
 
-    @support_date_range("DAY_START")
+    # NB: For the SPP Real Time Binding Constraints,
+    # Daily files are more performant for older historical dates than interval files.
+    # Use interval files for today and yesterday so recent data matches RTBM interval
+    # publishing (daily By_Day files can lag). The decorator splits by day.
+    # Daily files contain the first 2.25 hours of the next day, so interval files for
+    # today don't start until ~02:15.
+    def _normalize_binding_constraints_window(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None,
+    ) -> tuple[pd.Timestamp, pd.Timestamp | None]:
+        start = utils._handle_date(date, self.default_timezone)
+        window_end = (
+            utils._handle_date(end, self.default_timezone) if end is not None else None
+        )
+        return start, window_end
+
+    def _binding_constraints_real_time_5_min_frequency(
+        self,
+        args_dict: dict[str, object],
+    ) -> str:
+        end = args_dict.get("end")
+        if end is None:
+            return "DAY_START"
+
+        start_date = utils._handle_date(args_dict["date"], self.default_timezone)
+        end_date = utils._handle_date(end, self.default_timezone)
+        if (
+            start_date.normalize() == end_date.normalize()
+            and self._is_recent_binding_constraints_window(start_date, end_date)
+        ):
+            return "5_MIN"
+        return "DAY_START"
+
+    def _is_recent_binding_constraints_window(
+        self,
+        start: pd.Timestamp,
+        end: pd.Timestamp | None,
+    ) -> bool:
+        if utils.is_within_last_days(start, 1, self.default_timezone):
+            return True
+        if end is None:
+            return False
+        return utils.is_within_last_days(
+            end - pd.Timedelta(minutes=5),
+            1,
+            self.default_timezone,
+        )
+
+    def _route_binding_constraints_source(
+        self,
+        start: pd.Timestamp,
+        end: pd.Timestamp | None,
+    ) -> str:
+        if utils.is_today(start, self.default_timezone):
+            return "intervals"
+        if utils.is_yesterday(start, self.default_timezone) and (
+            start == start.normalize()
+        ):
+            return "intervals"
+        if (
+            end is not None
+            and start.normalize() == end.normalize()
+            and self._is_recent_binding_constraints_window(start, end)
+        ):
+            return "intervals"
+        return "daily"
+
+    def _adjust_today_interval_window(
+        self,
+        start: pd.Timestamp,
+        end: pd.Timestamp | None,
+    ) -> tuple[pd.Timestamp, pd.Timestamp]:
+        day_floor = start.normalize()
+        adjusted_start = max(
+            start,
+            day_floor + pd.Timedelta(hours=2, minutes=10),
+        )
+        adjusted_end = end
+        if adjusted_end is None:
+            if start == day_floor:
+                now_ceiled = pd.Timestamp.now(
+                    tz=self.default_timezone,
+                ).ceil("5min")
+                adjusted_end = min(
+                    now_ceiled,
+                    day_floor + pd.Timedelta(days=1),
+                )
+            else:
+                adjusted_end = start + pd.Timedelta(minutes=5)
+        if adjusted_end <= adjusted_start:
+            adjusted_end = adjusted_start + pd.Timedelta(minutes=5)
+        return adjusted_start, adjusted_end
+
+    def _get_binding_constraints_interval_window(
+        self,
+        start: pd.Timestamp,
+        end: pd.Timestamp | None,
+    ) -> tuple[pd.Timestamp, pd.Timestamp]:
+        if utils.is_today(start, self.default_timezone):
+            return self._adjust_today_interval_window(start, end)
+        if end is None:
+            if start == start.normalize():
+                return start, start + pd.Timedelta(days=1)
+            return start, start + pd.Timedelta(minutes=5)
+        return start, end
+
+    @support_date_range(
+        lambda args_dict: args_dict[
+            "self"
+        ]._binding_constraints_real_time_5_min_frequency(
+            args_dict,
+        ),
+    )
     def get_binding_constraints_real_time_5_min(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
@@ -2555,53 +2668,25 @@ class SPP(ISOBase):
                 verbose=verbose,
             )
 
-        # NB: Daily files are more performant for older historical dates than interval files.
-        # Use interval files for today and yesterday so recent data matches RTBM interval
-        # publishing (daily By_Day files can lag). The decorator splits by day.
-        # Daily files contain the first 2.25 hours of the next day, so interval files for
-        # today don't start until ~02:15.
-        start_date = utils._handle_date(date, self.default_timezone)
-        if utils.is_within_last_days(start_date, 1, self.default_timezone):
-            if utils.is_today(start_date, self.default_timezone):
-                # When decorator splits by day, we need to provide end of day for interval method
-                # to get all intervals for that day. Also adjust start time since interval files
-                # for today don't exist for the first ~2 hours (they're in yesterday's daily file)
-                day_floor = start_date.normalize()
-                # Interval files for today start around 02:15, so adjust start if needed
-                adjusted_start = max(
-                    start_date,
-                    day_floor + pd.Timedelta(hours=2, minutes=10),
+        start, window_end = self._normalize_binding_constraints_window(date, end)
+        source = self._route_binding_constraints_source(start, window_end)
+
+        if source == "intervals":
+            interval_start, interval_end = (
+                self._get_binding_constraints_interval_window(
+                    start,
+                    window_end,
                 )
-                if end is None:
-                    if start_date == day_floor:
-                        now_ceiled = pd.Timestamp.now(
-                            tz=self.default_timezone,
-                        ).ceil("5min")
-                        end = min(
-                            now_ceiled,
-                            day_floor + pd.Timedelta(days=1),
-                        )
-                    else:
-                        # Assume getting 5 minutes since this is a five minute dataset
-                        end = start_date + pd.Timedelta(minutes=5)
-                if end <= adjusted_start:
-                    end = adjusted_start + pd.Timedelta(minutes=5)
-                return self._get_binding_constraints_real_time_5_min_from_intervals(
-                    adjusted_start,
-                    end=end,
-                    verbose=verbose,
-                )
-            if start_date == start_date.normalize():
-                day_start = start_date.normalize()
-                interval_end = day_start + pd.Timedelta(days=1)
-                return self._get_binding_constraints_real_time_5_min_from_intervals(
-                    day_start,
-                    end=interval_end,
-                    verbose=verbose,
-                )
+            )
+            return self._get_binding_constraints_real_time_5_min_from_intervals(
+                interval_start,
+                end=interval_end,
+                verbose=verbose,
+            )
+
         return self._get_binding_constraints_real_time_5_min_from_daily_files(
-            date,
-            end=end,
+            start,
+            end=window_end,
             verbose=verbose,
         )
 

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -2552,11 +2552,16 @@ class SPP(ISOBase):
 
         return df[cols_to_keep].sort_values(["Interval Start", "Constraint Name"])
 
-    # NB: SPP RTBM publishes per-interval CSVs and daily aggregates, both
-    # aligned to local midnight. Daily files are faster (one request per day)
-    # but lag publication, so we use interval files for today/yesterday and
-    # daily files for older history.
-    @support_date_range(_binding_constraints_real_time_5_min_frequency)
+    # NB: SPP RTBM publishes per-interval CSVs and daily aggregates. Both are
+    # aligned to local midnight. Interval files live under
+    # By_Interval/<DD>/RTBM-BC-<YYYYMMDDHHMM>.csv where DD is the interval's
+    # start-day and HHMM is the interval's end-time; the midnight-crossing
+    # interval (start = prev day 23:55, end = next day 00:00) sits in the
+    # previous day's folder with the next day's filename. Daily files are
+    # faster (one request per day) but lag publication, so we use interval
+    # files for today/yesterday and daily files for older history. Daily files
+    # always return the whole local day; this method slices the result to the
+    # caller's [date, end) window.
     def get_binding_constraints_real_time_5_min(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
@@ -2580,6 +2585,32 @@ class SPP(ISOBase):
                 verbose=verbose,
             )
 
+        start_ts = utils._handle_date(date, self.default_timezone)
+        end_ts = (
+            utils._handle_date(end, self.default_timezone) if end is not None else None
+        )
+
+        df = self._fetch_binding_constraints_real_time_5_min(
+            date=start_ts,
+            end=end_ts,
+            verbose=verbose,
+        )
+
+        if end_ts is None:
+            return df
+
+        return df[
+            (df["Interval Start"] >= start_ts) & (df["Interval Start"] < end_ts)
+        ].reset_index(drop=True)
+
+    @support_date_range(_binding_constraints_real_time_5_min_frequency)
+    def _fetch_binding_constraints_real_time_5_min(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Per-chunk fetch dispatching to interval or daily-file source."""
         start = utils._handle_date(date, self.default_timezone)
         if not utils.is_within_last_days(start, 1, self.default_timezone):
             return self._get_binding_constraints_real_time_5_min_from_daily_files(

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -2555,35 +2555,55 @@ class SPP(ISOBase):
                 verbose=verbose,
             )
 
-        # NB: Daily files are more performant for historical dates than getting from interval files
-        # The decorator splits by day, so we can check if this specific date is today
-        # Use interval files only for today; use daily files for all historical dates
-        # Note: Daily files contain the first 2.25 hours of the next day, so interval files
-        # for today don't start until 02:15
+        # NB: Daily files are more performant for older historical dates than interval files.
+        # Use interval files for today and yesterday so recent data matches RTBM interval
+        # publishing (daily By_Day files can lag). The decorator splits by day.
+        # Daily files contain the first 2.25 hours of the next day, so interval files for
+        # today don't start until ~02:15.
         start_date = utils._handle_date(date, self.default_timezone)
-        if utils.is_today(start_date, self.default_timezone):
-            # When decorator splits by day, we need to provide end of day for interval method
-            # to get all intervals for that day. Also adjust start time since interval files
-            # for today don't exist for the first ~2 hours (they're in yesterday's daily file)
-            if end is None:
-                # Assume getting 5 minutes since this is a five minute dataset
-                end = start_date + pd.Timedelta(minutes=5)
-            # Interval files for today start around 02:15, so adjust start if needed
-            adjusted_start = max(
-                start_date,
-                start_date.normalize() + pd.Timedelta(hours=2, minutes=10),
-            )
-            return self._get_binding_constraints_real_time_5_min_from_intervals(
-                adjusted_start,
-                end=end,
-                verbose=verbose,
-            )
-        else:
-            return self._get_binding_constraints_real_time_5_min_from_daily_files(
-                date,
-                end=end,
-                verbose=verbose,
-            )
+        if utils.is_within_last_days(start_date, 1, self.default_timezone):
+            if utils.is_today(start_date, self.default_timezone):
+                # When decorator splits by day, we need to provide end of day for interval method
+                # to get all intervals for that day. Also adjust start time since interval files
+                # for today don't exist for the first ~2 hours (they're in yesterday's daily file)
+                day_floor = start_date.normalize()
+                # Interval files for today start around 02:15, so adjust start if needed
+                adjusted_start = max(
+                    start_date,
+                    day_floor + pd.Timedelta(hours=2, minutes=10),
+                )
+                if end is None:
+                    if start_date == day_floor:
+                        now_ceiled = pd.Timestamp.now(
+                            tz=self.default_timezone,
+                        ).ceil("5min")
+                        end = min(
+                            now_ceiled,
+                            day_floor + pd.Timedelta(days=1),
+                        )
+                    else:
+                        # Assume getting 5 minutes since this is a five minute dataset
+                        end = start_date + pd.Timedelta(minutes=5)
+                if end <= adjusted_start:
+                    end = adjusted_start + pd.Timedelta(minutes=5)
+                return self._get_binding_constraints_real_time_5_min_from_intervals(
+                    adjusted_start,
+                    end=end,
+                    verbose=verbose,
+                )
+            if start_date == start_date.normalize():
+                day_start = start_date.normalize()
+                interval_end = day_start + pd.Timedelta(days=1)
+                return self._get_binding_constraints_real_time_5_min_from_intervals(
+                    day_start,
+                    end=interval_end,
+                    verbose=verbose,
+                )
+        return self._get_binding_constraints_real_time_5_min_from_daily_files(
+            date,
+            end=end,
+            verbose=verbose,
+        )
 
     def _get_binding_constraints_real_time_5_min_from_daily_files(
         self,

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -2552,11 +2552,10 @@ class SPP(ISOBase):
 
         return df[cols_to_keep].sort_values(["Interval Start", "Constraint Name"])
 
-    # NB: SPP RTBM publishes per-interval CSVs and daily aggregates. Daily files
-    # are faster (one request per day) but lag publication, so we use interval
-    # files for today/yesterday and daily files for older history. Today's first
-    # ~2.25 hours don't have interval files yet (they live in yesterday's daily
-    # file), so today's interval start is floored to 02:10 local.
+    # NB: SPP RTBM publishes per-interval CSVs and daily aggregates, both
+    # aligned to local midnight. Daily files are faster (one request per day)
+    # but lag publication, so we use interval files for today/yesterday and
+    # daily files for older history.
     @support_date_range(_binding_constraints_real_time_5_min_frequency)
     def get_binding_constraints_real_time_5_min(
         self,
@@ -2606,20 +2605,13 @@ class SPP(ISOBase):
     ) -> tuple[pd.Timestamp, pd.Timestamp]:
         """Window for today/yesterday interval fetches.
 
-        Today's first ~2.25 hours live in yesterday's daily file, so start
-        is floored to 02:10. When end is omitted (DAY_START chunk), fetch
-        through end-of-local-day, capping today at the most recent 5-min
-        boundary so we don't request future intervals.
+        When end is omitted (DAY_START chunk), fetch through end-of-local-day,
+        capping today at the most recent 5-min boundary so we don't request
+        future intervals.
         """
-        is_today = utils.is_today(start, self.default_timezone)
-        day_floor = start.normalize()
-
-        if is_today:
-            start = max(start, day_floor + pd.Timedelta(hours=2, minutes=10))
-
         if end is None:
-            end = day_floor + pd.Timedelta(days=1)
-            if is_today:
+            end = start.normalize() + pd.Timedelta(days=1)
+            if utils.is_today(start, self.default_timezone):
                 end = min(
                     end,
                     pd.Timestamp.now(tz=self.default_timezone).ceil("5min"),

--- a/gridstatus/tests/source_specific/test_spp.py
+++ b/gridstatus/tests/source_specific/test_spp.py
@@ -2745,12 +2745,9 @@ class TestSPP(BaseTestISO):
             )
 
         self._check_binding_constraints_real_time(df)
-        assert df["Interval Start"].min() == three_days_ago
-        # Daily files return full day, so max is end of day
-        assert df["Interval Start"].max() == three_days_ago + pd.Timedelta(
-            hours=23,
-            minutes=55,
-        )
+        # Daily file is sliced to caller's [date, end) window
+        assert df["Interval Start"].min() >= three_days_ago
+        assert df["Interval Start"].max() < three_days_ago_0215
 
     def test_get_binding_constraints_real_time_5_min_range_includes_today(self):
         start_date = self.local_now() - pd.Timedelta(days=1)
@@ -2765,8 +2762,8 @@ class TestSPP(BaseTestISO):
             )
 
         self._check_binding_constraints_real_time(df)
-        assert df["Interval Start"].min() <= start_date
-        assert df["Interval End"].max() >= end_date - pd.Timedelta(minutes=5)
+        assert df["Interval Start"].min() >= start_date
+        assert df["Interval Start"].max() < end_date
 
     def test_get_binding_constraints_real_time_5_min_same_day_range_uses_intervals(
         self,

--- a/gridstatus/tests/source_specific/test_spp.py
+++ b/gridstatus/tests/source_specific/test_spp.py
@@ -2768,6 +2768,55 @@ class TestSPP(BaseTestISO):
         assert df["Interval Start"].min() <= start_date
         assert df["Interval End"].max() >= end_date - pd.Timedelta(minutes=5)
 
+    def test_get_binding_constraints_real_time_5_min_same_day_range_uses_intervals(
+        self,
+        monkeypatch,
+    ):
+        start_date = self.local_start_of_today() + pd.Timedelta(hours=12)
+        end_date = start_date + pd.Timedelta(minutes=30)
+
+        calls = {}
+
+        def fake_intervals_fetch(date, end=None, verbose=False):
+            calls["date"] = date
+            calls["end"] = end
+            return pd.DataFrame(
+                {
+                    "Interval Start": [start_date],
+                    "Interval End": [start_date + pd.Timedelta(minutes=5)],
+                    "Constraint Name": ["C"],
+                    "Constraint Type": ["RTBM"],
+                    "NERC ID": pd.Series([1], dtype="Int64"),
+                    "TLR Level": [None],
+                    "State": ["ACTIVE"],
+                    "Shadow Price": [0.0],
+                    "Monitored Facility": ["M"],
+                    "Contingent Facility": ["CF"],
+                },
+            )
+
+        def fail_daily_fetch(*args, **kwargs):
+            raise AssertionError("Expected interval route, not daily route")
+
+        monkeypatch.setattr(
+            self.iso,
+            "_get_binding_constraints_real_time_5_min_from_intervals",
+            fake_intervals_fetch,
+        )
+        monkeypatch.setattr(
+            self.iso,
+            "_get_binding_constraints_real_time_5_min_from_daily_files",
+            fail_daily_fetch,
+        )
+
+        self.iso.get_binding_constraints_real_time_5_min(
+            date=start_date,
+            end=end_date,
+        )
+
+        assert calls["date"] == start_date
+        assert calls["end"] == end_date
+
     """get_interchange_real_time"""
 
     interchange_real_time_cols = [

--- a/gridstatus/tests/source_specific/test_spp.py
+++ b/gridstatus/tests/source_specific/test_spp.py
@@ -2775,11 +2775,10 @@ class TestSPP(BaseTestISO):
         start_date = self.local_start_of_today() + pd.Timedelta(hours=12)
         end_date = start_date + pd.Timedelta(minutes=30)
 
-        calls = {}
+        calls = []
 
         def fake_intervals_fetch(date, end=None, verbose=False):
-            calls["date"] = date
-            calls["end"] = end
+            calls.append((date, end))
             return pd.DataFrame(
                 {
                     "Interval Start": [start_date],
@@ -2814,8 +2813,9 @@ class TestSPP(BaseTestISO):
             end=end_date,
         )
 
-        assert calls["date"] == start_date
-        assert calls["end"] == end_date
+        assert len(calls) == 6
+        assert calls[0][0] == start_date
+        assert calls[-1][1] == end_date
 
     """get_interchange_real_time"""
 

--- a/gridstatus/tests/source_specific/test_spp.py
+++ b/gridstatus/tests/source_specific/test_spp.py
@@ -2765,8 +2765,8 @@ class TestSPP(BaseTestISO):
             )
 
         self._check_binding_constraints_real_time(df)
-        assert df["Interval Start"].min() == start_date
-        assert df["Interval Start"].max() == end_date
+        assert df["Interval Start"].min() <= start_date
+        assert df["Interval End"].max() >= end_date - pd.Timedelta(minutes=5)
 
     """get_interchange_real_time"""
 


### PR DESCRIPTION
## Summary
The SPP Binding Constraints Real Time 5 Min has 2 codepaths that can either fetch daily files or interval files. We had some logic to figure out which to use based on the query, but this was not doing the correct switching such that daily files were pulled more often than they should have been (the daily files only have data once the day is complete, while the interval files have up-to-date data but are very slow if used to get more than a few intervals). 

Updates the method to do interval data pulling more often with a wider window and some helper functions to figure out the case. 

### Details
