### PR TITLE
[ENG-3917] IESO Align Shadow Prices Publish Time with last_modified Filter

### DIFF
--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -4302,7 +4302,7 @@ class IESO(ISOBase):
         dfs = []
         for json_data, file_last_modified in json_data_with_times:
             df = self._parse_real_time_shadow_prices_report(json_data)
-            df["Last Modified"] = file_last_modified
+            df["Publish Time"] = file_last_modified
             dfs.append(df)
         df = pd.concat(dfs)
         df = utils.move_cols_to_front(
@@ -4363,8 +4363,9 @@ class IESO(ISOBase):
             last_modified=last_modified,
         )
         dfs = []
-        for json_data, _ in json_data_with_times:
+        for json_data, file_last_modified in json_data_with_times:
             df = self._parse_day_ahead_shadow_prices_report(json_data)
+            df["Publish Time"] = file_last_modified
             dfs.append(df)
         df = pd.concat(dfs)
         df = utils.move_cols_to_front(
@@ -4450,7 +4451,8 @@ class IESO(ISOBase):
             return "connection reset" in msg or "connection aborted" in msg
 
         def _fetch_with_retries(
-            file: str, last_modified_time: str
+            file: str,
+            last_modified_time: str,
         ) -> tuple[dict, pd.Timestamp]:
             # small stagger based on filename hash so not all tasks start at once
             initial_delay = (hash(file) % 2000) / 1000.0  # 0–2s

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -4278,8 +4278,13 @@ class IESO(ISOBase):
         if date == "latest":
             base_url = f"{PUBLIC_REPORTS_URL_PREFIX}/RealtimeConstrShadowPrices"
             file = "PUB_RealtimeConstrShadowPrices.xml"
+            file_last_modified = self._get_shadow_prices_file_last_modified(
+                base_url,
+                file,
+            )
             json_data = self._fetch_and_parse_shadow_prices_file(base_url, file)
             df = self._parse_real_time_shadow_prices_report(json_data)
+            df["Publish Time"] = file_last_modified
             df.sort_values(
                 ["Interval Start", "Publish Time", "Constraint"],
                 inplace=True,
@@ -4341,8 +4346,13 @@ class IESO(ISOBase):
         if date == "latest":
             base_url = f"{PUBLIC_REPORTS_URL_PREFIX}/DAConstrShadowPrices"
             file = "PUB_DAConstrShadowPrices.xml"
+            file_last_modified = self._get_shadow_prices_file_last_modified(
+                base_url,
+                file,
+            )
             json_data = self._fetch_and_parse_shadow_prices_file(base_url, file)
             df = self._parse_day_ahead_shadow_prices_report(json_data)
+            df["Publish Time"] = file_last_modified
             df.sort_values(
                 ["Interval Start", "Publish Time", "Constraint"],
                 inplace=True,
@@ -4396,6 +4406,23 @@ class IESO(ISOBase):
         r = self._request(url)
         json_data = xmltodict.parse(r.text)
         return json_data
+
+    def _get_shadow_prices_file_last_modified(
+        self,
+        base_url: str,
+        file: str,
+    ) -> pd.Timestamp:
+        r = self._request(base_url)
+        pattern = (
+            rf'<a href="{re.escape(file)}">.*?</a>'
+            r"\s+(\d{2}-\w{3}-\d{4} \d{2}:\d{2})"
+        )
+        match = re.search(pattern, r.text)
+        if not match:
+            raise FileNotFoundError(
+                f"Could not find {file} in index at {base_url}",
+            )
+        return pd.Timestamp(match.group(1), tz=self.default_timezone)
 
     def _get_all_shadow_prices_jsons(
         self,

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -4490,7 +4490,7 @@ class IESO(ISOBase):
                 for file, last_modified_time in filtered_files
             }
             for future in as_completed(future_to_file):
-                file, last_modified_time = future_to_file[future]
+                file, _ = future_to_file[future]
                 try:
                     json_data, ts = future.result()
                     json_data_with_times.append((json_data, ts))

--- a/gridstatus/tests/source_specific/test_ieso.py
+++ b/gridstatus/tests/source_specific/test_ieso.py
@@ -2270,6 +2270,7 @@ class TestIESO(BaseTestISO):
             df = self.iso.get_shadow_prices_real_time_5_min("latest")
             self._check_shadow_prices(df)
             assert df["Interval Start"].is_monotonic_increasing
+            assert df["Publish Time"].nunique() == 1
 
     @pytest.mark.parametrize(
         "date, end",
@@ -2304,6 +2305,7 @@ class TestIESO(BaseTestISO):
             df = self.iso.get_shadow_prices_day_ahead_hourly("latest")
             self._check_shadow_prices(df)
             assert df["Interval Start"].is_monotonic_increasing
+            assert df["Publish Time"].nunique() == 1
 
     @pytest.mark.parametrize(
         "date, end",

--- a/gridstatus/tests/source_specific/test_ieso.py
+++ b/gridstatus/tests/source_specific/test_ieso.py
@@ -2286,6 +2286,17 @@ class TestIESO(BaseTestISO):
             df = self.iso.get_shadow_prices_real_time_5_min(date, end=end)
             self._check_shadow_prices(df)
 
+            last_modified = pd.Timestamp(date, tz=self.default_timezone) + pd.Timedelta(
+                hours=12,
+            )
+            filtered = self.iso.get_shadow_prices_real_time_5_min(
+                date,
+                end=end,
+                last_modified=last_modified,
+            )
+            self._check_shadow_prices(filtered)
+            assert (filtered["Publish Time"] >= last_modified).all()
+
     def test_get_shadow_prices_day_ahead_hourly_latest(self):
         with file_vcr.use_cassette(
             "test_get_shadow_prices_day_ahead_hourly_latest.yaml",
@@ -2308,6 +2319,17 @@ class TestIESO(BaseTestISO):
         with file_vcr.use_cassette(cassette_name):
             df = self.iso.get_shadow_prices_day_ahead_hourly(date, end=end)
             self._check_shadow_prices(df)
+
+            last_modified = pd.Timestamp(date, tz=self.default_timezone) + pd.Timedelta(
+                hours=12,
+            )
+            filtered = self.iso.get_shadow_prices_day_ahead_hourly(
+                date,
+                end=end,
+                last_modified=last_modified,
+            )
+            self._check_shadow_prices(filtered)
+            assert (filtered["Publish Time"] >= last_modified).all()
 
         """get_lmp_real_time_operating_reserves"""
 


### PR DESCRIPTION
## Summary
The IESO shadow prices `last_modified` filter compares against the directory index's `Last modified` time, but `Publish Time` was sourced from the XML's `CreatedAt` (~20 min earlier), so filtered results showed `Publish Time < last_modified`.

Now both `get_shadow_prices_real_time_5_min` and `get_shadow_prices_day_ahead_hourly` use the index `Last modified` as `Publish Time` across all paths (latest, historical range, and last_modified-filtered).

## Test plan
- [ ] `VCR_RECORD_MODE=all uv run pytest -s -vv --reruns 5 --reruns-delay 10 gridstatus/tests/source_specific/test_ieso.py::TestIESO::test_get_shadow_prices_real_time_5_min_latest gridstatus/tests/source_specific/test_ieso.py::TestIESO::test_get_shadow_prices_day_ahead_hourly_latest`
- [ ] `VCR_RECORD_MODE=all uv run pytest -s -vv --reruns 5 --reruns-delay 10 gridstatus/tests/source_specific/test_ieso.py::TestIESO::test_get_shadow_prices_real_time_5_min_historical_range gridstatus/tests/source_specific/test_ieso.py::TestIESO::test_get_shadow_prices_day_ahead_hourly_historical_range`

🤖 Generated with [Claude Code](https://claude.com/claude-code)