### PR TITLE
feat(ENG 3998): Add CAISO IR/RC Requirements and Awards scrapers

### DIFF
--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -2175,6 +2175,166 @@ class CAISO(ISOBase):
 
         return df
 
+    def _parse_ir_rc_requirements_awards(self, df: pd.DataFrame) -> pd.DataFrame:
+        df = df.rename(
+            columns={
+                "BAA_GRP_ID": "BAA",
+                "PRODUCT_TYPE": "Product",
+            },
+        )
+
+        df = df.melt(
+            id_vars=[
+                "Interval Start",
+                "Interval End",
+                "BAA",
+                "Product",
+            ],
+            value_vars=["REQ_MW", "AGG_AWD_MW"],
+            var_name="Type",
+            value_name="MW",
+        )
+
+        df["Type"] = df["Type"].map(
+            {
+                "REQ_MW": "Requirement",
+                "AGG_AWD_MW": "Award",
+            },
+        )
+
+        df["MW"] = pd.to_numeric(df["MW"], errors="coerce")
+        df = df.dropna(subset=["MW"])
+
+        columns = [
+            "Interval Start",
+            "Interval End",
+            "BAA",
+            "Product",
+            "Type",
+            "MW",
+        ]
+
+        return (
+            df[columns]
+            .sort_values(["Interval Start", "BAA", "Product", "Type"])
+            .reset_index(drop=True)
+        )
+
+    @support_date_range(frequency="DAY_START")
+    def get_ir_rc_requirements_awards_dam(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        sleep: int = 4,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Return day-ahead hourly Imbalance Reserve requirements and
+        Imbalance Reserve and Reliability Capacity awards by BAA.
+
+        Arguments:
+            date (datetime.date, str): date to return data
+
+            end (datetime.date, str): last date of range to return data.
+                If None, returns only date. Defaults to None.
+
+            verbose (bool, optional): print out url being fetched. Defaults to False.
+
+        Returns:
+            pandas.DataFrame: A DataFrame with one row per
+            (Interval Start, BAA, Product, Type). Earliest available date is
+            May 1, 2026.
+        """
+        df = self.get_oasis_dataset(
+            dataset="ir_rc_requirements_awards",
+            start=date,
+            end=end,
+            params={"groupid": "DAM_CAP_REQ_AWRD_GRP"},
+            sleep=sleep,
+            verbose=verbose,
+            raw_data=False,
+        )
+
+        if df.empty:
+            return df
+
+        return self._parse_ir_rc_requirements_awards(df)
+
+    @support_date_range(frequency="DAY_START")
+    def get_ir_rc_requirements_awards_2da(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        sleep: int = 4,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Return two-day-ahead hourly Imbalance Reserve requirements by BAA.
+
+        Arguments:
+            date (datetime.date, str): date to return data
+
+            end (datetime.date, str): last date of range to return data.
+                If None, returns only date. Defaults to None.
+
+            verbose (bool, optional): print out url being fetched. Defaults to False.
+
+        Returns:
+            pandas.DataFrame: A DataFrame with one row per
+            (Interval Start, BAA, Product, Type). Earliest available date is
+            May 1, 2026.
+        """
+        df = self.get_oasis_dataset(
+            dataset="ir_rc_requirements_awards",
+            start=date,
+            end=end,
+            params={"groupid": "2DA_CAP_REQ_AWRD_GRP"},
+            sleep=sleep,
+            verbose=verbose,
+            raw_data=False,
+        )
+
+        if df.empty:
+            return df
+
+        return self._parse_ir_rc_requirements_awards(df)
+
+    @support_date_range(frequency="DAY_START")
+    def get_ir_rc_requirements_awards_3da(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        sleep: int = 4,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Return three-day-ahead hourly Imbalance Reserve requirements by BAA.
+
+        Arguments:
+            date (datetime.date, str): date to return data
+
+            end (datetime.date, str): last date of range to return data.
+                If None, returns only date. Defaults to None.
+
+            verbose (bool, optional): print out url being fetched. Defaults to False.
+
+        Returns:
+            pandas.DataFrame: A DataFrame with one row per
+            (Interval Start, BAA, Product, Type). Earliest available date is
+            May 1, 2026.
+        """
+        df = self.get_oasis_dataset(
+            dataset="ir_rc_requirements_awards",
+            start=date,
+            end=end,
+            params={"groupid": "3DA_CAP_REQ_AWRD_GRP"},
+            sleep=sleep,
+            verbose=verbose,
+            raw_data=False,
+        )
+
+        if df.empty:
+            return df
+
+        return self._parse_ir_rc_requirements_awards(df)
+
     @support_date_range(frequency="DAY_START")
     def get_curtailed_non_operational_generator_report(
         self,

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -2254,9 +2254,6 @@ class CAISO(ISOBase):
             raw_data=False,
         )
 
-        if df.empty:
-            return df
-
         return self._parse_ir_rc_requirements_awards(df)
 
     @support_date_range(frequency="DAY_START")
@@ -2292,9 +2289,6 @@ class CAISO(ISOBase):
             raw_data=False,
         )
 
-        if df.empty:
-            return df
-
         return self._parse_ir_rc_requirements_awards(df)
 
     @support_date_range(frequency="DAY_START")
@@ -2329,9 +2323,6 @@ class CAISO(ISOBase):
             verbose=verbose,
             raw_data=False,
         )
-
-        if df.empty:
-            return df
 
         return self._parse_ir_rc_requirements_awards(df)
 

--- a/gridstatus/caiso/caiso_constants.py
+++ b/gridstatus/caiso/caiso_constants.py
@@ -95,6 +95,20 @@ OASIS_DATASET_CONFIG = {
             "max_query_frequency": "1d",
         },
     },
+    "ir_rc_requirements_awards": {
+        "query": {
+            "path": "GroupZip",
+            "resultformat": 6,
+            "version": 1,
+        },
+        "params": {
+            "groupid": [
+                "DAM_CAP_REQ_AWRD_GRP",
+                "2DA_CAP_REQ_AWRD_GRP",
+                "3DA_CAP_REQ_AWRD_GRP",
+            ],
+        },
+    },
     "fuel_prices": {
         "query": {
             "path": "SingleZip",

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -106,6 +106,90 @@ class TestCAISO(BaseTestISO):
                 end,
             ) - pd.Timedelta(hours=1)
 
+    """get_ir_rc_requirements_awards"""
+
+    IR_RC_REQUIREMENTS_AWARDS_COLUMNS = [
+        "Interval Start",
+        "Interval End",
+        "BAA",
+        "Product",
+        "Type",
+        "MW",
+    ]
+
+    def _check_ir_rc_requirements_awards(self, df: pd.DataFrame) -> None:
+        assert df.columns.tolist() == self.IR_RC_REQUIREMENTS_AWARDS_COLUMNS
+        assert df.shape[0] > 0
+        assert set(df["Product"].unique()).issubset({"IRU", "IRD", "RCU", "RCD"})
+        assert set(df["Type"].unique()) == {"Requirement", "Award"}
+        interval_minutes = (
+            df["Interval End"] - df["Interval Start"]
+        ).dt.total_seconds() / 60
+        assert (interval_minutes == 60).all()
+        assert not df.duplicated(
+            subset=["Interval Start", "BAA", "Product", "Type"],
+        ).any()
+        assert pd.api.types.is_numeric_dtype(df["MW"])
+
+    @pytest.mark.parametrize("date", ["2026-05-01"])
+    def test_get_ir_rc_requirements_awards_dam(self, date):
+        with caiso_vcr.use_cassette(
+            f"test_get_ir_rc_requirements_awards_dam_{date}.yaml",
+        ):
+            df = self.iso.get_ir_rc_requirements_awards_dam(date=date)
+            self._check_ir_rc_requirements_awards(df)
+            assert set(df["Product"].unique()) == {"IRU", "IRD", "RCU", "RCD"}
+            assert df["Interval Start"].min() == self.local_start_of_day(date)
+            assert df["Interval Start"].max() == self.local_start_of_day(
+                date,
+            ) + pd.Timedelta(hours=23)
+
+    @pytest.mark.parametrize("date", ["2026-05-01"])
+    def test_get_ir_rc_requirements_awards_2da(self, date):
+        with caiso_vcr.use_cassette(
+            f"test_get_ir_rc_requirements_awards_2da_{date}.yaml",
+        ):
+            df = self.iso.get_ir_rc_requirements_awards_2da(date=date)
+            self._check_ir_rc_requirements_awards(df)
+            assert set(df["Product"].unique()) == {"IRU", "IRD"}
+            assert df["Interval Start"].min() == self.local_start_of_day(date)
+            assert df["Interval Start"].max() == self.local_start_of_day(
+                date,
+            ) + pd.Timedelta(hours=23)
+
+    @pytest.mark.parametrize("date", ["2026-05-01"])
+    def test_get_ir_rc_requirements_awards_3da(self, date):
+        with caiso_vcr.use_cassette(
+            f"test_get_ir_rc_requirements_awards_3da_{date}.yaml",
+        ):
+            df = self.iso.get_ir_rc_requirements_awards_3da(date=date)
+            self._check_ir_rc_requirements_awards(df)
+            assert set(df["Product"].unique()) == {"IRU", "IRD"}
+            assert df["Interval Start"].min() == self.local_start_of_day(date)
+            assert df["Interval Start"].max() == self.local_start_of_day(
+                date,
+            ) + pd.Timedelta(hours=23)
+
+    @pytest.mark.real_sleep
+    @pytest.mark.parametrize(
+        "start, end",
+        [("2026-05-01", "2026-05-03")],
+    )
+    def test_get_ir_rc_requirements_awards_dam_date_range(self, start, end):
+        with caiso_vcr.use_cassette(
+            f"test_get_ir_rc_requirements_awards_dam_{start}_{end}.yaml",
+        ):
+            df = self.iso.get_ir_rc_requirements_awards_dam(
+                date=start,
+                end=end,
+                sleep=15,
+            )
+            self._check_ir_rc_requirements_awards(df)
+            assert df["Interval Start"].min() == self.local_start_of_day(start)
+            assert df["Interval Start"].max() == self.local_start_of_day(
+                end,
+            ) - pd.Timedelta(hours=1)
+
     """get_fuel_mix"""
 
     # NOTE: these dates are across the DST transition which caused a bug in the past


### PR DESCRIPTION
## Summary
- Adds `get_ir_rc_requirements_awards_dam`, `get_ir_rc_requirements_awards_2da`, and `get_ir_rc_requirements_awards_3da` scrapers for CAISO

### Details
These methods fetch hourly Imbalance Reserve requirements and Imbalance Reserve/Reliability Capacity awards from CAISO OASIS `CAP_REQ_AWRD` group reports (`DAM_CAP_REQ_AWRD_GRP`, `2DA_CAP_REQ_AWRD_GRP`, `3DA_CAP_REQ_AWRD_GRP`). Wide-format `REQ_MW` and `AGG_AWD_MW` columns are melted into long format with `Type` values of Requirement and Award. DAM includes all four products (IRU, IRD, RCU, RCD); 2DA and 3DA include IRU and IRD only. Earliest available date is May 1, 2026.

To run tests:
```bash
VCR_RECORD_MODE=all uv run pytest -vvv gridstatus/tests/ -k "caiso" -k "ir_rc_requirements_awards"
```

