### PR TITLE
fix(IESO): Retry _request on transient connection errors

### DIFF
--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -863,8 +863,21 @@ class IESO(ISOBase):
         else:
             tls_verify = True
 
+        r = None
         while retry_num < max_retries:
-            r = requests.get(url, verify=tls_verify)
+            try:
+                r = requests.get(url, verify=tls_verify)
+            except (
+                requests.exceptions.ConnectionError,
+                http.client.RemoteDisconnected,
+            ) as exc:
+                retry_num += 1
+                logger.info(
+                    f"Connection error for {url}: {exc}. Retrying {retry_num}...",
+                )
+                time.sleep(sleep)
+                sleep *= 2
+                continue
 
             if r.ok:
                 break
@@ -882,7 +895,7 @@ class IESO(ISOBase):
 
             sleep *= 2
 
-        if not r.ok:
+        if r is None or not r.ok:
             raise Exception(
                 f"Failed to retrieve data from {url} in {max_retries} tries.",
             )


### PR DESCRIPTION
## Summary
- `_request` retried on non-OK HTTP status but propagated `requests.exceptions.ConnectionError` / `http.client.RemoteDisconnected` immediately. IESO frequently drops connections during index/file fetches, so callers had to layer `--reruns` on top.
- Wrap `requests.get` in the existing retry loop and use the same exponential backoff for transient connection errors.

## Test plan
- [ ] `VCR_RECORD_MODE=all uv run pytest -s -vv gridstatus/tests/source_specific/test_ieso.py::TestIESO::test_get_shadow_prices_real_time_5_min_latest gridstatus/tests/source_specific/test_ieso.py::TestIESO::test_get_shadow_prices_day_ahead_hourly_latest`
- [ ] `VCR_RECORD_MODE=all uv run pytest -s -vv gridstatus/tests/source_specific/test_ieso.py::TestIESO::test_get_shadow_prices_real_time_5_min_historical_range gridstatus/tests/source_specific/test_ieso.py::TestIESO::test_get_shadow_prices_day_ahead_hourly_historical_range`

🤖 Generated with [Claude Code](https://claude.com/claude-code)