### PR TITLE
Update /code-guard to diff against up-to-date origin base

### DIFF
--- a/.claude/commands/code-guard.md
+++ b/.claude/commands/code-guard.md
@@ -3,10 +3,15 @@
 Follow the steps below and only output the final Report Out section.
 
 1. **Collect Inputs**
-   - Review changes in this branch only
-   - Base branch for the diff: `$ARGUMENTS` (default to `main` if empty)
-   - Use `git diff <base>...HEAD` to show all changes
-   - Note any context the user provided (goal, constraints, known tradeoffs)
+   - Review changes in this branch only.
+   - Base branch for the diff: `$ARGUMENTS` (default to `main` if empty).
+   - Always diff against the latest base from origin, and review the most recent local state of the branch (committed *and* uncommitted):
+     - Fetch the base so the comparison reflects current remote state: `git fetch origin <base>`.
+     - Resolve the base ref to `origin/<base>`, falling back to the local `<base>` ref only if it does not exist on origin.
+     - Find the fork point: `mb=$(git merge-base <base_ref> HEAD)`.
+     - Diff the merge-base against the working tree so committed and uncommitted changes are both captured: `git diff "$mb"` (changed files: `git diff --name-only "$mb"`; untracked: `git ls-files --others --exclude-standard`).
+   - This is exactly what a PR from this branch into the up-to-date base would show, plus any local work-in-progress.
+   - Note any context the user provided (goal, constraints, known tradeoffs).
 
 2. **Load Guidelines**
    - Read the workspace `../CLAUDE.md` for monorepo-wide rules


### PR DESCRIPTION
## What

Updates the `/code-guard` command so the review diff is always computed against an **up-to-date base** and the **most recent local state** of the branch.

Previously the command ran `git diff <base>...HEAD`, which:
- diffed against the **local** `<base>` ref (often stale — a `git fetch` updates `origin/<base>`, not the local branch), and
- compared only **committed** state (`...HEAD`), missing uncommitted work-in-progress.

## Now

- Fetches the base: `git fetch origin <base>`.
- Diffs against the remote-tracking ref `origin/<base>` (falls back to local `<base>` only if it doesn't exist on origin).
- Compares the **merge-base → working tree** (`git diff "$mb"`), so the review includes committed *and* uncommitted changes — exactly what a PR into the up-to-date base would show, plus local work-in-progress.

Docs-only change to `.claude/commands/code-guard.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a Claude command; no runtime or application code affected.
> 
> **Overview**
> Updates **Collect Inputs** in `/code-guard` so reviews use an up-to-date base and the full local branch state.
> 
> Instead of `git diff <base>...HEAD` on a possibly stale local base and committed-only `HEAD`, the command now **`git fetch origin <base>`**, resolves **`origin/<base>`** (with local fallback), finds **`merge-base`**, and runs **`git diff "$mb"`** against the working tree so committed and uncommitted changes match what a PR into current remote base would show, plus WIP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 742083fe455c610c354700994f2f4cef49693d27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->