### PR TITLE
feat(ERCOT): Add get_load_by_forecast_zone to ErcotAPI

### DIFF
--- a/gridstatus/ercot_api/ercot_api.py
+++ b/gridstatus/ercot_api/ercot_api.py
@@ -133,6 +133,10 @@ LOAD_FORECAST_BY_MODEL_ENDPOINT = "/np3-565-cd/lf_by_model_weather_zone"
 # https://data.ercot.com/data-product-archive/NP6-345-CD
 ACTUAL_SYSTEM_LOAD_BY_WEATHER_ZONE_ENDPOINT = "/np6-345-cd/act_sys_load_by_wzn"
 
+# Actual System Load by Forecast Zone
+# https://data.ercot.com/data-product-archive/NP6-346-CD
+ACTUAL_SYSTEM_LOAD_BY_FORECAST_ZONE_ENDPOINT = "/np6-346-cd/act_sys_load_by_fzn"
+
 
 # Settlement Point Price for each Settlement Point, produced from SCED LMPs every 15 minutes. # noqa
 # https://data.ercot.com/data-product-archive/NP6-905-CD
@@ -782,6 +786,88 @@ class ErcotAPI:
             + Ercot()._weather_zone_column_name_order()
             + ["System Total"]
         )
+
+        return (
+            utils.move_cols_to_front(data, columns)
+            .sort_values("Interval Start")
+            .reset_index(drop=True)[columns]
+        )
+
+    @support_date_range(frequency=None)
+    def get_load_by_forecast_zone(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Get Actual System Load by Forecast Zone.
+
+        Hourly actual load by ERCOT forecast zone (North, South, West, Houston),
+        published once per operating day on the following day.
+
+        Arguments:
+            date: the operating day to fetch reports for.
+            end: the end operating day (exclusive). Defaults to one day after date.
+            verbose: print verbose output. Defaults to False.
+
+        Returns:
+            A DataFrame with hourly load by forecast zone.
+
+        Source:
+            https://www.ercot.com/mp/data-products/data-product-details?id=NP6-346-CD
+        """
+        end = self._handle_end_date(date, end, days_to_add_if_no_end=1)
+
+        if self._should_use_historical(date):
+            data = self.get_historical_data(
+                endpoint=ACTUAL_SYSTEM_LOAD_BY_FORECAST_ZONE_ENDPOINT,
+                # The archive is filtered by posted date, which runs the day
+                # after the operating day, so shift the window forward by 1 day.
+                start_date=date + pd.Timedelta(days=1),
+                end_date=end + pd.Timedelta(days=1),
+                verbose=verbose,
+            )
+        else:
+            api_params = {
+                "operatingDayFrom": date,
+                # Subtract off one second to avoid including the end date
+                "operatingDayTo": end - pd.Timedelta(seconds=1),
+            }
+            data = self.hit_ercot_api(
+                endpoint=ACTUAL_SYSTEM_LOAD_BY_FORECAST_ZONE_ENDPOINT,
+                page_size=DEFAULT_PAGE_SIZE,
+                verbose=verbose,
+                **api_params,
+            )
+
+        # Normalize the date column name to what Ercot.parse_doc expects.
+        data = data.rename(columns={"OperatingDay": "DeliveryDate"})
+
+        data = Ercot().parse_doc(data, verbose=verbose)
+
+        # The live API returns capitalized columns like "North", while the
+        # historical archive returns "NORTH" — normalize both to uppercase
+        # to match Ercot.get_load_by_forecast_zone.
+        data = data.rename(
+            columns={
+                "North": "NORTH",
+                "South": "SOUTH",
+                "West": "WEST",
+                "Houston": "HOUSTON",
+                "Total": "TOTAL",
+            },
+        )
+
+        columns = [
+            "Time",
+            "Interval Start",
+            "Interval End",
+            "NORTH",
+            "SOUTH",
+            "WEST",
+            "HOUSTON",
+            "TOTAL",
+        ]
 
         return (
             utils.move_cols_to_front(data, columns)

--- a/gridstatus/tests/source_specific/test_ercot_api.py
+++ b/gridstatus/tests/source_specific/test_ercot_api.py
@@ -381,6 +381,43 @@ class TestErcotAPI(TestHelperMixin):
         # 48 hours of data (2 operating days)
         assert len(df) == 48
 
+    """get_load_by_forecast_zone"""
+
+    LOAD_BY_FORECAST_ZONE_COLUMNS = [
+        "Time",
+        "Interval Start",
+        "Interval End",
+        "NORTH",
+        "SOUTH",
+        "WEST",
+        "HOUSTON",
+        "TOTAL",
+    ]
+
+    def _check_load_by_forecast_zone(self, df):
+        assert df.columns.tolist() == self.LOAD_BY_FORECAST_ZONE_COLUMNS
+        assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()
+        assert df["Interval Start"].is_monotonic_increasing
+
+    def test_get_load_by_forecast_zone_historical_date_range(self):
+        date = self.local_today() - pd.DateOffset(days=HISTORICAL_DAYS_THRESHOLD * 3)
+        end = date + pd.DateOffset(days=2)
+
+        with api_vcr.use_cassette(
+            "test_get_load_by_forecast_zone_historical_date_range.yaml",
+        ):
+            df = self.iso.get_load_by_forecast_zone(date, end, verbose=True)
+
+        self._check_load_by_forecast_zone(df)
+
+        assert df["Interval Start"].min() == self.local_start_of_day(date.date())
+        assert df["Interval End"].max() == self.local_start_of_day(
+            date.date(),
+        ) + pd.DateOffset(days=2)
+
+        # 48 hours of data (2 operating days)
+        assert len(df) == 48
+
     """get_as_prices"""
 
     def _check_as_prices(self, df):


### PR DESCRIPTION
## Summary
- Wraps the `np6-346-cd/act_sys_load_by_fzn` endpoint as `ErcotAPI.get_load_by_forecast_zone`, routing recent dates through the public API and older dates through the historical archive.
- Output schema (`Time`, `Interval Start`, `Interval End`, `NORTH`, `SOUTH`, `WEST`, `HOUSTON`, `TOTAL`) matches `Ercot.get_load_by_forecast_zone`.

## Test plan
- [x] `VCR_RECORD_MODE=all uv run pytest gridstatus/tests/source_specific/test_ercot_api.py::TestErcotAPI::test_get_load_by_forecast_zone_historical_date_range`
- [x] Live API path manually verified against a 7-day-old date; `NORTH + SOUTH + WEST + HOUSTON == TOTAL` per row.

Generated with [Claude Code](https://claude.com/claude-code)