### PR TITLE
fix: Update ERCOT planned outage capacity columns for NPRR 1287 POL schema

### DIFF
--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -4347,34 +4347,58 @@ class Ercot(ISOBase):
 
         return self._handle_planned_outage_capacity_df(df)
 
+    PLANNED_OUTAGE_CAPACITY_COLUMNS = [
+        "Interval Start",
+        "Interval End",
+        "Publish Time",
+        "POL Non IRR Non PUN",
+        "Approved POL Non IRR Non PUN",
+        "Received POL Non IRR Non PUN",
+        "POL IRR",
+        "Approved POL IRR",
+        "Received POL IRR",
+        "POL ESR",
+        "Approved POL ESR",
+        "Received POL ESR",
+    ]
+
+    _PLANNED_OUTAGE_CAPACITY_POC_COLUMN_MAP = {
+        "MaxDailyResourcePOCnonIRRnonPUN": "POL Non IRR Non PUN",
+        "AggApprovedResourcePOCnonIRRnonPUN": "Approved POL Non IRR Non PUN",
+        "AggReceivedResourcePOCnonIRRnonPUN": "Received POL Non IRR Non PUN",
+        "MaxDailyResourcePOCIRR": "POL IRR",
+        "AggApprovedResourcePOCIRR": "Approved POL IRR",
+        "AggReceivedResourcePOCIRR": "Received POL IRR",
+    }
+
+    _PLANNED_OUTAGE_CAPACITY_POL_COLUMN_MAP = {
+        "ResourcePOLnonIRRnonPUN": "POL Non IRR Non PUN",
+        "AggApprovedResourcePOLnonIRRnonPUN": "Approved POL Non IRR Non PUN",
+        "AggReceivedResourcePOLnonIRRnonPUN": "Received POL Non IRR Non PUN",
+        "ResourcePOLIRR": "POL IRR",
+        "AggApprovedResourcePOLIRR": "Approved POL IRR",
+        "AggReceivedResourcePOLIRR": "Received POL IRR",
+        "ResourcePOLESR": "POL ESR",
+        "AggApprovedResourcePOLESR": "Approved POL ESR",
+        "AggReceivedResourcePOLESR": "Received POL ESR",
+    }
+
     def _handle_planned_outage_capacity_df(
         self,
         df: pd.DataFrame,
     ) -> pd.DataFrame:
-        df = df.rename(
-            columns={
-                "MaxDailyResourcePOCnonIRRnonPUN": "Max POC Non IRR Non PUN",
-                "AggApprovedResourcePOCnonIRRnonPUN": "Approved POC Non IRR Non PUN",
-                "AggReceivedResourcePOCnonIRRnonPUN": "Received POC Non IRR Non PUN",
-                "MaxDailyResourcePOCIRR": "Max POC IRR",
-                "AggApprovedResourcePOCIRR": "Approved POC IRR",
-                "AggReceivedResourcePOCIRR": "Received POC IRR",
-            },
-        )
+        if "ResourcePOLnonIRRnonPUN" in df.columns:
+            column_map = self._PLANNED_OUTAGE_CAPACITY_POL_COLUMN_MAP
+        else:
+            column_map = self._PLANNED_OUTAGE_CAPACITY_POC_COLUMN_MAP
 
-        return df[
-            [
-                "Interval Start",
-                "Interval End",
-                "Publish Time",
-                "Max POC Non IRR Non PUN",
-                "Approved POC Non IRR Non PUN",
-                "Received POC Non IRR Non PUN",
-                "Max POC IRR",
-                "Approved POC IRR",
-                "Received POC IRR",
-            ]
-        ]
+        df = df.rename(columns=column_map)
+
+        for column in self.PLANNED_OUTAGE_CAPACITY_COLUMNS:
+            if column not in df.columns:
+                df[column] = pd.NA
+
+        return df[self.PLANNED_OUTAGE_CAPACITY_COLUMNS]
 
     @support_date_range(frequency=None)
     def get_unplanned_resource_outages(

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -1885,12 +1885,15 @@ class TestErcot(BaseTestISO):
         "Interval Start",
         "Interval End",
         "Publish Time",
-        "Max POC Non IRR Non PUN",
-        "Approved POC Non IRR Non PUN",
-        "Received POC Non IRR Non PUN",
-        "Max POC IRR",
-        "Approved POC IRR",
-        "Received POC IRR",
+        "POL Non IRR Non PUN",
+        "Approved POL Non IRR Non PUN",
+        "Received POL Non IRR Non PUN",
+        "POL IRR",
+        "Approved POL IRR",
+        "Received POL IRR",
+        "POL ESR",
+        "Approved POL ESR",
+        "Received POL ESR",
     ]
 
     def _check_planned_outage_capacity(self, df):


### PR DESCRIPTION
## Summary
- Handle ERCOT's NPRR 1287 schema change (MDRPOC → RPOL) for both NP3-161 and NP3-162 planned outage reports
- Support both old POC and new POL raw column names, outputting unified POL-friendly column names
- Add three new ESR columns (`POL ESR`, `Approved POL ESR`, `Received POL ESR`); old-schema reports get `pd.NA` for these

## Column mapping

| Old friendly name | New friendly name |
|---|---|
| Max POC Non IRR Non PUN | POL Non IRR Non PUN |
| Approved POC Non IRR Non PUN | Approved POL Non IRR Non PUN |
| Received POC Non IRR Non PUN | Received POL Non IRR Non PUN |
| Max POC IRR | POL IRR |
| Approved POC IRR | Approved POL IRR |
| Received POC IRR | Received POL IRR |
| *(new)* | POL ESR |
| *(new)* | Approved POL ESR |
| *(new)* | Received POL ESR |

## Test plan
- [x] `pytest gridstatus/tests/source_specific/test_ercot.py::TestErcot::test_get_planned_outage_capacity_7_day`
- [x] `pytest gridstatus/tests/source_specific/test_ercot.py::TestErcot::test_get_planned_outage_capacity_future`
- [x] Live fetch of post-transition reports (Jun 25 18:00+)


Made with [Cursor](https://cursor.com)