### PR TITLE
feat(ENG 4137/4140/4143): Add NYISO, SPP, and MISO dataset scrapers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 * Removed the `save_to` parameter from data retrieval methods. Data is no longer written to CSV files as it is fetched; callers should save the returned DataFrame themselves (e.g. with `df.to_csv(...)`). The `load_folder` utility remains available for loading previously saved CSV folders.
+* Removed `MISOAPI.get_medium_term_load_forecast_hourly`. Use `get_load_forecast_mid_term_by_region` instead, which fetches the mid-term load forecast by publish date across the full horizon. Use `max_offset=1` to fetch only the first forecast day after the publish date. in [#892](https://github.com/gridstatus/gridstatus/pull/892)
 
 ### Additions (New Features/Datasets)
 

--- a/gridstatus/miso_api.py
+++ b/gridstatus/miso_api.py
@@ -1524,7 +1524,9 @@ class MISOAPI:
                 "Local Resource Zone",
                 "init",
             ]:
-                data[col] = data[col].astype(float)
+                data[col] = (
+                    pd.to_numeric(data[col], errors="coerce").round().astype("Int64")
+                )
 
         data = data.sort_values(
             ["Interval Start", "Publish Time", "Region", "Local Resource Zone"],
@@ -1672,6 +1674,18 @@ class MISOAPI:
                 "LRZ8_9_10 MTLF",
             ]
         ].sum(axis=1)
+
+        mtlf_cols = [
+            "LRZ1 MTLF",
+            "LRZ2_7 MTLF",
+            "LRZ3_5 MTLF",
+            "LRZ4 MTLF",
+            "LRZ6 MTLF",
+            "LRZ8_9_10 MTLF",
+            "MISO MTLF",
+        ]
+        for col in mtlf_cols:
+            df[col] = pd.to_numeric(df[col], errors="coerce").round().astype("Int64")
 
         return df
 

--- a/gridstatus/miso_api.py
+++ b/gridstatus/miso_api.py
@@ -1522,6 +1522,7 @@ class MISOAPI:
                 "Publish Time",
                 "Region",
                 "Local Resource Zone",
+                "init",
             ]:
                 data[col] = data[col].astype(float)
 
@@ -1554,6 +1555,59 @@ class MISOAPI:
             publish_time=publish_time,
             time_resolution=HOURLY_RESOLUTION,
         )
+
+    @support_date_range(frequency="DAY_START")
+    def get_load_forecast_mid_term_by_region(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Get hourly mid-term load forecast by region and LRZ for a publish date.
+
+        The ``date`` parameter is the forecast run publish date (``init`` date), not
+        the forecast interval date. Each publish date is queried across the available
+        forecast horizon.
+        """
+        publish_time = utils._handle_date(date, self.default_timezone).normalize()
+        all_dfs: list[pd.DataFrame] = []
+
+        for offset in range(1, 8):
+            forecast_date = publish_time + pd.DateOffset(days=offset)
+            df = self._get_medium_term_load_forecast(
+                date=forecast_date,
+                verbose=verbose,
+                publish_time=publish_time,
+                time_resolution=HOURLY_RESOLUTION,
+            )
+            if not df.empty:
+                all_dfs.append(df)
+
+        if not all_dfs:
+            return pd.DataFrame(
+                columns=[
+                    "Interval Start",
+                    "Interval End",
+                    "Publish Time",
+                    "Region",
+                    "LRZ",
+                    "Load Forecast",
+                ],
+            )
+
+        data = pd.concat(all_dfs, ignore_index=True)
+        data = data.rename(columns={"Local Resource Zone": "LRZ"})
+
+        return data[
+            [
+                "Interval Start",
+                "Interval End",
+                "Publish Time",
+                "Region",
+                "LRZ",
+                "Load Forecast",
+            ]
+        ].reset_index(drop=True)
 
     @support_date_range(frequency="DAY_START")
     def get_medium_term_load_forecast_hourly_aggregated(

--- a/gridstatus/miso_api.py
+++ b/gridstatus/miso_api.py
@@ -1543,38 +1543,28 @@ class MISOAPI:
         ].reset_index(drop=True)
 
     @support_date_range(frequency="DAY_START")
-    def get_medium_term_load_forecast_hourly(
-        self,
-        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
-        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
-        verbose: bool = False,
-        publish_time: str | pd.Timestamp | None = None,
-    ) -> pd.DataFrame:
-        return self._get_medium_term_load_forecast(
-            date,
-            end=end,
-            verbose=verbose,
-            publish_time=publish_time,
-            time_resolution=HOURLY_RESOLUTION,
-        )
-
-    @support_date_range(frequency="DAY_START")
     def get_load_forecast_mid_term_by_region(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
+        max_offset: int = 7,
     ) -> pd.DataFrame:
         """Get hourly mid-term load forecast by region and LRZ for a publish date.
 
         The ``date`` parameter is the forecast run publish date (``init`` date), not
         the forecast interval date. Each publish date is queried across the available
         forecast horizon.
+
+        Args:
+            max_offset: Number of forecast days after the publish date to include.
+                Defaults to 7 (the full mid-term horizon). Use 1 to fetch only the
+                first forecast day.
         """
         publish_time = utils._handle_date(date, self.default_timezone).normalize()
         all_dfs: list[pd.DataFrame] = []
 
-        for offset in range(1, 8):
+        for offset in range(1, max_offset + 1):
             forecast_date = publish_time + pd.DateOffset(days=offset)
             df = self._get_medium_term_load_forecast(
                 date=forecast_date,
@@ -1627,11 +1617,12 @@ class MISOAPI:
         LRZ1 MTLF, LRZ2_7 MTLF, LRZ3_5 MTLF, LRZ4 MTLF, LRZ6 MTLF,
         LRZ8_9_10 MTLF, MISO MTLF
         """
-        df = self.get_medium_term_load_forecast_hourly(
+        df = self._get_medium_term_load_forecast(
             date=date,
             end=end,
             verbose=verbose,
             publish_time=publish_time,
+            time_resolution=HOURLY_RESOLUTION,
         )
 
         # Map individual zones to aggregated LRZ format
@@ -1799,11 +1790,12 @@ class MISOAPI:
             )
 
         # Get medium-term load forecast
-        load_forecast = self.get_medium_term_load_forecast_hourly(
+        load_forecast = self._get_medium_term_load_forecast(
             date,
             end=end,
             verbose=verbose,
             publish_time=publish_time,
+            time_resolution=HOURLY_RESOLUTION,
         )
 
         # Get outage forecast

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -361,6 +361,9 @@ class NYISO(ISOBase):
 
         Source: https://mis.nyiso.com/public/P-70Clist.htm
         """
+        if date == "latest":
+            raise ValueError("Latest not supported for BTM installed capacity")
+
         data = self._download_nyiso_archive(
             date=date,
             end=end,

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -39,6 +39,7 @@ REAL_TIME_HOURLY_LMP_DATASET = "rtlbmp"
 REAL_TIME_EVENTS_DATASET = "RealTimeEvents"
 BTM_SOLAR_ACTUAL_DATASET = "btmactualforecast"
 BTM_SOLAR_FORECAST_DATASET = "btmdaforecast"
+BTM_INSTALLED_CAPACITY_DATASET = "btminstalledcapacitytracking"
 INTERFACE_LIMITS_AND_FLOWS_DATASET = "ExternalLimitsFlows"
 LAKE_ERIE_CIRCULATION_REAL_TIME_DATASET = "eriecirculationrt"
 LAKE_ERIE_CIRCULATION_DAY_AHEAD_DATASET = "eriecirculationda"
@@ -69,6 +70,7 @@ DATASET_INTERVAL_MAP: Dict[str, DatasetInterval] = {
     REAL_TIME_EVENTS_DATASET: DatasetInterval("instantaneous", None),
     BTM_SOLAR_ACTUAL_DATASET: DatasetInterval("start", 60),
     BTM_SOLAR_FORECAST_DATASET: DatasetInterval("start", 60),
+    BTM_INSTALLED_CAPACITY_DATASET: DatasetInterval("start", 1440),
     INTERFACE_LIMITS_AND_FLOWS_DATASET: DatasetInterval("start", 5),
     LAKE_ERIE_CIRCULATION_REAL_TIME_DATASET: DatasetInterval("instantaneous", None),
     LAKE_ERIE_CIRCULATION_DAY_AHEAD_DATASET: DatasetInterval("instantaneous", None),
@@ -346,6 +348,40 @@ class NYISO(ISOBase):
         df.columns.name = None
 
         return df
+
+    @support_date_range(frequency="DAY_START")
+    def get_btm_installed_capacity(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Returns NYISO's daily estimate of installed behind-the-meter solar capacity
+        by zone.
+
+        Source: https://mis.nyiso.com/public/P-70Clist.htm
+        """
+        data = self._download_nyiso_archive(
+            date=date,
+            end=end,
+            dataset_name=BTM_INSTALLED_CAPACITY_DATASET,
+            filename="btminstalledcapacitytracking",
+            verbose=verbose,
+        )
+
+        return data[
+            [
+                "Interval Start",
+                "Interval End",
+                "Zone Name",
+                "MW Value",
+            ]
+        ].rename(
+            columns={
+                "Zone Name": "Zone",
+                "MW Value": "MW",
+            },
+        )
 
     @support_date_range(frequency="MONTH_START")
     def get_load_forecast(

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -46,6 +46,10 @@ BASE_SOLAR_AND_WIND_MID_TERM_URL = (
     f"{FILE_BROWSER_DOWNLOAD_URL}/midterm-resource-forecast?path="
 )
 
+BASE_RESERVE_ZONE_FORECAST_URL = (
+    f"{FILE_BROWSER_DOWNLOAD_URL}/resource-forecast-by-reserve-zone?path="
+)
+
 BASE_LOAD_FORECAST_SHORT_TERM_URL = f"{FILE_BROWSER_DOWNLOAD_URL}/stlf-vs-actual?path="
 
 BASE_LOAD_FORECAST_MID_TERM_URL = f"{FILE_BROWSER_DOWNLOAD_URL}/mtlf-vs-actual?path="
@@ -863,6 +867,37 @@ class SPP(ISOBase):
 
         return df
 
+    @support_date_range("HOUR_START")
+    def get_solar_and_wind_forecast_by_reserve_zone(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame | None:
+        """Returns hourly solar and wind forecasts and actuals by reserve zone.
+
+        Data from https://portal.spp.org/pages/resource-forecast-by-reserve-zone.
+        The ``date`` parameter is the publish hour of the source file.
+        """
+        result = self._get_mid_term_forecast_data(
+            date,
+            base_url=BASE_RESERVE_ZONE_FORECAST_URL,
+            file_prefix="RF_RESERVE_ZONE",
+            buffer_minutes=10,
+        )
+
+        if result is None:
+            return None
+
+        df, url = result
+
+        return self._post_process_solar_and_wind_forecast_by_reserve_zone(
+            df,
+            url,
+            end_time_col="GMTIntervalEnd",
+            interval_duration=pd.Timedelta(hours=1),
+        )
+
     def get_load_by_baa(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
@@ -1026,6 +1061,61 @@ class SPP(ISOBase):
         return df.dropna(subset=["Wind Forecast MW", "Solar Forecast MW"]).reset_index(
             drop=True,
         )
+
+    def _post_process_solar_and_wind_forecast_by_reserve_zone(
+        self,
+        df: pd.DataFrame,
+        url: str,
+        end_time_col: str,
+        interval_duration: pd.Timedelta,
+    ) -> pd.DataFrame:
+        df.columns = [col.strip() for col in df.columns]
+
+        df = self._handle_market_end_to_interval(df, end_time_col, interval_duration)
+
+        df["Publish Time"] = pd.Timestamp(
+            re.search(r"[0-9]{12}", url).group(0),
+        ).tz_localize(
+            tz=self.default_timezone,
+            ambiguous=not url.endswith("d.csv"),
+        )
+
+        df.columns = [col.strip() for col in df.columns]
+
+        df = df.rename(
+            columns={
+                "ReserveZone": "Reserve Zone",
+                "WindForecastMW": "Wind Forecast",
+                "WindActualMW": "Wind Actual",
+                "SolarForecastMW": "Solar Forecast",
+                "SolarActualMW": "Solar Actual",
+            },
+        )
+
+        df = (
+            utils.move_cols_to_front(
+                df,
+                [
+                    "Interval Start",
+                    "Interval End",
+                    "Publish Time",
+                    "BAA",
+                    "Reserve Zone",
+                ],
+            )
+            .drop(columns=["Time", "IntervalEnd", "Interval"], errors="ignore")
+            .sort_values(["Interval Start", "Publish Time", "Reserve Zone"])
+        )
+
+        return df.dropna(
+            subset=[
+                "Wind Forecast",
+                "Wind Actual",
+                "Solar Forecast",
+                "Solar Actual",
+            ],
+            how="all",
+        ).reset_index(drop=True)
 
     def _mid_term_solar_and_wind_url(self, date: pd.Timestamp) -> str:
         # Explicitly set the minutes to 00.

--- a/gridstatus/tests/source_specific/test_miso_api.py
+++ b/gridstatus/tests/source_specific/test_miso_api.py
@@ -1112,6 +1112,28 @@ class TestMISOAPI(TestHelperMixin):
         assert df["Publish Time"].min() == publish_time
 
     @pytest.mark.integration
+    def test_get_load_forecast_mid_term_by_region(self):
+        publish_time = self.local_start_of_today() - pd.Timedelta(days=2)
+
+        with api_vcr.use_cassette(
+            f"get_load_forecast_mid_term_by_region_{publish_time.date()}",
+        ):
+            df = self.iso.get_load_forecast_mid_term_by_region(publish_time)
+
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "Publish Time",
+            "Region",
+            "LRZ",
+            "Load Forecast",
+        ]
+        assert (df["Publish Time"] == publish_time.normalize()).all()
+        assert df["Region"].isin(["NORTH", "CENTRAL", "SOUTH"]).all()
+        assert df["LRZ"].str.startswith("Z").all()
+        assert df["Interval Start"].min() >= publish_time + pd.Timedelta(days=1)
+
+    @pytest.mark.integration
     def test_get_medium_term_load_forecast_daily(self):
         date = self.local_start_of_today() - pd.Timedelta(days=1)
 

--- a/gridstatus/tests/source_specific/test_miso_api.py
+++ b/gridstatus/tests/source_specific/test_miso_api.py
@@ -1066,7 +1066,7 @@ class TestMISOAPI(TestHelperMixin):
                 "Region",
                 "Local Resource Zone",
             ]:
-                assert df[col].dtype == "float64"
+                assert df[col].dtype == "Int64"
 
     @pytest.mark.integration
     def test_get_medium_term_load_forecast_hourly(self):
@@ -1132,6 +1132,7 @@ class TestMISOAPI(TestHelperMixin):
         assert df["Region"].isin(["NORTH", "CENTRAL", "SOUTH"]).all()
         assert df["LRZ"].str.startswith("Z").all()
         assert df["Interval Start"].min() >= publish_time + pd.Timedelta(days=1)
+        assert df["Load Forecast"].dtype == "Int64"
 
     @pytest.mark.integration
     def test_get_medium_term_load_forecast_daily(self):
@@ -1215,9 +1216,8 @@ class TestMISOAPI(TestHelperMixin):
         assert df["Interval End"].dtype == "datetime64[ns, EST]"
         assert df["Publish Time"].dtype == "datetime64[ns, EST]"
 
-        # All load columns should be float
         for col in expected_columns[3:]:
-            assert df[col].dtype == "float64"
+            assert df[col].dtype == "Int64"
 
     def test_get_medium_term_load_forecast_hourly_aggregated(self):
         date = self.local_start_of_today() - pd.Timedelta(days=1)

--- a/gridstatus/tests/source_specific/test_miso_api.py
+++ b/gridstatus/tests/source_specific/test_miso_api.py
@@ -1069,49 +1069,6 @@ class TestMISOAPI(TestHelperMixin):
                 assert df[col].dtype == "Int64"
 
     @pytest.mark.integration
-    def test_get_medium_term_load_forecast_hourly(self):
-        date = self.local_start_of_today() - pd.Timedelta(days=1)
-
-        with api_vcr.use_cassette(
-            f"get_medium_term_load_forecast_hourly_{date.date()}",
-        ):
-            df = self.iso.get_medium_term_load_forecast_hourly(date)
-
-        self._check_test_medium_term_load_forecast(df)
-
-        assert df["Interval Start"].min() == date
-        assert df["Interval Start"].max() == date + pd.Timedelta(
-            hours=23,
-        )
-        assert df["Interval End"].max() == date + pd.Timedelta(
-            days=1,
-        )
-
-    @pytest.mark.integration
-    def test_get_medium_term_load_forecast_hourly_with_publish_time(self):
-        date = self.local_start_of_today() - pd.Timedelta(days=1)
-        publish_time = date - pd.Timedelta(days=2)
-
-        with api_vcr.use_cassette(
-            f"test_get_medium_term_load_forecast_hourly_with_publish_time_{date.date()}",
-        ):
-            df = self.iso.get_medium_term_load_forecast_hourly(
-                date,
-                publish_time=publish_time,
-            )
-
-        self._check_test_medium_term_load_forecast(df)
-
-        assert df["Interval Start"].min() == date
-        assert df["Interval Start"].max() == date + pd.Timedelta(
-            hours=23,
-        )
-        assert df["Interval End"].max() == date + pd.Timedelta(
-            days=1,
-        )
-        assert df["Publish Time"].min() == publish_time
-
-    @pytest.mark.integration
     def test_get_load_forecast_mid_term_by_region(self):
         publish_time = self.local_start_of_today() - pd.Timedelta(days=2)
 
@@ -1133,6 +1090,22 @@ class TestMISOAPI(TestHelperMixin):
         assert df["LRZ"].str.startswith("Z").all()
         assert df["Interval Start"].min() >= publish_time + pd.Timedelta(days=1)
         assert df["Load Forecast"].dtype == "Int64"
+
+    @pytest.mark.integration
+    def test_get_load_forecast_mid_term_by_region_max_offset(self):
+        publish_time = self.local_start_of_today() - pd.Timedelta(days=2)
+        forecast_date = publish_time + pd.Timedelta(days=1)
+
+        with api_vcr.use_cassette(
+            f"get_load_forecast_mid_term_by_region_{publish_time.date()}",
+        ):
+            df = self.iso.get_load_forecast_mid_term_by_region(
+                publish_time,
+                max_offset=1,
+            )
+
+        assert df["Interval Start"].min() >= forecast_date
+        assert df["Interval Start"].max() < forecast_date + pd.Timedelta(days=1)
 
     @pytest.mark.integration
     def test_get_medium_term_load_forecast_daily(self):
@@ -1310,8 +1283,8 @@ class TestMISOAPI(TestHelperMixin):
         assert df["Interval Start"].dtype == "datetime64[ns, EST]"
         assert df["Interval End"].dtype == "datetime64[ns, EST]"
 
-        for col in ["MTLF", "Outage"]:
-            assert df[col].dtype == "float64"
+        assert df["MTLF"].dtype == "Int64"
+        assert df["Outage"].dtype == "float64"
 
     def test_get_look_ahead_hourly(self):
         # Look ahead is for today and future dates
@@ -1334,7 +1307,10 @@ class TestMISOAPI(TestHelperMixin):
         # Try to get look ahead for yesterday - should raise NotSupported
         yesterday = self.local_start_of_today() - pd.Timedelta(days=1)
 
-        with pytest.raises(NotSupported, match="only available for future dates"):
+        with pytest.raises(
+            NotSupported,
+            match="only available for today and future dates",
+        ):
             self.iso.get_look_ahead_hourly(yesterday)
 
     def test_get_pricing_nodes(self):

--- a/gridstatus/tests/source_specific/test_nyiso.py
+++ b/gridstatus/tests/source_specific/test_nyiso.py
@@ -700,6 +700,51 @@ class TestNYISO(BaseTestISO):
             assert df.columns.tolist() == columns
             assert df.shape[0] >= 0
 
+    def test_get_btm_installed_capacity(self):
+        two_days_ago = pd.Timestamp.now(tz="US/Eastern").date() - pd.Timedelta(days=2)
+
+        with nyiso_vcr.use_cassette(
+            f"test_get_btm_installed_capacity_{two_days_ago}.yaml",
+        ):
+            df = self.iso.get_btm_installed_capacity(
+                date=two_days_ago,
+                verbose=True,
+            )
+
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "Zone",
+            "MW",
+        ]
+        assert not df.empty
+        assert df["Interval Start"].dt.normalize().nunique() == 1
+        assert df["Zone"].nunique() > 1
+
+    @pytest.mark.parametrize(
+        "date, end",
+        [
+            ("2023-08-15", "2023-08-17"),
+        ],
+    )
+    def test_get_btm_installed_capacity_historical_date_range(self, date, end):
+        with nyiso_vcr.use_cassette(
+            f"test_get_btm_installed_capacity_historical_date_range_{date}_{end}.yaml",
+        ):
+            df = self.iso.get_btm_installed_capacity(
+                start=date,
+                end=end,
+                verbose=True,
+            )
+
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "Zone",
+            "MW",
+        ]
+        assert not df.empty
+
     @pytest.mark.parametrize(
         "date, end",
         [

--- a/gridstatus/tests/source_specific/test_nyiso.py
+++ b/gridstatus/tests/source_specific/test_nyiso.py
@@ -721,6 +721,10 @@ class TestNYISO(BaseTestISO):
         assert df["Interval Start"].dt.normalize().nunique() == 1
         assert df["Zone"].nunique() > 1
 
+    def test_get_btm_installed_capacity_latest_not_supported(self):
+        with pytest.raises(ValueError, match="Latest not supported"):
+            self.iso.get_btm_installed_capacity(date="latest")
+
     @pytest.mark.parametrize(
         "date, end",
         [

--- a/gridstatus/tests/source_specific/test_spp.py
+++ b/gridstatus/tests/source_specific/test_spp.py
@@ -1923,6 +1923,33 @@ class TestSPP(BaseTestISO):
 
         self._check_solar_and_wind_forecast(latest, "MID_TERM")
 
+    def test_get_solar_and_wind_forecast_by_reserve_zone_historical(self):
+        publish_time = self.iso.now().normalize() - pd.Timedelta(days=3)
+        publish_time = publish_time.replace(hour=10, minute=0, second=0, microsecond=0)
+
+        with api_vcr.use_cassette(
+            "test_get_solar_and_wind_forecast_by_reserve_zone_historical_"
+            f"{publish_time.strftime('%Y%m%d%H')}.yaml",
+        ):
+            df = self.iso.get_solar_and_wind_forecast_by_reserve_zone(
+                date=publish_time,
+            )
+
+        assert df.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "Publish Time",
+            "BAA",
+            "Reserve Zone",
+            "Wind Forecast",
+            "Wind Actual",
+            "Solar Forecast",
+            "Solar Actual",
+        ]
+        assert (df["Publish Time"].unique() == publish_time).all()
+        assert df["Reserve Zone"].nunique() > 1
+        assert df["Interval Start"].max() >= publish_time + pd.Timedelta(days=5)
+
     def test_get_solar_and_wind_forecast_mid_term_historical(self):
         now = self.iso.now()
 


### PR DESCRIPTION
## Summary
- Adds `get_btm_installed_capacity` for NYISO (ENG-4137)
- Adds `get_solar_and_wind_forecast_by_reserve_zone` for SPP (ENG-4140)
- Adds `get_load_forecast_mid_term_by_region` for MISO (ENG-4143)

### Details
**NYISO BTM Installed Capacity** pulls daily behind-the-meter installed capacity by zone from MIS P-70Clist (`btminstalledcapacitytracking`).

**SPP Solar and Wind Forecast by Reserve Zone** fetches hourly flat files from `resource-forecast-by-reserve-zone`. The `date` parameter is the publish hour (file timestamp). Publish time is derived from the filename. Each file contains ~24 hours of actuals (intervals before publish time) and ~7 days of forecasts. **NaN actuals are expected** for current and future intervals — actuals are only populated for intervals before publish time. Forecast columns are null only on the horizon edge (dropped when all value columns are null).

**MISO Load Forecast by Region** wraps the Data Exchange API with publish-date semantics: `date` is the forecast run init/publish date, and the method queries the 7-day forecast horizon for that vintage. Returns long-format rows by region and LRZ.

To run tests:
```bash
VCR_RECORD_MODE=all uv run pytest -vvv gridstatus/tests/ -k "btm_installed_capacity"
VCR_RECORD_MODE=all uv run pytest -vvv gridstatus/tests/ -k "solar_and_wind_forecast_by_reserve_zone"
VCR_RECORD_MODE=all uv run pytest -vvv gridstatus/tests/ -k "load_forecast_mid_term_by_region"
```