### PR TITLE
feat(ENG 3945): Add ERCOT Available Resource Planned Outage Capacity scrapers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 * Removed the `save_to` parameter from data retrieval methods. Data is no longer written to CSV files as it is fetched; callers should save the returned DataFrame themselves (e.g. with `df.to_csv(...)`). The `load_folder` utility remains available for loading previously saved CSV folders.
 
+### Additions (New Features/Datasets)
+
+#### ERCOT
+* ERCOT Available Resource Planned Outage Capacity 7 Day and Future datasets in [#884](https://github.com/gridstatus/gridstatus/pull/884)
+
 ## v0.36.0 - April 20, 2026
 
 ### Additions (New Features/Datasets)

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -4233,13 +4233,17 @@ class Ercot(ISOBase):
         Returns:
             pandas.DataFrame: A DataFrame with hourly planned outage capacity data
         """
-        return self._get_hourly_report(
-            start=date,
-            end=end,
-            report_type_id=PLANNED_OUTAGE_CAPACITY_7_DAY_RTID,
-            extension="csv",
-            handle_doc=self._handle_planned_outage_capacity_7_day,
-            verbose=verbose,
+        return (
+            self._get_hourly_report(
+                start=date,
+                end=end,
+                report_type_id=PLANNED_OUTAGE_CAPACITY_7_DAY_RTID,
+                extension="csv",
+                handle_doc=self._handle_planned_outage_capacity_7_day,
+                verbose=verbose,
+            )
+            .sort_values(["Interval Start", "Publish Time"])
+            .reset_index(drop=True)
         )
 
     def _handle_planned_outage_capacity_7_day(
@@ -4281,13 +4285,17 @@ class Ercot(ISOBase):
         Returns:
             pandas.DataFrame: A DataFrame with daily planned outage capacity data
         """
-        return self._get_hourly_report(
-            start=date,
-            end=end,
-            report_type_id=PLANNED_OUTAGE_CAPACITY_FUTURE_RTID,
-            extension="csv",
-            handle_doc=self._handle_planned_outage_capacity_future,
-            verbose=verbose,
+        return (
+            self._get_hourly_report(
+                start=date,
+                end=end,
+                report_type_id=PLANNED_OUTAGE_CAPACITY_FUTURE_RTID,
+                extension="csv",
+                handle_doc=self._handle_planned_outage_capacity_future,
+                verbose=verbose,
+            )
+            .sort_values(["Interval Start", "Publish Time"])
+            .reset_index(drop=True)
         )
 
     def _handle_planned_outage_capacity_future(
@@ -4325,7 +4333,7 @@ class Ercot(ISOBase):
                 "AggReceivedResourcePOCIRR": "Received POC IRR",
             },
         )
-        df = df.sort_values(["Interval Start", "Publish Time"]).reset_index(drop=True)
+
         return df[
             [
                 "Interval Start",

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -353,27 +353,6 @@ PLANNED_OUTAGE_CAPACITY_7_DAY_RTID = 22469
 # https://www.ercot.com/mp/data-products/data-product-details?id=NP3-161-CD
 PLANNED_OUTAGE_CAPACITY_FUTURE_RTID = 22470
 
-PLANNED_OUTAGE_CAPACITY_COLUMN_MAP = {
-    "MaxDailyResourcePOCnonIRRnonPUN": "Max POC Non IRR Non PUN",
-    "AggApprovedResourcePOCnonIRRnonPUN": "Approved POC Non IRR Non PUN",
-    "AggReceivedResourcePOCnonIRRnonPUN": "Received POC Non IRR Non PUN",
-    "MaxDailyResourcePOCIRR": "Max POC IRR",
-    "AggApprovedResourcePOCIRR": "Approved POC IRR",
-    "AggReceivedResourcePOCIRR": "Received POC IRR",
-}
-
-PLANNED_OUTAGE_CAPACITY_COLUMNS = [
-    "Interval Start",
-    "Interval End",
-    "Publish Time",
-    "Max POC Non IRR Non PUN",
-    "Approved POC Non IRR Non PUN",
-    "Received POC Non IRR Non PUN",
-    "Max POC IRR",
-    "Approved POC IRR",
-    "Received POC IRR",
-]
-
 # Wind Power Production - Hourly Averaged Actual and Forecasted Values
 # https://www.ercot.com/mp/data-products/data-product-details?id=NP4-732-CD
 WIND_POWER_PRODUCTION_HOURLY_AVERAGED_ACTUAL_AND_FORECASTED_VALUES_RTID = 13028
@@ -4334,9 +4313,30 @@ class Ercot(ISOBase):
         self,
         df: pd.DataFrame,
     ) -> pd.DataFrame:
-        df = df.rename(columns=PLANNED_OUTAGE_CAPACITY_COLUMN_MAP)
+        df = df.rename(
+            columns={
+                "MaxDailyResourcePOCnonIRRnonPUN": "Max POC Non IRR Non PUN",
+                "AggApprovedResourcePOCnonIRRnonPUN": "Approved POC Non IRR Non PUN",
+                "AggReceivedResourcePOCnonIRRnonPUN": "Received POC Non IRR Non PUN",
+                "MaxDailyResourcePOCIRR": "Max POC IRR",
+                "AggApprovedResourcePOCIRR": "Approved POC IRR",
+                "AggReceivedResourcePOCIRR": "Received POC IRR",
+            },
+        )
 
-        return df[PLANNED_OUTAGE_CAPACITY_COLUMNS]
+        return df[
+            [
+                "Interval Start",
+                "Interval End",
+                "Publish Time",
+                "Max POC Non IRR Non PUN",
+                "Approved POC Non IRR Non PUN",
+                "Received POC Non IRR Non PUN",
+                "Max POC IRR",
+                "Approved POC IRR",
+                "Received POC IRR",
+            ]
+        ]
 
     @support_date_range(frequency=None)
     def get_unplanned_resource_outages(

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -4211,6 +4211,7 @@ class Ercot(ISOBase):
 
         return df
 
+    @support_date_range(frequency=None)
     def get_planned_outage_capacity_7_day(
         self,
         date: str | pd.Timestamp,
@@ -4258,6 +4259,7 @@ class Ercot(ISOBase):
 
         return self._handle_planned_outage_capacity_df(df)
 
+    @support_date_range(frequency=None)
     def get_planned_outage_capacity_future(
         self,
         date: str | pd.Timestamp,
@@ -4323,7 +4325,7 @@ class Ercot(ISOBase):
                 "AggReceivedResourcePOCIRR": "Received POC IRR",
             },
         )
-
+        df = df.sort_values(["Interval Start", "Publish Time"]).reset_index(drop=True)
         return df[
             [
                 "Interval Start",

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -345,6 +345,35 @@ AS_EXCLUDE_PRODUCTS = [
 # https://www.ercot.com/mp/data-products/data-product-details?id=NP3-233-CD
 HOURLY_RESOURCE_OUTAGE_CAPACITY_RTID = 13103
 
+# Available Resource Planned Outage Capacity Margin_7 Day
+# https://www.ercot.com/mp/data-products/data-product-details?id=NP3-162-CD
+PLANNED_OUTAGE_CAPACITY_7_DAY_RTID = 22469
+
+# Available Resource Planned Outage Capacity Margin_7 Day Plus
+# https://www.ercot.com/mp/data-products/data-product-details?id=NP3-161-CD
+PLANNED_OUTAGE_CAPACITY_FUTURE_RTID = 22470
+
+PLANNED_OUTAGE_CAPACITY_COLUMN_MAP = {
+    "MaxDailyResourcePOCnonIRRnonPUN": "Max POC Non IRR Non PUN",
+    "AggApprovedResourcePOCnonIRRnonPUN": "Approved POC Non IRR Non PUN",
+    "AggReceivedResourcePOCnonIRRnonPUN": "Received POC Non IRR Non PUN",
+    "MaxDailyResourcePOCIRR": "Max POC IRR",
+    "AggApprovedResourcePOCIRR": "Approved POC IRR",
+    "AggReceivedResourcePOCIRR": "Received POC IRR",
+}
+
+PLANNED_OUTAGE_CAPACITY_COLUMNS = [
+    "Interval Start",
+    "Interval End",
+    "Publish Time",
+    "Max POC Non IRR Non PUN",
+    "Approved POC Non IRR Non PUN",
+    "Received POC Non IRR Non PUN",
+    "Max POC IRR",
+    "Approved POC IRR",
+    "Received POC IRR",
+]
+
 # Wind Power Production - Hourly Averaged Actual and Forecasted Values
 # https://www.ercot.com/mp/data-products/data-product-details?id=NP4-732-CD
 WIND_POWER_PRODUCTION_HOURLY_AVERAGED_ACTUAL_AND_FORECASTED_VALUES_RTID = 13028
@@ -4202,6 +4231,111 @@ class Ercot(ISOBase):
             )
 
         return df
+
+    def get_planned_outage_capacity_7_day(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Hourly maximum resource capacity available for planned outages within 7
+        days of the operating day, as reported by ERCOT (NP3-162-CD).
+
+        The date argument refers to the publish time of the report, which is
+        published hourly.
+
+        Arguments:
+            date (str, pd.Timestamp): publish time to download.
+            end (str, pd.Timestamp, optional): end publish time to download.
+                Defaults to None.
+            verbose (bool, optional): print verbose output. Defaults to False.
+
+        Returns:
+            pandas.DataFrame: A DataFrame with hourly planned outage capacity data
+        """
+        return self._get_hourly_report(
+            start=date,
+            end=end,
+            report_type_id=PLANNED_OUTAGE_CAPACITY_7_DAY_RTID,
+            extension="csv",
+            handle_doc=self._handle_planned_outage_capacity_7_day,
+            verbose=verbose,
+        )
+
+    def _handle_planned_outage_capacity_7_day(
+        self,
+        doc: Document,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        df = self.read_doc(doc, parse=False, verbose=verbose)
+        df = df.rename(columns={"OperatingDate": "DeliveryDate"})
+        df = self.parse_doc(df, verbose=verbose)
+
+        df.insert(
+            0,
+            "Publish Time",
+            pd.to_datetime(doc.publish_date).tz_convert(self.default_timezone),
+        )
+
+        return self._handle_planned_outage_capacity_df(df)
+
+    def get_planned_outage_capacity_future(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Daily maximum resource capacity available for planned outages from 7 days
+        to 60 months ahead of the operating day, as reported by ERCOT (NP3-161-CD).
+
+        The date argument refers to the publish time of the report, which is
+        published twice each business day.
+
+        Arguments:
+            date (str, pd.Timestamp): publish time to download.
+            end (str, pd.Timestamp, optional): end publish time to download.
+                Defaults to None.
+            verbose (bool, optional): print verbose output. Defaults to False.
+
+        Returns:
+            pandas.DataFrame: A DataFrame with daily planned outage capacity data
+        """
+        return self._get_hourly_report(
+            start=date,
+            end=end,
+            report_type_id=PLANNED_OUTAGE_CAPACITY_FUTURE_RTID,
+            extension="csv",
+            handle_doc=self._handle_planned_outage_capacity_future,
+            verbose=verbose,
+        )
+
+    def _handle_planned_outage_capacity_future(
+        self,
+        doc: Document,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        df = self.read_doc(doc, parse=False, verbose=verbose)
+
+        df["Interval Start"] = pd.to_datetime(df["OperatingDate"]).dt.tz_localize(
+            self.default_timezone,
+        )
+        df["Interval End"] = df["Interval Start"] + pd.DateOffset(days=1)
+
+        df.insert(
+            0,
+            "Publish Time",
+            pd.to_datetime(doc.publish_date).tz_convert(self.default_timezone),
+        )
+
+        return self._handle_planned_outage_capacity_df(df)
+
+    def _handle_planned_outage_capacity_df(
+        self,
+        df: pd.DataFrame,
+    ) -> pd.DataFrame:
+        df = df.rename(columns=PLANNED_OUTAGE_CAPACITY_COLUMN_MAP)
+
+        return df[PLANNED_OUTAGE_CAPACITY_COLUMNS]
 
     @support_date_range(frequency=None)
     def get_unplanned_resource_outages(

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -4316,9 +4316,10 @@ class Ercot(ISOBase):
     ) -> pd.DataFrame:
         df = self.read_doc(doc, parse=False, verbose=verbose)
 
-        df["Interval Start"] = pd.to_datetime(df["OperatingDate"]).dt.tz_localize(
-            self.default_timezone,
-        )
+        df["Interval Start"] = pd.to_datetime(
+            df["OperatingDate"],
+            format="%m/%d/%Y",
+        ).dt.tz_localize(self.default_timezone)
         df["Interval End"] = df["Interval Start"] + pd.DateOffset(days=1)
 
         df.insert(

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -1882,6 +1882,79 @@ class TestErcot(BaseTestISO):
         assert df.columns.tolist() == cols
         assert df["Publish Time"].nunique() == 3
 
+    """get_planned_outage_capacity_7_day"""
+
+    PLANNED_OUTAGE_CAPACITY_COLUMNS = [
+        "Interval Start",
+        "Interval End",
+        "Publish Time",
+        "Max POC Non IRR Non PUN",
+        "Approved POC Non IRR Non PUN",
+        "Received POC Non IRR Non PUN",
+        "Max POC IRR",
+        "Approved POC IRR",
+        "Received POC IRR",
+    ]
+
+    def _check_planned_outage_capacity(self, df):
+        assert df.columns.tolist() == self.PLANNED_OUTAGE_CAPACITY_COLUMNS
+
+        assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
+        assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
+        assert df.dtypes["Publish Time"].kind == "M"
+
+        assert not df.duplicated(
+            subset=["Publish Time", "Interval Start"],
+        ).any()
+
+    def test_get_planned_outage_capacity_7_day(self):
+        end = (
+            pd.Timestamp.now(tz=self.iso.default_timezone) - pd.Timedelta(days=1)
+        ).floor("h")
+        start = end - pd.Timedelta(hours=3)
+
+        with api_vcr.use_cassette(
+            f"test_get_planned_outage_capacity_7_day_{start}_{end}.yaml",
+        ):
+            df = self.iso.get_planned_outage_capacity_7_day(
+                date=start,
+                end=end,
+                verbose=True,
+            )
+
+        self._check_planned_outage_capacity(df)
+
+        assert df["Publish Time"].nunique() == 3
+        assert (
+            (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(hours=1)
+        ).all()
+
+    """get_planned_outage_capacity_future"""
+
+    def test_get_planned_outage_capacity_future(self):
+        start = self.local_start_of_today() - pd.Timedelta(days=1)
+        end = start + pd.Timedelta(days=1)
+
+        with api_vcr.use_cassette(
+            f"test_get_planned_outage_capacity_future_{start}_{end}.yaml",
+        ):
+            df = self.iso.get_planned_outage_capacity_future(
+                date=start,
+                end=end,
+                verbose=True,
+            )
+
+        self._check_planned_outage_capacity(df)
+
+        assert df["Publish Time"].nunique() >= 1
+        # Daily intervals are day-aligned. A fixed 24h delta does not hold across
+        # DST transitions, so we check that each interval spans one calendar day.
+        assert (df["Interval Start"] == df["Interval Start"].dt.normalize()).all()
+        assert (
+            df["Interval End"] == df["Interval Start"] + pd.DateOffset(days=1)
+        ).all()
+        assert (df["Interval Start"] > end).all()
+
     """get_wind_actual_and_forecast_hourly"""
 
     def _check_hourly_wind_report(self, df, geographic_data=False):

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -1901,11 +1901,15 @@ class TestErcot(BaseTestISO):
 
         assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
         assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["Publish Time"].kind == "M"
+        assert df.dtypes["Publish Time"] == "datetime64[s, US/Central]"
 
         assert not df.duplicated(
             subset=["Publish Time", "Interval Start"],
         ).any()
+
+        assert df.equals(
+            df.sort_values(["Interval Start", "Publish Time"]).reset_index(drop=True),
+        )
 
     def test_get_planned_outage_capacity_7_day(self):
         end = (


### PR DESCRIPTION
## Summary
- Adds `get_planned_outage_capacity_7_day` scraper for ERCOT (NP3-162-CD)
- Adds `get_planned_outage_capacity_future` scraper for ERCOT (NP3-161-CD)

### Details
These two reports come from the ERCOT EMIL MIS archive and share the same six capacity columns (Max/Approved/Received POC Non IRR Non PUN and Max/Approved/Received POC IRR), so they share a column-rename map and a common dataframe handler. `get_planned_outage_capacity_7_day` is the hourly report giving maximum resource capacity available for planned outages within 7 days of the operating day; it has both OperatingDate and HourEnding plus a DSTFlag, so it reuses `parse_doc` (after renaming OperatingDate to DeliveryDate) to build hourly `Interval Start`/`Interval End`. `get_planned_outage_capacity_future` is the daily report that begins 7 days out and extends up to 60 months ahead; it has only an OperatingDate with no hour column, so intervals are built directly as day-aligned `Interval Start`/`Interval End` (which correctly span 23h/24h/25h across DST transitions rather than a fixed 24h). Both methods accept the report publish time as the `date` argument and support a publish-time range via `end`, fetching every report published in that window. The `Received` columns are spelled correctly here; note the Notion ticket lists the Non IRR Non PUN one as "Receieved".

To run tests:
```bash
VCR_RECORD_MODE=all uv run pytest -vvv gridstatus/tests/ -k "ercot" -k "planned_outage_capacity"
```

Made with [Cursor](https://cursor.com)