### PR TITLE
feat(caiso): add get_price_corrections from PRC_CORR_GRP summary

### DIFF
--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -1767,14 +1767,14 @@ class CAISO(ISOBase):
         Raises:
             NoDataFoundException: if no corrections were issued for the range.
         """
-        df = self._get_price_corrections_grouped(
+        raw = self._get_price_corrections_raw(
             date=date,
             end=end,
             sleep=sleep,
             verbose=verbose,
         )
 
-        result = self._parse_price_corrections(df)
+        result = self._parse_price_corrections(raw)
 
         if result.empty:
             raise NoDataFoundException(
@@ -1784,106 +1784,60 @@ class CAISO(ISOBase):
         return result
 
     @support_date_range(frequency="DAY_START")
-    def _get_price_corrections_grouped(
+    def _get_price_corrections_raw(
         self,
         date: pd.Timestamp,
         end: pd.Timestamp | None = None,
         sleep: int = 4,
         verbose: bool = False,
     ) -> pd.DataFrame:
-        """Fetch the ``PRC_CORR_GRP`` summary for a single trade date.
-
-        ``@support_date_range`` calls this once per day and concatenates the
-        results, so range handling lives in the decorator.
-        """
-        return self._get_oasis_group_zip(
-            group_id="PRC_CORR_GRP",
-            version=1,
-            date=date,
-            sleep=sleep,
-            verbose=verbose,
-        )
-
-    def _get_oasis_group_zip(
-        self,
-        group_id: str,
-        version: int,
-        date: pd.Timestamp,
-        sleep: int = 4,
-        verbose: bool = False,
-        max_retries: int = 3,
-    ) -> pd.DataFrame:
-        """Fetch a single trade date from an OASIS ``GroupZip`` report group.
-
-        The group endpoint serves one trade date per request and returns a
-        small response, so it is never too large. A "no data" response
-        therefore means the group has not been generated for the date yet or a
-        transient rate limit, both of which are retried; a persistent "no data"
-        is returned as an empty frame.
+        """Fetch the ``PRC_CORR_GRP`` summary for one trade date; the decorator
+        iterates and concatenates a range. A "no data" response (the group is
+        not generated for the date yet, or a transient rate limit) is retried,
+        then returns an empty frame.
         """
         start, _ = _caiso_handle_start_end(date)
         url = (
             "http://oasis.caiso.com/oasisapi/GroupZip?resultformat=6"
-            f"&groupid={group_id}&version={version}&startdatetime={start}"
+            f"&groupid=PRC_CORR_GRP&version=1&startdatetime={start}"
         )
-
         if verbose:
             print(f"Fetching URL: {url}")
         logger.info(f"Fetching URL: {url}")
 
-        retry_num = 0
-        while retry_num <= max_retries:
+        for _ in range(4):
             response = requests.get(url, verify=True)
-
             if response.status_code == 200:
                 archive = ZipFile(io.BytesIO(response.content))
                 contents = archive.read(archive.namelist()[0])
-                # An error XML rather than a CSV means no data is available for
-                # the trade date yet, or a transient rate limit.
-                if not (b"<?xml" in contents[:200] and b"ERR_CODE" in contents[:600]):
+                # A data response is a CSV; "no data" is an XML error document.
+                if b"ERR_CODE" not in contents[:600]:
                     return pd.read_csv(io.BytesIO(contents))
-                logger.info(f"No price corrections for {date.date()} yet")
-
-            retry_num += 1
             time.sleep(sleep)
 
         return pd.DataFrame()
 
     def _parse_price_corrections(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Standardize ``PRC_CORR_GRP`` rows.
-
-        Each trade date lists every market/correction-method combination;
-        combinations with no corrections are placeholder rows marked with a
-        sentinel reason and are dropped here so only actual corrections remain.
+        """Rename and type the ``PRC_CORR_GRP`` columns, dropping the placeholder
+        rows that mark market/method combinations with no correction for the day.
         """
-        columns = [
-            "Trade Date",
-            "Hour Ending",
-            "Interval",
-            "Market",
-            "Affected Area",
-            "Correction Method",
-            "Correction Count",
-            "Energy Type",
-            "Correction Reason",
-            "Report Generated",
-        ]
-
         if df.empty:
-            return pd.DataFrame(columns=columns)
+            return df
 
         df = df[df["CORRECTION_REASON"] != PRICE_CORRECTION_NO_RECORDS_REASON]
-
         if df.empty:
-            return pd.DataFrame(columns=columns)
+            return df
+
+        def to_pacific(column: pd.Series) -> pd.Series:
+            return pd.to_datetime(column).dt.tz_localize(
+                self.default_timezone,
+                ambiguous=True,
+                nonexistent="shift_forward",
+            )
 
         result = pd.DataFrame(
             {
-                "Trade Date": pd.to_datetime(df["TRADE_DATE"]).dt.tz_localize(
-                    self.default_timezone,
-                    ambiguous=True,
-                    nonexistent="shift_forward",
-                ),
+                "Trade Date": to_pacific(df["TRADE_DATE"]),
                 "Hour Ending": df["HOUR_ENDING"].astype("Int64"),
                 "Interval": df["INTERVAL"].astype("Int64"),
                 "Market": df["MARKET"],
@@ -1892,16 +1846,9 @@ class CAISO(ISOBase):
                 "Correction Count": df["CORRECTION_COUNT"].astype("Int64"),
                 "Energy Type": df["ENERGY_TYPECODE"],
                 "Correction Reason": df["CORRECTION_REASON"],
-                "Report Generated": pd.to_datetime(
-                    df["REPORT_GENERATED"],
-                ).dt.tz_localize(
-                    self.default_timezone,
-                    ambiguous=True,
-                    nonexistent="shift_forward",
-                ),
+                "Report Generated": to_pacific(df["REPORT_GENERATED"]),
             },
         )
-
         return result.sort_values(
             ["Trade Date", "Market", "Hour Ending", "Interval"],
         ).reset_index(drop=True)

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -33,6 +33,14 @@ from gridstatus.decorators import support_date_range
 from gridstatus.gs_logging import logger
 from gridstatus.lmp_config import lmp_config
 
+# In ATL_PRC_CORR_MSG messages the corrected operating day is written into the
+# free-text body as e.g. "Trade Date: 03/30/2026" or "trade day 4/1/2026". The
+# date is anchored to the "Trade Date"/"trade day" prefix so unrelated dates in
+# the message (such as a future publish date) are not picked up.
+PRICE_CORRECTION_TRADE_DATE_REGEX = re.compile(
+    r"[Tt]rade [Dd](?:ate|ay):?\s*(\d{1,2}/\d{1,2}/\d{4})",
+)
+
 
 def _determine_lmp_frequency(args: dict) -> str:
     """if querying all must use 1d frequency"""
@@ -1716,6 +1724,113 @@ class CAISO(ISOBase):
             end=end,
             verbose=verbose,
         )
+
+    @support_date_range(frequency="31D")
+    def get_price_corrections(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp | None = None,
+        sleep: int = 4,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Return CAISO price correction messages (OASIS ``ATL_PRC_CORR_MSG``).
+
+        CAISO publishes a message whenever it reprices an operating day. Each
+        message names the affected market and trade date and is filtered by the
+        time the message was published (not the trade date being corrected), so
+        a message published today may reference a trade date several days or
+        weeks earlier.
+
+        Arguments:
+            date (datetime.date, str): start of the publish-time window.
+
+            end (datetime.date, str): end of the publish-time window. If None,
+                returns only ``date``. Defaults to None.
+
+            sleep (int): seconds to sleep between requests to avoid the OASIS
+                rate limit. Defaults to 4.
+
+            verbose (bool, optional): print out url being fetched. Defaults to
+                False.
+
+        Returns:
+            pandas.DataFrame: one row per correction message with columns
+            ``Publish Time`` (when the message was posted), ``Market`` (the
+            CAISO market run id, e.g. ``DAM``, ``RTD``, ``RTPD``), ``Trade Date``
+            (the corrected operating day; ``NaT`` for administrative messages
+            that do not name one) and ``Message`` (the full message text).
+        """
+        df = self.get_oasis_dataset(
+            dataset="price_corrections",
+            start=date,
+            end=end,
+            sleep=sleep,
+            verbose=verbose,
+            raw_data=False,
+        )
+
+        return self._parse_price_corrections(df)
+
+    def _parse_price_corrections(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Reconstruct ATL_PRC_CORR_MSG messages into one row per message.
+
+        The OASIS CSV puts the multi-line message body in the ``MSG_TEXT`` field,
+        but some messages are not quoted and the parser spills their body across
+        rows where only the first column is populated and the time columns are
+        empty. A row with a populated ``MSG_TIME_GMT`` therefore starts a new
+        message; rows without one are continuation fragments of the message
+        above them.
+        """
+        columns = ["Publish Time", "Market", "Trade Date", "Message"]
+
+        if df.empty:
+            return pd.DataFrame(columns=columns)
+
+        records = []
+        current = None
+        for row in df.itertuples(index=False):
+            market = getattr(row, "MARKET_RUN_ID", None)
+            publish_time = getattr(row, "MSG_TIME_GMT", None)
+            message = getattr(row, "MSG_TEXT", None)
+
+            if pd.notna(publish_time):
+                if current is not None:
+                    records.append(current)
+                current = {
+                    "Publish Time": publish_time,
+                    "Market": market if pd.notna(market) else None,
+                    "Message": "" if pd.isna(message) else str(message),
+                }
+            elif current is not None:
+                # Continuation fragment: its text spilled into the leading
+                # columns. Append whatever is populated to the running body.
+                for fragment in (market, message):
+                    if pd.notna(fragment):
+                        current["Message"] += "\n" + str(fragment)
+
+        if current is not None:
+            records.append(current)
+
+        result = pd.DataFrame.from_records(records)
+        result["Trade Date"] = result["Message"].apply(self._parse_trade_date)
+        result["Publish Time"] = result["Publish Time"].dt.tz_convert(
+            self.default_timezone,
+        )
+
+        return (
+            result[columns]
+            .sort_values(["Publish Time", "Trade Date"])
+            .reset_index(drop=True)
+        )
+
+    @staticmethod
+    def _parse_trade_date(message: str) -> pd.Timestamp:
+        """Extract the corrected operating day from a message body as a
+        Pacific-localized midnight timestamp, or ``NaT`` if none is present."""
+        match = PRICE_CORRECTION_TRADE_DATE_REGEX.search(message or "")
+        if not match:
+            return pd.NaT
+        return pd.Timestamp(match.group(1)).tz_localize(CAISO.default_timezone)
 
     @support_date_range(frequency="DAY_START")
     def get_storage(

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -33,13 +33,10 @@ from gridstatus.decorators import support_date_range
 from gridstatus.gs_logging import logger
 from gridstatus.lmp_config import lmp_config
 
-# In ATL_PRC_CORR_MSG messages the corrected operating day is written into the
-# free-text body as e.g. "Trade Date: 03/30/2026" or "trade day 4/1/2026". The
-# date is anchored to the "Trade Date"/"trade day" prefix so unrelated dates in
-# the message (such as a future publish date) are not picked up.
-PRICE_CORRECTION_TRADE_DATE_REGEX = re.compile(
-    r"[Tt]rade [Dd](?:ate|ay):?\s*(\d{1,2}/\d{1,2}/\d{4})",
-)
+# The PRC_CORR_GRP summary lists every market/correction-method combination for a
+# trade date; combinations with no corrections carry this sentinel in the reason
+# column and are dropped during parsing.
+PRICE_CORRECTION_NO_RECORDS_REASON = "No records found for report."
 
 
 def _determine_lmp_frequency(args: dict) -> str:
@@ -1732,22 +1729,24 @@ class CAISO(ISOBase):
         sleep: int = 4,
         verbose: bool = False,
     ) -> pd.DataFrame:
-        """Return CAISO price correction messages (OASIS ``ATL_PRC_CORR_MSG``).
+        """Return CAISO price corrections (OASIS ``PRC_CORR_GRP`` summary).
 
-        CAISO publishes a message whenever it reprices an operating day. Each
-        message names the affected market and trade date and is filtered by the
-        time the message was published (not the trade date being corrected), so
-        a message published today may reference a trade date several days or
-        weeks earlier.
+        CAISO reprices an operating day when it detects an error in published
+        prices and posts a structured summary of every correction to the
+        ``PRC_CORR_GRP`` report group. Each row describes a single corrected
+        interval: the trade date (operating day) and market that were
+        corrected, the hour ending and interval, the correction method and
+        reason, and the time the correction was generated.
 
-        The report has a small maximum query range and returns "no data" rather
-        than an error when it is exceeded, so the request is chunked into short
-        windows via ``max_query_frequency`` in ``OASIS_DATASET_CONFIG``.
+        The report is keyed by trade date and serves one day per request, so a
+        range is fetched one day at a time. A correction is typically generated
+        several days to two weeks after the trade date, so ``Report Generated``
+        is the column to use when selecting recently issued corrections.
 
         Arguments:
-            date (datetime.date, str): start of the publish-time window.
+            date (datetime.date, str): start of the trade-date range.
 
-            end (datetime.date, str): end of the publish-time window. If None,
+            end (datetime.date, str): end of the trade-date range. If None,
                 returns only ``date``. Defaults to None.
 
             sleep (int): seconds to sleep between requests to avoid the OASIS
@@ -1757,94 +1756,155 @@ class CAISO(ISOBase):
                 False.
 
         Returns:
-            pandas.DataFrame: one row per correction message with columns
-            ``Publish Time`` (when the message was posted), ``Market`` (the
-            CAISO market run id, e.g. ``DAM``, ``RTD``, ``RTPD``), ``Trade Date``
-            (the corrected operating day; ``NaT`` for administrative messages
-            that do not name one) and ``Message`` (the full message text).
+            pandas.DataFrame: one row per corrected interval with columns
+            ``Trade Date`` (the corrected operating day), ``Hour Ending``,
+            ``Interval``, ``Market`` (e.g. ``DAM``, ``RTD``, ``RTPD``),
+            ``Affected Area``, ``Correction Method``, ``Correction Count``,
+            ``Energy Type``, ``Correction Reason`` and ``Report Generated``
+            (when the correction was issued). ``Trade Date`` and
+            ``Report Generated`` are Pacific-localized timestamps.
 
         Raises:
-            NoDataFoundException: if no correction messages were published in the
-                window.
+            NoDataFoundException: if no corrections were issued for the range.
         """
-        df = self.get_oasis_dataset(
-            dataset="price_corrections",
-            start=date,
+        df = self._get_price_corrections_grouped(
+            date=date,
             end=end,
             sleep=sleep,
             verbose=verbose,
-            raw_data=False,
         )
 
         result = self._parse_price_corrections(df)
 
         if result.empty:
             raise NoDataFoundException(
-                f"No CAISO price corrections published between {date} and {end}",
+                f"No CAISO price corrections for trade dates between {date} and {end}",
             )
 
         return result
 
-    def _parse_price_corrections(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Reconstruct ATL_PRC_CORR_MSG messages into one row per message.
+    @support_date_range(frequency="DAY_START")
+    def _get_price_corrections_grouped(
+        self,
+        date: pd.Timestamp,
+        end: pd.Timestamp | None = None,
+        sleep: int = 4,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Fetch the ``PRC_CORR_GRP`` summary for a single trade date.
 
-        The OASIS CSV puts the multi-line message body in the ``MSG_TEXT`` field,
-        but some messages are not quoted and the parser spills their body across
-        rows where only the first column is populated and the time columns are
-        empty. A row with a populated ``MSG_TIME_GMT`` therefore starts a new
-        message; rows without one are continuation fragments of the message
-        above them.
+        ``@support_date_range`` calls this once per day and concatenates the
+        results, so range handling lives in the decorator.
         """
-        columns = ["Publish Time", "Market", "Trade Date", "Message"]
+        return self._get_oasis_group_zip(
+            group_id="PRC_CORR_GRP",
+            version=1,
+            date=date,
+            sleep=sleep,
+            verbose=verbose,
+        )
+
+    def _get_oasis_group_zip(
+        self,
+        group_id: str,
+        version: int,
+        date: pd.Timestamp,
+        sleep: int = 4,
+        verbose: bool = False,
+        max_retries: int = 3,
+    ) -> pd.DataFrame:
+        """Fetch a single trade date from an OASIS ``GroupZip`` report group.
+
+        The group endpoint serves one trade date per request and returns a
+        small response, so it is never too large. A "no data" response
+        therefore means the group has not been generated for the date yet or a
+        transient rate limit, both of which are retried; a persistent "no data"
+        is returned as an empty frame.
+        """
+        start, _ = _caiso_handle_start_end(date)
+        url = (
+            "http://oasis.caiso.com/oasisapi/GroupZip?resultformat=6"
+            f"&groupid={group_id}&version={version}&startdatetime={start}"
+        )
+
+        if verbose:
+            print(f"Fetching URL: {url}")
+        logger.info(f"Fetching URL: {url}")
+
+        retry_num = 0
+        while retry_num <= max_retries:
+            response = requests.get(url, verify=True)
+
+            if response.status_code == 200:
+                archive = ZipFile(io.BytesIO(response.content))
+                contents = archive.read(archive.namelist()[0])
+                # An error XML rather than a CSV means no data is available for
+                # the trade date yet, or a transient rate limit.
+                if not (b"<?xml" in contents[:200] and b"ERR_CODE" in contents[:600]):
+                    return pd.read_csv(io.BytesIO(contents))
+                logger.info(f"No price corrections for {date.date()} yet")
+
+            retry_num += 1
+            time.sleep(sleep)
+
+        return pd.DataFrame()
+
+    def _parse_price_corrections(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Standardize ``PRC_CORR_GRP`` rows.
+
+        Each trade date lists every market/correction-method combination;
+        combinations with no corrections are placeholder rows marked with a
+        sentinel reason and are dropped here so only actual corrections remain.
+        """
+        columns = [
+            "Trade Date",
+            "Hour Ending",
+            "Interval",
+            "Market",
+            "Affected Area",
+            "Correction Method",
+            "Correction Count",
+            "Energy Type",
+            "Correction Reason",
+            "Report Generated",
+        ]
 
         if df.empty:
             return pd.DataFrame(columns=columns)
 
-        records = []
-        current = None
-        for row in df.itertuples(index=False):
-            market = getattr(row, "MARKET_RUN_ID", None)
-            publish_time = getattr(row, "MSG_TIME_GMT", None)
-            message = getattr(row, "MSG_TEXT", None)
+        df = df[df["CORRECTION_REASON"] != PRICE_CORRECTION_NO_RECORDS_REASON]
 
-            if pd.notna(publish_time):
-                if current is not None:
-                    records.append(current)
-                current = {
-                    "Publish Time": publish_time,
-                    "Market": market if pd.notna(market) else None,
-                    "Message": "" if pd.isna(message) else str(message),
-                }
-            elif current is not None:
-                # Continuation fragment: its text spilled into the leading
-                # columns. Append whatever is populated to the running body.
-                for fragment in (market, message):
-                    if pd.notna(fragment):
-                        current["Message"] += "\n" + str(fragment)
+        if df.empty:
+            return pd.DataFrame(columns=columns)
 
-        if current is not None:
-            records.append(current)
-
-        result = pd.DataFrame.from_records(records)
-        result["Trade Date"] = result["Message"].apply(self._parse_trade_date)
-        result["Publish Time"] = result["Publish Time"].dt.tz_convert(
-            self.default_timezone,
+        result = pd.DataFrame(
+            {
+                "Trade Date": pd.to_datetime(df["TRADE_DATE"]).dt.tz_localize(
+                    self.default_timezone,
+                    ambiguous=True,
+                    nonexistent="shift_forward",
+                ),
+                "Hour Ending": df["HOUR_ENDING"].astype("Int64"),
+                "Interval": df["INTERVAL"].astype("Int64"),
+                "Market": df["MARKET"],
+                "Affected Area": df["AFFECTED_AREA"],
+                "Correction Method": df["CORRECTION_METHOD"],
+                "Correction Count": df["CORRECTION_COUNT"].astype("Int64"),
+                "Energy Type": df["ENERGY_TYPECODE"],
+                "Correction Reason": df["CORRECTION_REASON"],
+                "Report Generated": pd.to_datetime(
+                    df["REPORT_GENERATED"],
+                ).dt.tz_localize(
+                    self.default_timezone,
+                    ambiguous=True,
+                    nonexistent="shift_forward",
+                ),
+            },
         )
 
-        return (
-            result[columns]
-            .sort_values(["Publish Time", "Trade Date"])
-            .reset_index(drop=True)
-        )
-
-    @staticmethod
-    def _parse_trade_date(message: str) -> pd.Timestamp:
-        """Extract the corrected operating day from a message body as a
-        Pacific-localized midnight timestamp, or ``NaT`` if none is present."""
-        match = PRICE_CORRECTION_TRADE_DATE_REGEX.search(message or "")
-        if not match:
-            return pd.NaT
-        return pd.Timestamp(match.group(1)).tz_localize(CAISO.default_timezone)
+        return result.sort_values(
+            ["Trade Date", "Market", "Hour Ending", "Interval"],
+        ).reset_index(drop=True)
 
     @support_date_range(frequency="DAY_START")
     def get_storage(

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -1725,7 +1725,6 @@ class CAISO(ISOBase):
             verbose=verbose,
         )
 
-    @support_date_range(frequency="31D")
     def get_price_corrections(
         self,
         date: str | pd.Timestamp,
@@ -1740,6 +1739,10 @@ class CAISO(ISOBase):
         time the message was published (not the trade date being corrected), so
         a message published today may reference a trade date several days or
         weeks earlier.
+
+        The report has a small maximum query range and returns "no data" rather
+        than an error when it is exceeded, so the request is chunked into short
+        windows via ``max_query_frequency`` in ``OASIS_DATASET_CONFIG``.
 
         Arguments:
             date (datetime.date, str): start of the publish-time window.
@@ -1759,6 +1762,10 @@ class CAISO(ISOBase):
             CAISO market run id, e.g. ``DAM``, ``RTD``, ``RTPD``), ``Trade Date``
             (the corrected operating day; ``NaT`` for administrative messages
             that do not name one) and ``Message`` (the full message text).
+
+        Raises:
+            NoDataFoundException: if no correction messages were published in the
+                window.
         """
         df = self.get_oasis_dataset(
             dataset="price_corrections",
@@ -1769,7 +1776,14 @@ class CAISO(ISOBase):
             raw_data=False,
         )
 
-        return self._parse_price_corrections(df)
+        result = self._parse_price_corrections(df)
+
+        if result.empty:
+            raise NoDataFoundException(
+                f"No CAISO price corrections published between {date} and {end}",
+            )
+
+        return result
 
     def _parse_price_corrections(self, df: pd.DataFrame) -> pd.DataFrame:
         """Reconstruct ATL_PRC_CORR_MSG messages into one row per message.

--- a/gridstatus/caiso/caiso_constants.py
+++ b/gridstatus/caiso/caiso_constants.py
@@ -477,24 +477,6 @@ OASIS_DATASET_CONFIG = {
             "schedule": "ALL",
         },
     },
-    # Price correction messages CAISO publishes when it reprices an operating
-    # day. The report is filtered by message (publish) time, not trade date. No
-    # market_run_id parameter is sent because passing "ALL" returns no data; the
-    # market is read from the MARKET_RUN_ID column of the response instead.
-    # The report silently returns "no data" once the query range exceeds ~10
-    # days, so it is chunked into 5-day windows to stay safely under that limit.
-    "price_corrections": {
-        "query": {
-            "path": "SingleZip",
-            "resultformat": 6,
-            "queryname": "ATL_PRC_CORR_MSG",
-            "version": 3,
-        },
-        "params": {},
-        "meta": {
-            "max_query_frequency": "5D",
-        },
-    },
 }
 
 

--- a/gridstatus/caiso/caiso_constants.py
+++ b/gridstatus/caiso/caiso_constants.py
@@ -477,6 +477,22 @@ OASIS_DATASET_CONFIG = {
             "schedule": "ALL",
         },
     },
+    # Price correction messages CAISO publishes when it reprices an operating
+    # day. The report is filtered by message (publish) time, not trade date. No
+    # market_run_id parameter is sent because passing "ALL" returns no data; the
+    # market is read from the MARKET_RUN_ID column of the response instead.
+    "price_corrections": {
+        "query": {
+            "path": "SingleZip",
+            "resultformat": 6,
+            "queryname": "ATL_PRC_CORR_MSG",
+            "version": 3,
+        },
+        "params": {},
+        "meta": {
+            "max_query_frequency": "31D",
+        },
+    },
 }
 
 

--- a/gridstatus/caiso/caiso_constants.py
+++ b/gridstatus/caiso/caiso_constants.py
@@ -481,6 +481,8 @@ OASIS_DATASET_CONFIG = {
     # day. The report is filtered by message (publish) time, not trade date. No
     # market_run_id parameter is sent because passing "ALL" returns no data; the
     # market is read from the MARKET_RUN_ID column of the response instead.
+    # The report silently returns "no data" once the query range exceeds ~10
+    # days, so it is chunked into 5-day windows to stay safely under that limit.
     "price_corrections": {
         "query": {
             "path": "SingleZip",
@@ -490,7 +492,7 @@ OASIS_DATASET_CONFIG = {
         },
         "params": {},
         "meta": {
-            "max_query_frequency": "31D",
+            "max_query_frequency": "5D",
         },
     },
 }

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -62,7 +62,10 @@ class TestCAISO(BaseTestISO):
         "Message",
     ]
 
-    @pytest.mark.parametrize("start, end", [("2026-04-01", "2026-05-01")])
+    # The window spans more than the report's max query range, exercising the
+    # 5-day chunking that stitches the messages back together.
+    @pytest.mark.real_sleep
+    @pytest.mark.parametrize("start, end", [("2026-05-26", "2026-06-05")])
     def test_get_price_corrections(self, start, end):
         with caiso_vcr.use_cassette(
             f"test_get_price_corrections_{start}_{end}.yaml",
@@ -73,7 +76,13 @@ class TestCAISO(BaseTestISO):
             assert df.shape[0] > 0
 
             # Market comes from the response's MARKET_RUN_ID column.
-            assert set(df["Market"].dropna().unique()) <= {"DAM", "RTD", "RTPD"}
+            assert set(df["Market"].dropna().unique()) <= {
+                "DAM",
+                "RTD",
+                "RTPD",
+                "HASP",
+                "RUC",
+            }
 
             # Publish Time and Trade Date are Pacific-localized timestamps.
             assert str(df["Publish Time"].dt.tz) == "US/Pacific"
@@ -84,9 +93,18 @@ class TestCAISO(BaseTestISO):
             assert df["Publish Time"].min() >= self.local_start_of_day(start)
             assert df["Publish Time"].max() < self.local_start_of_day(end)
 
-            # Almost every message names the corrected trade date; the rare
-            # exception is a purely administrative notice.
-            assert df["Trade Date"].notna().mean() > 0.9
+            # Most messages name the corrected trade date; the remainder are
+            # administrative notices (which can be a meaningful fraction).
+            assert df["Trade Date"].notna().mean() > 0.5
+
+    def test_get_price_corrections_raises_when_empty(self):
+        # A window with no published corrections raises rather than returning an
+        # empty frame, so callers can distinguish "no corrections" explicitly.
+        with caiso_vcr.use_cassette(
+            "test_get_price_corrections_empty.yaml",
+        ):
+            with pytest.raises(NoDataFoundException):
+                self.iso.get_price_corrections(date="2026-05-21", end="2026-05-26")
 
     """get_ir_rc_prices"""
 

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -56,16 +56,22 @@ class TestCAISO(BaseTestISO):
     """get_price_corrections"""
 
     PRICE_CORRECTIONS_COLUMNS = [
-        "Publish Time",
-        "Market",
         "Trade Date",
-        "Message",
+        "Hour Ending",
+        "Interval",
+        "Market",
+        "Affected Area",
+        "Correction Method",
+        "Correction Count",
+        "Energy Type",
+        "Correction Reason",
+        "Report Generated",
     ]
 
-    # The window spans more than the report's max query range, exercising the
-    # 5-day chunking that stitches the messages back together.
+    # PRC_CORR_GRP serves one trade date per request, so the range exercises the
+    # per-day fetch and concatenation.
     @pytest.mark.real_sleep
-    @pytest.mark.parametrize("start, end", [("2026-05-26", "2026-06-05")])
+    @pytest.mark.parametrize("start, end", [("2026-06-01", "2026-06-13")])
     def test_get_price_corrections(self, start, end):
         with caiso_vcr.use_cassette(
             f"test_get_price_corrections_{start}_{end}.yaml",
@@ -75,36 +81,32 @@ class TestCAISO(BaseTestISO):
             assert df.columns.tolist() == self.PRICE_CORRECTIONS_COLUMNS
             assert df.shape[0] > 0
 
-            # Market comes from the response's MARKET_RUN_ID column.
-            assert set(df["Market"].dropna().unique()) <= {
-                "DAM",
-                "RTD",
-                "RTPD",
-                "HASP",
-                "RUC",
-            }
+            # Market comes from the PRC_CORR_GRP MARKET column.
+            assert set(df["Market"].unique()) <= {"DAM", "RTD", "RTPD", "HASP", "RUC"}
 
-            # Publish Time and Trade Date are Pacific-localized timestamps.
-            assert str(df["Publish Time"].dt.tz) == "US/Pacific"
+            # Trade Date and Report Generated are Pacific-localized timestamps.
             assert str(df["Trade Date"].dt.tz) == "US/Pacific"
+            assert str(df["Report Generated"].dt.tz) == "US/Pacific"
 
-            # The report is filtered by publish time, so every message falls in
-            # the requested window.
-            assert df["Publish Time"].min() >= self.local_start_of_day(start)
-            assert df["Publish Time"].max() < self.local_start_of_day(end)
+            # The report is keyed by trade date, so every correction falls in the
+            # requested range (end exclusive).
+            assert df["Trade Date"].min() >= pd.Timestamp(start, tz="US/Pacific")
+            assert df["Trade Date"].max() < pd.Timestamp(end, tz="US/Pacific")
 
-            # Most messages name the corrected trade date; the remainder are
-            # administrative notices (which can be a meaningful fraction).
-            assert df["Trade Date"].notna().mean() > 0.5
+            # Placeholder "no corrections" rows are dropped, and a correction is
+            # never generated before its trade date.
+            assert "No records found for report." not in set(df["Correction Reason"])
+            assert (df["Report Generated"] >= df["Trade Date"]).all()
 
     def test_get_price_corrections_raises_when_empty(self):
-        # A window with no published corrections raises rather than returning an
-        # empty frame, so callers can distinguish "no corrections" explicitly.
+        # Future trade dates have no issued corrections, so the method raises
+        # rather than returning an empty frame, letting callers distinguish
+        # "no corrections" explicitly.
         with caiso_vcr.use_cassette(
             "test_get_price_corrections_empty.yaml",
         ):
             with pytest.raises(NoDataFoundException):
-                self.iso.get_price_corrections(date="2026-05-21", end="2026-05-26")
+                self.iso.get_price_corrections(date="2026-07-01", end="2026-07-04")
 
     """get_ir_rc_prices"""
 

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -53,6 +53,41 @@ class TestCAISO(BaseTestISO):
                 df = self.iso.get_as_procurement(date, market=market)
                 self._check_as_data(df, market)
 
+    """get_price_corrections"""
+
+    PRICE_CORRECTIONS_COLUMNS = [
+        "Publish Time",
+        "Market",
+        "Trade Date",
+        "Message",
+    ]
+
+    @pytest.mark.parametrize("start, end", [("2026-04-01", "2026-05-01")])
+    def test_get_price_corrections(self, start, end):
+        with caiso_vcr.use_cassette(
+            f"test_get_price_corrections_{start}_{end}.yaml",
+        ):
+            df = self.iso.get_price_corrections(date=start, end=end)
+
+            assert df.columns.tolist() == self.PRICE_CORRECTIONS_COLUMNS
+            assert df.shape[0] > 0
+
+            # Market comes from the response's MARKET_RUN_ID column.
+            assert set(df["Market"].dropna().unique()) <= {"DAM", "RTD", "RTPD"}
+
+            # Publish Time and Trade Date are Pacific-localized timestamps.
+            assert str(df["Publish Time"].dt.tz) == "US/Pacific"
+            assert str(df["Trade Date"].dt.tz) == "US/Pacific"
+
+            # The report is filtered by publish time, so every message falls in
+            # the requested window.
+            assert df["Publish Time"].min() >= self.local_start_of_day(start)
+            assert df["Publish Time"].max() < self.local_start_of_day(end)
+
+            # Almost every message names the corrected trade date; the rare
+            # exception is a purely administrative notice.
+            assert df["Trade Date"].notna().mean() > 0.9
+
     """get_ir_rc_prices"""
 
     IR_RC_PRICES_COLUMNS = [


### PR DESCRIPTION
Adds `CAISO.get_price_corrections()` — CAISO price corrections from the OASIS `PRC_CORR_GRP` summary.

**What changed**
- New `get_price_corrections(date, end)`: one row per corrected interval — `Trade Date`, `Hour Ending`, `Interval`, `Market`, `Affected Area`, `Correction Method`, `Correction Count`, `Energy Type`, `Correction Reason`, `Report Generated` (timestamps Pacific-localized).
- Keyed by trade date, fetched one day per request; single-day "no data" is retried, then raises `NoDataFoundException` if the range is empty.
- Drops placeholder `"No records found for report."` rows.

**Validate:** `uv run pytest gridstatus/tests/source_specific/test_caiso.py -k price_correction`
