### PR TITLE
fix(ercot): handle 60-Day SCED Resource AS Offers column rename

### DIFF
--- a/gridstatus/ercot_60d_utils.py
+++ b/gridstatus/ercot_60d_utils.py
@@ -1479,6 +1479,28 @@ def process_sced_resource_as_offers(
             "pg_array_as_string" returns PG array strings like '{{mw,price},{mw,price}}'
             directly, using ~3x less peak memory.
     """
+    # ERCOT renamed the AS-price column suffixes in late March 2026
+    # (_URS->_REGUP, _DRS->_REGDN, _NS->_NSPIN, _RRSPF->_RRSPFR,
+    # _RRSUF->_RRSUFR, _RRSFF->_RRSFFR). Rename them back to the original names
+    # so the curve-type and curve-extraction logic below works unchanged for
+    # both old and new files.
+    new_to_old_suffix = {
+        "_REGUP": "_URS",
+        "_REGDN": "_DRS",
+        "_RRSPFR": "_RRSPF",
+        "_RRSUFR": "_RRSUF",
+        "_RRSFFR": "_RRSFF",
+        "_NSPIN": "_NS",
+    }
+
+    def _rename_suffix(col):
+        for new_suffix, old_suffix in new_to_old_suffix.items():
+            if col.endswith(new_suffix):
+                return col[: -len(new_suffix)] + old_suffix
+        return col
+
+    df = df.rename(columns=_rename_suffix)
+
     # First create a curve_type column with the logic:
     # regulation down : values only in _DRS columns and not in other columns
     # offline: values in _NS and optionally _ECRS columns and not in other columns

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -4522,6 +4522,68 @@ class TestProcessScedResourceAsOffers:
         assert result.columns.tolist() == SCED_RESOURCE_AS_OFFERS_COLUMNS
 
 
+def _to_new_suffixes(df):
+    """Rename AS-price columns to ERCOT's post-March-2026 suffixes."""
+    old_to_new = {
+        "_URS": "_REGUP",
+        "_DRS": "_REGDN",
+        "_RRSPF": "_RRSPFR",
+        "_RRSUF": "_RRSUFR",
+        "_RRSFF": "_RRSFFR",
+        "_NS": "_NSPIN",
+    }
+
+    def rename(col):
+        for old, new in old_to_new.items():
+            if col.endswith(old):
+                return col[: -len(old)] + new
+        return col
+
+    return df.rename(columns=rename)
+
+
+class TestProcessScedResourceAsOffersNewSuffixes:
+    """ERCOT renamed the AS-price column suffixes in late March 2026
+    (_URS->_REGUP, _DRS->_REGDN, _NS->_NSPIN, _RRSPF->_RRSPFR, etc.). The
+    parser renames them back, so the new layout produces the same result as the
+    old one. Before the fix every offer type collapsed to "Online", producing
+    duplicate (SCED Timestamp, Resource Name, Curve Type) keys.
+    """
+
+    _ROWS = [
+        _AEEC_ANTLP_3_ONRES_CORRECTED,
+        _AEEC_ANTLP_3_REGDN_CORRECTED,
+        _AEEC_ANTLP_3_OFFNS_CORRECTED,
+    ]
+
+    def test_curve_types_match_old_layout(self):
+        """Renamed columns classify into the same three curve types."""
+        df = _to_new_suffixes(_make_sced_resource_as_offers_df(self._ROWS))
+        result = process_sced_resource_as_offers(df)
+        assert list(result["Curve Type"]) == ["Online", "Regulation Down", "Offline"]
+
+    def test_no_duplicate_primary_keys(self):
+        """The three offer rows at one timestamp resolve to distinct keys."""
+        df = _to_new_suffixes(_make_sced_resource_as_offers_df(self._ROWS))
+        result = process_sced_resource_as_offers(df)
+        pk = ["SCED Timestamp", "Resource Name", "Curve Type"]
+        assert not result.duplicated(subset=pk).any()
+
+    def test_curves_and_columns_match_old_layout(self):
+        """Renamed columns produce identical output to the old layout."""
+        old = process_sced_resource_as_offers(
+            _make_sced_resource_as_offers_df([_AEEC_ANTLP_3_ONRES_CORRECTED]),
+        )
+        new = process_sced_resource_as_offers(
+            _to_new_suffixes(
+                _make_sced_resource_as_offers_df([_AEEC_ANTLP_3_ONRES_CORRECTED]),
+            ),
+        )
+        assert new.columns.tolist() == SCED_RESOURCE_AS_OFFERS_COLUMNS
+        for col in [c for c in new.columns if c.endswith("Offer Curve")]:
+            assert old[col].iloc[0] == new[col].iloc[0], col
+
+
 def check_60_day_dam_disclosure(df_dict):
     assert df_dict is not None
 


### PR DESCRIPTION
## What changed
ERCOT renamed the AS-price column suffixes in the 60-Day SCED Resource AS Offers report in late March 2026 (`_URS/_DRS/_NS/_RRSPF/_RRSUF/_RRSFF` → `_REGUP/_REGDN/_NSPIN/_RRSPFR/_RRSUFR/_RRSFFR`). `process_sced_resource_as_offers` infers `Curve Type` from which suffix columns are non-zero, so on the renamed files every offer type collapsed to `Online`, producing duplicate `(SCED Timestamp, Resource Name, Curve Type)` primary keys.

Fix: rename the new suffixes back to the original names at the top of the function. The existing curve-type classification and curve-extraction logic is unchanged and now works for both old and new files. (The pre-rename inference was already correct — only the column names changed.)

Suffix mapping is evidenced by the raw headers (old vs new files are byte-identical except these 6 suffixes) and by ERCOT's RRS sub-type definitions (RRSPFR = Primary Frequency Response, RRSUFR = Under Frequency Relay, RRSFFR = Fast Frequency Response).

## How to validate
```
pytest gridstatus/tests/source_specific/test_ercot.py -k ScedResourceAsOffers
```
12 pass (9 existing old-suffix tests + 3 new-suffix tests: same curve types, no duplicate PKs, identical output to the old layout). Also verified against real disclosure files for OD 2026-01-10, 2026-02-15 (old suffixes) and 2026-03-31 (new suffixes): 0 duplicate PKs on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)