### PR TITLE
fix(ENG-4133): Pivot CAISO aggregated generation outages to wide schema

### DIFF
--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -2291,6 +2291,12 @@ class CAISO(ISOBase):
             if column not in df.columns:
                 df[column] = np.nan
 
+        component_sum = df[["Hydro", "Not Available", "Renewable", "Thermal"]].sum(
+            axis=1,
+            min_count=1,
+        )
+        df["Aggregated"] = df["Aggregated"].combine_first(component_sum)
+
         return df[
             [
                 "Interval Start",
@@ -2315,10 +2321,12 @@ class CAISO(ISOBase):
     ) -> pd.DataFrame:
         """Return hourly aggregated generator outages by trading hub.
 
-        Outage MW is split across fuel-category columns (Thermal, Renewable,
-        Hydro, Aggregated, and Not Available). Each query returns roughly 30
-        days of forward-looking outage schedules published on the requested
-        date(s).
+        Outage MW is reported with an ``Aggregated`` hub-total column plus
+        fuel-category breakdown columns where CAISO provides them. Some hubs
+        (e.g. ZP26) publish only the aggregate; others publish Thermal,
+        Renewable, Hydro, and sometimes Not Available. ``Aggregated`` uses the
+        published value when present, otherwise the sum of the breakdown
+        columns.
 
         Arguments:
             date (datetime.date, str): date to return data

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -2258,6 +2258,53 @@ class CAISO(ISOBase):
         df = df.replace("", np.nan)
         return df
 
+    def _pivot_aggregated_generation_outages(
+        self,
+        df: pd.DataFrame,
+    ) -> pd.DataFrame:
+        df = df.copy()
+        df["Fuel Category"] = df["Fuel Category"].replace(
+            {"Not Avail": "Not Available"},
+        )
+
+        df = df.pivot_table(
+            index=[
+                "Interval Start",
+                "Interval End",
+                "Publish Time",
+                "Trading Hub",
+            ],
+            columns="Fuel Category",
+            values="MW",
+            aggfunc="first",
+        ).reset_index()
+
+        df.columns.name = None
+
+        for column in [
+            "Aggregated",
+            "Hydro",
+            "Not Available",
+            "Renewable",
+            "Thermal",
+        ]:
+            if column not in df.columns:
+                df[column] = np.nan
+
+        return df[
+            [
+                "Interval Start",
+                "Interval End",
+                "Publish Time",
+                "Trading Hub",
+                "Aggregated",
+                "Hydro",
+                "Not Available",
+                "Renewable",
+                "Thermal",
+            ]
+        ]
+
     @support_date_range(frequency="DAY_START")
     def get_aggregated_generation_outages(
         self,
@@ -2266,10 +2313,12 @@ class CAISO(ISOBase):
         sleep: int = 4,
         verbose: bool = False,
     ) -> pd.DataFrame:
-        """Return hourly aggregated generator outages by fuel category and trading hub.
+        """Return hourly aggregated generator outages by trading hub.
 
-        Each query returns roughly 30 days of forward-looking outage schedules
-        published on the requested date(s).
+        Outage MW is split across fuel-category columns (Thermal, Renewable,
+        Hydro, Aggregated, and Not Available). Each query returns roughly 30
+        days of forward-looking outage schedules published on the requested
+        date(s).
 
         Arguments:
             date (datetime.date, str): date to return data
@@ -2284,7 +2333,8 @@ class CAISO(ISOBase):
 
         Returns:
             pandas.DataFrame: A DataFrame with one row per
-            (Interval Start, Publish Time, Fuel Category, Trading Hub).
+            (Interval Start, Publish Time, Trading Hub), with outage MW by
+            fuel category in separate columns.
         """
         df = self.get_oasis_dataset(
             dataset="aggregated_generation_outages",
@@ -2312,18 +2362,9 @@ class CAISO(ISOBase):
 
         df["MW"] = pd.to_numeric(df["MW"])
 
-        columns = [
-            "Interval Start",
-            "Interval End",
-            "Publish Time",
-            "Fuel Category",
-            "Trading Hub",
-            "MW",
-        ]
-
         return (
-            df[columns]
-            .sort_values(["Interval Start", "Trading Hub", "Fuel Category"])
+            self._pivot_aggregated_generation_outages(df)
+            .sort_values(["Interval Start", "Trading Hub"])
             .reset_index(drop=True)
         )
 

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -29,9 +29,12 @@ class TestCAISO(BaseTestISO):
         "Interval Start",
         "Interval End",
         "Publish Time",
-        "Fuel Category",
         "Trading Hub",
-        "MW",
+        "Aggregated",
+        "Hydro",
+        "Not Available",
+        "Renewable",
+        "Thermal",
     ]
 
     def _check_aggregated_generation_outages(self, df: pd.DataFrame) -> None:
@@ -44,15 +47,6 @@ class TestCAISO(BaseTestISO):
             "SP15",
             "ZP26",
         }
-        assert set(df["Fuel Category"].unique()).issubset(
-            {
-                "Aggregated",
-                "Hydro",
-                "Not Avail",
-                "Renewable",
-                "Thermal",
-            },
-        )
         interval_minutes = (
             df["Interval End"] - df["Interval Start"]
         ).dt.total_seconds() / 60
@@ -61,11 +55,11 @@ class TestCAISO(BaseTestISO):
             subset=[
                 "Interval Start",
                 "Publish Time",
-                "Fuel Category",
                 "Trading Hub",
             ],
         ).any()
-        assert pd.api.types.is_numeric_dtype(df["MW"])
+        for column in ["Aggregated", "Hydro", "Not Available", "Renewable", "Thermal"]:
+            assert pd.api.types.is_numeric_dtype(df[column])
 
     @pytest.mark.caiso_oasis
     @pytest.mark.real_sleep

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -58,7 +58,22 @@ class TestCAISO(BaseTestISO):
                 "Trading Hub",
             ],
         ).any()
-        for column in ["Aggregated", "Hydro", "Not Available", "Renewable", "Thermal"]:
+        assert df["Aggregated"].notna().all()
+        breakdown_hubs = {"NP15", "PACE", "PACW", "SP15"}
+        breakdown = df[df["Trading Hub"].isin(breakdown_hubs)]
+        component_sum = breakdown[
+            ["Hydro", "Not Available", "Renewable", "Thermal"]
+        ].sum(axis=1, min_count=1)
+        assert (breakdown["Aggregated"] == component_sum).all()
+        assert df.loc[df["Trading Hub"] == "ZP26", "Aggregated"].notna().all()
+        assert df.loc[df["Trading Hub"] == "ZP26", "Thermal"].isna().all()
+        for column in [
+            "Aggregated",
+            "Hydro",
+            "Not Available",
+            "Renewable",
+            "Thermal",
+        ]:
             assert pd.api.types.is_numeric_dtype(df[column])
 
     @pytest.mark.caiso_oasis


### PR DESCRIPTION
## Summary
- Pivot `get_aggregated_generation_outages` from long format (`Fuel Category` + `MW`) to wide format with per-category columns (`Thermal`, `Renewable`, `Hydro`, `Aggregated`, `Not Available`)
- One row per `(Interval Start, Publish Time, Trading Hub)` instead of per fuel category
- Rename source `Not Avail` to `Not Available`

## Test plan
- [x] `VCR_RECORD_MODE="all" pytest -vv gridstatus/tests/source_specific/test_caiso.py -k "outages"`


Made with [Cursor](https://cursor.com)