### PR TITLE
[ENG-3891] Add SPP Day-Ahead LMP by Bus scraper

### DIFF
--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -23,6 +23,7 @@ from gridstatus.gs_logging import logger
 RTBM_LMP_BY_BUS = "rtbm-lmp-by-bus"
 FS_RTBM_LMP_BY_LOCATION = "rtbm-lmp-by-location"
 FS_DAM_LMP_BY_LOCATION = "da-lmp-by-settlement-location"
+FS_DAM_LMP_BY_BUS = "da-lmp-by-bus"
 LMP_BY_SETTLEMENT_LOCATION_WEIS = "lmp-by-settlement-location-weis"
 OPERATING_RESERVES = "operating-reserves"
 RTBM_MCP = "rtbm-mcp"
@@ -1601,12 +1602,42 @@ class SPP(ISOBase):
         if date == "latest":
             raise NotSupported("Latest not supported for day ahead hourly")
 
-        df = self._get_dam_lmp(date, verbose)
+        df = self._get_dam_lmp(date, location_type=location_type, verbose=verbose)
 
         return self._finalize_spp_df(
             df,
             market=Markets.DAY_AHEAD_HOURLY,
             location_type=location_type,
+            verbose=verbose,
+            include_baa=True,
+        )
+
+    @support_date_range(frequency="DAY_START")
+    def get_lmp_day_ahead_hourly_by_bus(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Get day ahead hourly LMP data by bus (pnode-level).
+
+        Args:
+            date: date to get data for
+            end: end date
+            verbose: print url
+
+        NOTE: does not take a location_type argument because it always returns
+        LOCATION_TYPE_BUS.
+        """
+        if date == "latest":
+            raise NotSupported("Latest not supported for day ahead hourly by bus")
+
+        df = self._get_dam_lmp(date, location_type=LOCATION_TYPE_BUS, verbose=verbose)
+
+        return self._finalize_spp_df(
+            df,
+            market=Markets.DAY_AHEAD_HOURLY,
+            location_type=LOCATION_TYPE_BUS,
             verbose=verbose,
             include_baa=True,
         )
@@ -1630,9 +1661,17 @@ class SPP(ISOBase):
     def _get_dam_lmp(
         self,
         date: pd.Timestamp,
+        location_type: str = LOCATION_TYPE_ALL,
         verbose: bool = False,
     ) -> pd.DataFrame:
-        url = f"{FILE_BROWSER_DOWNLOAD_URL}/{FS_DAM_LMP_BY_LOCATION}?path=/{date.strftime('%Y')}/{date.strftime('%m')}/By_Day/DA-LMP-SL-{date.strftime('%Y%m%d')}0100.csv"  # noqa
+        if location_type == LOCATION_TYPE_BUS:
+            endpoint = FS_DAM_LMP_BY_BUS
+            file_prefix = "DA-LMP-B"
+        else:
+            endpoint = FS_DAM_LMP_BY_LOCATION
+            file_prefix = "DA-LMP-SL"
+
+        url = f"{FILE_BROWSER_DOWNLOAD_URL}/{endpoint}?path=/{date.strftime('%Y')}/{date.strftime('%m')}/By_Day/{file_prefix}-{date.strftime('%Y%m%d')}0100.csv"  # noqa
         logger.info(f"Downloading {url}")
         df = pd.read_csv(url)
         return df

--- a/gridstatus/tests/source_specific/test_spp.py
+++ b/gridstatus/tests/source_specific/test_spp.py
@@ -655,6 +655,77 @@ class TestSPP(BaseTestISO):
 
         self._check_lmp_day_ahead_hourly(df, location_types=[location_type])
 
+    """get_lmp_day_ahead_hourly_by_bus"""
+
+    def _check_lmp_day_ahead_hourly_by_bus(self, df):
+        assert df.columns.tolist() == [
+            "Time",
+            "Interval Start",
+            "Interval End",
+            "Market",
+            "BAA",
+            "Location",
+            "Location Type",
+            "LMP",
+            "Energy",
+            "Congestion",
+            "Loss",
+        ]
+
+        assert df["Market"].unique() == [Markets.DAY_AHEAD_HOURLY.value]
+        assert df["Location Type"].unique() == [LOCATION_TYPE_BUS]
+        assert (
+            df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
+        ).all()
+
+        assert np.allclose(df["LMP"], df["Energy"] + df["Congestion"] + df["Loss"])
+
+    @pytest.mark.integration
+    def test_get_lmp_day_ahead_hourly_by_bus_latest_not_supported(self):
+        with pytest.raises(NotSupported):
+            self.iso.get_lmp_day_ahead_hourly_by_bus(date="latest")
+
+    def test_get_lmp_day_ahead_hourly_by_bus_today(self):
+        with api_vcr.use_cassette(
+            "test_get_lmp_day_ahead_hourly_by_bus_today.yaml",
+        ):
+            df = self.iso.get_lmp_day_ahead_hourly_by_bus(date="today")
+
+        self._check_lmp_day_ahead_hourly_by_bus(df)
+        assert df["Interval Start"].min() == self.local_start_of_today()
+        assert df["Interval End"].max() == self.local_start_of_today() + pd.DateOffset(
+            days=1,
+        )
+
+    def test_get_lmp_day_ahead_hourly_by_bus_date_range(self):
+        four_days_ago = self.local_start_of_today() - pd.DateOffset(days=4)
+        two_days_ago = four_days_ago + pd.DateOffset(days=2)
+
+        with api_vcr.use_cassette(
+            f"test_get_lmp_day_ahead_hourly_by_bus_date_range_{four_days_ago.strftime('%Y%m%d')}_{two_days_ago.strftime('%Y%m%d')}.yaml",
+        ):
+            df = self.iso.get_lmp_day_ahead_hourly_by_bus(
+                start=four_days_ago,
+                end=two_days_ago,
+            )
+
+        self._check_lmp_day_ahead_hourly_by_bus(df)
+        assert df["Interval Start"].min() == four_days_ago
+        # Not end day inclusive
+        assert df["Interval End"].max() == two_days_ago
+
+    def test_get_lmp_day_ahead_hourly_by_bus_historical_date(self):
+        thirty_days_ago = self.local_start_of_today() - pd.DateOffset(days=30)
+
+        with api_vcr.use_cassette(
+            f"test_get_lmp_day_ahead_hourly_by_bus_historical_date_{thirty_days_ago.strftime('%Y%m%d')}.yaml",
+        ):
+            df = self.iso.get_lmp_day_ahead_hourly_by_bus(date=thirty_days_ago)
+
+        self._check_lmp_day_ahead_hourly_by_bus(df)
+        assert df["Interval Start"].min() == thirty_days_ago
+        assert df["Interval End"].max() == thirty_days_ago + pd.DateOffset(days=1)
+
     # This is not a method in the class, but the base class calls it. So we need to
     # override these tests
     """get_lmp"""


### PR DESCRIPTION
## Summary
- Add `SPP.get_lmp_day_ahead_hourly_by_bus(date, end, verbose)` that pulls `da-lmp-by-bus` files from the SPP portal and returns the canonical LMP schema with `Location Type = Bus`.
- Parameterize `_get_dam_lmp` by `location_type` to route between `da-lmp-by-settlement-location` and `da-lmp-by-bus`. Public `get_lmp_day_ahead_hourly` behavior is unchanged.

## Test plan
- [ ] `VCR_RECORD_MODE=all uv run pytest -vv gridstatus/tests/source_specific/test_spp.py::TestSPP::test_get_lmp_day_ahead_hourly_by_bus_today gridstatus/tests/source_specific/test_spp.py::TestSPP::test_get_lmp_day_ahead_hourly_by_bus_historical_date gridstatus/tests/source_specific/test_spp.py::TestSPP::test_get_lmp_day_ahead_hourly_by_bus_date_range`
- [ ] Re-run existing DA-by-location test to confirm no regression: `VCR_RECORD_MODE=all uv run pytest -vv gridstatus/tests/source_specific/test_spp.py::TestSPP::test_get_lmp_day_ahead_hourly_today`

🤖 Generated with [Claude Code](https://claude.com/claude-code)