### PR TITLE
[ENG-3766] feat(ERCOT): Remove "latest" support except where used by gs-etl

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -489,7 +489,7 @@ class Ercot(ISOBase):
 
     def get_energy_storage_resources(
         self,
-        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = "latest",
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
         """Get energy storage resources.
@@ -694,15 +694,12 @@ class Ercot(ISOBase):
         """Get load for a date
 
         Arguments:
-            date (datetime.date, str): "latest", "today", or a date string
+            date (datetime.date, str): "today", or a date string
                 are supported.
 
 
         """
-        if date == "latest":
-            return self.get_load("today", verbose=verbose)
-
-        elif utils.is_today(date, tz=self.default_timezone):
+        if utils.is_today(date, tz=self.default_timezone):
             df = self._get_todays_outlook_non_forecast(date, verbose=verbose)
             df = df.rename(columns={"demand": "Load"})
             return df[["Time", "Interval Start", "Interval End", "Load"]]
@@ -892,19 +889,13 @@ class Ercot(ISOBase):
         and parses the historical load data by weather zones.
 
         Arguments:
-            date (str, datetime): Year to download data for, or "latest" for most recent data
+            date (str, datetime): Year to download data for
             end (str, datetime): End date for range, or None for single date
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
             pandas.DataFrame
         """
-        if date == "latest":
-            # NB: Gets the most recent year available, since they are published as annual files
-            current_year = pd.Timestamp.now().year
-            date = pd.Timestamp(f"{current_year}-01-01")
-            end = pd.Timestamp(f"{current_year + 1}-01-01")
-
         date = utils._handle_date(date, self.default_timezone)
         end = utils._handle_date(end, self.default_timezone)
 
@@ -1250,7 +1241,7 @@ class Ercot(ISOBase):
         Released every hour for the current day and the next 7.
 
         Arguments:
-            date (str, datetime): date to get report for. Supports "latest" or a
+            date (str, datetime): date to get report for. Supports a
                 date string.
             end (str, datetime, optional): end date for date range. Defaults to None.
             verbose (bool, optional): print verbose output. Defaults to False.
@@ -1976,7 +1967,7 @@ class Ercot(ISOBase):
         https://www.ercot.com/mp/data-products/data-product-details?id=NP4-183-CD
 
         Arguments:
-            date (str, datetime): date to get data for. Supports "latest",
+            date (str, datetime): date to get data for. Supports
                 "today", or a specific date.
             end (str, datetime, optional): end date for a date range query.
                 If None, returns 1 day of data. Defaults to None.
@@ -1985,9 +1976,6 @@ class Ercot(ISOBase):
         Returns:
             pandas.DataFrame: A DataFrame with day-ahead LMPs by electrical bus
         """
-        if date == "latest":
-            return self.get_lmp_by_bus_dam("today", verbose=verbose)
-
         # DAM data is published the day before delivery
         publish_date = date.normalize() - pd.DateOffset(days=1)
 
@@ -2049,8 +2037,8 @@ class Ercot(ISOBase):
 
     @lmp_config(
         supports={
-            Markets.REAL_TIME_15_MIN: ["latest", "today", "historical"],
-            Markets.DAY_AHEAD_HOURLY: ["latest", "today", "historical"],
+            Markets.REAL_TIME_15_MIN: ["today", "historical"],
+            Markets.DAY_AHEAD_HOURLY: ["today", "historical"],
         },
     )
     @support_date_range(frequency=None)
@@ -2082,9 +2070,7 @@ class Ercot(ISOBase):
         friendly_name_timestamp_after = None
 
         if market == Markets.REAL_TIME_15_MIN:
-            if date == "latest":
-                publish_date = "latest"
-            elif end is None:
+            if end is None:
                 # no end, so assume requesting one day
                 # use the timestamp from the friendly name
                 friendly_name_timestamp_after = date.normalize()
@@ -2098,9 +2084,7 @@ class Ercot(ISOBase):
 
             report = SETTLEMENT_POINT_PRICES_AT_RESOURCE_NODES_HUBS_AND_LOAD_ZONES_RTID
         elif market == Markets.DAY_AHEAD_HOURLY:
-            if date == "latest":
-                publish_date = "latest"
-            elif end is None:
+            if end is None:
                 # no end, so assume requesting one day
                 # data is publish one day prior
                 publish_date = date.normalize() - pd.DateOffset(days=1)
@@ -2308,7 +2292,7 @@ class Ercot(ISOBase):
         https://www.ercot.com/mp/data-products/data-product-details?id=NP4-188-CD
 
         Arguments:
-            date (str, datetime): date to get data for. Supports "latest",
+            date (str, datetime): date to get data for. Supports
                 "today", or a specific date.
             end (str, datetime, optional): end date for a date range query.
                 If None, returns 1 day of data. Defaults to None.
@@ -2318,9 +2302,6 @@ class Ercot(ISOBase):
             pandas.DataFrame: A DataFrame with columns: Interval Start,
                 Interval End, AS Type, MCPC
         """
-        if date == "latest":
-            return self.get_mcpc_dam("today", verbose=verbose)
-
         # DAM data is published the day before delivery
         publish_date = date.normalize() - pd.DateOffset(days=1)
 
@@ -2385,7 +2366,7 @@ class Ercot(ISOBase):
         https://www.ercot.com/mp/data-products/data-product-details?id=NP4-191-CD
 
         Arguments:
-            date (str, datetime): date to get data for. Supports "latest",
+            date (str, datetime): date to get data for. Supports
                 "today", or a specific date.
             end (str, datetime, optional): end date for a date range query.
                 If None, returns 1 day of data. Defaults to None.
@@ -2394,9 +2375,6 @@ class Ercot(ISOBase):
         Returns:
             pandas.DataFrame: A DataFrame with day-ahead market shadow prices
         """
-        if date == "latest":
-            return self.get_shadow_prices_dam("today", verbose=verbose)
-
         # DAM data is published the day before delivery
         publish_date = date.normalize() - pd.DateOffset(days=1)
 
@@ -2550,9 +2528,6 @@ class Ercot(ISOBase):
         Returns:
             pandas.DataFrame: A DataFrame with prices for ECRS, NSPIN, REGDN, REGUP, RRS
         """
-        if date == "latest":
-            return self.get_as_plan("today", verbose=verbose)
-
         doc_info = self._get_document(
             report_type_id=DAM_ANCILLARY_SERVICE_PLAN_RTID,
             date=date,
@@ -3875,7 +3850,7 @@ class Ercot(ISOBase):
         which is uncurtailed power generation potential.
 
         Arguments:
-            date (str): date to get report for. Supports "latest"
+            date (str): date to get report for.
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
@@ -3904,7 +3879,7 @@ class Ercot(ISOBase):
         """Get Hourly Wind Report by geographical region
 
         Arguments:
-            date (str): date to get report for. Supports "latest"
+            date (str): date to get report for.
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
@@ -3933,7 +3908,7 @@ class Ercot(ISOBase):
         """Get Hourly Solar Report.
 
         Arguments:
-            date (str): date to get report for. Supports "latest" or a date string
+            date (str): date to get report for. Supports a date string
             end (str, optional): end date for date range. Defaults to None.
             verbose (bool, optional): print verbose output. Defaults to False.
 
@@ -3969,7 +3944,7 @@ class Ercot(ISOBase):
         On-Line PVGRs for the rolling future 168-hour period.
 
         Arguments:
-            date (str): date to get report for. Supports "latest" or a date string
+            date (str): date to get report for. Supports a date string
             end (str, optional): end date for date range. Defaults to None.
             verbose (bool, optional): print verbose output. Defaults to False.
 
@@ -4118,7 +4093,7 @@ class Ercot(ISOBase):
 
         Arguments:
             date (str, pd.Timestamp): time to download. Returns last hourly report
-                before this time. Supports "latest"
+                before this time.
             end (str, pd.Timestamp, optional): end time to download. Defaults to None.
             verbose (bool, optional): print verbose output. Defaults to False.
 
@@ -4458,7 +4433,7 @@ class Ercot(ISOBase):
         """
         # This method is not supported starting with the file published on 2025-12-08
         # (with data for 2025-12-06)
-        if date == "latest" or date >= pd.Timestamp(
+        if date >= pd.Timestamp(
             "2025-12-06",
             tz=self.default_timezone,
         ):
@@ -4574,19 +4549,16 @@ class Ercot(ISOBase):
     ) -> Document:
         """Get the AS report document for a given date.
 
-        Handles "latest" date and applies the 2-day delay offset.
+        Applies the 2-day delay offset.
 
         Arguments:
-            date: date to fetch reports for (or "latest")
+            date: date to fetch reports for
             report_type_id: RTID of the report type to fetch
             verbose: print verbose output
 
         Returns:
             Document: The document for the requested date
         """
-        if date == "latest":
-            date = self.local_now().normalize() - pd.DateOffset(days=2)
-
         report_date = date.normalize() + pd.DateOffset(days=2)
 
         return self._get_document(
@@ -4921,7 +4893,7 @@ class Ercot(ISOBase):
             pandas.DataFrame: A DataFrame with day-ahead market system lambda data
         """
         # Subtract one day since this is the day ahead market
-        date = date if date == "latest" else date - pd.DateOffset(days=1)
+        date = date - pd.DateOffset(days=1)
 
         doc = self._get_document(
             report_type_id=DAM_SYSTEM_LAMBDA_RTID,
@@ -4979,11 +4951,7 @@ class Ercot(ISOBase):
 
         # no end, so assume requesting one day
         # use the timestamp from the friendly name
-        if date == "latest":
-            date = date
-            friendly_name_timestamp_after = None
-            friendly_name_timestamp_before = None
-        elif end is None:
+        if end is None:
             friendly_name_timestamp_after = date.normalize()
             friendly_name_timestamp_before = (
                 friendly_name_timestamp_after + pd.DateOffset(days=1)
@@ -5100,7 +5068,7 @@ class Ercot(ISOBase):
             pandas.DataFrame: A DataFrameq
         """
         # This report ends on 2025-12-05
-        if date == "latest" or date >= pd.Timestamp(
+        if date >= pd.Timestamp(
             "2025-12-06",
             tz=self.default_timezone,
         ):
@@ -5686,12 +5654,6 @@ class Ercot(ISOBase):
         """
         report_type_id = SYSTEM_WIDE_ACTUALS_RTID
 
-        if date == "latest":
-            # Go back one hour to ensure we have data
-            date = pd.Timestamp.now(tz=self.default_timezone).floor("h") - pd.Timedelta(
-                hours=1,
-            )
-
         if end is None:
             doc = self._get_document(
                 report_type_id=report_type_id,
@@ -5811,26 +5773,17 @@ class Ercot(ISOBase):
 
         NOTE: data only goes back 5 days
         """
-        if date == "latest":
-            docs = [
-                self._get_document(
-                    report_type_id=REAL_TIME_ADDERS_AND_RESERVES_RTID,
-                    published_before=date,
-                    verbose=verbose,
-                ),
-            ]
-        else:
-            # Set date to get a full day of published data
-            if not end:
-                end = date + pd.DateOffset(days=1)
+        # Set date to get a full day of published data
+        if not end:
+            end = date + pd.DateOffset(days=1)
 
-            docs = self._get_documents(
-                report_type_id=REAL_TIME_ADDERS_AND_RESERVES_RTID,
-                published_after=date,
-                published_before=end,
-                extension="csv",
-                verbose=verbose,
-            )
+        docs = self._get_documents(
+            report_type_id=REAL_TIME_ADDERS_AND_RESERVES_RTID,
+            published_after=date,
+            published_before=end,
+            extension="csv",
+            verbose=verbose,
+        )
 
         return self._handle_real_time_adders_and_reserves_docs(docs, verbose=verbose)
 
@@ -5869,22 +5822,16 @@ class Ercot(ISOBase):
         Returns:
             pandas.DataFrame: A DataFrame with temperature forecast data
         """
-        if date == "latest":
-            return self.get_temperature_forecast_by_weather_zone(
-                "today",
-                verbose=verbose,
-            )
-        else:
-            # Set end to get a full day of published data
-            if not end:
-                end = date + pd.DateOffset(days=1)
+        # Set end to get a full day of published data
+        if not end:
+            end = date + pd.DateOffset(days=1)
 
-            docs = self._get_documents(
-                report_type_id=TEMPERATURE_FORECAST_BY_WEATHER_ZONE_RTID,
-                extension="csv",
-                published_after=date,
-                published_before=end,
-            )
+        docs = self._get_documents(
+            report_type_id=TEMPERATURE_FORECAST_BY_WEATHER_ZONE_RTID,
+            extension="csv",
+            published_after=date,
+            published_before=end,
+        )
 
         return self._handle_temperature_forecast_by_weather_zone_docs(docs, verbose)
 
@@ -6614,8 +6561,6 @@ class Ercot(ISOBase):
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
-        if date == "latest":
-            self.get_indicative_lmp_by_settlement_point(date="today")
         if not end:
             end = date + pd.DateOffset(days=1)
 
@@ -6685,12 +6630,6 @@ class Ercot(ISOBase):
         Returns:
             pandas.DataFrame: A DataFrame with DAM total energy purchased data
         """
-        if date == "latest":
-            return self.get_dam_total_energy_purchased(
-                date="today",
-                verbose=verbose,
-            )
-
         # DAM data so subtract one from the date
         doc = self._get_document(
             report_type_id=DAM_TOTAL_ENERGY_PURCHASED_RTID,
@@ -6741,12 +6680,6 @@ class Ercot(ISOBase):
         Returns:
             pandas.DataFrame: A DataFrame with DAM total energy sold data
         """
-        if date == "latest":
-            return self.get_dam_total_energy_sold(
-                date="today",
-                verbose=verbose,
-            )
-
         # DAM data so subtract one from the date
         doc = self._get_document(
             report_type_id=DAM_TOTAL_ENERGY_SOLD_RTID,
@@ -6766,7 +6699,7 @@ class Ercot(ISOBase):
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
-        if date == "latest" or date > pd.Timestamp.now(
+        if date > pd.Timestamp.now(
             tz=self.default_timezone,
         ) - pd.DateOffset(days=60):
             raise ValueError(
@@ -6857,28 +6790,20 @@ class Ercot(ISOBase):
         verbose: bool = False,
     ) -> pd.DataFrame:
         """Get Market Clearing Prices for Capacity by SCED interval"""
-        if date == "latest":
-            docs = self._get_documents(
-                report_type_id=REAL_TIME_CLEARING_PRICES_FOR_CAPACITY_BY_SCED_INTERVAL_RTID,
-                extension="csv",
-                date=date,
-                verbose=verbose,
-            )
-        else:
-            if end is None:
-                # Assume getting data for one day
-                end = date + pd.DateOffset(days=1)
+        if end is None:
+            # Assume getting data for one day
+            end = date + pd.DateOffset(days=1)
 
-            published_before = end
-            published_after = date
+        published_before = end
+        published_after = date
 
-            docs = self._get_documents(
-                report_type_id=REAL_TIME_CLEARING_PRICES_FOR_CAPACITY_BY_SCED_INTERVAL_RTID,
-                extension="csv",
-                published_before=published_before,
-                published_after=published_after,
-                verbose=verbose,
-            )
+        docs = self._get_documents(
+            report_type_id=REAL_TIME_CLEARING_PRICES_FOR_CAPACITY_BY_SCED_INTERVAL_RTID,
+            extension="csv",
+            published_before=published_before,
+            published_after=published_after,
+            verbose=verbose,
+        )
 
         df = self.read_docs(docs, parse=False, verbose=verbose)
         return self._handle_mcpc_sced(df)
@@ -6905,29 +6830,20 @@ class Ercot(ISOBase):
         verbose: bool = False,
     ) -> pd.DataFrame:
         """Get Market Clearing Prices for Capacity by 15-minute interval"""
-        if date == "latest":
-            docs = self._get_documents(
-                report_type_id=REAL_TIME_CLEARING_PRICES_FOR_CAPACITY_15_MIN_RTID,
-                extension="csv",
-                date=date,
-                verbose=verbose,
-            )
+        # Assume getting data for one day
+        if not end:
+            end = date + pd.DateOffset(days=1)
 
-        else:
-            # Assume getting data for one day
-            if not end:
-                end = date + pd.DateOffset(days=1)
+        published_before = end + pd.Timedelta(minutes=15)
+        published_after = date + pd.Timedelta(minutes=15)
 
-            published_before = end + pd.Timedelta(minutes=15)
-            published_after = date + pd.Timedelta(minutes=15)
-
-            docs = self._get_documents(
-                report_type_id=REAL_TIME_CLEARING_PRICES_FOR_CAPACITY_15_MIN_RTID,
-                extension="csv",
-                published_before=published_before,
-                published_after=published_after,
-                verbose=verbose,
-            )
+        docs = self._get_documents(
+            report_type_id=REAL_TIME_CLEARING_PRICES_FOR_CAPACITY_15_MIN_RTID,
+            extension="csv",
+            published_before=published_before,
+            published_after=published_after,
+            verbose=verbose,
+        )
 
         df = self.read_docs(docs, parse=False, verbose=verbose)
         return self._handle_mcpc_real_time_15_min(df)
@@ -6961,24 +6877,16 @@ class Ercot(ISOBase):
         verbose: bool = False,
     ) -> pd.DataFrame:
         """Get Ancillary Service Demand Curves"""
-        if date == "latest":
-            docs = self._get_documents(
-                report_type_id=DAM_AND_SCED_ANCILLARY_SERVICE_DEMAND_CURVES_RTID,
-                extension="csv",
-                date=date,
-                verbose=verbose,
-            )
-        else:
-            if end is None:
-                end = date + pd.DateOffset(days=1)
+        if end is None:
+            end = date + pd.DateOffset(days=1)
 
-            docs = self._get_documents(
-                report_type_id=DAM_AND_SCED_ANCILLARY_SERVICE_DEMAND_CURVES_RTID,
-                extension="csv",
-                published_before=end,
-                published_after=date,
-                verbose=verbose,
-            )
+        docs = self._get_documents(
+            report_type_id=DAM_AND_SCED_ANCILLARY_SERVICE_DEMAND_CURVES_RTID,
+            extension="csv",
+            published_before=end,
+            published_after=date,
+            verbose=verbose,
+        )
 
         df = pd.concat(
             [
@@ -7043,24 +6951,16 @@ class Ercot(ISOBase):
 
         https://www.ercot.com/mp/data-products/data-product-details?id=np4-19-cd
         """
-        if date == "latest":
-            docs = self._get_documents(
-                report_type_id=DAM_AGGREGATED_AS_OFFER_CURVE_RTID,
-                extension="csv",
-                date=date,
-                verbose=verbose,
-            )
-        else:
-            if end is None:
-                end = date + pd.DateOffset(days=1)
+        if end is None:
+            end = date + pd.DateOffset(days=1)
 
-            docs = self._get_documents(
-                report_type_id=DAM_AGGREGATED_AS_OFFER_CURVE_RTID,
-                extension="csv",
-                published_after=date - pd.Timedelta(days=1),
-                published_before=end - pd.Timedelta(days=1),
-                verbose=verbose,
-            )
+        docs = self._get_documents(
+            report_type_id=DAM_AGGREGATED_AS_OFFER_CURVE_RTID,
+            extension="csv",
+            published_after=date - pd.Timedelta(days=1),
+            published_before=end - pd.Timedelta(days=1),
+            verbose=verbose,
+        )
 
         df = self.read_docs(docs, parse=False, verbose=verbose)
         return self._handle_dam_asdc_aggregated(df)
@@ -7092,24 +6992,16 @@ class Ercot(ISOBase):
         verbose: bool = False,
     ) -> pd.DataFrame:
         """Get Projected Ancillary Service Deployment Factors"""
-        if date == "latest":
-            docs = self._get_documents(
-                report_type_id=PROJECTED_ANCILLARY_SERVICE_DEPLOYMENTS_FACTORS_RTID,
-                extension="csv",
-                date=date,
-                verbose=verbose,
-            )
-        else:
-            if end is None:
-                end = date + pd.DateOffset(days=1)
+        if end is None:
+            end = date + pd.DateOffset(days=1)
 
-            docs = self._get_documents(
-                report_type_id=PROJECTED_ANCILLARY_SERVICE_DEPLOYMENTS_FACTORS_RTID,
-                extension="csv",
-                published_before=end,
-                published_after=date,
-                verbose=verbose,
-            )
+        docs = self._get_documents(
+            report_type_id=PROJECTED_ANCILLARY_SERVICE_DEPLOYMENTS_FACTORS_RTID,
+            extension="csv",
+            published_before=end,
+            published_after=date,
+            verbose=verbose,
+        )
 
         return self._handle_as_deployment_factors_projected(docs, verbose=verbose)
 
@@ -7164,24 +7056,16 @@ class Ercot(ISOBase):
             DataFrame with columns: Interval Start, Interval End, RUC Timestamp,
             AS Type, and AS Deployment Factors.
         """
-        if date == "latest":
-            docs = self._get_documents(
-                report_type_id=WEEKLY_RUC_AS_DEPLOYMENT_FACTORS_RTID,
-                date=date,
-                constructed_name_contains="csv",
-                verbose=verbose,
-            )
-        else:
-            if not end:
-                end = date + pd.DateOffset(days=1)
+        if not end:
+            end = date + pd.DateOffset(days=1)
 
-            docs = self._get_documents(
-                report_type_id=WEEKLY_RUC_AS_DEPLOYMENT_FACTORS_RTID,
-                constructed_name_contains="csv",
-                published_after=date,
-                published_before=end,
-                verbose=verbose,
-            )
+        docs = self._get_documents(
+            report_type_id=WEEKLY_RUC_AS_DEPLOYMENT_FACTORS_RTID,
+            constructed_name_contains="csv",
+            published_after=date,
+            published_before=end,
+            verbose=verbose,
+        )
 
         return self._handle_as_deployment_factors_ruc(docs, verbose=verbose)
 
@@ -7194,24 +7078,16 @@ class Ercot(ISOBase):
         verbose: bool = False,
     ) -> pd.DataFrame:
         """Get Daily RUC Ancillary Service Deployment Factors"""
-        if date == "latest":
-            docs = self._get_documents(
-                report_type_id=DAILY_RUC_AS_DEPLOYMENT_FACTORS_RTID,
-                date=date,
-                constructed_name_contains="csv",
-                verbose=verbose,
-            )
-        else:
-            if not end:
-                end = date + pd.DateOffset(days=1)
+        if not end:
+            end = date + pd.DateOffset(days=1)
 
-            docs = self._get_documents(
-                report_type_id=DAILY_RUC_AS_DEPLOYMENT_FACTORS_RTID,
-                constructed_name_contains="csv",
-                published_after=date,
-                published_before=end,
-                verbose=verbose,
-            )
+        docs = self._get_documents(
+            report_type_id=DAILY_RUC_AS_DEPLOYMENT_FACTORS_RTID,
+            constructed_name_contains="csv",
+            published_after=date,
+            published_before=end,
+            verbose=verbose,
+        )
 
         return self._handle_as_deployment_factors_ruc(docs, verbose=verbose)
 
@@ -7225,24 +7101,16 @@ class Ercot(ISOBase):
         verbose: bool = False,
     ) -> pd.DataFrame:
         """Get Hourly RUC Ancillary Service Deployment Factors"""
-        if date == "latest":
-            docs = self._get_documents(
-                report_type_id=HOURLY_RUC_AS_DEPLOYMENT_FACTORS_RTID,
-                date=date,
-                constructed_name_contains="csv",
-                verbose=verbose,
-            )
-        else:
-            if not end:
-                end = date + pd.DateOffset(days=1)
+        if not end:
+            end = date + pd.DateOffset(days=1)
 
-            docs = self._get_documents(
-                report_type_id=HOURLY_RUC_AS_DEPLOYMENT_FACTORS_RTID,
-                constructed_name_contains="csv",
-                published_after=date,
-                published_before=end,
-                verbose=verbose,
-            )
+        docs = self._get_documents(
+            report_type_id=HOURLY_RUC_AS_DEPLOYMENT_FACTORS_RTID,
+            constructed_name_contains="csv",
+            published_after=date,
+            published_before=end,
+            verbose=verbose,
+        )
 
         return self._handle_as_deployment_factors_ruc(docs, verbose=verbose)
 
@@ -7296,24 +7164,16 @@ class Ercot(ISOBase):
         verbose: bool = False,
     ) -> pd.DataFrame:
         """Get Hourly RUC Ancillary Service Demand Curves"""
-        if date == "latest":
-            docs = self._get_documents(
-                report_type_id=HOURLY_RUC_AS_DEMAND_CURVES_RTID,
-                extension="csv",
-                date=date,
-                verbose=verbose,
-            )
-        else:
-            if not end:
-                end = date + pd.DateOffset(days=1)
+        if not end:
+            end = date + pd.DateOffset(days=1)
 
-            docs = self._get_documents(
-                report_type_id=HOURLY_RUC_AS_DEMAND_CURVES_RTID,
-                published_before=end,
-                published_after=date,
-                extension="csv",
-                verbose=verbose,
-            )
+        docs = self._get_documents(
+            report_type_id=HOURLY_RUC_AS_DEMAND_CURVES_RTID,
+            published_before=end,
+            published_after=date,
+            extension="csv",
+            verbose=verbose,
+        )
 
         df = self.read_docs(docs, parse=False, verbose=verbose)
         return self._handle_ruc_as_demand_curves(df)
@@ -7327,24 +7187,16 @@ class Ercot(ISOBase):
         verbose: bool = False,
     ) -> pd.DataFrame:
         """Get Daily RUC Ancillary Service Demand Curves"""
-        if date == "latest":
-            docs = self._get_documents(
-                report_type_id=DAILY_RUC_AS_DEMAND_CURVES_RTID,
-                extension="csv",
-                date=date,
-                verbose=verbose,
-            )
-        else:
-            if not end:
-                end = date + pd.DateOffset(days=1)
+        if not end:
+            end = date + pd.DateOffset(days=1)
 
-            docs = self._get_documents(
-                report_type_id=DAILY_RUC_AS_DEMAND_CURVES_RTID,
-                published_before=end,
-                published_after=date,
-                extension="csv",
-                verbose=verbose,
-            )
+        docs = self._get_documents(
+            report_type_id=DAILY_RUC_AS_DEMAND_CURVES_RTID,
+            published_before=end,
+            published_after=date,
+            extension="csv",
+            verbose=verbose,
+        )
 
         df = self.read_docs(docs, parse=False, verbose=verbose)
         return self._handle_ruc_as_demand_curves(df)
@@ -7358,24 +7210,16 @@ class Ercot(ISOBase):
         verbose: bool = False,
     ) -> pd.DataFrame:
         """Get Weekly RUC Ancillary Service Demand Curves"""
-        if date == "latest":
-            docs = self._get_documents(
-                report_type_id=WEEKLY_RUC_AS_DEMAND_CURVES_RTID,
-                extension="csv",
-                date=date,
-                verbose=verbose,
-            )
-        else:
-            if not end:
-                end = date + pd.DateOffset(days=1)
+        if not end:
+            end = date + pd.DateOffset(days=1)
 
-            docs = self._get_documents(
-                report_type_id=WEEKLY_RUC_AS_DEMAND_CURVES_RTID,
-                published_before=end,
-                published_after=date,
-                extension="csv",
-                verbose=verbose,
-            )
+        docs = self._get_documents(
+            report_type_id=WEEKLY_RUC_AS_DEMAND_CURVES_RTID,
+            published_before=end,
+            published_after=date,
+            extension="csv",
+            verbose=verbose,
+        )
 
         df = self.read_docs(docs, parse=False, verbose=verbose)
         return self._handle_ruc_as_demand_curves(df)
@@ -7430,8 +7274,7 @@ class Ercot(ISOBase):
         verbose: bool = False,
     ) -> pd.DataFrame:
         """Get DAM Total Ancillary Services Sold"""
-        if date != "latest":
-            date -= pd.DateOffset(days=1)
+        date -= pd.DateOffset(days=1)
 
         docs = self._get_documents(
             report_type_id=DAM_TOTAL_AS_SOLD_RTID,
@@ -7478,27 +7321,19 @@ class Ercot(ISOBase):
         verbose: bool = False,
     ) -> pd.DataFrame:
         """Get RTD Indicative Real-Time Market Clearing Prices for Capacity"""
-        if date == "latest":
-            docs = self._get_documents(
-                report_type_id=RTD_INDICATIVE_REAL_TIME_MCPC_RTID,
-                extension="csv",
-                date=date,
-                verbose=verbose,
-            )
-        else:
-            if not end:
-                end = date + pd.DateOffset(days=1)
+        if not end:
+            end = date + pd.DateOffset(days=1)
 
-            published_before = end
-            published_after = date
+        published_before = end
+        published_after = date
 
-            docs = self._get_documents(
-                report_type_id=RTD_INDICATIVE_REAL_TIME_MCPC_RTID,
-                extension="csv",
-                published_before=published_before,
-                published_after=published_after,
-                verbose=verbose,
-            )
+        docs = self._get_documents(
+            report_type_id=RTD_INDICATIVE_REAL_TIME_MCPC_RTID,
+            extension="csv",
+            published_before=published_before,
+            published_after=published_after,
+            verbose=verbose,
+        )
 
         df = self.read_docs(docs, parse=False, verbose=verbose)
         return self._handle_indicative_mcpc_rtd(df)
@@ -7545,27 +7380,19 @@ class Ercot(ISOBase):
         verbose: bool = False,
     ) -> pd.DataFrame:
         """Get Total Capability of Resources Available to Provide Ancillary Service"""
-        if date == "latest":
-            docs = self._get_documents(
-                report_type_id=TOTAL_CAPABILITY_OF_RESOURCES_AS_RTID,
-                extension="csv",
-                date=date,
-                verbose=verbose,
-            )
-        else:
-            if not end:
-                end = date + pd.DateOffset(days=1)
+        if not end:
+            end = date + pd.DateOffset(days=1)
 
-            published_before = end
-            published_after = date
+        published_before = end
+        published_after = date
 
-            docs = self._get_documents(
-                report_type_id=TOTAL_CAPABILITY_OF_RESOURCES_AS_RTID,
-                extension="csv",
-                published_before=published_before,
-                published_after=published_after,
-                verbose=verbose,
-            )
+        docs = self._get_documents(
+            report_type_id=TOTAL_CAPABILITY_OF_RESOURCES_AS_RTID,
+            extension="csv",
+            published_before=published_before,
+            published_after=published_after,
+            verbose=verbose,
+        )
 
         # Add the publish time to deal with duplicates downstream
         df = pd.concat(
@@ -7637,28 +7464,20 @@ class Ercot(ISOBase):
         Returns:
             pandas.DataFrame: A DataFrame with ORDC price adders data
         """
-        if date == "latest":
-            docs = self._get_documents(
-                report_type_id=REAL_TIME_ADDERS_RTID,
-                extension="csv",
-                date=date,
-                verbose=verbose,
-            )
-        else:
-            if not end:
-                # Assume getting data for one day
-                end = date + pd.DateOffset(days=1)
+        if not end:
+            # Assume getting data for one day
+            end = date + pd.DateOffset(days=1)
 
-            published_before = end
-            published_after = date
+        published_before = end
+        published_after = date
 
-            docs = self._get_documents(
-                report_type_id=REAL_TIME_ADDERS_RTID,
-                published_after=published_after,
-                published_before=published_before,
-                extension="csv",
-                verbose=verbose,
-            )
+        docs = self._get_documents(
+            report_type_id=REAL_TIME_ADDERS_RTID,
+            published_after=published_after,
+            published_before=published_before,
+            extension="csv",
+            verbose=verbose,
+        )
 
         return self._handle_real_time_adders(docs, verbose=verbose)
 

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -10,6 +10,7 @@ import pytest
 from gridstatus import Markets, NoDataFoundException, NotSupported
 from gridstatus.ercot import (
     ELECTRICAL_BUS_LOCATION_TYPE,
+    Document,
     Ercot,
     ERCOTSevenDayLoadForecastReport,
     parse_timestamp_from_friendly_name,
@@ -2569,25 +2570,40 @@ class TestErcot(BaseTestISO):
         )
         self._check_temperature_forecast_by_weather_zone(df)
 
-    def test_get_temperature_forecast_by_weather_zone_dst_end_2025(self):
-        # This forecast date includes 2025-11-02, DST end
-        with api_vcr.use_cassette(
-            "test_get_temperature_forecast_by_weather_zone_dst_end_2025.yaml",
-        ):
-            df = self.iso.get_temperature_forecast_by_weather_zone("2025-10-26")
+    def test_get_temperature_forecast_by_weather_zone_dst_end_2025(self) -> None:
+        dst_raw_data = pd.DataFrame(
+            {
+                "DeliveryDate": ["11/02/2025"] * 4,
+                "HourEnding": ["01:00", "02:00", "03:00", "03:00"],
+                "Coast": [63.3, 124.3, 60.9, 60.9],
+                "East": [58.0, 113.0, 55.0, 55.0],
+                "FarWest": [60.0, 114.0, 54.0, 54.0],
+                "North": [57.0, 111.0, 54.0, 54.0],
+                "NorthCentral": [60.0, 116.25, 56.25, 56.25],
+                "SouthCentral": [63.5, 120.5, 58.0, 58.0],
+                "Southern": [71.4, 140.6, 68.8, 68.8],
+                "West": [59.0, 112.8, 54.2, 54.2],
+                "DSTFlag": ["N", "N", "Y", "N"],
+            },
+        )
+
+        doc = Document(
+            url="https://example.com",
+            publish_date=pd.Timestamp("2025-10-26 05:00:00", tz="US/Central"),
+            constructed_name="test",
+            friendly_name="test",
+            friendly_name_timestamp=None,
+        )
+
+        with mock.patch.object(self.iso, "read_doc", return_value=dst_raw_data):
+            df = self.iso._handle_temperature_forecast_by_weather_zone_docs([doc])
 
         self._check_temperature_forecast_by_weather_zone(df)
 
-        # Check for the presence of the repeated hour
-        assert (
-            pd.Timestamp("2025-11-02 01:00:00-0500", tz="US/Central")
-            == df["Interval Start"].iloc[-48]
-        )
-
-        assert (
-            pd.Timestamp("2025-11-02 01:00:00-0600", tz="US/Central")
-            == df["Interval Start"].iloc[-47]
-        )
+        repeated_hour_cdt = pd.Timestamp("2025-11-02 01:00:00-0500", tz="US/Central")
+        repeated_hour_cst = pd.Timestamp("2025-11-02 01:00:00-0600", tz="US/Central")
+        assert (df["Interval Start"] == repeated_hour_cdt).any()
+        assert (df["Interval Start"] == repeated_hour_cst).any()
 
     """parse_doc"""
 

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -101,14 +101,6 @@ class TestErcot(BaseTestISO):
     """dam_system_lambda"""
 
     @pytest.mark.integration
-    def test_get_dam_system_lambda_latest(self):
-        df = self.iso.get_dam_system_lambda("latest", verbose=True)
-        self._check_dam_system_lambda(df)
-        # We don't know the exact publish date because it could be yesterday
-        # or today depending on when this test is run
-        assert df["Publish Time"].dt.date.nunique() == 1
-
-    @pytest.mark.integration
     def test_get_dam_system_lambda_today(self):
         df = self.iso.get_dam_system_lambda("today", verbose=True)
         self._check_dam_system_lambda(df)
@@ -149,18 +141,17 @@ class TestErcot(BaseTestISO):
 
     @pytest.mark.integration
     def test_get_sced_system_lambda(self):
-        for i in ["latest", "today"]:
-            df = self.iso.get_sced_system_lambda(i, verbose=True)
-            assert df.shape[0] >= 0
-            assert df.columns.tolist() == [
-                "Interval Start",
-                "Interval End",
-                "SCED Timestamp",
-                "System Lambda",
-            ]
-            today = pd.Timestamp.now(tz=self.iso.default_timezone).date()
-            assert df["SCED Timestamp"].unique()[0].date() == today
-            assert isinstance(df["System Lambda"].unique()[0], float)
+        df = self.iso.get_sced_system_lambda("today", verbose=True)
+        assert df.shape[0] >= 0
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "SCED Timestamp",
+            "System Lambda",
+        ]
+        today = pd.Timestamp.now(tz=self.iso.default_timezone).date()
+        assert df["SCED Timestamp"].unique()[0].date() == today
+        assert isinstance(df["System Lambda"].unique()[0], float)
 
     """as_prices"""
 
@@ -206,7 +197,7 @@ class TestErcot(BaseTestISO):
         ]
 
     @pytest.mark.integration
-    def test_get_as_plan_today_or_latest(self):
+    def test_get_as_plan_today(self):
         df = self.iso.get_as_plan("today")
         self._check_as_plan(df)
         assert df["Interval Start"].min() == self.local_start_of_today()
@@ -214,7 +205,6 @@ class TestErcot(BaseTestISO):
             days=7,
         )
         assert df["Publish Time"].dt.date.unique().tolist() == [self.local_today()]
-        assert self.iso.get_as_plan("latest").equals(df)
 
     @pytest.mark.integration
     def test_get_as_plan_historical_date(self):
@@ -542,6 +532,12 @@ class TestErcot(BaseTestISO):
     @pytest.mark.skip(reason="Not Applicable")
     def test_get_lmp_historical(self, markets=None):
         pass
+
+    """get_load"""
+
+    @pytest.mark.skip("Not Supported")
+    def test_get_load_latest(self):
+        super().test_get_load_latest()
 
     @pytest.mark.integration
     def test_get_load_3_days_ago(self):
@@ -879,7 +875,7 @@ class TestErcot(BaseTestISO):
     @pytest.mark.integration
     def test_get_spp_real_time_handles_all_location_types(self):
         df = self.iso.get_spp(
-            date="latest",
+            date="today",
             market=Markets.REAL_TIME_15_MIN,
             verbose=True,
         )
@@ -2289,20 +2285,6 @@ class TestErcot(BaseTestISO):
         assert df.shape[0] == 4
         assert df.columns.tolist() == cols
 
-    @pytest.mark.integration
-    def test_get_system_wide_actual_load_latest(self):
-        df = self.iso.get_system_wide_actual_load("latest")
-
-        cols = ["Time", "Interval Start", "Interval End", "Demand"]
-
-        assert df["Interval Start"].min() == pd.Timestamp.now(
-            tz=self.iso.default_timezone,
-        ).floor("h") - pd.Timedelta(hours=1)
-
-        # 1 Hour of data
-        assert df.shape[0] == 4
-        assert df.columns.tolist() == cols
-
     """get_short_term_system_adequacy"""
 
     def _check_short_term_system_adequacy(self, df):
@@ -2464,14 +2446,6 @@ class TestErcot(BaseTestISO):
         )
 
     @pytest.mark.integration
-    def test_get_real_time_adders_and_reserves_latest(self):
-        df = self.iso.get_real_time_adders_and_reserves("latest")
-
-        self._check_real_time_adders_and_reserves(df)
-
-        assert len(df) == 1
-
-    @pytest.mark.integration
     def test_get_real_time_adders_and_reserves_historical(self):
         date = self.local_today() - pd.DateOffset(days=3)
         df = self.iso.get_real_time_adders_and_reserves(date)
@@ -2522,25 +2496,35 @@ class TestErcot(BaseTestISO):
     temperature_forecast_end_offset = pd.DateOffset(days=9)
 
     @pytest.mark.integration
-    def test_get_temperature_forecast_by_weather_zone_today_and_latest(self):
+    def test_get_temperature_forecast_by_weather_zone_today(self):
         df = self.iso.get_temperature_forecast_by_weather_zone("today")
         self._check_temperature_forecast_by_weather_zone(df)
 
         # One publish time
         assert df["Publish Time"].nunique() == 1
 
-        # Data goes into the past 3 days.
-        assert (
-            df["Interval Start"].min()
-            == self.local_start_of_today() + self.temperature_forecast_start_offset
+        expected_start = (
+            self.local_start_of_today() + self.temperature_forecast_start_offset
+        )
+        expected_end = (
+            self.local_start_of_today() + self.temperature_forecast_end_offset
         )
 
+        # Data goes into the past 3 days. The forecast window may shift by an
+        # hour depending on publication timing, but the span (12 days) is fixed.
         assert (
-            df["Interval End"].max()
-            == self.local_start_of_today() + self.temperature_forecast_end_offset
+            expected_start
+            <= df["Interval Start"].min()
+            <= expected_start + pd.Timedelta(hours=1)
         )
-
-        assert self.iso.get_temperature_forecast_by_weather_zone("latest").equals(df)
+        assert (
+            expected_end
+            <= df["Interval End"].max()
+            <= expected_end + pd.Timedelta(hours=1)
+        )
+        assert df["Interval End"].max() - df["Interval Start"].min() == pd.Timedelta(
+            days=12,
+        )
 
     @pytest.mark.integration
     def test_get_temperature_forecast_by_weather_zone_historical_date(self):
@@ -2823,12 +2807,6 @@ class TestErcot(BaseTestISO):
     def test_get_lmp_by_bus_dam_today(self):
         with api_vcr.use_cassette("test_get_lmp_by_bus_dam_today.yaml"):
             df = self.iso.get_lmp_by_bus_dam("today", verbose=True)
-        self._check_lmp_by_bus_dam(df)
-        assert df.shape[0] > 0
-
-    def test_get_lmp_by_bus_dam_latest(self):
-        with api_vcr.use_cassette("test_get_lmp_by_bus_dam_latest.yaml"):
-            df = self.iso.get_lmp_by_bus_dam("latest", verbose=True)
         self._check_lmp_by_bus_dam(df)
         assert df.shape[0] > 0
 
@@ -3144,18 +3122,6 @@ class TestErcot(BaseTestISO):
             if col in df.columns:
                 assert pd.api.types.is_numeric_dtype(df[col])
 
-    def test_get_hourly_load_post_settlements_latest(self):
-        """Test getting the latest year's data."""
-        with api_vcr.use_cassette(
-            "test_get_hourly_load_post_settlements_latest.yaml",
-        ):
-            df = self.iso.get_hourly_load_post_settlements("latest")
-        self._check_hourly_load_post_settlements(df)
-
-        # Should be current year data
-        current_year = pd.Timestamp.now().year
-        assert df["Interval Start"].dt.year.unique() == [current_year]
-
     @pytest.mark.parametrize("date, end", [("2010-03-01", "2010-08-02")])
     def test_get_hourly_load_post_settlements_xls(self, date, end):
         """Test getting historical data from the 2004-2016 era."""
@@ -3201,11 +3167,6 @@ class TestErcot(BaseTestISO):
     def test_get_mcpc_dam_today(self):
         with api_vcr.use_cassette("test_get_mcpc_dam_today.yaml"):
             df = self.iso.get_mcpc_dam("today", verbose=True)
-        self._check_get_mcpc_dam(df)
-
-    def test_get_mcpc_dam_latest(self):
-        with api_vcr.use_cassette("test_get_mcpc_dam_latest.yaml"):
-            df = self.iso.get_mcpc_dam("latest")
         self._check_get_mcpc_dam(df)
 
     def test_get_mcpc_dam_historical(self):
@@ -3270,12 +3231,6 @@ class TestErcot(BaseTestISO):
         self._check_shadow_prices_dam(df)
         assert df.shape[0] > 0
 
-    def test_get_shadow_prices_dam_latest(self):
-        with api_vcr.use_cassette("test_get_shadow_prices_dam_latest.yaml"):
-            df = self.iso.get_shadow_prices_dam("latest")
-        self._check_shadow_prices_dam(df)
-        assert df.shape[0] > 0
-
     def test_get_shadow_prices_dam_historical(self):
         date = pd.Timestamp("2026-03-05", tz=self.iso.default_timezone)
         with api_vcr.use_cassette("test_get_shadow_prices_dam_historical.yaml"):
@@ -3304,18 +3259,6 @@ class TestErcot(BaseTestISO):
         assert df.dtypes["SCED Timestamp"] == "datetime64[ns, US/Central]"
         assert df.dtypes["AS Type"] == "object"
         assert df.dtypes["MCPC"] == "float64"
-
-    def test_get_mcpc_sced_latest(self):
-        with api_vcr.use_cassette(
-            "test_get_mcpc_sced_date_range_latest.yaml",
-        ):
-            df = self.iso.get_mcpc_sced("latest")
-
-        self._check_get_mcpc_sced(df)
-
-        assert df["SCED Timestamp"].nunique() == 1
-        assert df["SCED Timestamp"].min() <= self.local_now()
-        assert df["SCED Timestamp"].min() >= self.local_now() - pd.Timedelta(minutes=10)
 
     def test_get_mcpc_sced_date_range(self):
         # Choose a date range that spans two days to test we handle day transitions
@@ -3350,20 +3293,6 @@ class TestErcot(BaseTestISO):
         assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
         assert df.dtypes["AS Type"] == "object"
         assert df.dtypes["MCPC"] == "float64"
-
-    def test_get_mcpc_real_time_15_min_latest(self):
-        with api_vcr.use_cassette(
-            "test_get_mcpc_real_time_15_min_date_range_latest.yaml",
-        ):
-            df = self.iso.get_mcpc_real_time_15_min("latest")
-
-        self._check_get_mcpc_real_time_15_min(df)
-
-        assert df["Interval Start"].nunique() == 1
-        assert df["Interval Start"].min() <= self.local_now()
-        assert df["Interval Start"].min() >= self.local_now() - pd.Timedelta(
-            minutes=60,
-        )
 
     def test_get_mcpc_real_time_15_min_date_range(self):
         # Choose a date range that spans two days to test we handle day transitions
@@ -3404,20 +3333,6 @@ class TestErcot(BaseTestISO):
         assert df.dtypes["Demand Curve Point"] == "int64"
         assert df.dtypes["Quantity"] == "int64"
         assert df.dtypes["Price"] == "float64"
-
-    def test_get_as_demand_curves_dam_and_sced_latest(self):
-        with api_vcr.use_cassette(
-            "test_get_as_demand_curves_dam_and_sced_date_range_latest.yaml",
-        ):
-            df = self.iso.get_as_demand_curves_dam_and_sced("latest")
-
-        self._check_get_as_demand_curves_dam_and_sced(df)
-
-        # The "latest" method will still get us two days of data
-        assert df["Interval Start"].min() == self.local_now().normalize()
-        assert df[
-            "Interval Start"
-        ].max() == self.local_now().normalize() + pd.DateOffset(days=1, hours=23)
 
     def test_get_as_demand_curves_dam_and_sced_date_range(self):
         date = pd.Timestamp.now().normalize() - pd.Timedelta(days=2)
@@ -3475,11 +3390,6 @@ class TestErcot(BaseTestISO):
             self.allowed_dam_asdc_aggregated_as_types,
         )
 
-    def test_get_dam_asdc_aggregated_latest(self):
-        with api_vcr.use_cassette("test_get_dam_asdc_aggregated_latest.yaml"):
-            df = self.iso.get_dam_asdc_aggregated("latest")
-        self._check_get_dam_asdc_aggregated(df)
-
     def test_get_dam_asdc_aggregated_date_range(self):
         date = pd.Timestamp.now().normalize() - pd.Timedelta(days=2)
         end = date + pd.Timedelta(days=1)
@@ -3511,21 +3421,6 @@ class TestErcot(BaseTestISO):
         assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
         assert df.dtypes["AS Type"] == "object"
         assert df.dtypes["AS Deployment Factors"] == "float64"
-
-    def test_get_as_deployment_factors_projected_latest(self):
-        with api_vcr.use_cassette(
-            "test_get_as_deployment_factors_projected_latest.yaml",
-        ):
-            df = self.iso.get_as_deployment_factors_projected("latest")
-
-        self._check_as_deployment_factors_projected(df)
-
-        # "latest" gets one day of data for tomorrow
-        assert df["Interval Start"].min() >= self.local_now().normalize()
-        assert df[
-            "Interval Start"
-        ].max() >= self.local_now().normalize() + pd.Timedelta(hours=23)
-        assert df["Interval Start"].nunique() == 24
 
     def test_get_as_deployment_factors_projected_date_range(self):
         date = self.local_start_of_today() - pd.Timedelta(days=2)
@@ -3566,17 +3461,6 @@ class TestErcot(BaseTestISO):
             (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(hours=1)
         ).all()
 
-    def test_get_as_deployment_factors_weekly_ruc_latest(self):
-        with api_vcr.use_cassette(
-            "test_get_as_deployment_factors_weekly_ruc_latest.yaml",
-        ):
-            df = self.iso.get_as_deployment_factors_weekly_ruc("latest")
-
-        self._check_as_deployment_factors_ruc(df)
-
-        assert df["RUC Timestamp"].nunique() == 1
-        assert df["Interval Start"].nunique() == 120
-
     def test_get_as_deployment_factors_weekly_ruc_date_range(self):
         date = self.local_start_of_day(self.local_today() - pd.Timedelta(days=2))
         end = date + pd.DateOffset(days=2)
@@ -3598,17 +3482,6 @@ class TestErcot(BaseTestISO):
         assert df["Interval Start"].nunique() == 144
 
     """get_as_deployment_factors_daily_ruc"""
-
-    def test_get_as_deployment_factors_daily_ruc_latest(self):
-        with api_vcr.use_cassette(
-            "test_get_as_deployment_factors_daily_ruc_latest.yaml",
-        ):
-            df = self.iso.get_as_deployment_factors_daily_ruc("latest")
-
-        self._check_as_deployment_factors_ruc(df)
-
-        assert df["RUC Timestamp"].nunique() == 1
-        assert df["Interval Start"].nunique() == 24
 
     def test_get_as_deployment_factors_daily_ruc_date_range(self):
         # Data is published per DRUC run (once per day) for the next day
@@ -3632,18 +3505,6 @@ class TestErcot(BaseTestISO):
         assert df["Interval Start"].nunique() == 48
 
     """get_as_deployment_factors_hourly_ruc"""
-
-    def test_get_as_deployment_factors_hourly_ruc_latest(self):
-        with api_vcr.use_cassette(
-            "test_get_as_deployment_factors_hourly_ruc_latest.yaml",
-        ):
-            df = self.iso.get_as_deployment_factors_hourly_ruc("latest")
-
-        self._check_as_deployment_factors_ruc(df)
-
-        assert df["RUC Timestamp"].nunique() == 1
-        # The number of intervals in the latest file differs depending on time of day
-        assert df["Interval Start"].nunique() > 1
 
     def test_get_as_deployment_factors_hourly_ruc_date_range(self):
         # Data is published per HRUC run (once per hour) for the rest of the current day
@@ -3676,16 +3537,6 @@ class TestErcot(BaseTestISO):
         assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
         assert df.dtypes["AS Type"] == "object"
         assert df.dtypes["Quantity"] == "float64"
-
-    def test_get_dam_total_as_sold_latest(self):
-        with api_vcr.use_cassette(
-            "test_get_dam_total_as_sold_latest.yaml",
-        ):
-            df = self.iso.get_dam_total_as_sold("latest")
-
-        self._check_get_dam_total_as_sold(df)
-
-        assert df["Interval Start"].nunique() == 25
 
     def test_get_dam_total_as_sold_date_range(self):
         # Data is only available per DAM run so we use a set time we know it exists
@@ -3722,16 +3573,6 @@ class TestErcot(BaseTestISO):
         assert df.dtypes["Demand Curve Point"] == "int64"
         assert df.dtypes["Quantity"] == "int64"
         assert df.dtypes["Price"] == "float64"
-
-    def test_get_as_demand_curves_hourly_ruc_latest(self):
-        with api_vcr.use_cassette(
-            "test_get_as_demand_curves_hourly_ruc_latest.yaml",
-        ):
-            df = self.iso.get_as_demand_curves_hourly_ruc("latest")
-
-        self._check_hourly_ruc_as_demand_curves(df)
-
-        assert df["RUC Timestamp"].nunique() == 1
 
     def test_get_as_demand_curves_hourly_ruc_date_range(self):
         date = self.local_start_of_today() - pd.Timedelta(hours=1)
@@ -3771,18 +3612,6 @@ class TestErcot(BaseTestISO):
         assert df.dtypes["Quantity"] == "int64"
         assert df.dtypes["Price"] == "float64"
 
-    def test_get_as_demand_curves_daily_ruc_latest(self):
-        with api_vcr.use_cassette(
-            "test_get_as_demand_curves_daily_ruc_latest.yaml",
-        ):
-            df = self.iso.get_as_demand_curves_daily_ruc("latest")
-
-        self._check_daily_ruc_as_demand_curves(df)
-
-        # One day of data is published at once
-        assert df["Interval Start"].nunique() == 24
-        assert df["RUC Timestamp"].nunique() == 1
-
     def test_get_as_demand_curves_daily_ruc_date_range(self):
         date = self.local_start_of_today() - pd.Timedelta(days=2)
         end = date + pd.Timedelta(days=2)
@@ -3818,18 +3647,6 @@ class TestErcot(BaseTestISO):
         assert df.dtypes["Demand Curve Point"] == "int64"
         assert df.dtypes["Quantity"] == "int64"
         assert df.dtypes["Price"] == "float64"
-
-    def test_get_as_demand_curves_weekly_ruc_latest(self):
-        with api_vcr.use_cassette(
-            "test_get_as_demand_curves_weekly_ruc_latest.yaml",
-        ):
-            df = self.iso.get_as_demand_curves_weekly_ruc("latest")
-
-        self._check_weekly_ruc_as_demand_curves(df)
-
-        # Five days worth of data is published at once
-        assert df["Interval Start"].nunique() == 120
-        assert df["RUC Timestamp"].nunique() == 1
 
     def test_get_as_demand_curves_weekly_ruc_date_range(self):
         date = self.local_start_of_today() - pd.DateOffset(days=2)
@@ -3870,16 +3687,6 @@ class TestErcot(BaseTestISO):
 
         for col in ["REGUP", "REGDN", "RRS", "ECRS", "NSPIN"]:
             assert df.dtypes[col] == "float64"
-
-    def test_get_indicative_mcpc_rtd_latest(self):
-        with api_vcr.use_cassette(
-            "test_get_indicative_mcpc_rtd_latest.yaml",
-        ):
-            df = self.iso.get_indicative_mcpc_rtd("latest")
-
-        self._check_get_indicative_mcpc_rtd(df)
-
-        assert df["RTD Timestamp"].nunique() == 1
 
     def test_get_indicative_mcpc_rtd_date_range(self):
         # Use a date range that spans two days to test we handle day transitions
@@ -3930,18 +3737,6 @@ class TestErcot(BaseTestISO):
             "Cap RegUp RRS ECRS NonSpin Total",
         ]:
             assert df.dtypes[col] == "float64"
-
-    def test_get_as_total_capability_latest(self):
-        with api_vcr.use_cassette(
-            "test_get_as_total_capability_latest.yaml",
-        ):
-            df = self.iso.get_as_total_capability("latest")
-
-        self._check_get_as_total_capability(df)
-
-        # Each file has 5 SCED intervals
-        assert df["SCED Timestamp"].nunique() == 5
-        assert df["Publish Time"].nunique() == 1
 
     def test_get_as_total_capability_date_range(self):
         # Choose a date range that spans two days to test we handle day transitions
@@ -4020,16 +3815,6 @@ class TestErcot(BaseTestISO):
             "RTOLHSL",
         ]:
             assert df.dtypes[col] == "float64"
-
-    def test_get_real_time_adders_latest(self):
-        with api_vcr.use_cassette(
-            "test_get_real_time_adders_latest.yaml",
-        ):
-            df = self.iso.get_real_time_adders("latest")
-
-        self._check_real_time_adders(df)
-
-        assert len(df) == 1
 
     def test_get_real_time_adders_date_range(self):
         # Choose a date range that spans two days to test we handle day transitions

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -2495,36 +2495,52 @@ class TestErcot(BaseTestISO):
     temperature_forecast_start_offset = -pd.DateOffset(days=3)
     temperature_forecast_end_offset = pd.DateOffset(days=9)
 
-    @pytest.mark.integration
-    def test_get_temperature_forecast_by_weather_zone_today(self):
-        df = self.iso.get_temperature_forecast_by_weather_zone("today")
-        self._check_temperature_forecast_by_weather_zone(df)
-
-        # One publish time
-        assert df["Publish Time"].nunique() == 1
-
+    def _assert_temperature_forecast_start_window(
+        self,
+        df: pd.DataFrame,
+        anchor: pd.Timestamp,
+    ) -> None:
         expected_start = (
-            self.local_start_of_today() + self.temperature_forecast_start_offset
+            self.local_start_of_day(anchor) + self.temperature_forecast_start_offset
         )
-        expected_end = (
-            self.local_start_of_today() + self.temperature_forecast_end_offset
-        )
-
-        # Data goes into the past 3 days. The forecast window may shift by an
-        # hour depending on publication timing, but the span (12 days) is fixed.
         assert (
             expected_start
             <= df["Interval Start"].min()
             <= expected_start + pd.Timedelta(hours=1)
+        )
+
+    def _assert_temperature_forecast_end_window(
+        self,
+        df: pd.DataFrame,
+        anchor: pd.Timestamp,
+    ) -> None:
+        expected_end = (
+            self.local_start_of_day(anchor) + self.temperature_forecast_end_offset
         )
         assert (
             expected_end
             <= df["Interval End"].max()
             <= expected_end + pd.Timedelta(hours=1)
         )
+
+    def _assert_temperature_forecast_window(
+        self,
+        df: pd.DataFrame,
+        anchor: pd.Timestamp,
+    ) -> None:
+        self._assert_temperature_forecast_start_window(df, anchor)
+        self._assert_temperature_forecast_end_window(df, anchor)
         assert df["Interval End"].max() - df["Interval Start"].min() == pd.Timedelta(
             days=12,
         )
+
+    @pytest.mark.integration
+    def test_get_temperature_forecast_by_weather_zone_today(self):
+        df = self.iso.get_temperature_forecast_by_weather_zone("today")
+        self._check_temperature_forecast_by_weather_zone(df)
+
+        assert df["Publish Time"].nunique() == 1
+        self._assert_temperature_forecast_window(df, self.local_today())
 
     @pytest.mark.integration
     def test_get_temperature_forecast_by_weather_zone_historical_date(self):
@@ -2532,20 +2548,7 @@ class TestErcot(BaseTestISO):
         df = self.iso.get_temperature_forecast_by_weather_zone(date)
 
         assert df["Publish Time"].nunique() == 1
-
-        assert (
-            df["Interval Start"].min()
-            == self.local_start_of_day(date) + self.temperature_forecast_start_offset
-        )
-
-        assert (
-            df["Interval End"].max()
-            == self.local_start_of_day(
-                date,
-            )
-            + self.temperature_forecast_end_offset
-        )
-
+        self._assert_temperature_forecast_window(df, date)
         self._check_temperature_forecast_by_weather_zone(df)
 
     @pytest.mark.integration
@@ -2559,16 +2562,11 @@ class TestErcot(BaseTestISO):
         )
 
         assert df["Publish Time"].nunique() == 3
-        assert (
-            df["Interval Start"].min()
-            == self.local_start_of_day(start) + self.temperature_forecast_start_offset
+        self._assert_temperature_forecast_start_window(df, start)
+        self._assert_temperature_forecast_end_window(
+            df,
+            end - pd.DateOffset(days=1),
         )
-
-        assert df["Interval End"].max() == self.local_start_of_day(
-            end,
-            # Non-inclusive end date
-        ) + self.temperature_forecast_end_offset - pd.DateOffset(days=1)
-
         self._check_temperature_forecast_by_weather_zone(df)
 
     def test_get_temperature_forecast_by_weather_zone_dst_end_2025(self):


### PR DESCRIPTION
## Summary
- Mirrors the NYISO (#769) and PJM (#779) "latest" removal PRs.
- Preserves "latest" support on methods `gs-etl` calls (`get_fuel_mix*`, `get_load_forecast`, `get_capacity_committed`/`get_capacity_forecast`/`get_available_seasonal_capacity_forecast`) and on latest-only scrapers (`get_status`, `get_as_monitor`, `get_system_as_capacity_monitor`, `get_real_time_system_conditions`). Helpers (`_get_document(s)`, `_get_hourly_report`, `_get_settlement_points_mapping_documents`) keep "latest" pass-through.
- Relaxes temperature forecast integration tests to tolerate ERCOT's 1-hour publication-time shift.
- Converts the DST end 2025 temperature forecast test to a unit test so it no longer depends on a stale VCR cassette.
- Rebases onto `main` and supersedes draft PR #864.

## Test plan
- [x] Rebased onto `main`
- [x] Temperature forecast DST unit test passes locally
- [ ] `make test-ercot` passes locally
- [ ] gs-etl scrapers that pass `date="latest"` (fuel mix, capacity, load forecast) still return data


Made with [Cursor](https://cursor.com)