### PR TITLE
feat(ENG-2896): Add ERCOT Annual CRR Auction scrapers (5 datasets)

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -6863,11 +6863,11 @@ class Ercot(ISOBase):
         all_df = []
         for _year_start, strip, sequence, _basename, raw in frames:
             df = raw.copy()
-            df["Interval Start"] = pd.to_datetime(
+            df["Start Date"] = pd.to_datetime(
                 df["StartDate"],
                 format="%m/%d/%Y",
             ).dt.tz_localize(self.default_timezone)
-            df["Interval End"] = pd.to_datetime(
+            df["End Date"] = pd.to_datetime(
                 df["EndDate"],
                 format="%m/%d/%Y",
             ).dt.tz_localize(self.default_timezone)
@@ -6888,8 +6888,8 @@ class Ercot(ISOBase):
         df = pd.concat(all_df, ignore_index=True)
         return df[
             [
-                "Interval Start",
-                "Interval End",
+                "Start Date",
+                "End Date",
                 "Path",
                 "Source",
                 "Sink",
@@ -6914,7 +6914,7 @@ class Ercot(ISOBase):
         """Base loading for each annual (long-term) ERCOT CRR Auction.
 
         Each auction zip publishes one base-loading CSV per covered month;
-        ``Interval Start`` / ``Interval End`` are derived from the trailing
+        ``Start Date`` / ``End Date`` are derived from the trailing
         ``_AUCTION_<MMM>_<YYYY>.csv`` segment of the file name.
 
         Source: https://www.ercot.com/mp/data-products/data-product-details?id=NP7-802-M
@@ -6938,8 +6938,8 @@ class Ercot(ISOBase):
                 datetime.datetime.strptime(month_year, "%b_%Y"),
             ).tz_localize(self.default_timezone)
             df = raw.copy()
-            df["Interval Start"] = month_start
-            df["Interval End"] = month_start + pd.offsets.MonthEnd(0)
+            df["Start Date"] = month_start
+            df["End Date"] = month_start + pd.offsets.MonthEnd(0)
             df = df.rename(
                 columns={
                     "CRR_ID": "CRR ID",
@@ -6957,8 +6957,8 @@ class Ercot(ISOBase):
         df = pd.concat(all_df, ignore_index=True)
         return df[
             [
-                "Interval Start",
-                "Interval End",
+                "Start Date",
+                "End Date",
                 "CRR ID",
                 "Account Holder",
                 "Source",
@@ -6998,12 +6998,12 @@ class Ercot(ISOBase):
                 df["CalendarPeriod"],
                 format="%b_%Y",
             )
-            df["Interval Start"] = calendar_start.dt.tz_localize(
+            df["Start Date"] = calendar_start.dt.tz_localize(
                 self.default_timezone,
             )
-            df["Interval End"] = (
-                calendar_start + pd.offsets.MonthEnd(0)
-            ).dt.tz_localize(self.default_timezone)
+            df["End Date"] = (calendar_start + pd.offsets.MonthEnd(0)).dt.tz_localize(
+                self.default_timezone,
+            )
             df = df.rename(
                 columns={
                     "DeviceName": "Device Name",
@@ -7019,8 +7019,8 @@ class Ercot(ISOBase):
         df = pd.concat(all_df, ignore_index=True)
         return df[
             [
-                "Interval Start",
-                "Interval End",
+                "Start Date",
+                "End Date",
                 "Device Name",
                 "Device Type",
                 "Direction",
@@ -7056,11 +7056,11 @@ class Ercot(ISOBase):
         all_df = []
         for _year_start, strip, sequence, _basename, raw in frames:
             df = raw.copy()
-            df["Interval Start"] = pd.to_datetime(
+            df["Start Date"] = pd.to_datetime(
                 df["StartDate"],
                 format="%m/%d/%Y",
             ).dt.tz_localize(self.default_timezone)
-            df["Interval End"] = pd.to_datetime(
+            df["End Date"] = pd.to_datetime(
                 df["EndDate"],
                 format="%m/%d/%Y",
             ).dt.tz_localize(self.default_timezone)
@@ -7085,8 +7085,8 @@ class Ercot(ISOBase):
         df = pd.concat(all_df, ignore_index=True)
         return df[
             [
-                "Interval Start",
-                "Interval End",
+                "Start Date",
+                "End Date",
                 "CRR ID",
                 "Original CRR ID",
                 "Account Holder",
@@ -7130,12 +7130,12 @@ class Ercot(ISOBase):
                 df["CalendarPeriod"],
                 format="%b_%Y",
             )
-            df["Interval Start"] = calendar_start.dt.tz_localize(
+            df["Start Date"] = calendar_start.dt.tz_localize(
                 self.default_timezone,
             )
-            df["Interval End"] = (
-                calendar_start + pd.offsets.MonthEnd(0)
-            ).dt.tz_localize(self.default_timezone)
+            df["End Date"] = (calendar_start + pd.offsets.MonthEnd(0)).dt.tz_localize(
+                self.default_timezone,
+            )
             df = df.rename(
                 columns={
                     "SourceSink": "Source Sink",
@@ -7150,8 +7150,8 @@ class Ercot(ISOBase):
         df = pd.concat(all_df, ignore_index=True)
         return df[
             [
-                "Interval Start",
-                "Interval End",
+                "Start Date",
+                "End Date",
                 "Source Sink",
                 "Time of Use",
                 "Shadow Price Per MWh",

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -6762,6 +6762,74 @@ class Ercot(ISOBase):
         )
         return year_start, strip, sequence
 
+    def _annual_crr_request_window(
+        self,
+        date: pd.Timestamp,
+        end: pd.Timestamp | None,
+    ) -> tuple[pd.Timestamp, pd.Timestamp]:
+        """Return the ``[start, end)`` request window in the default timezone.
+
+        When ``end`` is ``None``, the window snaps to the full auction year
+        containing ``date`` (Jan 1 → Jan 1 next year), matching the legacy
+        behavior. Otherwise ``end`` is taken verbatim as the exclusive upper
+        bound.
+        """
+        start_dt = date.tz_convert(self.default_timezone)
+        if end is None:
+            year_start = start_dt.normalize().replace(month=1, day=1)
+            end_dt = year_start + pd.DateOffset(years=1)
+        else:
+            end_dt = end.tz_convert(self.default_timezone)
+        return start_dt, end_dt
+
+    def _annual_crr_relevant_year_strips(
+        self,
+        request_start: pd.Timestamp,
+        request_end: pd.Timestamp,
+    ) -> set[tuple[int, int]]:
+        """Return the set of ``(auction_year, strip)`` pairs to download.
+
+        Strip 1 covers Jan-Jun of its auction year; strip 2 covers Jul-Dec.
+        A pair is included when its calendar coverage overlaps
+        ``[request_start, request_end)``. Skipping irrelevant pairs avoids
+        downloading half a year's worth of zips when a request only touches
+        the other strip.
+        """
+        tz = self.default_timezone
+        relevant: set[tuple[int, int]] = set()
+        for year in range(request_start.year, request_end.year + 1):
+            year_start = pd.Timestamp(year=year, month=1, day=1).tz_localize(tz)
+            mid_year = pd.Timestamp(year=year, month=7, day=1).tz_localize(tz)
+            next_year_start = pd.Timestamp(
+                year=year + 1,
+                month=1,
+                day=1,
+            ).tz_localize(tz)
+            strip_windows = (
+                (1, year_start, mid_year),
+                (2, mid_year, next_year_start),
+            )
+            for strip, strip_start, strip_end in strip_windows:
+                if strip_end > request_start and strip_start < request_end:
+                    relevant.add((year, strip))
+        return relevant
+
+    @staticmethod
+    def _filter_annual_crr_rows_to_window(
+        df: pd.DataFrame,
+        request_start: pd.Timestamp,
+        request_end: pd.Timestamp,
+    ) -> pd.DataFrame:
+        """Keep rows whose ``[Start Date, End Date]`` overlaps the request window.
+
+        The predicate is ``Start Date < request_end AND End Date >= request_start``,
+        which keeps any row whose interval has non-empty intersection with
+        ``[request_start, request_end)``. Used to honor sub-strip date ranges
+        after concatenation across multiple zips.
+        """
+        mask = (df["Start Date"] < request_end) & (df["End Date"] >= request_start)
+        return df.loc[mask].reset_index(drop=True)
+
     def _handle_annual_crr_auction_zip(
         self,
         z: ZipFile,
@@ -6790,26 +6858,25 @@ class Ercot(ISOBase):
         end: pd.Timestamp | None,
         verbose: bool = False,
     ) -> list[tuple[pd.Timestamp, int, int, str, pd.DataFrame]]:
-        """Download all annual CRR ZIPs whose auction year falls in [date, end).
+        """Download annual CRR ZIPs whose (year, strip) overlaps [date, end).
 
         Returns a list of ``(year_start_central, strip, sequence, basename, df)``
         tuples for the requested ``dataset_key``, sorted by
         ``(year_start, strip, sequence, basename)``. ``end`` is treated as
         exclusive; when ``end`` is ``None`` only the auction year containing
         ``date`` is returned.
+
+        Each ERCOT annual auction publishes 12 zips per auction year
+        (6 sequences × 2 strips); the 1st strip covers Jan-Jun and the 2nd
+        strip covers Jul-Dec. Only zips whose strip window overlaps the
+        request range are downloaded, so a request that lives entirely within
+        one strip avoids 6 unnecessary downloads.
         """
-        start_year = (
-            date.tz_convert(self.default_timezone)
-            .normalize()
-            .replace(
-                month=1,
-                day=1,
-            )
+        request_start, request_end = self._annual_crr_request_window(date, end)
+        relevant_year_strips = self._annual_crr_relevant_year_strips(
+            request_start,
+            request_end,
         )
-        if end is None:
-            end_exclusive = start_year + pd.DateOffset(years=1)
-        else:
-            end_exclusive = end.tz_convert(self.default_timezone)
 
         docs = self._get_documents(
             report_type_id=ANNUAL_CRR_AUCTION_RESULTS_RTID,
@@ -6826,7 +6893,7 @@ class Ercot(ISOBase):
                 )
             except ValueError:
                 continue
-            if year_start < start_year or year_start >= end_exclusive:
+            if (year_start.year, strip) not in relevant_year_strips:
                 continue
             z = utils.get_zip_folder(doc.url, verbose=verbose)
             frames = self._handle_annual_crr_auction_zip(z)
@@ -6842,7 +6909,7 @@ class Ercot(ISOBase):
         results.sort(key=lambda item: (item[0], item[1], item[2], item[3]))
         return results
 
-    @support_date_range(frequency="YEAR_START")
+    @support_date_range(frequency=None)
     def get_crr_auction_bids_offers_annual(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
@@ -6851,8 +6918,16 @@ class Ercot(ISOBase):
     ) -> pd.DataFrame:
         """Bids and offers for each annual (long-term) ERCOT CRR Auction.
 
+        Each annual auction year publishes 12 zips (6 sequences × 2 strips).
+        Only zips whose strip window (Jan-Jun for strip 1, Jul-Dec for strip
+        2) overlaps the requested ``[date, end)`` range are downloaded, and
+        the returned rows are filtered to that same window. ``end`` is
+        exclusive; when ``end`` is ``None`` the full auction year containing
+        ``date`` is returned.
+
         Source: https://www.ercot.com/mp/data-products/data-product-details?id=NP7-802-M
         """
+        request_start, request_end = self._annual_crr_request_window(date, end)
         frames = self._get_annual_crr_auction_frames(
             "auction_bids_offers",
             date=date,
@@ -6886,7 +6961,7 @@ class Ercot(ISOBase):
             all_df.append(df)
 
         df = pd.concat(all_df, ignore_index=True)
-        return df[
+        df = df[
             [
                 "Start Date",
                 "End Date",
@@ -6903,8 +6978,13 @@ class Ercot(ISOBase):
                 "Strip",
             ]
         ]
+        return self._filter_annual_crr_rows_to_window(
+            df,
+            request_start,
+            request_end,
+        )
 
-    @support_date_range(frequency="YEAR_START")
+    @support_date_range(frequency=None)
     def get_crr_base_loading_annual(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
@@ -6915,10 +6995,13 @@ class Ercot(ISOBase):
 
         Each auction zip publishes one base-loading CSV per covered month;
         ``Start Date`` / ``End Date`` are derived from the trailing
-        ``_AUCTION_<MMM>_<YYYY>.csv`` segment of the file name.
+        ``_AUCTION_<MMM>_<YYYY>.csv`` segment of the file name. Zips outside
+        the requested strip window are skipped, and rows are filtered to
+        ``[date, end)`` after concatenation.
 
         Source: https://www.ercot.com/mp/data-products/data-product-details?id=NP7-802-M
         """
+        request_start, request_end = self._annual_crr_request_window(date, end)
         frames = self._get_annual_crr_auction_frames(
             "base_loading",
             date=date,
@@ -6955,7 +7038,7 @@ class Ercot(ISOBase):
             all_df.append(df)
 
         df = pd.concat(all_df, ignore_index=True)
-        return df[
+        df = df[
             [
                 "Start Date",
                 "End Date",
@@ -6972,8 +7055,13 @@ class Ercot(ISOBase):
                 "Strip",
             ]
         ]
+        return self._filter_annual_crr_rows_to_window(
+            df,
+            request_start,
+            request_end,
+        )
 
-    @support_date_range(frequency="YEAR_START")
+    @support_date_range(frequency=None)
     def get_crr_binding_constraints_annual(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
@@ -6982,8 +7070,12 @@ class Ercot(ISOBase):
     ) -> pd.DataFrame:
         """Binding constraints for each annual (long-term) ERCOT CRR Auction.
 
+        Zips outside the requested strip window are skipped, and rows are
+        filtered to ``[date, end)`` after concatenation.
+
         Source: https://www.ercot.com/mp/data-products/data-product-details?id=NP7-802-M
         """
+        request_start, request_end = self._annual_crr_request_window(date, end)
         frames = self._get_annual_crr_auction_frames(
             "binding_constraints",
             date=date,
@@ -7017,7 +7109,7 @@ class Ercot(ISOBase):
             all_df.append(df)
 
         df = pd.concat(all_df, ignore_index=True)
-        return df[
+        df = df[
             [
                 "Start Date",
                 "End Date",
@@ -7034,8 +7126,13 @@ class Ercot(ISOBase):
                 "Strip",
             ]
         ]
+        return self._filter_annual_crr_rows_to_window(
+            df,
+            request_start,
+            request_end,
+        )
 
-    @support_date_range(frequency="YEAR_START")
+    @support_date_range(frequency=None)
     def get_crr_market_results_annual(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
@@ -7044,8 +7141,12 @@ class Ercot(ISOBase):
     ) -> pd.DataFrame:
         """Market results for each annual (long-term) ERCOT CRR Auction.
 
+        Zips outside the requested strip window are skipped, and rows are
+        filtered to ``[date, end)`` after concatenation.
+
         Source: https://www.ercot.com/mp/data-products/data-product-details?id=NP7-802-M
         """
+        request_start, request_end = self._annual_crr_request_window(date, end)
         frames = self._get_annual_crr_auction_frames(
             "market_results",
             date=date,
@@ -7083,7 +7184,7 @@ class Ercot(ISOBase):
             all_df.append(df)
 
         df = pd.concat(all_df, ignore_index=True)
-        return df[
+        df = df[
             [
                 "Start Date",
                 "End Date",
@@ -7104,8 +7205,13 @@ class Ercot(ISOBase):
                 "Strip",
             ]
         ]
+        return self._filter_annual_crr_rows_to_window(
+            df,
+            request_start,
+            request_end,
+        )
 
-    @support_date_range(frequency="YEAR_START")
+    @support_date_range(frequency=None)
     def get_crr_source_sink_shadow_prices_annual(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
@@ -7114,8 +7220,12 @@ class Ercot(ISOBase):
     ) -> pd.DataFrame:
         """Source and sink shadow prices for each annual (long-term) ERCOT CRR Auction.
 
+        Zips outside the requested strip window are skipped, and rows are
+        filtered to ``[date, end)`` after concatenation.
+
         Source: https://www.ercot.com/mp/data-products/data-product-details?id=NP7-802-M
         """
+        request_start, request_end = self._annual_crr_request_window(date, end)
         frames = self._get_annual_crr_auction_frames(
             "source_sink_shadow_prices",
             date=date,
@@ -7148,7 +7258,7 @@ class Ercot(ISOBase):
             all_df.append(df)
 
         df = pd.concat(all_df, ignore_index=True)
-        return df[
+        df = df[
             [
                 "Start Date",
                 "End Date",
@@ -7159,6 +7269,11 @@ class Ercot(ISOBase):
                 "Strip",
             ]
         ]
+        return self._filter_annual_crr_rows_to_window(
+            df,
+            request_start,
+            request_end,
+        )
 
     # Keyed by dataset, the prefix the corresponding CSV file inside a monthly
     # CRR auction ZIP starts with.

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -1,5 +1,6 @@
 import datetime
 import io
+import re
 import time
 from dataclasses import dataclass
 from enum import Enum
@@ -195,6 +196,28 @@ COP_ADJUSTMENT_PERIOD_SNAPSHOT_RTID = 10038
 # binding constraints, market results, and source/sink shadow prices CSVs)
 # https://www.ercot.com/mp/data-products/data-product-details?id=NP7-803-M
 MONTHLY_CRR_AUCTION_RESULTS_RTID = 11201
+
+# Annual (long-term) CRR Auction Results. One ZIP per (auction year, strip,
+# sequence) clearing event; each ZIP contains the same five CSV prefixes as the
+# monthly bundle, except base loading which is split into one CSV per covered
+# month.
+# https://www.ercot.com/mp/data-products/data-product-details?id=NP7-802-M
+ANNUAL_CRR_AUCTION_RESULTS_RTID = 11203
+
+# Friendly names look like 20262nd6AnnualAuctionSeq1CRRAuctionResults: 4-digit
+# auction year, the strip label (1st/2nd), the literal '6AnnualAuctionSeq',
+# the sequence number, then 'CRRAuctionResults'.
+_ANNUAL_CRR_FRIENDLY_NAME_RE = re.compile(
+    r"^(?P<year>\d{4})(?P<strip>1st|2nd)6AnnualAuctionSeq(?P<seq>\d+)CRRAuctionResults$",
+)
+
+# Base loading CSV names look like
+# Common_BaseLoading_2026.2nd6.AnnualAuction.Seq1_AUCTION_AUG_2026.csv -- the
+# tail encodes the month covered by that file.
+_ANNUAL_CRR_BASE_LOADING_MONTH_RE = re.compile(
+    r"_AUCTION_(?P<month>[A-Z]{3})_(?P<year>\d{4})\.csv$",
+    re.IGNORECASE,
+)
 
 # https://www.ercot.com/mp/data-products/data-product-details?id=NP6-332-CD
 REAL_TIME_CLEARING_PRICES_FOR_CAPACITY_BY_SCED_INTERVAL_RTID = 24891
@@ -6706,6 +6729,436 @@ class Ercot(ISOBase):
         ]
 
         return data
+
+    # Annual CRR auction ZIPs share the Common_* CSV prefixes used by the
+    # monthly bundle.
+    _ANNUAL_CRR_AUCTION_FILE_PREFIXES = {
+        "auction_bids_offers": "Common_AuctionBidsAndOffers_",
+        "base_loading": "Common_BaseLoading_",
+        "binding_constraints": "Common_BindingConstraint_",
+        "market_results": "Common_MarketResults_",
+        "source_sink_shadow_prices": "Common_SourceAndSinkShadowPrices_",
+    }
+
+    def _parse_crr_annual_auction_friendly_name(
+        self,
+        friendly_name: str,
+    ) -> tuple[pd.Timestamp, int, int]:
+        """Parse (auction year-start Central, strip, sequence) from a friendly name.
+
+        Strip is returned as 1 (1st) or 2 (2nd). Raises ``ValueError`` when the
+        name does not match the expected annual CRR pattern.
+        """
+        match = _ANNUAL_CRR_FRIENDLY_NAME_RE.match(friendly_name)
+        if match is None:
+            raise ValueError(
+                f"Friendly name {friendly_name!r} does not look like an annual CRR auction",
+            )
+        year = int(match.group("year"))
+        strip = 1 if match.group("strip") == "1st" else 2
+        sequence = int(match.group("seq"))
+        year_start = pd.Timestamp(year=year, month=1, day=1).tz_localize(
+            self.default_timezone,
+        )
+        return year_start, strip, sequence
+
+    def _handle_annual_crr_auction_zip(
+        self,
+        z: ZipFile,
+    ) -> dict[str, list[tuple[str, pd.DataFrame]]]:
+        """Parse an annual CRR auction zip into a dict of (filename, DataFrame) lists.
+
+        Unlike the monthly bundle, the annual zip may contain multiple CSVs per
+        dataset (base loading publishes one CSV per covered month), so each
+        dataset key maps to a list of frames keyed by their basename.
+        """
+        result: dict[str, list[tuple[str, pd.DataFrame]]] = {}
+        for key, prefix in self._ANNUAL_CRR_AUCTION_FILE_PREFIXES.items():
+            matches: list[tuple[str, pd.DataFrame]] = []
+            for file in z.namelist():
+                basename = file.rsplit("/", 1)[-1]
+                if basename.startswith(prefix) and basename.lower().endswith(".csv"):
+                    matches.append((basename, pd.read_csv(z.open(file))))
+            if matches:
+                result[key] = matches
+        return result
+
+    def _get_annual_crr_auction_frames(
+        self,
+        dataset_key: str,
+        date: pd.Timestamp,
+        end: pd.Timestamp | None,
+        verbose: bool = False,
+    ) -> list[tuple[pd.Timestamp, int, int, str, pd.DataFrame]]:
+        """Download all annual CRR ZIPs whose auction year falls in [date, end).
+
+        Returns a list of ``(year_start_central, strip, sequence, basename, df)``
+        tuples for the requested ``dataset_key``, sorted by
+        ``(year_start, strip, sequence, basename)``. ``end`` is treated as
+        exclusive; when ``end`` is ``None`` only the auction year containing
+        ``date`` is returned.
+        """
+        start_year = (
+            date.tz_convert(self.default_timezone)
+            .normalize()
+            .replace(
+                month=1,
+                day=1,
+            )
+        )
+        if end is None:
+            end_exclusive = start_year + pd.DateOffset(years=1)
+        else:
+            end_exclusive = end.tz_convert(self.default_timezone)
+
+        docs = self._get_documents(
+            report_type_id=ANNUAL_CRR_AUCTION_RESULTS_RTID,
+            verbose=verbose,
+        )
+
+        results: list[tuple[pd.Timestamp, int, int, str, pd.DataFrame]] = []
+        for doc in docs:
+            try:
+                year_start, strip, sequence = (
+                    self._parse_crr_annual_auction_friendly_name(
+                        doc.friendly_name,
+                    )
+                )
+            except ValueError:
+                continue
+            if year_start < start_year or year_start >= end_exclusive:
+                continue
+            z = utils.get_zip_folder(doc.url, verbose=verbose)
+            frames = self._handle_annual_crr_auction_zip(z)
+            for basename, raw in frames.get(dataset_key, []):
+                results.append((year_start, strip, sequence, basename, raw))
+
+        if not results:
+            raise NoDataFoundException(
+                "No Annual CRR Auction documents found for "
+                f"dataset={dataset_key}, date={date}, end={end}",
+            )
+
+        results.sort(key=lambda item: (item[0], item[1], item[2], item[3]))
+        return results
+
+    @support_date_range(frequency="YEAR_START")
+    def get_crr_auction_bids_offers_annual(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Bids and offers for each annual (long-term) ERCOT CRR Auction.
+
+        Source: https://www.ercot.com/mp/data-products/data-product-details?id=NP7-802-M
+        """
+        frames = self._get_annual_crr_auction_frames(
+            "auction_bids_offers",
+            date=date,
+            end=end,
+            verbose=verbose,
+        )
+
+        all_df = []
+        for _year_start, strip, sequence, _basename, raw in frames:
+            df = raw.copy()
+            df["Interval Start"] = pd.to_datetime(
+                df["StartDate"],
+                format="%m/%d/%Y",
+            ).dt.tz_localize(self.default_timezone)
+            df["Interval End"] = pd.to_datetime(
+                df["EndDate"],
+                format="%m/%d/%Y",
+            ).dt.tz_localize(self.default_timezone)
+            df = df.rename(
+                columns={
+                    "BidType": "Bid Type",
+                    "HedgeType": "Hedge Type",
+                    "TimeOfUse": "Time of Use",
+                    "BidPricePerMWH": "Bid Price Per MWh",
+                    "ShadowPricePerMWH": "Shadow Price Per MWh",
+                },
+            )
+            df["Path"] = df["Source"].astype(str) + "-" + df["Sink"].astype(str)
+            df["Sequence"] = sequence
+            df["Strip"] = strip
+            all_df.append(df)
+
+        df = pd.concat(all_df, ignore_index=True)
+        return df[
+            [
+                "Interval Start",
+                "Interval End",
+                "Path",
+                "Source",
+                "Sink",
+                "Bid Type",
+                "Hedge Type",
+                "Time of Use",
+                "MW",
+                "Bid Price Per MWh",
+                "Shadow Price Per MWh",
+                "Sequence",
+                "Strip",
+            ]
+        ]
+
+    @support_date_range(frequency="YEAR_START")
+    def get_crr_base_loading_annual(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Base loading for each annual (long-term) ERCOT CRR Auction.
+
+        Each auction zip publishes one base-loading CSV per covered month;
+        ``Interval Start`` / ``Interval End`` are derived from the trailing
+        ``_AUCTION_<MMM>_<YYYY>.csv`` segment of the file name.
+
+        Source: https://www.ercot.com/mp/data-products/data-product-details?id=NP7-802-M
+        """
+        frames = self._get_annual_crr_auction_frames(
+            "base_loading",
+            date=date,
+            end=end,
+            verbose=verbose,
+        )
+
+        all_df = []
+        for _year_start, strip, sequence, basename, raw in frames:
+            match = _ANNUAL_CRR_BASE_LOADING_MONTH_RE.search(basename)
+            if match is None:
+                raise ValueError(
+                    f"Could not parse base-loading month from filename {basename!r}",
+                )
+            month_year = f"{match.group('month').upper()}_{match.group('year')}"
+            month_start = pd.Timestamp(
+                datetime.datetime.strptime(month_year, "%b_%Y"),
+            ).tz_localize(self.default_timezone)
+            df = raw.copy()
+            df["Interval Start"] = month_start
+            df["Interval End"] = month_start + pd.offsets.MonthEnd(0)
+            df = df.rename(
+                columns={
+                    "CRR_ID": "CRR ID",
+                    "AccountHolder": "Account Holder",
+                    "HedgeType": "Hedge Type",
+                    "TimeOfUse": "Time of Use",
+                    "ShadowPricePerMWH": "Shadow Price Per MWh",
+                },
+            )
+            df["Path"] = df["Source"].astype(str) + "-" + df["Sink"].astype(str)
+            df["Sequence"] = sequence
+            df["Strip"] = strip
+            all_df.append(df)
+
+        df = pd.concat(all_df, ignore_index=True)
+        return df[
+            [
+                "Interval Start",
+                "Interval End",
+                "CRR ID",
+                "Account Holder",
+                "Source",
+                "Sink",
+                "Hedge Type",
+                "Time of Use",
+                "MW",
+                "Shadow Price Per MWh",
+                "Path",
+                "Sequence",
+                "Strip",
+            ]
+        ]
+
+    @support_date_range(frequency="YEAR_START")
+    def get_crr_binding_constraints_annual(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Binding constraints for each annual (long-term) ERCOT CRR Auction.
+
+        Source: https://www.ercot.com/mp/data-products/data-product-details?id=NP7-802-M
+        """
+        frames = self._get_annual_crr_auction_frames(
+            "binding_constraints",
+            date=date,
+            end=end,
+            verbose=verbose,
+        )
+
+        all_df = []
+        for _year_start, strip, sequence, _basename, raw in frames:
+            df = raw.copy()
+            calendar_start = pd.to_datetime(
+                df["CalendarPeriod"],
+                format="%b_%Y",
+            )
+            df["Interval Start"] = calendar_start.dt.tz_localize(
+                self.default_timezone,
+            )
+            df["Interval End"] = (
+                calendar_start + pd.offsets.MonthEnd(0)
+            ).dt.tz_localize(self.default_timezone)
+            df = df.rename(
+                columns={
+                    "DeviceName": "Device Name",
+                    "DeviceType": "Device Type",
+                    "TimeOfUse": "Time of Use",
+                    "ShadowPrice": "Shadow Price",
+                },
+            )
+            df["Sequence"] = sequence
+            df["Strip"] = strip
+            all_df.append(df)
+
+        df = pd.concat(all_df, ignore_index=True)
+        return df[
+            [
+                "Interval Start",
+                "Interval End",
+                "Device Name",
+                "Device Type",
+                "Direction",
+                "Flow",
+                "Limit",
+                "Description",
+                "Contingency",
+                "Time of Use",
+                "Shadow Price",
+                "Sequence",
+                "Strip",
+            ]
+        ]
+
+    @support_date_range(frequency="YEAR_START")
+    def get_crr_market_results_annual(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Market results for each annual (long-term) ERCOT CRR Auction.
+
+        Source: https://www.ercot.com/mp/data-products/data-product-details?id=NP7-802-M
+        """
+        frames = self._get_annual_crr_auction_frames(
+            "market_results",
+            date=date,
+            end=end,
+            verbose=verbose,
+        )
+
+        all_df = []
+        for _year_start, strip, sequence, _basename, raw in frames:
+            df = raw.copy()
+            df["Interval Start"] = pd.to_datetime(
+                df["StartDate"],
+                format="%m/%d/%Y",
+            ).dt.tz_localize(self.default_timezone)
+            df["Interval End"] = pd.to_datetime(
+                df["EndDate"],
+                format="%m/%d/%Y",
+            ).dt.tz_localize(self.default_timezone)
+            df = df.rename(
+                columns={
+                    "CRR_ID": "CRR ID",
+                    "OriginalCRR_ID": "Original CRR ID",
+                    "AccountHolder": "Account Holder",
+                    "HedgeType": "Hedge Type",
+                    "BidType": "Bid Type",
+                    "CRRType": "CRR Type",
+                    "TimeOfUse": "Time of Use",
+                    "Bid24Hour": "Bid 24 Hour",
+                    "ShadowPricePerMWH": "Shadow Price Per MWh",
+                },
+            )
+            df["Path"] = df["Source"].astype(str) + "-" + df["Sink"].astype(str)
+            df["Sequence"] = sequence
+            df["Strip"] = strip
+            all_df.append(df)
+
+        df = pd.concat(all_df, ignore_index=True)
+        return df[
+            [
+                "Interval Start",
+                "Interval End",
+                "CRR ID",
+                "Original CRR ID",
+                "Account Holder",
+                "Hedge Type",
+                "Bid Type",
+                "CRR Type",
+                "Source",
+                "Sink",
+                "Time of Use",
+                "Bid 24 Hour",
+                "MW",
+                "Shadow Price Per MWh",
+                "Path",
+                "Sequence",
+                "Strip",
+            ]
+        ]
+
+    @support_date_range(frequency="YEAR_START")
+    def get_crr_source_sink_shadow_prices_annual(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Source and sink shadow prices for each annual (long-term) ERCOT CRR Auction.
+
+        Source: https://www.ercot.com/mp/data-products/data-product-details?id=NP7-802-M
+        """
+        frames = self._get_annual_crr_auction_frames(
+            "source_sink_shadow_prices",
+            date=date,
+            end=end,
+            verbose=verbose,
+        )
+
+        all_df = []
+        for _year_start, strip, sequence, _basename, raw in frames:
+            df = raw.copy()
+            calendar_start = pd.to_datetime(
+                df["CalendarPeriod"],
+                format="%b_%Y",
+            )
+            df["Interval Start"] = calendar_start.dt.tz_localize(
+                self.default_timezone,
+            )
+            df["Interval End"] = (
+                calendar_start + pd.offsets.MonthEnd(0)
+            ).dt.tz_localize(self.default_timezone)
+            df = df.rename(
+                columns={
+                    "SourceSink": "Source Sink",
+                    "TimeOfUse": "Time of Use",
+                    "ShadowPricePerMWH": "Shadow Price Per MWh",
+                },
+            )
+            df["Sequence"] = sequence
+            df["Strip"] = strip
+            all_df.append(df)
+
+        df = pd.concat(all_df, ignore_index=True)
+        return df[
+            [
+                "Interval Start",
+                "Interval End",
+                "Source Sink",
+                "Time of Use",
+                "Shadow Price Per MWh",
+                "Sequence",
+                "Strip",
+            ]
+        ]
 
     # Keyed by dataset, the prefix the corresponding CSV file inside a monthly
     # CRR auction ZIP starts with.

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -3216,6 +3216,219 @@ class TestErcot(BaseTestISO):
             pd.Timestamp("2026-03-31", tz=tz),
         ]
 
+    """get_crr_*_annual"""
+
+    CRR_TEST_AUCTION_YEAR_START = "2026-01-01"
+    CRR_TEST_AUCTION_YEAR_END = "2027-01-01"
+
+    crr_auction_bids_offers_annual_cols = [
+        "Interval Start",
+        "Interval End",
+        "Path",
+        "Source",
+        "Sink",
+        "Bid Type",
+        "Hedge Type",
+        "Time of Use",
+        "MW",
+        "Bid Price Per MWh",
+        "Shadow Price Per MWh",
+        "Sequence",
+        "Strip",
+    ]
+
+    crr_base_loading_annual_cols = [
+        "Interval Start",
+        "Interval End",
+        "CRR ID",
+        "Account Holder",
+        "Source",
+        "Sink",
+        "Hedge Type",
+        "Time of Use",
+        "MW",
+        "Shadow Price Per MWh",
+        "Path",
+        "Sequence",
+        "Strip",
+    ]
+
+    crr_binding_constraints_annual_cols = [
+        "Interval Start",
+        "Interval End",
+        "Device Name",
+        "Device Type",
+        "Direction",
+        "Flow",
+        "Limit",
+        "Description",
+        "Contingency",
+        "Time of Use",
+        "Shadow Price",
+        "Sequence",
+        "Strip",
+    ]
+
+    crr_market_results_annual_cols = [
+        "Interval Start",
+        "Interval End",
+        "CRR ID",
+        "Original CRR ID",
+        "Account Holder",
+        "Hedge Type",
+        "Bid Type",
+        "CRR Type",
+        "Source",
+        "Sink",
+        "Time of Use",
+        "Bid 24 Hour",
+        "MW",
+        "Shadow Price Per MWh",
+        "Path",
+        "Sequence",
+        "Strip",
+    ]
+
+    crr_source_sink_shadow_prices_annual_cols = [
+        "Interval Start",
+        "Interval End",
+        "Source Sink",
+        "Time of Use",
+        "Shadow Price Per MWh",
+        "Sequence",
+        "Strip",
+    ]
+
+    def _check_crr_annual_frame(
+        self,
+        df: pd.DataFrame,
+        expected_cols: list[str],
+        expected_year: int = 2026,
+    ) -> None:
+        assert df.columns.tolist() == expected_cols
+        assert len(df) > 0
+        assert pd.api.types.is_datetime64_any_dtype(df["Interval Start"])
+        assert pd.api.types.is_datetime64_any_dtype(df["Interval End"])
+        assert df["Interval Start"].dt.tz is not None
+        assert df["Interval End"].dt.tz is not None
+        tz = self.iso.default_timezone
+        assert (
+            df["Interval Start"] >= pd.Timestamp(f"{expected_year}-01-01", tz=tz)
+        ).all()
+        assert (
+            df["Interval Start"] < pd.Timestamp(f"{expected_year + 1}-01-01", tz=tz)
+        ).all()
+        assert df["Sequence"].between(1, 6).all()
+        assert df["Strip"].isin([1, 2]).all()
+
+    def test_get_crr_auction_bids_offers_annual_historical(self):
+        with api_vcr.use_cassette(
+            "test_get_crr_auction_bids_offers_annual_historical.yaml",
+        ):
+            df = self.iso.get_crr_auction_bids_offers_annual(
+                date=self.CRR_TEST_AUCTION_YEAR_START,
+                end=self.CRR_TEST_AUCTION_YEAR_END,
+            )
+
+        self._check_crr_annual_frame(df, self.crr_auction_bids_offers_annual_cols)
+        assert (df["Path"] == df["Source"] + "-" + df["Sink"]).all()
+        assert df["Bid Type"].isin(["BUY", "SELL"]).all()
+        observed_combos = sorted(
+            map(
+                tuple,
+                df[["Sequence", "Strip"]].drop_duplicates().to_numpy().tolist(),
+            ),
+        )
+        expected_combos = sorted(
+            (seq, strip) for strip in (1, 2) for seq in range(1, 7)
+        )
+        assert observed_combos == expected_combos
+
+    def test_get_crr_base_loading_annual_historical(self):
+        with api_vcr.use_cassette(
+            "test_get_crr_base_loading_annual_historical.yaml",
+        ):
+            df = self.iso.get_crr_base_loading_annual(
+                date=self.CRR_TEST_AUCTION_YEAR_START,
+                end=self.CRR_TEST_AUCTION_YEAR_END,
+            )
+
+        self._check_crr_annual_frame(df, self.crr_base_loading_annual_cols)
+        assert (df["Path"] == df["Source"] + "-" + df["Sink"]).all()
+        pk = ["Interval Start", "Sequence", "Strip", "CRR ID"]
+        assert not df.duplicated(subset=pk).any()
+
+    def test_get_crr_binding_constraints_annual_historical(self):
+        with api_vcr.use_cassette(
+            "test_get_crr_binding_constraints_annual_historical.yaml",
+        ):
+            df = self.iso.get_crr_binding_constraints_annual(
+                date=self.CRR_TEST_AUCTION_YEAR_START,
+                end=self.CRR_TEST_AUCTION_YEAR_END,
+            )
+
+        self._check_crr_annual_frame(df, self.crr_binding_constraints_annual_cols)
+        assert df["Direction"].notna().all()
+        assert df["Device Type"].notna().all()
+        pk = [
+            "Interval Start",
+            "Sequence",
+            "Strip",
+            "Device Name",
+            "Contingency",
+            "Direction",
+            "Time of Use",
+        ]
+        assert not df.duplicated(subset=pk).any()
+
+    def test_get_crr_market_results_annual_historical(self):
+        with api_vcr.use_cassette(
+            "test_get_crr_market_results_annual_historical.yaml",
+        ):
+            df = self.iso.get_crr_market_results_annual(
+                date=self.CRR_TEST_AUCTION_YEAR_START,
+                end=self.CRR_TEST_AUCTION_YEAR_END,
+            )
+
+        self._check_crr_annual_frame(df, self.crr_market_results_annual_cols)
+        assert (df["Path"] == df["Source"] + "-" + df["Sink"]).all()
+        pk = ["Interval Start", "Sequence", "Strip", "CRR ID"]
+        assert not df.duplicated(subset=pk).any()
+
+    def test_get_crr_source_sink_shadow_prices_annual_historical(self):
+        with api_vcr.use_cassette(
+            "test_get_crr_source_sink_shadow_prices_annual_historical.yaml",
+        ):
+            df = self.iso.get_crr_source_sink_shadow_prices_annual(
+                date=self.CRR_TEST_AUCTION_YEAR_START,
+                end=self.CRR_TEST_AUCTION_YEAR_END,
+            )
+
+        self._check_crr_annual_frame(
+            df,
+            self.crr_source_sink_shadow_prices_annual_cols,
+        )
+        pk = ["Interval Start", "Sequence", "Strip", "Source Sink", "Time of Use"]
+        assert not df.duplicated(subset=pk).any()
+
+    def test_get_crr_market_results_annual_multi_year_range(self):
+        with api_vcr.use_cassette(
+            "test_get_crr_market_results_annual_multi_year_range.yaml",
+        ):
+            df = self.iso.get_crr_market_results_annual(
+                date="2026-01-01",
+                end="2028-01-01",
+            )
+
+        assert df.columns.tolist() == self.crr_market_results_annual_cols
+        tz = self.iso.default_timezone
+        years_covered = sorted(df["Interval Start"].dt.year.unique())
+        assert set(years_covered).issubset({2026, 2027})
+        assert (df["Interval Start"] >= pd.Timestamp("2026-01-01", tz=tz)).all()
+        assert (df["Interval Start"] < pd.Timestamp("2028-01-01", tz=tz)).all()
+        assert df["Sequence"].between(1, 6).all()
+        assert df["Strip"].isin([1, 2]).all()
+
     """get_hourly_load_post_settlements"""
 
     def _check_hourly_load_post_settlements(self, df):

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -3222,8 +3222,8 @@ class TestErcot(BaseTestISO):
     CRR_TEST_AUCTION_YEAR_END = "2027-01-01"
 
     crr_auction_bids_offers_annual_cols = [
-        "Interval Start",
-        "Interval End",
+        "Start Date",
+        "End Date",
         "Path",
         "Source",
         "Sink",
@@ -3238,8 +3238,8 @@ class TestErcot(BaseTestISO):
     ]
 
     crr_base_loading_annual_cols = [
-        "Interval Start",
-        "Interval End",
+        "Start Date",
+        "End Date",
         "CRR ID",
         "Account Holder",
         "Source",
@@ -3254,8 +3254,8 @@ class TestErcot(BaseTestISO):
     ]
 
     crr_binding_constraints_annual_cols = [
-        "Interval Start",
-        "Interval End",
+        "Start Date",
+        "End Date",
         "Device Name",
         "Device Type",
         "Direction",
@@ -3270,8 +3270,8 @@ class TestErcot(BaseTestISO):
     ]
 
     crr_market_results_annual_cols = [
-        "Interval Start",
-        "Interval End",
+        "Start Date",
+        "End Date",
         "CRR ID",
         "Original CRR ID",
         "Account Holder",
@@ -3290,8 +3290,8 @@ class TestErcot(BaseTestISO):
     ]
 
     crr_source_sink_shadow_prices_annual_cols = [
-        "Interval Start",
-        "Interval End",
+        "Start Date",
+        "End Date",
         "Source Sink",
         "Time of Use",
         "Shadow Price Per MWh",
@@ -3307,16 +3307,14 @@ class TestErcot(BaseTestISO):
     ) -> None:
         assert df.columns.tolist() == expected_cols
         assert len(df) > 0
-        assert pd.api.types.is_datetime64_any_dtype(df["Interval Start"])
-        assert pd.api.types.is_datetime64_any_dtype(df["Interval End"])
-        assert df["Interval Start"].dt.tz is not None
-        assert df["Interval End"].dt.tz is not None
+        assert pd.api.types.is_datetime64_any_dtype(df["Start Date"])
+        assert pd.api.types.is_datetime64_any_dtype(df["End Date"])
+        assert df["Start Date"].dt.tz is not None
+        assert df["End Date"].dt.tz is not None
         tz = self.iso.default_timezone
+        assert (df["Start Date"] >= pd.Timestamp(f"{expected_year}-01-01", tz=tz)).all()
         assert (
-            df["Interval Start"] >= pd.Timestamp(f"{expected_year}-01-01", tz=tz)
-        ).all()
-        assert (
-            df["Interval Start"] < pd.Timestamp(f"{expected_year + 1}-01-01", tz=tz)
+            df["Start Date"] < pd.Timestamp(f"{expected_year + 1}-01-01", tz=tz)
         ).all()
         assert df["Sequence"].between(1, 6).all()
         assert df["Strip"].isin([1, 2]).all()
@@ -3355,7 +3353,7 @@ class TestErcot(BaseTestISO):
 
         self._check_crr_annual_frame(df, self.crr_base_loading_annual_cols)
         assert (df["Path"] == df["Source"] + "-" + df["Sink"]).all()
-        pk = ["Interval Start", "Sequence", "Strip", "CRR ID"]
+        pk = ["Start Date", "Sequence", "Strip", "CRR ID"]
         assert not df.duplicated(subset=pk).any()
 
     def test_get_crr_binding_constraints_annual_historical(self):
@@ -3371,7 +3369,7 @@ class TestErcot(BaseTestISO):
         assert df["Direction"].notna().all()
         assert df["Device Type"].notna().all()
         pk = [
-            "Interval Start",
+            "Start Date",
             "Sequence",
             "Strip",
             "Device Name",
@@ -3392,7 +3390,7 @@ class TestErcot(BaseTestISO):
 
         self._check_crr_annual_frame(df, self.crr_market_results_annual_cols)
         assert (df["Path"] == df["Source"] + "-" + df["Sink"]).all()
-        pk = ["Interval Start", "Sequence", "Strip", "CRR ID"]
+        pk = ["Start Date", "Sequence", "Strip", "CRR ID"]
         assert not df.duplicated(subset=pk).any()
 
     def test_get_crr_source_sink_shadow_prices_annual_historical(self):
@@ -3408,7 +3406,7 @@ class TestErcot(BaseTestISO):
             df,
             self.crr_source_sink_shadow_prices_annual_cols,
         )
-        pk = ["Interval Start", "Sequence", "Strip", "Source Sink", "Time of Use"]
+        pk = ["Start Date", "Sequence", "Strip", "Source Sink", "Time of Use"]
         assert not df.duplicated(subset=pk).any()
 
     def test_get_crr_market_results_annual_multi_year_range(self):
@@ -3422,10 +3420,10 @@ class TestErcot(BaseTestISO):
 
         assert df.columns.tolist() == self.crr_market_results_annual_cols
         tz = self.iso.default_timezone
-        years_covered = sorted(df["Interval Start"].dt.year.unique())
+        years_covered = sorted(df["Start Date"].dt.year.unique())
         assert set(years_covered).issubset({2026, 2027})
-        assert (df["Interval Start"] >= pd.Timestamp("2026-01-01", tz=tz)).all()
-        assert (df["Interval Start"] < pd.Timestamp("2028-01-01", tz=tz)).all()
+        assert (df["Start Date"] >= pd.Timestamp("2026-01-01", tz=tz)).all()
+        assert (df["Start Date"] < pd.Timestamp("2028-01-01", tz=tz)).all()
         assert df["Sequence"].between(1, 6).all()
         assert df["Strip"].isin([1, 2]).all()
 


### PR DESCRIPTION
## Summary
- Adds five `get_crr_*_annual` scrapers for ERCOT's long-term CRR auction (NP7-802-M, report_type_id 11203), mirroring the existing monthly CRR set.

### Details
Each annual auction publishes one ZIP per (auction year, strip, sequence) clearing event: 6 sequences (capacity bands 70/55/40/30/20/10%) by 2 strips (1st / 2nd) = 12 ZIPs per auction year. The helper functions parse the friendly name to derive auction year, strip (1 or 2), and sequence (1-6), iterate over every matching CSV inside each ZIP, and stamp `Sequence` and `Strip` columns onto every returned row so downstream consumers can disambiguate the otherwise-overlapping clearings. CSV prefixes inside the ZIP match the monthly bundle (`Common_AuctionBidsAndOffers_`, `Common_BaseLoading_`, etc.). 

The Base Loading dataset additionally splits CSVs by covered month — for that dataset `Interval Start`/`Interval End` come from the trailing `_AUCTION_<MMM>_<YYYY>.csv` segment of each filename rather than the friendly name. Bids/offers and market results keep their per-row `StartDate`/`EndDate` semantics; binding constraints and source/sink shadow prices keep their per-row `CalendarPeriod` (`MMM_YYYY`) semantics. The methods are decorated with `@support_date_range(frequency="YEAR_START")` and filter the MIS document list by auction year.

To run tests:

```bash
VCR_RECORD_MODE=all uv run pytest -vvv gridstatus/tests/ -k "ercot" -k "crr and annual"
```