### PR TITLE
feat(ENG 4133): Add CAISO Aggregated Generation Outages scraper

### DIFF
--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -2123,6 +2123,75 @@ class CAISO(ISOBase):
         return df
 
     @support_date_range(frequency="DAY_START")
+    def get_aggregated_generation_outages(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        sleep: int = 4,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Return hourly aggregated generator outages by fuel category and trading hub.
+
+        Each query returns roughly 30 days of forward-looking outage schedules
+        published on the requested date(s).
+
+        Arguments:
+            date (datetime.date, str): date to return data
+
+            end (datetime.date, str): last date of range to return data.
+                If None, returns only date. Defaults to None.
+
+            sleep (int, optional): seconds to sleep between requests.
+                Defaults to 4.
+
+            verbose (bool, optional): print out url being fetched. Defaults to False.
+
+        Returns:
+            pandas.DataFrame: A DataFrame with one row per
+            (Interval Start, Publish Time, Fuel Category, Trading Hub).
+        """
+        df = self.get_oasis_dataset(
+            dataset="aggregated_generation_outages",
+            date=date,
+            end=end,
+            raw_data=False,
+            sleep=sleep,
+            verbose=verbose,
+        )
+
+        if df.empty:
+            return df
+
+        df["Publish Time"] = pd.to_datetime(
+            df["REPORT_DATE_GMT"],
+            utc=True,
+        ).dt.tz_convert(self.default_timezone)
+
+        df = df.rename(
+            columns={
+                "FUEL_CATEGORY": "Fuel Category",
+                "TRADING_HUB": "Trading Hub",
+            },
+        )
+
+        df["MW"] = pd.to_numeric(df["MW"])
+
+        columns = [
+            "Interval Start",
+            "Interval End",
+            "Publish Time",
+            "Fuel Category",
+            "Trading Hub",
+            "MW",
+        ]
+
+        return (
+            df[columns]
+            .sort_values(["Interval Start", "Trading Hub", "Fuel Category"])
+            .reset_index(drop=True)
+        )
+
+    @support_date_range(frequency="DAY_START")
     def get_as_prices(
         self,
         date: str | pd.Timestamp,

--- a/gridstatus/caiso/caiso_constants.py
+++ b/gridstatus/caiso/caiso_constants.py
@@ -61,6 +61,16 @@ OASIS_DATASET_CONFIG = {
             ],
         },
     },
+    "aggregated_generation_outages": {
+        "query": {
+            "path": "GroupZip",
+            "resultformat": 6,
+            "version": 1,
+        },
+        "params": {
+            "groupid": "AGGR_OUTAGE_SCH_GRP",
+        },
+    },
     "as_clearing_prices": {
         "query": {
             "path": "SingleZip",

--- a/gridstatus/tests/source_specific/conftest.py
+++ b/gridstatus/tests/source_specific/conftest.py
@@ -1,23 +1,36 @@
+import os
 import time
 
 import pytest
 
-from gridstatus.tests.vcr_utils import RECORD_MODE
+CAISO_OASIS_RECORD_COOLDOWN_SECONDS = 30
 
-CAISO_OASIS_RECORD_COOLDOWN_SECONDS = 15
+_last_caiso_oasis_record_time: float | None = None
 
 
 @pytest.fixture(autouse=True)
 def caiso_oasis_record_cooldown(request: pytest.FixtureRequest):
-    """Sleep after CAISO OASIS tests when re-recording VCR cassettes.
+    """Pause between CAISO OASIS tests when re-recording VCR cassettes.
 
     CAISO rate-limits OASIS to roughly one request every few seconds. When
     ``VCR_RECORD_MODE=all``, back-to-back tests that hit the same endpoint can
     get HTTP 429 unless we pause between them.
+
+    Pair with ``@pytest.mark.real_sleep`` on the test so ``time.sleep`` is not
+    mocked during recording.
     """
-    if RECORD_MODE != "all" or request.node.get_closest_marker("caiso_oasis") is None:
-        yield
-        return
+    global _last_caiso_oasis_record_time
+
+    recording = os.getenv("VCR_RECORD_MODE", "new_episodes") == "all"
+    marked = request.node.get_closest_marker("caiso_oasis") is not None
+
+    if recording and marked and _last_caiso_oasis_record_time is not None:
+        elapsed = time.time() - _last_caiso_oasis_record_time
+        wait = CAISO_OASIS_RECORD_COOLDOWN_SECONDS - elapsed
+        if wait > 0:
+            time.sleep(wait)
 
     yield
-    time.sleep(CAISO_OASIS_RECORD_COOLDOWN_SECONDS)
+
+    if recording and marked:
+        _last_caiso_oasis_record_time = time.time()

--- a/gridstatus/tests/source_specific/conftest.py
+++ b/gridstatus/tests/source_specific/conftest.py
@@ -1,0 +1,23 @@
+import time
+
+import pytest
+
+from gridstatus.tests.vcr_utils import RECORD_MODE
+
+CAISO_OASIS_RECORD_COOLDOWN_SECONDS = 15
+
+
+@pytest.fixture(autouse=True)
+def caiso_oasis_record_cooldown(request: pytest.FixtureRequest):
+    """Sleep after CAISO OASIS tests when re-recording VCR cassettes.
+
+    CAISO rate-limits OASIS to roughly one request every few seconds. When
+    ``VCR_RECORD_MODE=all``, back-to-back tests that hit the same endpoint can
+    get HTTP 429 unless we pause between them.
+    """
+    if RECORD_MODE != "all" or request.node.get_closest_marker("caiso_oasis") is None:
+        yield
+        return
+
+    yield
+    time.sleep(CAISO_OASIS_RECORD_COOLDOWN_SECONDS)

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -23,6 +23,81 @@ class TestCAISO(BaseTestISO):
 
     trading_hub_locations = CAISO().trading_hub_locations
 
+    """get_aggregated_generation_outages"""
+
+    AGGREGATED_GENERATION_OUTAGES_COLUMNS = [
+        "Interval Start",
+        "Interval End",
+        "Publish Time",
+        "Fuel Category",
+        "Trading Hub",
+        "MW",
+    ]
+
+    def _check_aggregated_generation_outages(self, df: pd.DataFrame) -> None:
+        assert df.columns.tolist() == self.AGGREGATED_GENERATION_OUTAGES_COLUMNS
+        assert df.shape[0] > 0
+        assert set(df["Trading Hub"].unique()) == {
+            "NP15",
+            "PACE",
+            "PACW",
+            "SP15",
+            "ZP26",
+        }
+        assert set(df["Fuel Category"].unique()).issubset(
+            {
+                "Aggregated",
+                "Hydro",
+                "Not Avail",
+                "Renewable",
+                "Thermal",
+            },
+        )
+        interval_minutes = (
+            df["Interval End"] - df["Interval Start"]
+        ).dt.total_seconds() / 60
+        assert (interval_minutes == 60).all()
+        assert not df.duplicated(
+            subset=[
+                "Interval Start",
+                "Publish Time",
+                "Fuel Category",
+                "Trading Hub",
+            ],
+        ).any()
+        assert pd.api.types.is_numeric_dtype(df["MW"])
+
+    @pytest.mark.parametrize("date", ["2026-06-10"])
+    def test_get_aggregated_generation_outages(self, date):
+        with caiso_vcr.use_cassette(
+            f"test_get_aggregated_generation_outages_{date}.yaml",
+        ):
+            df = self.iso.get_aggregated_generation_outages(date=date)
+            self._check_aggregated_generation_outages(df)
+            assert df["Publish Time"].nunique() == 1
+            assert df["Publish Time"].iloc[0] == self.local_start_of_day(date)
+            assert df["Interval Start"].min() == self.local_start_of_day(date)
+            assert df["Interval End"].max() == self.local_start_of_day(
+                date,
+            ) + pd.Timedelta(days=30)
+
+    @pytest.mark.real_sleep
+    @pytest.mark.parametrize(
+        "start, end",
+        [("2026-06-10", "2026-06-12")],
+    )
+    def test_get_aggregated_generation_outages_date_range(self, start, end):
+        with caiso_vcr.use_cassette(
+            f"test_get_aggregated_generation_outages_{start}_{end}.yaml",
+        ):
+            df = self.iso.get_aggregated_generation_outages(
+                date=start,
+                end=end,
+                sleep=15,
+            )
+            self._check_aggregated_generation_outages(df)
+            assert df["Publish Time"].nunique() == 2
+
     """get_as"""
 
     @pytest.mark.parametrize("date", ["2022-10-15", "2022-10-16"])

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -67,12 +67,17 @@ class TestCAISO(BaseTestISO):
         ).any()
         assert pd.api.types.is_numeric_dtype(df["MW"])
 
+    @pytest.mark.caiso_oasis
+    @pytest.mark.real_sleep
     @pytest.mark.parametrize("date", ["2026-06-10"])
     def test_get_aggregated_generation_outages(self, date):
         with caiso_vcr.use_cassette(
             f"test_get_aggregated_generation_outages_{date}.yaml",
         ):
-            df = self.iso.get_aggregated_generation_outages(date=date)
+            df = self.iso.get_aggregated_generation_outages(
+                date=date,
+                sleep=15,
+            )
             self._check_aggregated_generation_outages(df)
             assert df["Publish Time"].nunique() == 1
             assert df["Publish Time"].iloc[0] == self.local_start_of_day(date)
@@ -81,10 +86,11 @@ class TestCAISO(BaseTestISO):
                 date,
             ) + pd.Timedelta(days=30)
 
+    @pytest.mark.caiso_oasis
     @pytest.mark.real_sleep
     @pytest.mark.parametrize(
         "start, end",
-        [("2026-06-10", "2026-06-12")],
+        [("2026-06-08", "2026-06-10")],
     )
     def test_get_aggregated_generation_outages_date_range(self, start, end):
         with caiso_vcr.use_cassette(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests as integration tests that pull from an external API (deselect with '-m \"not integration\"')",
     "real_sleep: do not mock time.sleep for retries/throttling (use when re-recording VCR cassettes against rate-limited APIs)",
+    "caiso_oasis: CAISO OASIS tests that share a rate limit; adds cooldown between tests when VCR_RECORD_MODE=all",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests as integration tests that pull from an external API (deselect with '-m \"not integration\"')",
     "real_sleep: do not mock time.sleep for retries/throttling (use when re-recording VCR cassettes against rate-limited APIs)",
-    "caiso_oasis: CAISO OASIS tests that share a rate limit; adds cooldown between tests when VCR_RECORD_MODE=all",
+    "caiso_oasis: CAISO OASIS tests that share a rate limit; adds cooldown between tests when VCR_RECORD_MODE=all (use with real_sleep)",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary
- Adds `get_aggregated_generation_outages` scraper for CAISO

### Details
This adds a new CAISO OASIS GroupZip scraper for the `AGGR_OUTAGE_SCH_GRP` report (Energy → System → Aggregated Generation Outages). Each daily query returns roughly 30 days of forward-looking hourly outage MW by fuel category (Hydro, Renewable, Thermal, and related groupings) and trading hub (SP15, NP15, ZP26, PACE, PACW). The method uses the standard OASIS GET flow via `get_oasis_dataset`, maps `REPORT_DATE_GMT` to `Publish Time`, and returns Interval Start, Interval End, Publish Time, Fuel Category, Trading Hub, and MW.

To run tests:
```bash
VCR_RECORD_MODE=all uv run pytest -vvv gridstatus/tests/ -k "caiso" -k "aggregated_generation_outages"
```

Made with [Cursor](https://cursor.com)