### PR TITLE
[ENG-3417] Add ISO-NE get_total_demand 5-minute API scraper

### DIFF
--- a/gridstatus/isone_api/isone_api.py
+++ b/gridstatus/isone_api/isone_api.py
@@ -21,6 +21,7 @@ from gridstatus.isone_api.isone_api_constants import (
     ISONE_RESERVE_ZONE_ALL_COLUMNS,
     ISONE_RESERVE_ZONE_COLUMN_MAP,
     ISONE_RESERVE_ZONE_FLOAT_COLUMNS,
+    ISONE_TOTAL_DEMAND_COLUMNS,
 )
 
 # Default page size for API requests
@@ -966,6 +967,68 @@ class ISONEAPI:
         return df[ISONE_FIVE_MIN_ESTIMATED_ZONAL_LOAD_COLUMNS].sort_values(
             ["Interval Start", "Load Zone ID"],
         )
+
+    @support_date_range("DAY_START")
+    def get_total_demand(
+        self,
+        date: str | pd.Timestamp | Literal["latest"],
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """
+        Get five-minute system load ("total demand") data.
+
+        Includes Total Load, Native Load, Asset Related Load, and the
+        behind-the-meter (estimated solar) variants, as reported by the
+        ISO-NE /fiveminutesystemload web service endpoint.
+
+        Args:
+            date (pd.Timestamp | Literal["latest"]): The start date for the
+                data request. Use "latest" for most recent data.
+            end (pd.Timestamp | None): The end date for the data request. Only
+                used if date is not "latest".
+            verbose (bool): Whether to print verbose logging information.
+
+        Returns:
+            pd.DataFrame: A DataFrame containing five-minute total demand data.
+        """
+        url = self._build_url("fiveminutesystemload", date)
+        response = self.make_api_call(url, verbose=verbose)
+
+        # The /current endpoint returns {"FiveMinSystemLoad": [...]} while the
+        # /day endpoint nests the records under "FiveMinSystemLoads".
+        records = self._prepare_records(
+            self._safe_get(response, "FiveMinSystemLoads", "FiveMinSystemLoad")
+            or self._safe_get(response, "FiveMinSystemLoad"),
+        )
+
+        if not records:
+            raise NoDataFoundException(
+                f"No five-minute system load data found for {date}",
+            )
+
+        df = pd.DataFrame(records)
+
+        df["Interval Start"] = pd.to_datetime(
+            df["BeginDate"],
+            utc=True,
+        ).dt.tz_convert(self.default_timezone)
+        df["Interval End"] = df["Interval Start"] + pd.Timedelta(minutes=5)
+
+        df = df.rename(
+            columns={
+                "LoadMw": "Total Load",
+                "NativeLoad": "Native Load",
+                "ArdDemand": "Asset Related Load",
+                "SystemLoadBtmPv": "Total Load With Estimated Solar",
+                "NativeLoadBtmPv": "Native Load With Estimated Solar",
+            },
+        )
+
+        for col in ISONE_TOTAL_DEMAND_COLUMNS[2:]:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+
+        return df[ISONE_TOTAL_DEMAND_COLUMNS].sort_values("Interval Start")
 
     @support_date_range("HOUR_START")
     def get_lmp_real_time_5_min_prelim(

--- a/gridstatus/isone_api/isone_api.py
+++ b/gridstatus/isone_api/isone_api.py
@@ -995,12 +995,10 @@ class ISONEAPI:
         url = self._build_url("fiveminutesystemload", date)
         response = self.make_api_call(url, verbose=verbose)
 
-        # The /current endpoint returns {"FiveMinSystemLoad": [...]} while the
-        # /day endpoint nests the records under "FiveMinSystemLoads".
-        records = self._prepare_records(
-            self._safe_get(response, "FiveMinSystemLoads", "FiveMinSystemLoad")
-            or self._safe_get(response, "FiveMinSystemLoad"),
-        )
+        # /current returns {"FiveMinSystemLoad": [...]}; /day nests it under
+        # "FiveMinSystemLoads". Collapse both shapes to the inner container.
+        container = response.get("FiveMinSystemLoads", response)
+        records = self._prepare_records(container.get("FiveMinSystemLoad"))
 
         if not records:
             raise NoDataFoundException(

--- a/gridstatus/isone_api/isone_api_constants.py
+++ b/gridstatus/isone_api/isone_api_constants.py
@@ -97,6 +97,16 @@ ISONE_FIVE_MIN_ESTIMATED_ZONAL_LOAD_COLUMNS = [
     "Estimated BTM Solar",
 ]
 
+ISONE_TOTAL_DEMAND_COLUMNS = [
+    "Interval Start",
+    "Interval End",
+    "Total Load",
+    "Native Load",
+    "Asset Related Load",
+    "Total Load With Estimated Solar",
+    "Native Load With Estimated Solar",
+]
+
 ISONE_FCM_RECONFIGURATION_COLUMNS = [
     "Interval Start",
     "Interval End",

--- a/gridstatus/tests/source_specific/test_isone_api.py
+++ b/gridstatus/tests/source_specific/test_isone_api.py
@@ -9,6 +9,7 @@ from gridstatus.isone_api.isone_api_constants import (
     ISONE_FCM_RECONFIGURATION_COLUMNS,
     ISONE_FIVE_MIN_ESTIMATED_ZONAL_LOAD_COLUMNS,
     ISONE_RESERVE_ZONE_ALL_COLUMNS,
+    ISONE_TOTAL_DEMAND_COLUMNS,
 )
 from gridstatus.tests.base_test_iso import TestHelperMixin
 from gridstatus.tests.vcr_utils import RECORD_MODE, setup_vcr
@@ -628,6 +629,47 @@ class TestISONEAPI(TestHelperMixin):
             result = self.iso.get_zonal_load_estimated_5_min(date=date, end=end)
 
         self._check_zonal_load_estimated_5_min(result)
+
+        assert result["Interval Start"].min() == pd.Timestamp(date).tz_localize(
+            self.iso.default_timezone,
+        )
+        assert result["Interval Start"].max() == pd.Timestamp(end).tz_localize(
+            self.iso.default_timezone,
+        ) - pd.Timedelta(minutes=5)
+
+    """get_total_demand"""
+
+    def _check_total_demand(self, df: pd.DataFrame) -> None:
+        assert list(df.columns) == ISONE_TOTAL_DEMAND_COLUMNS
+        for col in ISONE_TOTAL_DEMAND_COLUMNS[2:]:
+            assert df[col].dtype in [np.int64, np.float64]
+        assert (
+            (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(minutes=5)
+        ).all()
+        assert df["Interval Start"].is_unique
+        assert df["Interval Start"].is_monotonic_increasing
+
+    def test_get_total_demand_latest(self):
+        with api_vcr.use_cassette("test_get_total_demand_latest.yaml"):
+            result = self.iso.get_total_demand(date="latest")
+
+        self._check_total_demand(result)
+        assert len(result) == 1
+
+    @pytest.mark.parametrize(
+        "date,end",
+        DST_CHANGE_TEST_DATES,
+    )
+    def test_get_total_demand_date_range(
+        self,
+        date: str,
+        end: str,
+    ):
+        cassette_name = f"test_get_total_demand_{date}_{end}.yaml"
+        with api_vcr.use_cassette(cassette_name):
+            result = self.iso.get_total_demand(date=date, end=end)
+
+        self._check_total_demand(result)
 
         assert result["Interval Start"].min() == pd.Timestamp(date).tz_localize(
             self.iso.default_timezone,


### PR DESCRIPTION
## Summary
- Adds `ISONEAPI.get_total_demand`, a 5-minute "total demand" scraper backed by the ISO-NE `/fiveminutesystemload` web service endpoint.
- Notion: [ENG-3417 — ISO-NE Total Demand](https://www.notion.so/gridstatus/318e835f42aa80a7bf34e0fd4a6c5d3e)

### Details
Exposes the full set of ISO-NE 5-minute system-load columns — `Total Load`, `Native Load`, `Asset Related Load`, `Total Load With Estimated Solar`, `Native Load With Estimated Solar` — rather than just the single `Native Load` value surfaced by the existing CSV-based `ISONE.get_load`. This backs the new `isone_total_demand_5_min` dataset (registered separately in gs-etl).

The method follows the existing `get_zonal_load_estimated_5_min` pattern: `@support_date_range("DAY_START")`, `_build_url` + `make_api_call`, `_safe_get` / `_prepare_records`, UTC→Eastern conversion, `+5 min` interval end. The `/current` and `/day/{YYYYMMDD}` endpoints nest the records under different keys (`FiveMinSystemLoad` vs `FiveMinSystemLoads.FiveMinSystemLoad`), so both shapes are handled. Source timestamps carry explicit UTC offsets, so DST transitions parse without ambiguity (verified across the spring-forward boundary). `ISONE_TOTAL_DEMAND_COLUMNS` added to `isone_api_constants.py`.

To run tests:

```bash
VCR_RECORD_MODE=all uv run pytest -vvv gridstatus/tests/source_specific/test_isone_api.py -k total_demand
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
