### PR TITLE
[ENG-3417] Rename ISO-NE "Asset Related Load" column to "Storage Load"

### DIFF
--- a/gridstatus/isone_api/isone_api.py
+++ b/gridstatus/isone_api/isone_api.py
@@ -978,7 +978,7 @@ class ISONEAPI:
         """
         Get five-minute system load ("total demand") data.
 
-        Includes Total Load, Native Load, Asset Related Load, and the
+        Includes Total Load, Native Load, Storage Load, and the
         behind-the-meter (estimated solar) variants, as reported by the
         ISO-NE /fiveminutesystemload web service endpoint.
 
@@ -1017,7 +1017,7 @@ class ISONEAPI:
             columns={
                 "LoadMw": "Total Load",
                 "NativeLoad": "Native Load",
-                "ArdDemand": "Asset Related Load",
+                "ArdDemand": "Storage Load",
                 "SystemLoadBtmPv": "Total Load With Estimated Solar",
                 "NativeLoadBtmPv": "Native Load With Estimated Solar",
             },

--- a/gridstatus/isone_api/isone_api_constants.py
+++ b/gridstatus/isone_api/isone_api_constants.py
@@ -102,7 +102,7 @@ ISONE_TOTAL_DEMAND_COLUMNS = [
     "Interval End",
     "Total Load",
     "Native Load",
-    "Asset Related Load",
+    "Storage Load",
     "Total Load With Estimated Solar",
     "Native Load With Estimated Solar",
 ]


### PR DESCRIPTION
## Summary
- Renames the `ArdDemand` output column from `Asset Related Load` to `Storage Load` in `IsoneAPI.get_total_demand()`. The field represents estimated charging demand from battery energy storage systems (BESS) and pumped hydro — `Storage Load` is the more accurate label.
- Updates the `ISONE_TOTAL_DEMAND_COLUMNS` constant so the final column selection still includes the renamed column.
- Updates the docstring on `get_total_demand()` to match.

Follow-up to ENG-3417 / #873.

## Test plan
- [x] `pytest gridstatus/tests/source_specific/test_isone_api.py -k total_demand` (test imports `ISONE_TOTAL_DEMAND_COLUMNS`, so the rename flows through automatically)
- [x] Spot-check a live call to `get_total_demand()` and confirm the `Storage Load` column is present with the same values previously surfaced as `Asset Related Load`

🤖 Generated with [Claude Code](https://claude.com/claude-code)