### PR TITLE
feat(ENG-3958): POC convert ISONE to polars

### DIFF
--- a/gridstatus/base.py
+++ b/gridstatus/base.py
@@ -105,27 +105,6 @@ class ISOBase:
 
     default_timezone = None
 
-    # Opt-in polars support. Defaults to False so public methods return pandas
-    # (unchanged for OSS users). Set per-instance via the constructor. Declared
-    # as a class attribute so it is always defined even for ISO subclasses whose
-    # __init__ does not call super().__init__().
-    return_polars = False
-
-    def __init__(self, return_polars: bool = False) -> None:
-        self.return_polars = return_polars
-
-    def _maybe_to_pandas(self, df: object) -> object:
-        """Convert a polars frame to pandas unless ``return_polars`` is set.
-
-        Migrated methods build their result in polars internally and return it
-        through this helper so the public default stays pandas.
-        """
-        if self.return_polars:
-            return df
-        if _is_polars(df):
-            return df.to_pandas()
-        return df
-
     def local_now(self):
         return pd.Timestamp.now(tz=self.default_timezone)
 

--- a/gridstatus/base.py
+++ b/gridstatus/base.py
@@ -3,6 +3,7 @@ from enum import Enum, StrEnum
 from typing import BinaryIO
 
 import pandas as pd
+import polars as pl
 import requests
 
 from gridstatus.gs_logging import logger
@@ -93,8 +94,8 @@ _interconnection_columns = [
 
 
 def _is_polars(obj: object) -> bool:
-    """Return whether ``obj`` is a polars frame without importing polars."""
-    return type(obj).__module__.split(".")[0] == "polars"
+    """Return whether ``obj`` is a polars DataFrame."""
+    return isinstance(obj, pl.DataFrame)
 
 
 class ISOBase:

--- a/gridstatus/base.py
+++ b/gridstatus/base.py
@@ -92,12 +92,38 @@ _interconnection_columns = [
 ]
 
 
+def _is_polars(obj: object) -> bool:
+    """Return whether ``obj`` is a polars frame without importing polars."""
+    return type(obj).__module__.split(".")[0] == "polars"
+
+
 class ISOBase:
     markets = []
     status_homepage = None
     interconnection_homepage = None
 
     default_timezone = None
+
+    # Opt-in polars support. Defaults to False so public methods return pandas
+    # (unchanged for OSS users). Set per-instance via the constructor. Declared
+    # as a class attribute so it is always defined even for ISO subclasses whose
+    # __init__ does not call super().__init__().
+    return_polars = False
+
+    def __init__(self, return_polars: bool = False) -> None:
+        self.return_polars = return_polars
+
+    def _maybe_to_pandas(self, df: object) -> object:
+        """Convert a polars frame to pandas unless ``return_polars`` is set.
+
+        Migrated methods build their result in polars internally and return it
+        through this helper so the public default stays pandas.
+        """
+        if self.return_polars:
+            return df
+        if _is_polars(df):
+            return df.to_pandas()
+        return df
 
     def local_now(self):
         return pd.Timestamp.now(tz=self.default_timezone)
@@ -180,6 +206,21 @@ class ISOBase:
             locations=locations,
             **kwargs,
         )
+
+        if _is_polars(lmp_df):
+            col_order = lmp_df.columns
+            # Special case to handle PJM 5 min LMPs
+            grouper_column_name = (
+                "Location" if "Location" in col_order else "Location Id"
+            )
+            # Assume sorted in ascending order; maintain_order keeps the last
+            # row per group, matching pandas groupby().last().
+            latest_df = lmp_df.group_by(
+                grouper_column_name,
+                maintain_order=True,
+            ).last()
+            return latest_df.select(col_order)
+
         col_order = lmp_df.columns.tolist()
 
         # Special case to handle PJM 5 min LMPs
@@ -192,6 +233,11 @@ class ISOBase:
 
     def _latest_from_today(self, method, *args, **kwargs):
         data = method(date="today", *args, **kwargs)
+
+        if _is_polars(data):
+            row = data.tail(1).to_dicts()[0]
+            return {k.lower(): v for k, v in row.items()}
+
         latest = data.iloc[-1]
 
         latest.index = latest.index.str.lower()

--- a/gridstatus/decorators.py
+++ b/gridstatus/decorators.py
@@ -302,9 +302,9 @@ class support_date_range:
                             df[k] = []
                         df[k].append(v)
                 for k, v in df.items():
-                    df[k] = pd.concat(v).reset_index(drop=True)
+                    df[k] = utils.concat_dataframes(v)
             else:
-                df = pd.concat(all_df).reset_index(drop=True)
+                df = utils.concat_dataframes(all_df)
 
             return df
 

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -3,6 +3,7 @@ import warnings
 from typing import BinaryIO
 
 import pandas as pd
+import polars as pl
 import requests
 from bs4 import BeautifulSoup
 
@@ -168,8 +169,6 @@ class ISONE(ISOBase):
         pivoted wide. Datetime parsing stays in pandas because it is the
         I/O-bound CSV step; the reshaping runs in polars.
         """
-        import polars as pl
-
         naive = pd.to_datetime(df["Date"] + " " + df["Time"])
         pl_df = pl.DataFrame(
             {
@@ -232,8 +231,6 @@ class ISONE(ISOBase):
 
     def _load_polars(self, data):
         """Polars implementation of get_load's transform."""
-        import polars as pl
-
         naive = pd.to_datetime(data["Date/Time"])
         pl_df = pl.DataFrame(
             {
@@ -266,8 +263,6 @@ class ISONE(ISOBase):
         )
 
         if self.return_polars:
-            import polars as pl
-
             df = df.with_columns(
                 (pl.col("NativeLoadBtmPv") - pl.col("Load")).alias("BTM Solar"),
             ).with_columns(
@@ -297,8 +292,6 @@ class ISONE(ISOBase):
         )
 
         if self.return_polars:
-            import polars as pl
-
             df = df.with_columns(
                 pl.col("Time").alias("Interval Start"),
                 (pl.col("Time") + pl.duration(hours=1)).alias("Interval End"),
@@ -1003,8 +996,6 @@ class ISONE(ISOBase):
         ``BeginDate``/``CreationDate`` are offset-aware ISO strings, so polars
         parses and converts them directly (no ambiguous-DST handling needed).
         """
-        import polars as pl
-
         pl_df = pl.DataFrame(records)
 
         # ISONE returns offset-aware ISO timestamps (e.g. 2024-01-01T00:00:00.000-05:00).

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -116,10 +116,7 @@ class ISONE(ISOBase):
         Provided at frequent, but irregular intervals by ISONE
         """
         if date == "latest":
-            today = self.get_fuel_mix("today", verbose=verbose)
-            if self.return_polars:
-                return today.tail(1)
-            return today.tail(1).reset_index(drop=True)
+            return self.get_fuel_mix("today", verbose=verbose).tail(1)
 
         url = "https://www.iso-ne.com/transform/csv/genfuelmix?start=" + date.strftime(
             "%Y%m%d",
@@ -127,48 +124,6 @@ class ISONE(ISOBase):
 
         df = _make_request(url, skiprows=[0, 1, 2, 3, 5], verbose=verbose)
 
-        if self.return_polars:
-            return self._maybe_to_pandas(self._fuel_mix_polars(df))
-
-        df["Date"] = pd.to_datetime(df["Date"] + " " + df["Time"])
-
-        # groupby FuelCategory to make it possible to infer DST changes
-        df["Date"] = df.groupby("Fuel Category", group_keys=False)["Date"].apply(
-            lambda x: x.dt.tz_localize(
-                self.default_timezone,
-                ambiguous="infer",
-            ),
-        )
-
-        mix_df = df.pivot_table(
-            index="Date",
-            columns="Fuel Category",
-            values="Gen Mw",
-            aggfunc="first",
-        ).reset_index()
-        mix_df.columns.name = None
-
-        # assume instant in time, unclear if this is correct
-        mix_df = mix_df.rename(columns={"Date": "Time"})
-
-        mix_df = mix_df.fillna(0)
-
-        # move time columns front
-        mix_df = utils.move_cols_to_front(
-            mix_df,
-            ["Time"],
-        )
-
-        return mix_df
-
-    def _fuel_mix_polars(self, df):
-        """Polars implementation of get_fuel_mix's transform.
-
-        The naive timestamps are localized with the shared ambiguous-infer
-        helper (grouped by fuel category, matching the pandas groupby) then
-        pivoted wide. Datetime parsing stays in pandas because it is the
-        I/O-bound CSV step; the reshaping runs in polars.
-        """
         naive = pd.to_datetime(df["Date"] + " " + df["Time"])
         pl_df = pl.DataFrame(
             {
@@ -209,40 +164,17 @@ class ISONE(ISOBase):
         url = f"https://www.iso-ne.com/transform/csv/fiveminutesystemload?start={date_str}&end={date_str}"  # noqa
         data = _make_request(url, skiprows=[0, 1, 2, 3, 5], verbose=verbose)
 
-        if self.return_polars:
-            return self._maybe_to_pandas(self._load_polars(data))
-
-        data["Date/Time"] = pd.to_datetime(data["Date/Time"]).dt.tz_localize(
+        localized = pd.to_datetime(data["Date/Time"]).dt.tz_localize(
             self.default_timezone,
             ambiguous="infer",
         )
-
-        # todo what is the difference between Native Load and Asset Related Load?
-        df = data[["Date/Time", "Native Load"]].rename(
-            columns={"Date/Time": "Time", "Native Load": "Load"},
-        )
-
-        df["Interval Start"] = df["Time"]
-        df["Interval End"] = df["Time"] + pd.Timedelta(minutes=5)
-
-        df = df[["Time", "Interval Start", "Interval End", "Load"]]
-
-        return df
-
-    def _load_polars(self, data):
-        """Polars implementation of get_load's transform."""
-        naive = pd.to_datetime(data["Date/Time"])
-        pl_df = pl.DataFrame(
-            {
-                "Time": naive.to_numpy(),
-                "Load": pd.to_numeric(data["Native Load"], errors="coerce").to_numpy(),
-            },
-        )
-
-        pl_df = utils.localize_ambiguous_infer_polars(
-            pl_df,
-            "Time",
-            self.default_timezone,
+        pl_df = pl.from_pandas(
+            pd.DataFrame(
+                {
+                    "Time": localized,
+                    "Load": pd.to_numeric(data["Native Load"], errors="coerce"),
+                },
+            ),
         )
 
         pl_df = pl_df.with_columns(
@@ -262,23 +194,11 @@ class ISONE(ISOBase):
             verbose=verbose,
         )
 
-        if self.return_polars:
-            df = df.with_columns(
-                (pl.col("NativeLoadBtmPv") - pl.col("Load")).alias("BTM Solar"),
-            ).with_columns(
-                pl.col("Time").alias("Interval Start"),
-                (pl.col("Time") + pl.duration(minutes=5)).alias("Interval End"),
-            )
-            return self._maybe_to_pandas(
-                df.select(["Time", "Interval Start", "Interval End", "BTM Solar"]),
-            )
-
-        df["BTM Solar"] = df["NativeLoadBtmPv"] - df["Load"]
-
-        df["Interval Start"] = df["Time"]
-        df["Interval End"] = df["Time"] + pd.Timedelta(minutes=5)
-
-        return df[["Time", "Interval Start", "Interval End", "BTM Solar"]]
+        return df.with_columns(
+            (pl.col("NativeLoadBtmPv") - pl.col("Load")).alias("BTM Solar"),
+            pl.col("Time").alias("Interval Start"),
+            (pl.col("Time") + pl.duration(minutes=5)).alias("Interval End"),
+        ).select(["Time", "Interval Start", "Interval End", "BTM Solar"])
 
     @support_date_range(frequency="DAY_START")
     def get_load_forecast(self, date, end=None, verbose=False):
@@ -291,37 +211,18 @@ class ISONE(ISOBase):
             verbose=verbose,
         )
 
-        if self.return_polars:
-            df = df.with_columns(
-                pl.col("Time").alias("Interval Start"),
-                (pl.col("Time") + pl.duration(hours=1)).alias("Interval End"),
-            )
-            return self._maybe_to_pandas(
-                df.select(
-                    [
-                        "Time",
-                        "Interval Start",
-                        "Interval End",
-                        "Forecast Time",
-                        "Load Forecast",
-                    ],
-                ),
-            )
-
-        df["Interval Start"] = df["Time"]
-        df["Interval End"] = df["Time"] + pd.Timedelta(hours=1)
-
-        df = df[
+        return df.with_columns(
+            pl.col("Time").alias("Interval Start"),
+            (pl.col("Time") + pl.duration(hours=1)).alias("Interval End"),
+        ).select(
             [
                 "Time",
                 "Interval Start",
                 "Interval End",
                 "Forecast Time",
                 "Load Forecast",
-            ]
-        ]
-
-        return df
+            ],
+        )
 
     def get_solar_forecast(self, date, end=None, verbose=False):
         """Return solar forecast published on a specific date
@@ -962,40 +863,6 @@ class ISONE(ISOBase):
 
         records = raw_data[0]["data"][series]
 
-        if self.return_polars:
-            return self._system_load_polars(records, mw_rename)
-
-        data = pd.DataFrame(records)
-
-        # must convert this way rather than use pd.to_datetime
-        # to handle DST transitions
-        data["BeginDate"] = data["BeginDate"].apply(
-            lambda x: pd.Timestamp(x).tz_convert(ISONE.default_timezone),
-        )
-
-        # for times earlier this creation date is after the forecasted interval
-        # for all historical data
-        if "CreationDate" in data.columns:
-            data["CreationDate"] = data["CreationDate"].apply(
-                lambda x: pd.Timestamp(x).tz_convert(ISONE.default_timezone),
-            )
-
-        data = data.rename(
-            columns={
-                "BeginDate": "Time",
-                "Mw": mw_rename,
-                "CreationDate": "Forecast Time",
-            },
-        )
-
-        return data
-
-    def _system_load_polars(self, records, mw_rename):
-        """Polars implementation of _get_system_load's frame construction.
-
-        ``BeginDate``/``CreationDate`` are offset-aware ISO strings, so polars
-        parses and converts them directly (no ambiguous-DST handling needed).
-        """
         pl_df = pl.DataFrame(records)
 
         # ISONE returns offset-aware ISO timestamps (e.g. 2024-01-01T00:00:00.000-05:00).

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -115,17 +115,19 @@ class ISONE(ISOBase):
         Provided at frequent, but irregular intervals by ISONE
         """
         if date == "latest":
-            return (
-                self.get_fuel_mix("today", verbose=verbose)
-                .tail(1)
-                .reset_index(drop=True)
-            )
+            today = self.get_fuel_mix("today", verbose=verbose)
+            if self.return_polars:
+                return today.tail(1)
+            return today.tail(1).reset_index(drop=True)
 
         url = "https://www.iso-ne.com/transform/csv/genfuelmix?start=" + date.strftime(
             "%Y%m%d",
         )
 
         df = _make_request(url, skiprows=[0, 1, 2, 3, 5], verbose=verbose)
+
+        if self.return_polars:
+            return self._maybe_to_pandas(self._fuel_mix_polars(df))
 
         df["Date"] = pd.to_datetime(df["Date"] + " " + df["Time"])
 
@@ -158,6 +160,44 @@ class ISONE(ISOBase):
 
         return mix_df
 
+    def _fuel_mix_polars(self, df):
+        """Polars implementation of get_fuel_mix's transform.
+
+        The naive timestamps are localized with the shared ambiguous-infer
+        helper (grouped by fuel category, matching the pandas groupby) then
+        pivoted wide. Datetime parsing stays in pandas because it is the
+        I/O-bound CSV step; the reshaping runs in polars.
+        """
+        import polars as pl
+
+        naive = pd.to_datetime(df["Date"] + " " + df["Time"])
+        pl_df = pl.DataFrame(
+            {
+                "Date": naive.to_numpy(),
+                "Fuel Category": df["Fuel Category"].astype(str).to_numpy(),
+                "Gen Mw": pd.to_numeric(df["Gen Mw"], errors="coerce").to_numpy(),
+            },
+        )
+
+        pl_df = utils.localize_ambiguous_infer_polars(
+            pl_df,
+            "Date",
+            self.default_timezone,
+            group_cols=["Fuel Category"],
+        )
+
+        mix_df = pl_df.pivot(
+            "Fuel Category",
+            index="Date",
+            values="Gen Mw",
+            aggregate_function="first",
+        )
+
+        mix_df = mix_df.rename({"Date": "Time"}).fill_null(0)
+
+        fuel_cols = sorted(c for c in mix_df.columns if c != "Time")
+        return mix_df.select(["Time", *fuel_cols]).sort("Time")
+
     @support_date_range(frequency="DAY_START")
     def get_load(self, date, end=None, verbose=False):
         """Return load at a previous date in 5 minute intervals"""
@@ -169,6 +209,9 @@ class ISONE(ISOBase):
         date_str = date.strftime("%Y%m%d")
         url = f"https://www.iso-ne.com/transform/csv/fiveminutesystemload?start={date_str}&end={date_str}"  # noqa
         data = _make_request(url, skiprows=[0, 1, 2, 3, 5], verbose=verbose)
+
+        if self.return_polars:
+            return self._maybe_to_pandas(self._load_polars(data))
 
         data["Date/Time"] = pd.to_datetime(data["Date/Time"]).dt.tz_localize(
             self.default_timezone,
@@ -187,6 +230,31 @@ class ISONE(ISOBase):
 
         return df
 
+    def _load_polars(self, data):
+        """Polars implementation of get_load's transform."""
+        import polars as pl
+
+        naive = pd.to_datetime(data["Date/Time"])
+        pl_df = pl.DataFrame(
+            {
+                "Time": naive.to_numpy(),
+                "Load": pd.to_numeric(data["Native Load"], errors="coerce").to_numpy(),
+            },
+        )
+
+        pl_df = utils.localize_ambiguous_infer_polars(
+            pl_df,
+            "Time",
+            self.default_timezone,
+        )
+
+        pl_df = pl_df.with_columns(
+            pl.col("Time").alias("Interval Start"),
+            (pl.col("Time") + pl.duration(minutes=5)).alias("Interval End"),
+        )
+
+        return pl_df.select(["Time", "Interval Start", "Interval End", "Load"])
+
     @support_date_range(frequency="DAY_START")
     def get_btm_solar(self, date, end=None, verbose=False):
         """Return BTM solar at a previous date in 5 minute intervals"""
@@ -196,6 +264,19 @@ class ISONE(ISOBase):
             series="actual",
             verbose=verbose,
         )
+
+        if self.return_polars:
+            import polars as pl
+
+            df = df.with_columns(
+                (pl.col("NativeLoadBtmPv") - pl.col("Load")).alias("BTM Solar"),
+            ).with_columns(
+                pl.col("Time").alias("Interval Start"),
+                (pl.col("Time") + pl.duration(minutes=5)).alias("Interval End"),
+            )
+            return self._maybe_to_pandas(
+                df.select(["Time", "Interval Start", "Interval End", "BTM Solar"]),
+            )
 
         df["BTM Solar"] = df["NativeLoadBtmPv"] - df["Load"]
 
@@ -214,6 +295,25 @@ class ISONE(ISOBase):
             series="forecast",
             verbose=verbose,
         )
+
+        if self.return_polars:
+            import polars as pl
+
+            df = df.with_columns(
+                pl.col("Time").alias("Interval Start"),
+                (pl.col("Time") + pl.duration(hours=1)).alias("Interval End"),
+            )
+            return self._maybe_to_pandas(
+                df.select(
+                    [
+                        "Time",
+                        "Interval Start",
+                        "Interval End",
+                        "Forecast Time",
+                        "Load Forecast",
+                    ],
+                ),
+            )
 
         df["Interval Start"] = df["Time"]
         df["Interval End"] = df["Time"] + pd.Timedelta(hours=1)
@@ -860,7 +960,19 @@ class ISONE(ISOBase):
             verbose=verbose,
         )
 
-        data = pd.DataFrame(raw_data[0]["data"][series])
+        if series == "actual":
+            mw_rename = "Load"
+        elif series == "forecast":
+            mw_rename = "Load Forecast"
+        else:
+            raise ValueError(f"Unrecognized series: {series}")
+
+        records = raw_data[0]["data"][series]
+
+        if self.return_polars:
+            return self._system_load_polars(records, mw_rename)
+
+        data = pd.DataFrame(records)
 
         # must convert this way rather than use pd.to_datetime
         # to handle DST transitions
@@ -874,12 +986,6 @@ class ISONE(ISOBase):
             data["CreationDate"] = data["CreationDate"].apply(
                 lambda x: pd.Timestamp(x).tz_convert(ISONE.default_timezone),
             )
-        if series == "actual":
-            mw_rename = "Load"
-        elif series == "forecast":
-            mw_rename = "Load Forecast"
-        else:
-            raise ValueError(f"Unrecognized series: {series}")
 
         data = data.rename(
             columns={
@@ -890,6 +996,42 @@ class ISONE(ISOBase):
         )
 
         return data
+
+    def _system_load_polars(self, records, mw_rename):
+        """Polars implementation of _get_system_load's frame construction.
+
+        ``BeginDate``/``CreationDate`` are offset-aware ISO strings, so polars
+        parses and converts them directly (no ambiguous-DST handling needed).
+        """
+        import polars as pl
+
+        pl_df = pl.DataFrame(records)
+
+        # ISONE returns offset-aware ISO timestamps (e.g. 2024-01-01T00:00:00.000-05:00).
+        # polars requires an explicit format when the offset is part of the data.
+        iso_offset_format = "%Y-%m-%dT%H:%M:%S%.f%z"
+
+        pl_df = pl_df.with_columns(
+            pl.col("BeginDate")
+            .str.to_datetime(format=iso_offset_format)
+            .dt.convert_time_zone(self.default_timezone),
+        )
+
+        if "CreationDate" in pl_df.columns:
+            pl_df = pl_df.with_columns(
+                pl.col("CreationDate")
+                .str.to_datetime(format=iso_offset_format)
+                .dt.convert_time_zone(self.default_timezone),
+            )
+
+        rename = {
+            "BeginDate": "Time",
+            "Mw": mw_rename,
+            "CreationDate": "Forecast Time",
+        }
+        rename = {k: v for k, v in rename.items() if k in pl_df.columns}
+
+        return pl_df.rename(rename)
 
     def _create_interval_start_from_hour_start(self, data):
         # for DST end transitions isone uses 02X to represent repeated 1am hour

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -230,16 +230,12 @@ class ISONE(ISOBase):
         Forecast is published for 7 days and generated daily by 10 am.
         https://www.iso-ne.com/isoexpress/web/reports/operations/-/tree/seven-day-solar-power-forecast
         """
-        return (
-            self._get_solar_or_wind_forecast(
-                date,
-                end,
-                resource_type="Solar",
-                verbose=verbose,
-            )
-            .reset_index(drop=True)
-            .sort_values(["Interval Start", "Publish Time"])
-        )
+        return self._get_solar_or_wind_forecast(
+            date,
+            end,
+            resource_type="Solar",
+            verbose=verbose,
+        ).sort(["Interval Start", "Publish Time"])
 
     def get_wind_forecast(self, date, end=None, verbose=False):
         """Return wind forecast published on a specific date
@@ -247,16 +243,12 @@ class ISONE(ISOBase):
         Forecast is published for 7 days and generated daily by 10 am.
         https://www.iso-ne.com/isoexpress/web/reports/operations/-/tree/seven-day-wind-power-forecast
         """
-        return (
-            self._get_solar_or_wind_forecast(
-                date,
-                end,
-                resource_type="Wind",
-                verbose=verbose,
-            )
-            .reset_index(drop=True)
-            .sort_values(["Interval Start", "Publish Time"])
-        )
+        return self._get_solar_or_wind_forecast(
+            date,
+            end,
+            resource_type="Wind",
+            verbose=verbose,
+        ).sort(["Interval Start", "Publish Time"])
 
     @support_date_range(frequency="DAY_START")
     def _get_solar_or_wind_forecast(
@@ -283,45 +275,38 @@ class ISONE(ISOBase):
         df.columns = df.iloc[0]
         df = df.drop(columns=["D", "Date"], index=[0]).reset_index(drop=True)
 
-        data = df.melt(
-            id_vars=["Hour Ending"],
-            var_name="Date",
+        pl_df = pl.from_pandas(df)
+        value_cols = [c for c in pl_df.columns if c != "Hour Ending"]
+        data = pl_df.unpivot(
+            index="Hour Ending",
+            on=value_cols,
+            variable_name="Date",
             value_name=value_name,
-        ).dropna(subset=[value_name])
+        ).drop_nulls(subset=[value_name])
 
-        data = self._create_interval_start_from_hour_start(data)
-
-        data["Interval Start"] = data["Interval Start"].dt.tz_localize(
+        data = utils.create_interval_start_from_hour_start_polars(data)
+        data = utils.localize_interval_start_polars(
+            data,
+            "Interval Start",
             self.default_timezone,
-            ambiguous="infer",
-            nonexistent="NaT",
+            date_col="Date",
         )
 
-        # Handle start of DST since the hour ending in the raw data does not exist
-        if data["Interval Start"].isna().any():
-            hour_start = data.loc[data["Interval Start"].isna(), "Hour Start"] - 1
+        data = data.with_columns(
+            (pl.col("Interval Start") + pl.duration(hours=1)).alias("Interval End"),
+        )
 
-            data.loc[data["Interval Start"].isna(), "Interval Start"] = (
-                pd.to_datetime(data.loc[data["Interval Start"].isna(), "Date"])
-                + hour_start.astype("timedelta64[h]")
-            ).dt.tz_localize(
-                self.default_timezone,
-            )
-
-        data["Interval End"] = data["Interval Start"] + pd.Timedelta(hours=1)
-
-        # Website says report is generally available by 10 am.
         report_datetime = date.normalize() + pd.Timedelta(hours=10)
-        data["Publish Time"] = report_datetime
+        data = data.with_columns(pl.lit(report_datetime).alias("Publish Time"))
 
         data = utils.move_cols_to_front(
             data,
             ["Interval Start", "Interval End", "Publish Time", value_name],
-        ).drop(columns=["Date", "Hour Start", "Hour Ending"])
+        ).drop(["Date", "Hour Start", "Hour Ending"])
 
-        data[value_name] = data[value_name].astype(float)
-
-        return data
+        return data.with_columns(
+            pl.col(value_name).cast(pl.Float64),
+        )
 
     def _get_latest_lmp(self, market: str, locations: list = None, verbose=False):
         """
@@ -332,29 +317,23 @@ class ISONE(ISOBase):
 
         if market == Markets.REAL_TIME_5_MIN:
             url = "https://www.iso-ne.com/transform/csv/fiveminlmp/current?type=prelim"  # noqa
-            data = _make_request(url, skiprows=[0, 1, 2, 4], verbose=verbose)
-            data.rename(
-                columns={
-                    "Local Time": "Interval Start",
-                },
-                inplace=True,
+            data = pl.from_pandas(
+                _make_request(url, skiprows=[0, 1, 2, 4], verbose=verbose),
             )
+            data = data.rename({"Local Time": "Interval Start"})
 
         elif market == Markets.REAL_TIME_HOURLY:
             url = "https://www.iso-ne.com/transform/csv/hourlylmp/current?type=prelim&market=rt"  # noqa
-            data = _make_request(url, skiprows=[0, 1, 2, 4], verbose=verbose)
+            data = pl.from_pandas(
+                _make_request(url, skiprows=[0, 1, 2, 4], verbose=verbose),
+            )
 
-            # reformat this data so it looks like other endpoints
-            # this way it works with process_lmp below
-            data.rename(
-                columns={
+            data = data.rename(
+                {
                     "Local Date": "Date",
                     "Local Time": "Hour Ending",
                 },
-                inplace=True,
             )
-
-            # data["Hour Ending"] = data["Hour Ending"].astype(str).str.zfill(2)
 
         else:
             raise RuntimeError("LMP Market is not supported")
@@ -419,15 +398,15 @@ class ISONE(ISOBase):
                 msg = "Loading interval {}".format(interval)
                 log(msg, verbose=verbose)
                 u = f"https://www.iso-ne.com/static-transform/csv/histRpts/5min-rt-prelim/lmp_5min_{date_str}_{interval}.csv"  # noqa
-                # Use a try and except in case the data for previous intervals is not
-                # published yet.
                 try:
                     dfs.append(
-                        pd.read_csv(
-                            u,
-                            skiprows=[0, 1, 2, 3, 5],
-                            skipfooter=1,
-                            engine="python",
+                        pl.from_pandas(
+                            pd.read_csv(
+                                u,
+                                skiprows=[0, 1, 2, 3, 5],
+                                skipfooter=1,
+                                engine="python",
+                            ),
                         ),
                     )
                 except Exception as e:
@@ -436,41 +415,49 @@ class ISONE(ISOBase):
             data_intervals = None
 
             if dfs:
-                data_intervals = pd.concat(dfs)
-                data_intervals["Local Time"] = pd.to_datetime(
-                    date.strftime("%Y-%m-%d") + " " + data_intervals["Local Time"],
+                data_intervals = pl.concat(dfs, how="diagonal")
+                data_intervals = data_intervals.with_columns(
+                    (
+                        pl.lit(date.strftime("%Y-%m-%d "))
+                        + pl.col("Local Time").cast(pl.Utf8)
+                    )
+                    .str.to_datetime()
+                    .alias("Local Time"),
                 )
 
             if querying_for_today:
                 url = "https://www.iso-ne.com/transform/csv/fiveminlmp/currentrollinginterval"  # noqa
                 msg = "Loading current interval"
                 log(msg, verbose=verbose)
-                # this request is very very slow for some reason.
-                # I suspect b/c the server is making the response dynamically
-                data_current = _make_request(
-                    url,
-                    skiprows=[0, 1, 2, 4],
-                    verbose=verbose,
+                data_current = pl.from_pandas(
+                    _make_request(
+                        url,
+                        skiprows=[0, 1, 2, 4],
+                        verbose=verbose,
+                    ),
                 )
 
-                data_current["Local Time"] = pd.to_datetime(data_current["Local Time"])
+                data_current = data_current.with_columns(
+                    pl.col("Local Time").str.to_datetime().alias("Local Time"),
+                )
 
-                if data_intervals is not None:
-                    data_current = data_current[
-                        data_current["Local Time"] > data_intervals["Local Time"].max()
-                    ]
-
-                    data = pd.concat([data_intervals, data_current])
+                if data_intervals is not None and data_intervals.height > 0:
+                    max_time = data_intervals.select(
+                        pl.col("Local Time").max(),
+                    ).item()
+                    data_current = data_current.filter(
+                        pl.col("Local Time") > max_time,
+                    )
+                    data = pl.concat([data_intervals, data_current], how="diagonal")
                 else:
-                    # Only keep data from today
-                    data_current = data_current[
-                        data_current["Local Time"].dt.date == now.date()
-                    ]
-                    data = data_current.copy()
+                    data_current = data_current.filter(
+                        pl.col("Local Time").dt.date() == now.date(),
+                    )
+                    data = data_current
             else:
-                data = data_intervals.copy()
+                data = data_intervals
 
-            data = data.rename(columns={"Local Time": "Interval Start"})
+            data = data.rename({"Local Time": "Interval Start"})
 
         elif market == Markets.REAL_TIME_HOURLY:
             if date.date() > now.date():
@@ -479,18 +466,22 @@ class ISONE(ISOBase):
                 )
 
             url = f"https://www.iso-ne.com/static-transform/csv/histRpts/rt-lmp/lmp_rt_prelim_{date_str}.csv"  # noqa
-            data = _make_request(
-                url,
-                skiprows=[0, 1, 2, 3, 5],
-                verbose=verbose,
+            data = pl.from_pandas(
+                _make_request(
+                    url,
+                    skiprows=[0, 1, 2, 3, 5],
+                    verbose=verbose,
+                ),
             )
 
         elif market == Markets.DAY_AHEAD_HOURLY:
             url = f"https://www.iso-ne.com/static-transform/csv/histRpts/da-lmp/WW_DALMP_ISO_{date_str}.csv"  # noqa
-            data = _make_request(
-                url,
-                skiprows=[0, 1, 2, 3, 5],
-                verbose=verbose,
+            data = pl.from_pandas(
+                _make_request(
+                    url,
+                    skiprows=[0, 1, 2, 3, 5],
+                    verbose=verbose,
+                ),
             )
 
         else:
@@ -551,7 +542,7 @@ class ISONE(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get real-time 5-minute LMPs for all locations."""
         return self._get_lmp(
             date,
@@ -566,7 +557,7 @@ class ISONE(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get real-time hourly LMPs for all locations."""
         return self._get_lmp(
             date,
@@ -581,7 +572,7 @@ class ISONE(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get day-ahead hourly LMPs for all locations."""
         return self._get_lmp(
             date,
@@ -592,11 +583,6 @@ class ISONE(ISOBase):
         )
 
     def _process_lmp(self, data, market, timezone, locations, include_id=False):
-        # each market returns a slight different set of columns
-        # real time 5 minute has "Location ID"
-        # real time hourly has "Location" that represent location name
-        # day ahead hourly has "Location ID" and "Location Name
-
         rename = {
             "Location Name": "Location",
             "Location ID": "Location Id",
@@ -610,55 +596,55 @@ class ISONE(ISOBase):
             "Marginal Loss Component": "Loss",
         }
 
-        data.rename(columns=rename, inplace=True)
+        data = data.rename(
+            {k: v for k, v in rename.items() if k in data.columns},
+        )
+        data = data.with_columns(pl.lit(market.value).alias("Market"))
 
-        data["Market"] = market.value
-        interval = pd.Timedelta(hours=1)
         if market == Markets.REAL_TIME_5_MIN:
-            interval = pd.Timedelta(minutes=5)
+            interval_duration = pl.duration(minutes=5)
+        else:
+            interval_duration = pl.duration(hours=1)
 
         if "Hour Ending" in data.columns:
-            data = self._create_interval_start_from_hour_start(data)
-
-        def handle_date_time(s):
-            return pd.to_datetime(s).dt.tz_localize(
-                timezone,
-                ambiguous="infer",
+            data = utils.create_interval_start_from_hour_start_polars(data)
+        elif not data.schema["Interval Start"].is_temporal():
+            data = data.with_columns(
+                pl.col("Interval Start").str.to_datetime().alias("Interval Start"),
             )
 
-        # Location seems to be more unique than Location ID refer to #171
         location_groupby = "Location" if "Location" in data.columns else "Location Id"
-        # groupby location so that hours are increasing monotonically and can infer dst
-        data["Interval Start"] = data.groupby(location_groupby)[
-            "Interval Start"
-        ].transform(handle_date_time)
+        data = utils.localize_ambiguous_infer_polars(
+            data,
+            "Interval Start",
+            timezone,
+            group_cols=[location_groupby],
+        )
 
-        data["Interval End"] = data["Interval Start"] + interval
-        data["Time"] = data["Interval Start"]
+        data = data.with_columns(
+            (pl.col("Interval Start") + interval_duration).alias("Interval End"),
+            pl.col("Interval Start").alias("Time"),
+        )
 
-        # handle missing location information for some markets
         if market != Markets.DAY_AHEAD_HOURLY:
+            min_interval = data.select(pl.col("Interval Start").min()).item()
             day_ahead = self._get_lmp(
-                # query for same day in case it matters
-                date=data["Interval Start"].min().date(),
+                date=min_interval.date(),
                 market=Markets.DAY_AHEAD_HOURLY,
                 locations=locations,
                 include_id=True,
             )
-            location_mapping = day_ahead.drop_duplicates("Location Id")[
-                ["Location", "Location Id", "Location Type"]
-            ]
+            location_mapping = day_ahead.unique(
+                subset=["Location Id"],
+                keep="first",
+            ).select(["Location", "Location Id", "Location Type"])
 
             if "Location Id" in data.columns:
-                data = data.merge(
-                    location_mapping,
-                    how="left",
-                    on="Location Id",
-                )
+                data = data.join(location_mapping, on="Location Id", how="left")
             elif "Location" in data.columns:
-                data = data.merge(location_mapping, how="left", on="Location")
+                data = data.join(location_mapping, on="Location", how="left")
 
-        data = data[
+        data = data.select(
             [
                 "Time",
                 "Interval Start",
@@ -671,11 +657,11 @@ class ISONE(ISOBase):
                 "Energy",
                 "Congestion",
                 "Loss",
-            ]
-        ]
+            ],
+        )
 
         if not include_id:
-            data = data.drop(columns=["Location Id"])
+            data = data.drop("Location Id")
 
         data = utils.filter_lmp_locations(data, locations)
         return data
@@ -745,26 +731,27 @@ class ISONE(ISOBase):
         log(msg, verbose)
 
         raw_data = self.get_raw_interconnection_queue(verbose)
-        queue = pd.read_html(raw_data, attrs={"id": "publicqueue"})[0]
-
-        # only keep generator interconnection requests
-        queue["Type"] = queue["Type"].map(
-            {
-                "G": "Generation",
-                "ETU": "Elective Transmission Upgrade",
-                "TS": "Transmission Service",
-            },
+        queue = pl.from_pandas(
+            pd.read_html(raw_data, attrs={"id": "publicqueue"})[0],
         )
 
-        queue["Status"] = queue["Status"].map(
-            {
-                "W": InterconnectionQueueStatus.WITHDRAWN.value,
-                "A": InterconnectionQueueStatus.ACTIVE.value,
-                "C": InterconnectionQueueStatus.COMPLETED.value,
-            },
+        queue = queue.with_columns(
+            pl.col("Type").replace(
+                {
+                    "G": "Generation",
+                    "ETU": "Elective Transmission Upgrade",
+                    "TS": "Transmission Service",
+                },
+            ),
+            pl.col("Status").replace(
+                {
+                    "W": InterconnectionQueueStatus.WITHDRAWN.value,
+                    "A": InterconnectionQueueStatus.ACTIVE.value,
+                    "C": InterconnectionQueueStatus.COMPLETED.value,
+                },
+            ),
+            pl.col("Sync Date").alias("Proposed Completion Date"),
         )
-
-        queue["Proposed Completion Date"] = queue["Sync Date"]
 
         rename = {
             "QP": "Queue ID",
@@ -824,10 +811,7 @@ class ISONE(ISOBase):
             missing=missing,
         )
 
-        queue = queue.sort_values(
-            "Queue ID",
-            ascending=False,
-        ).reset_index(drop=True)
+        queue = queue.sort("Queue ID", descending=True)
 
         return queue
 
@@ -891,26 +875,6 @@ class ISONE(ISOBase):
 
         return pl_df.rename(rename)
 
-    def _create_interval_start_from_hour_start(self, data):
-        # for DST end transitions isone uses 02X to represent repeated 1am hour
-        data["Hour Start"] = (
-            data["Hour Ending"]
-            .replace(
-                "02X",
-                "02",
-            )
-            .astype(int)
-            - 1
-        )
-
-        data["Interval Start"] = pd.to_datetime(data["Date"]) + data[
-            "Hour Start"
-        ].astype(
-            "timedelta64[h]",
-        )
-
-        return data
-
     def _select_intervals_for_data_request(self, date, end, intervals):
         """Filters intervals given a start and end datetime. All completed intervals
         are included as well as any intervals that include the start datetime.
@@ -964,18 +928,17 @@ class ISONE(ISOBase):
             Total Reserve Clearing Price
         """
         if date == "latest":
-            # Try today first then yesterday then two days ago
             df = self.get_reserve_zone_prices_designations_real_time_5_min_final(
                 "today",
                 verbose=verbose,
             )
-            if df.empty:
+            if df.is_empty():
                 df = self.get_reserve_zone_prices_designations_real_time_5_min_final(
                     pd.Timestamp.now(tz=self.default_timezone).normalize()
                     - pd.Timedelta(days=1),
                     verbose=verbose,
                 )
-                if df.empty:
+                if df.is_empty():
                     df = (
                         self.get_reserve_zone_prices_designations_real_time_5_min_final(
                             pd.Timestamp.now(tz=self.default_timezone).normalize()
@@ -997,40 +960,38 @@ class ISONE(ISOBase):
 
         df = _make_request(url, skiprows=[0, 1, 2, 3, 5], verbose=verbose)
 
-        # Clean up column names - remove leading spaces and quotes
-        df.columns = df.columns.str.strip().str.replace('"', "")
-
-        # Parse the datetime. Since each reserve zone id has a DST switch, we need to
-        # group by it to infer the ambiguous times
-        df["Interval Start"] = df.groupby("Reserve Zone ID", group_keys=False)[
-            "Local Time"
-        ].apply(
-            lambda x: pd.to_datetime(x).dt.tz_localize(
-                self.default_timezone,
-                ambiguous="infer",
-            ),
+        pl_df = pl.from_pandas(df)
+        pl_df = pl_df.rename(
+            {c: c.strip().replace('"', "") for c in pl_df.columns},
         )
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(minutes=5)
 
-        # Rename columns to match our standards
-        df = df.rename(
-            columns={
-                "Reserve Zone ID": "Reserve Zone ID",
-                "Reserve Zone Name": "Reserve Zone Name",
+        pl_df = pl_df.with_columns(
+            pl.col("Local Time").str.to_datetime().alias("_naive_time"),
+        )
+        pl_df = utils.localize_ambiguous_infer_polars(
+            pl_df,
+            "_naive_time",
+            self.default_timezone,
+            group_cols=["Reserve Zone ID"],
+        )
+        pl_df = pl_df.with_columns(
+            pl.col("_naive_time").alias("Interval Start"),
+            (pl.col("_naive_time") + pl.duration(minutes=5)).alias("Interval End"),
+        ).drop("_naive_time")
+
+        pl_df = pl_df.rename(
+            {
                 "Ten-Minute Spinning Requirement": "Ten Min Spin Requirement",
                 "Ten-Minute Requirement": "Ten Min Requirement",
-                "Total Requirement": "Total Requirement",
                 "Ten Minute Spinning Reserve Designated MW": "TMSR Designated MW",
                 "Ten Minute Non Spinning Reserve Designated MW": "TMNSR Designated MW",
                 "Thirty Minute OperatingReserve Designated MW": "TMOR Designated MW",
                 "Ten-Minute Spinning Reserve Clearing Price": "TMSR Clearing Price",
                 "Ten-Minute Reserve Clearing Price": "TMR Clearing Price",
-                "Total Reserve Clearing Price": "Total Reserve Clearing Price",
             },
         )
 
-        # Select and order columns
-        df = df[
+        return pl_df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -1045,10 +1006,8 @@ class ISONE(ISOBase):
                 "TMSR Clearing Price",
                 "TMR Clearing Price",
                 "Total Reserve Clearing Price",
-            ]
-        ]
-
-        return df
+            ],
+        )
 
 
 def _make_request(url, skiprows, verbose):

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -9,6 +9,17 @@ from gridstatus.base import GridStatus, _interconnection_columns
 class TestHelperMixin:
     iso = None
 
+    @staticmethod
+    def _as_pandas(df):
+        """Accept either a pandas or polars frame, returning pandas for assertions.
+
+        Lets the shared checks validate methods that return polars (when an ISO
+        is constructed with return_polars=True) without importing polars here.
+        """
+        if type(df).__module__.split(".")[0] == "polars":
+            return df.to_pandas()
+        return df
+
     def local_now(self):
         return pd.Timestamp.now(tz=self.iso.default_timezone)
 
@@ -22,6 +33,7 @@ class TestHelperMixin:
         return self.local_start_of_day(self.local_today())
 
     def _check_ordered_by_time(self, df, col):
+        df = self._as_pandas(df)
         assert isinstance(df, pd.DataFrame)
         assert df.shape[0] > 0
         assert df[col].is_monotonic_increasing
@@ -33,6 +45,7 @@ class TestHelperMixin:
         skip_column_named_time=False,
         sced=False,
     ):
+        df = self._as_pandas(df)
         assert isinstance(df, pd.DataFrame)
 
         if instant_or_interval == "interval":
@@ -334,6 +347,7 @@ class BaseTestISO(TestHelperMixin):
     """other"""
 
     def _check_fuel_mix(self, df):
+        df = self._as_pandas(df)
         assert isinstance(df, pd.DataFrame)
         assert df.columns.name is None
 
@@ -347,6 +361,7 @@ class BaseTestISO(TestHelperMixin):
         self._check_time_columns(df, instant_or_interval=time_type)
 
     def _check_load(self, df):
+        df = self._as_pandas(df)
         assert isinstance(df, pd.DataFrame)
         assert df.shape[0] >= 0
 

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -11,11 +11,7 @@ class TestHelperMixin:
 
     @staticmethod
     def _as_pandas(df):
-        """Accept either a pandas or polars frame, returning pandas for assertions.
-
-        Lets the shared checks validate methods that return polars (when an ISO
-        is constructed with return_polars=True) without importing polars here.
-        """
+        """Accept either a pandas or polars frame, returning pandas for assertions."""
         if type(df).__module__.split(".")[0] == "polars":
             return df.to_pandas()
         return df
@@ -110,7 +106,7 @@ class BaseTestISO(TestHelperMixin):
     def test_get_fuel_mix_historical(self, time_column="Time"):
         # date string works
         date_str = "04/03/2022"
-        df = self.iso.get_fuel_mix(date_str)
+        df = self._as_pandas(self.iso.get_fuel_mix(date_str))
 
         assert isinstance(df, pd.DataFrame)
         assert df.loc[0][time_column].strftime("%m/%d/%Y") == date_str
@@ -119,7 +115,7 @@ class BaseTestISO(TestHelperMixin):
 
         # timestamp object works
         date_obj = pd.to_datetime("2019/11/19")
-        df = self.iso.get_fuel_mix(date_obj)
+        df = self._as_pandas(self.iso.get_fuel_mix(date_obj))
         assert isinstance(df, pd.DataFrame)
         assert df.loc[0][time_column].strftime(
             "%Y%m%d",
@@ -129,7 +125,7 @@ class BaseTestISO(TestHelperMixin):
 
         # datetime object works
         date_obj = pd.to_datetime("2021/05/09").date()
-        df = self.iso.get_fuel_mix(date_obj)
+        df = self._as_pandas(self.iso.get_fuel_mix(date_obj))
         assert isinstance(df, pd.DataFrame)
         assert df.loc[0][time_column].strftime(
             "%Y%m%d",
@@ -145,7 +141,9 @@ class BaseTestISO(TestHelperMixin):
         ) + pd.Timedelta(days=1)
         start = end - pd.Timedelta(days=num_days)
 
-        df = self.iso.get_fuel_mix(date=start.date(), end=end.date())
+        df = self._as_pandas(
+            self.iso.get_fuel_mix(date=start.date(), end=end.date()),
+        )
         self._check_fuel_mix(df)
 
         # make sure right number of days are returned
@@ -164,7 +162,9 @@ class BaseTestISO(TestHelperMixin):
 
         # add one minute since pjm is exclusive of end date
         # and does not include the whole day like other isos
-        df = self.iso.get_fuel_mix(start=start, end=yesterday + pd.Timedelta(minutes=1))
+        df = self._as_pandas(
+            self.iso.get_fuel_mix(start=start, end=yesterday + pd.Timedelta(minutes=1)),
+        )
 
         assert df[time_column].max() >= yesterday.replace(hour=0, minute=0, second=0)
         assert df[time_column].min() <= start
@@ -178,13 +178,13 @@ class BaseTestISO(TestHelperMixin):
         ) - pd.Timedelta(days=1)
         start = yesterday.replace(hour=0, minute=5, second=0, microsecond=0)
         end = yesterday.replace(hour=6, minute=5, second=0, microsecond=0)
-        df = self.iso.get_fuel_mix(start=start, end=end)
+        df = self._as_pandas(self.iso.get_fuel_mix(start=start, end=end))
         # ignore last row, since it is sometime midnight of next day
         assert df[time_column].iloc[:-1].dt.date.unique().tolist() == [yesterday.date()]
         self._check_fuel_mix(df)
 
     def test_get_fuel_mix_latest(self, time_column="Time"):
-        df = self.iso.get_fuel_mix("latest")
+        df = self._as_pandas(self.iso.get_fuel_mix("latest"))
         assert isinstance(df, pd.DataFrame)
         assert isinstance(df[time_column].iloc[0], pd.Timestamp)
         assert df.index.name is None
@@ -251,12 +251,16 @@ class BaseTestISO(TestHelperMixin):
         ) + pd.Timedelta(days=1)
         start = end - pd.Timedelta(days=num_days)
 
-        data = self.iso.get_load(date=start.date(), end=end.date())
+        data = self._as_pandas(
+            self.iso.get_load(date=start.date(), end=end.date()),
+        )
         self._check_load(data)
         # make sure right number of days are returned
         assert data["Time"].dt.day.nunique() == num_days
 
-        data_tuple = self.iso.get_load(date=(start.date(), end.date()))
+        data_tuple = self._as_pandas(
+            self.iso.get_load(date=(start.date(), end.date())),
+        )
 
         assert data_tuple.equals(data)
 
@@ -267,12 +271,12 @@ class BaseTestISO(TestHelperMixin):
 
         # date string works
         date_str = test_date.strftime("%Y%m%d")
-        df = self.iso.get_load(date_str)
+        df = self._as_pandas(self.iso.get_load(date_str))
         self._check_load(df)
         assert df.loc[0]["Time"].strftime("%Y%m%d") == date_str
 
         # timestamp object works
-        df = self.iso.get_load(test_date)
+        df = self._as_pandas(self.iso.get_load(test_date))
 
         self._check_load(df)
         assert df.loc[0]["Time"].strftime(
@@ -280,20 +284,20 @@ class BaseTestISO(TestHelperMixin):
         ) == test_date.strftime("%Y%m%d")
 
         # datetime object works
-        df = self.iso.get_load(test_date)
+        df = self._as_pandas(self.iso.get_load(test_date))
         self._check_load(df)
         assert df.loc[0]["Time"].strftime(
             "%Y%m%d",
         ) == test_date.strftime("%Y%m%d")
 
     def test_get_load_latest(self):
-        df = self.iso.get_load("latest")
+        df = self._as_pandas(self.iso.get_load("latest"))
         self._check_load(df)
         today = pd.Timestamp.now(tz=self.iso.default_timezone).date()
         assert df["Time"].max().date() == today
 
     def test_get_load_today(self):
-        df = self.iso.get_load("today")
+        df = self._as_pandas(self.iso.get_load("today"))
         self._check_load(df)
         today = pd.Timestamp.now(tz=self.iso.default_timezone).date()
 
@@ -382,6 +386,7 @@ class BaseTestISO(TestHelperMixin):
         assert is_numeric_dtype(df["Load"])
 
     def _check_forecast(self, df, expected_columns=None):
+        df = self._as_pandas(df)
         if expected_columns is not None:
             assert set(df.columns) == set(expected_columns)
         else:

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -223,21 +223,21 @@ class BaseTestISO(TestHelperMixin):
     # is not available for the selected date.
     def test_get_lmp_historical(self, market=None, date_str="2022-07-22"):
         if market is not None:
-            hist = self.iso.get_lmp(date_str, market=market)
+            hist = self._as_pandas(self.iso.get_lmp(date_str, market=market))
             assert isinstance(hist, pd.DataFrame)
             self._check_lmp_columns(hist, market)
 
     # @pytest.mark.parametrize in ISO
     def test_get_lmp_latest(self, market=None):
         if market is not None:
-            df = self.iso.get_lmp("latest", market=market)
+            df = self._as_pandas(self.iso.get_lmp("latest", market=market))
             assert isinstance(df, pd.DataFrame)
             self._check_lmp_columns(df, market)
 
     # @pytest.mark.parametrize in ISO
     def test_get_lmp_today(self, market=None):
         if market is not None:
-            df = self.iso.get_lmp("today", market=market)
+            df = self._as_pandas(self.iso.get_lmp("today", market=market))
             assert isinstance(df, pd.DataFrame)
             self._check_lmp_columns(df, market)
 
@@ -430,6 +430,7 @@ class BaseTestISO(TestHelperMixin):
     ]
 
     def _check_lmp_columns(self, df, market):
+        df = self._as_pandas(df)
         # todo in future all ISO should return same columns
         # maybe with the exception of "LMP" breakdown
         self._check_time_columns(df)

--- a/gridstatus/tests/source_specific/test_isone.py
+++ b/gridstatus/tests/source_specific/test_isone.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import pandas as pd
 import pytest
+from pandas.testing import assert_frame_equal
 
 from gridstatus import ISONE
 from gridstatus.base import Markets
@@ -137,10 +138,12 @@ class TestISONE(BaseTestISO):
             "_select_intervals_for_data_request",
             return_value=[],
         ):
-            df = self.iso.get_lmp(
-                date=(date, end),
-                market=Markets.REAL_TIME_5_MIN,
-                verbose=VERBOSE,
+            df = self._as_pandas(
+                self.iso.get_lmp(
+                    date=(date, end),
+                    market=Markets.REAL_TIME_5_MIN,
+                    verbose=VERBOSE,
+                ),
             )
 
         # Rolling data goes back 4 hours and should go up to the current time or close
@@ -162,7 +165,7 @@ class TestISONE(BaseTestISO):
     """get_wind_forecast"""
 
     def test_get_wind_forecast_today(self):
-        df = self.iso.get_wind_forecast(date="today", verbose=VERBOSE)
+        df = self._as_pandas(self.iso.get_wind_forecast(date="today", verbose=VERBOSE))
         now = pd.Timestamp.now(tz=self.iso.default_timezone).normalize()
 
         forecast_length = df["Interval Start"].max() - df["Interval Start"].min()
@@ -179,8 +182,9 @@ class TestISONE(BaseTestISO):
         self._check_solar_or_wind_forecast(df, resource_type="Wind")
 
     def test_get_wind_forecast_latest(self):
-        assert self.iso.get_wind_forecast(date="latest", verbose=VERBOSE).equals(
-            self.iso.get_wind_forecast(date="today", verbose=VERBOSE),
+        assert_frame_equal(
+            self._as_pandas(self.iso.get_wind_forecast(date="latest", verbose=VERBOSE)),
+            self._as_pandas(self.iso.get_wind_forecast(date="today", verbose=VERBOSE)),
         )
 
     def test_get_wind_forecast_historical_date_range(self):
@@ -191,9 +195,11 @@ class TestISONE(BaseTestISO):
             tz=self.iso.default_timezone,
         ).normalize() - pd.Timedelta(days=5)
 
-        df = self.iso.get_wind_forecast(
-            date=(five_days_ago, two_days_ago),
-            verbose=VERBOSE,
+        df = self._as_pandas(
+            self.iso.get_wind_forecast(
+                date=(five_days_ago, two_days_ago),
+                verbose=VERBOSE,
+            ),
         )
 
         assert (
@@ -219,7 +225,9 @@ class TestISONE(BaseTestISO):
             tz=self.iso.default_timezone,
         ).normalize() - pd.Timedelta(days=4)
 
-        df = self.iso.get_wind_forecast(date=four_days_ago, verbose=VERBOSE)
+        df = self._as_pandas(
+            self.iso.get_wind_forecast(date=four_days_ago, verbose=VERBOSE),
+        )
 
         assert df["Publish Time"].unique() == four_days_ago + pd.Timedelta(hours=10)
         assert df["Interval Start"].min() == four_days_ago + pd.Timedelta(hours=10)
@@ -233,7 +241,7 @@ class TestISONE(BaseTestISO):
     """get_solar_forecast"""
 
     def test_get_solar_forecast_today(self):
-        df = self.iso.get_solar_forecast(date="today", verbose=VERBOSE)
+        df = self._as_pandas(self.iso.get_solar_forecast(date="today", verbose=VERBOSE))
         now = pd.Timestamp.now(tz=self.iso.default_timezone).normalize()
 
         forecast_length = df["Interval Start"].max() - df["Interval Start"].min()
@@ -250,8 +258,11 @@ class TestISONE(BaseTestISO):
         self._check_solar_or_wind_forecast(df, resource_type="Solar")
 
     def test_get_solar_forecast_latest(self):
-        assert self.iso.get_solar_forecast(date="latest", verbose=VERBOSE).equals(
-            self.iso.get_solar_forecast(date="today", verbose=VERBOSE),
+        assert_frame_equal(
+            self._as_pandas(
+                self.iso.get_solar_forecast(date="latest", verbose=VERBOSE),
+            ),
+            self._as_pandas(self.iso.get_solar_forecast(date="today", verbose=VERBOSE)),
         )
 
     def test_get_solar_forecast_historical_date_range(self):
@@ -262,9 +273,11 @@ class TestISONE(BaseTestISO):
             tz=self.iso.default_timezone,
         ).normalize() - pd.Timedelta(days=5)
 
-        df = self.iso.get_solar_forecast(
-            date=(five_days_ago, two_days_ago),
-            verbose=VERBOSE,
+        df = self._as_pandas(
+            self.iso.get_solar_forecast(
+                date=(five_days_ago, two_days_ago),
+                verbose=VERBOSE,
+            ),
         )
 
         assert (
@@ -290,7 +303,9 @@ class TestISONE(BaseTestISO):
             tz=self.iso.default_timezone,
         ).normalize() - pd.Timedelta(days=4)
 
-        df = self.iso.get_solar_forecast(date=four_days_ago, verbose=VERBOSE)
+        df = self._as_pandas(
+            self.iso.get_solar_forecast(date=four_days_ago, verbose=VERBOSE),
+        )
 
         assert df["Publish Time"].unique() == four_days_ago + pd.Timedelta(hours=10)
         assert df["Interval Start"].min() == four_days_ago + pd.Timedelta(hours=10)
@@ -313,6 +328,7 @@ class TestISONE(BaseTestISO):
             super().test_get_storage_today()
 
     def _check_solar_or_wind_forecast(self, df, resource_type):
+        df = self._as_pandas(df)
         assert df.columns.tolist() == [
             "Interval Start",
             "Interval End",
@@ -394,6 +410,7 @@ class TestISONE(BaseTestISO):
 
     def _check_get_reserve_zone_prices_designations_real_time_5_min_final(self, df):
         """Helper method with common checks for reserve zone data"""
+        df = self._as_pandas(df)
         assert df.columns.tolist() == [
             "Interval Start",
             "Interval End",

--- a/gridstatus/tests/source_specific/test_isone.py
+++ b/gridstatus/tests/source_specific/test_isone.py
@@ -36,9 +36,7 @@ class TestISONE(BaseTestISO):
 
     def test_get_fuel_mix_nov_7_2022(self):
         data = self.iso.get_fuel_mix(date="Nov 7, 2022")
-        # make sure no nan values are returned
-        # nov 7 is a known data where nan values are returned
-        assert not data.isna().any().any()
+        assert not self._as_pandas(data).isna().any().any()
 
     def test_fuel_mix_across_dst_transition(self):
         # these dates are across the DST transition
@@ -59,7 +57,7 @@ class TestISONE(BaseTestISO):
     def test_get_btm_solar(self):
         df = self.iso.get_btm_solar(date="today", verbose=VERBOSE)
 
-        assert df.columns.tolist() == [
+        assert list(df.columns) == [
             "Time",
             "Interval Start",
             "Interval End",
@@ -75,7 +73,7 @@ class TestISONE(BaseTestISO):
 
         assert df.shape[0] == df.drop_duplicates().shape[0]
 
-        assert df.columns.tolist() == [
+        assert list(df.columns) == [
             "Time",
             "Interval Start",
             "Interval End",

--- a/gridstatus/tests/test_isone_polars.py
+++ b/gridstatus/tests/test_isone_polars.py
@@ -73,6 +73,17 @@ class TestUtilsDispatch:
             "2023-11-05 07:00",
         ]
 
+    def test_create_interval_start_from_hour_start_polars(self):
+        df = pl.DataFrame(
+            {
+                "Date": ["2024-01-01", "2024-01-01"],
+                "Hour Ending": ["1", "02X"],
+            },
+        )
+        out = utils.create_interval_start_from_hour_start_polars(df)
+        starts = out["Interval Start"].dt.strftime("%Y-%m-%d %H:%M").to_list()
+        assert starts == ["2024-01-01 00:00", "2024-01-01 01:00"]
+
 
 def _fuel_mix_raw():
     return pd.DataFrame(

--- a/gridstatus/tests/test_isone_polars.py
+++ b/gridstatus/tests/test_isone_polars.py
@@ -1,0 +1,195 @@
+"""Offline tests for the opt-in polars path (ENG-3958 POC).
+
+These tests mock the ISONE network helpers so they run without network access
+and assert that the polars path (ISONE(return_polars=True)) produces frames
+equivalent to the default pandas path for the migrated methods.
+"""
+
+import pandas as pd
+import polars as pl
+import pytest
+from pandas.testing import assert_frame_equal
+
+import gridstatus.isone as isone_module
+from gridstatus import utils
+from gridstatus.isone import ISONE
+
+TZ = ISONE.default_timezone
+
+
+def _normalize(df):
+    """Convert a (possibly polars) frame to pandas and reset its index."""
+    if utils.is_polars(df):
+        df = df.to_pandas()
+    return df.reset_index(drop=True)
+
+
+def _assert_parity(pandas_df, polars_df):
+    pl_as_pd = _normalize(polars_df)
+    assert utils.is_polars(polars_df)
+    assert list(pl_as_pd.columns) == list(pandas_df.columns)
+    assert_frame_equal(
+        pl_as_pd,
+        _normalize(pandas_df),
+        check_dtype=False,
+    )
+
+
+class TestUtilsDispatch:
+    def test_is_polars(self):
+        assert utils.is_polars(pl.DataFrame({"a": [1]}))
+        assert not utils.is_polars(pd.DataFrame({"a": [1]}))
+
+    def test_concat_dataframes_dispatch(self):
+        pl_out = utils.concat_dataframes(
+            [pl.DataFrame({"a": [1]}), pl.DataFrame({"a": [2]})],
+        )
+        assert utils.is_polars(pl_out)
+        assert pl_out.shape == (2, 1)
+
+        pd_out = utils.concat_dataframes(
+            [pd.DataFrame({"a": [1]}), pd.DataFrame({"a": [2]})],
+        )
+        assert isinstance(pd_out, pd.DataFrame)
+        assert pd_out.shape == (2, 1)
+
+    def test_move_cols_to_front_polars(self):
+        df = pl.DataFrame({"a": [1], "Time": [2], "b": [3]})
+        assert utils.move_cols_to_front(df, ["Time"]).columns == ["Time", "a", "b"]
+
+    def test_filter_lmp_locations_polars(self):
+        df = pl.DataFrame(
+            {"Location": ["A", "B"], "Location Type": ["Z", "Y"], "v": [1, 2]},
+        )
+        out = utils.filter_lmp_locations(df, locations=["A"], location_type="ALL")
+        assert out.to_dicts() == [{"Location": "A", "Location Type": "Z", "v": 1}]
+
+    def test_localize_ambiguous_infer_polars_dst_fall_back(self):
+        # Nov 5 2023 fall-back: the repeated 01:00 wall time should map to the
+        # pre-transition (EDT, 05:00 UTC) then post-transition (EST, 06:00 UTC).
+        naive = pd.to_datetime(
+            pd.Series(
+                [
+                    "2023-11-05 00:55:00",
+                    "2023-11-05 01:00:00",
+                    "2023-11-05 01:00:00",
+                    "2023-11-05 02:00:00",
+                ],
+            ),
+        )
+        df = pl.DataFrame({"Time": naive.to_numpy(), "v": [1, 2, 3, 4]})
+        out = utils.localize_ambiguous_infer_polars(df, "Time", TZ)
+        utc = (
+            out.select(pl.col("Time").dt.convert_time_zone("UTC"))
+            .to_series()
+            .dt.strftime("%Y-%m-%d %H:%M")
+            .to_list()
+        )
+        assert utc == [
+            "2023-11-05 04:55",
+            "2023-11-05 05:00",
+            "2023-11-05 06:00",
+            "2023-11-05 07:00",
+        ]
+
+
+class TestISONEReturnPolarsFlag:
+    def test_default_is_pandas(self):
+        assert ISONE().return_polars is False
+
+    def test_opt_in(self):
+        assert ISONE(return_polars=True).return_polars is True
+
+
+def _fuel_mix_raw():
+    return pd.DataFrame(
+        {
+            "Date": ["2024-01-01"] * 4,
+            "Time": ["00:00:00", "00:00:00", "00:05:00", "00:05:00"],
+            "Fuel Category": ["Solar", "Wind", "Solar", "Wind"],
+            "Gen Mw": [10.0, 20.0, 11.0, 21.0],
+        },
+    )
+
+
+def _load_raw():
+    return pd.DataFrame(
+        {
+            "Date/Time": ["2024-01-01 00:00:00", "2024-01-01 00:05:00"],
+            "Native Load": [100.0, 110.0],
+        },
+    )
+
+
+def _load_dst_raw():
+    # Fall-back transition: the 01:xx hour repeats.
+    times = [
+        "2023-11-05 00:55:00",
+        "2023-11-05 01:00:00",
+        "2023-11-05 01:00:00",
+        "2023-11-05 02:00:00",
+    ]
+    return pd.DataFrame({"Date/Time": times, "Native Load": [1.0, 2.0, 3.0, 4.0]})
+
+
+def _system_load_records(series):
+    base = [
+        {
+            "BeginDate": "2024-01-01T00:00:00.000-05:00",
+            "Mw": 50.0,
+            "NativeLoadBtmPv": 60.0,
+        },
+        {
+            "BeginDate": "2024-01-01T01:00:00.000-05:00",
+            "Mw": 55.0,
+            "NativeLoadBtmPv": 65.0,
+        },
+    ]
+    if series == "forecast":
+        for r in base:
+            r["CreationDate"] = "2023-12-31T10:00:00.000-05:00"
+    return [{"data": {series: base}}]
+
+
+class TestISONEPolarsParity:
+    @pytest.mark.parametrize("raw_factory", [_fuel_mix_raw])
+    def test_get_fuel_mix_parity(self, monkeypatch, raw_factory):
+        monkeypatch.setattr(
+            isone_module,
+            "_make_request",
+            lambda url, skiprows, verbose: raw_factory().copy(),
+        )
+        pandas_df = ISONE().get_fuel_mix(date="2024-01-01")
+        polars_df = ISONE(return_polars=True).get_fuel_mix(date="2024-01-01")
+        _assert_parity(pandas_df, polars_df)
+
+    @pytest.mark.parametrize("raw_factory", [_load_raw, _load_dst_raw])
+    def test_get_load_parity(self, monkeypatch, raw_factory):
+        monkeypatch.setattr(
+            isone_module,
+            "_make_request",
+            lambda url, skiprows, verbose: raw_factory().copy(),
+        )
+        pandas_df = ISONE().get_load(date="2023-11-05")
+        polars_df = ISONE(return_polars=True).get_load(date="2023-11-05")
+        _assert_parity(pandas_df, polars_df)
+
+    def test_get_load_forecast_parity(self, monkeypatch):
+        monkeypatch.setattr(
+            isone_module,
+            "_make_wsclient_request",
+            lambda url, data, verbose=False: _system_load_records("forecast"),
+        )
+        pandas_df = ISONE().get_load_forecast(date="2024-01-01")
+        polars_df = ISONE(return_polars=True).get_load_forecast(date="2024-01-01")
+        _assert_parity(pandas_df, polars_df)
+
+    def test_get_btm_solar_parity(self, monkeypatch):
+        monkeypatch.setattr(
+            isone_module,
+            "_make_wsclient_request",
+            lambda url, data, verbose=False: _system_load_records("actual"),
+        )
+        pandas_df = ISONE().get_btm_solar(date="2024-01-01")
+        polars_df = ISONE(return_polars=True).get_btm_solar(date="2024-01-01")
+        _assert_parity(pandas_df, polars_df)

--- a/gridstatus/tests/test_isone_polars.py
+++ b/gridstatus/tests/test_isone_polars.py
@@ -76,7 +76,7 @@ class TestUtilsDispatch:
     def test_create_interval_start_from_hour_start_polars(self):
         df = pl.DataFrame(
             {
-                "Date": ["2024-01-01", "2024-01-01"],
+                "Date": ["01/01/2024", "01/01/2024"],
                 "Hour Ending": ["1", "02X"],
             },
         )

--- a/gridstatus/tests/test_isone_polars.py
+++ b/gridstatus/tests/test_isone_polars.py
@@ -1,9 +1,4 @@
-"""Offline tests for the opt-in polars path (ENG-3958 POC).
-
-These tests mock the ISONE network helpers so they run without network access
-and assert that the polars path (ISONE(return_polars=True)) produces frames
-equivalent to the default pandas path for the migrated methods.
-"""
+"""Offline tests for ISONE methods that return polars frames."""
 
 import pandas as pd
 import polars as pl
@@ -17,22 +12,10 @@ from gridstatus.isone import ISONE
 TZ = ISONE.default_timezone
 
 
-def _normalize(df):
-    """Convert a (possibly polars) frame to pandas and reset its index."""
+def _to_pandas(df: object) -> pd.DataFrame:
     if utils.is_polars(df):
-        df = df.to_pandas()
+        return df.to_pandas()
     return df.reset_index(drop=True)
-
-
-def _assert_parity(pandas_df, polars_df):
-    pl_as_pd = _normalize(polars_df)
-    assert utils.is_polars(polars_df)
-    assert list(pl_as_pd.columns) == list(pandas_df.columns)
-    assert_frame_equal(
-        pl_as_pd,
-        _normalize(pandas_df),
-        check_dtype=False,
-    )
 
 
 class TestUtilsDispatch:
@@ -65,8 +48,6 @@ class TestUtilsDispatch:
         assert out.to_dicts() == [{"Location": "A", "Location Type": "Z", "v": 1}]
 
     def test_localize_ambiguous_infer_polars_dst_fall_back(self):
-        # Nov 5 2023 fall-back: the repeated 01:00 wall time should map to the
-        # pre-transition (EDT, 05:00 UTC) then post-transition (EST, 06:00 UTC).
         naive = pd.to_datetime(
             pd.Series(
                 [
@@ -93,14 +74,6 @@ class TestUtilsDispatch:
         ]
 
 
-class TestISONEReturnPolarsFlag:
-    def test_default_is_pandas(self):
-        assert ISONE().return_polars is False
-
-    def test_opt_in(self):
-        assert ISONE(return_polars=True).return_polars is True
-
-
 def _fuel_mix_raw():
     return pd.DataFrame(
         {
@@ -122,7 +95,6 @@ def _load_raw():
 
 
 def _load_dst_raw():
-    # Fall-back transition: the 01:xx hour repeats.
     times = [
         "2023-11-05 00:55:00",
         "2023-11-05 01:00:00",
@@ -151,45 +123,69 @@ def _system_load_records(series):
     return [{"data": {series: base}}]
 
 
-class TestISONEPolarsParity:
+class TestISONEPolarsMethods:
     @pytest.mark.parametrize("raw_factory", [_fuel_mix_raw])
-    def test_get_fuel_mix_parity(self, monkeypatch, raw_factory):
+    def test_get_fuel_mix_returns_polars(self, monkeypatch, raw_factory):
         monkeypatch.setattr(
             isone_module,
             "_make_request",
             lambda url, skiprows, verbose: raw_factory().copy(),
         )
-        pandas_df = ISONE().get_fuel_mix(date="2024-01-01")
-        polars_df = ISONE(return_polars=True).get_fuel_mix(date="2024-01-01")
-        _assert_parity(pandas_df, polars_df)
+        df = ISONE().get_fuel_mix(date="2024-01-01")
+        assert utils.is_polars(df)
+        assert df.columns == ["Time", "Solar", "Wind"]
+        assert df.height == 2
 
     @pytest.mark.parametrize("raw_factory", [_load_raw, _load_dst_raw])
-    def test_get_load_parity(self, monkeypatch, raw_factory):
+    def test_get_load_returns_polars(self, monkeypatch, raw_factory):
         monkeypatch.setattr(
             isone_module,
             "_make_request",
             lambda url, skiprows, verbose: raw_factory().copy(),
         )
-        pandas_df = ISONE().get_load(date="2023-11-05")
-        polars_df = ISONE(return_polars=True).get_load(date="2023-11-05")
-        _assert_parity(pandas_df, polars_df)
+        df = ISONE().get_load(date="2023-11-05")
+        assert utils.is_polars(df)
+        assert list(df.columns) == [
+            "Time",
+            "Interval Start",
+            "Interval End",
+            "Load",
+        ]
+        assert df.height == len(raw_factory())
 
-    def test_get_load_forecast_parity(self, monkeypatch):
+    def test_get_load_forecast_returns_polars(self, monkeypatch):
         monkeypatch.setattr(
             isone_module,
             "_make_wsclient_request",
             lambda url, data, verbose=False: _system_load_records("forecast"),
         )
-        pandas_df = ISONE().get_load_forecast(date="2024-01-01")
-        polars_df = ISONE(return_polars=True).get_load_forecast(date="2024-01-01")
-        _assert_parity(pandas_df, polars_df)
+        df = ISONE().get_load_forecast(date="2024-01-01")
+        assert utils.is_polars(df)
+        assert set(df.columns) == {
+            "Time",
+            "Interval Start",
+            "Interval End",
+            "Forecast Time",
+            "Load Forecast",
+        }
 
-    def test_get_btm_solar_parity(self, monkeypatch):
+    def test_get_btm_solar_returns_polars(self, monkeypatch):
         monkeypatch.setattr(
             isone_module,
             "_make_wsclient_request",
             lambda url, data, verbose=False: _system_load_records("actual"),
         )
-        pandas_df = ISONE().get_btm_solar(date="2024-01-01")
-        polars_df = ISONE(return_polars=True).get_btm_solar(date="2024-01-01")
-        _assert_parity(pandas_df, polars_df)
+        df = ISONE().get_btm_solar(date="2024-01-01")
+        assert utils.is_polars(df)
+        out = _to_pandas(df)
+        assert list(out.columns) == [
+            "Time",
+            "Interval Start",
+            "Interval End",
+            "BTM Solar",
+        ]
+        assert_frame_equal(
+            out[["BTM Solar"]],
+            pd.DataFrame({"BTM Solar": [10.0, 10.0]}),
+            check_dtype=False,
+        )

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -5,6 +5,7 @@ from typing import Callable
 from zipfile import ZipFile
 
 import pandas as pd
+import polars as pl
 import requests
 import tqdm
 
@@ -28,13 +29,8 @@ all_isos: list[ISOBase] = [MISO, CAISO, PJM, Ercot, SPP, NYISO, ISONE, IESO]
 
 
 def is_polars(obj: object) -> bool:
-    """Return whether ``obj`` is a polars DataFrame without importing polars.
-
-    Checking the module name avoids a hard polars dependency for the default
-    pandas code path: gridstatus only imports polars lazily when an ISO is
-    constructed with ``return_polars=True``.
-    """
-    return type(obj).__module__.split(".")[0] == "polars"
+    """Return whether ``obj`` is a polars DataFrame."""
+    return isinstance(obj, pl.DataFrame)
 
 
 def concat_dataframes(dfs: list) -> object:
@@ -44,8 +40,6 @@ def concat_dataframes(dfs: list) -> object:
     whether the decorated method produced pandas or polars frames.
     """
     if dfs and is_polars(dfs[0]):
-        import polars as pl
-
         return pl.concat(dfs, how="vertical_relaxed")
 
     return pd.concat(dfs).reset_index(drop=True)
@@ -220,8 +214,6 @@ def filter_lmp_locations(
         locations: "ALL" or list of locations to filter "Location" column by
     """
     if is_polars(df):
-        import polars as pl
-
         if location_type != "ALL" and location_type is not None:
             if isinstance(location_type, str):
                 location_type = [location_type]
@@ -320,8 +312,6 @@ def format_interconnection_df(
     ) - set(queue.columns)
 
     if is_polars(queue):
-        import polars as pl
-
         queue = queue.rename(rename)
         columns = _interconnection_columns.copy()
 
@@ -446,8 +436,6 @@ def localize_ambiguous_infer_polars(
     passing per-row "earliest"/"latest" to ``replace_time_zone``. The value is
     ignored for non-ambiguous rows.
     """
-    import polars as pl
-
     sort_cols = [*group_cols, time_col] if group_cols else [time_col]
     over_cols = [*group_cols, time_col] if group_cols else [time_col]
 

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -27,6 +27,30 @@ RED_X_HTML_ENTITY: str = "&#10060;"
 all_isos: list[ISOBase] = [MISO, CAISO, PJM, Ercot, SPP, NYISO, ISONE, IESO]
 
 
+def is_polars(obj: object) -> bool:
+    """Return whether ``obj`` is a polars DataFrame without importing polars.
+
+    Checking the module name avoids a hard polars dependency for the default
+    pandas code path: gridstatus only imports polars lazily when an ISO is
+    constructed with ``return_polars=True``.
+    """
+    return type(obj).__module__.split(".")[0] == "polars"
+
+
+def concat_dataframes(dfs: list) -> object:
+    """Concatenate a list of frames, dispatching on pandas vs polars.
+
+    Used by ``support_date_range`` to combine per-chunk results regardless of
+    whether the decorated method produced pandas or polars frames.
+    """
+    if dfs and is_polars(dfs[0]):
+        import polars as pl
+
+        return pl.concat(dfs, how="vertical_relaxed")
+
+    return pd.concat(dfs).reset_index(drop=True)
+
+
 def list_isos() -> pd.DataFrame:
     """List available ISOs"""
 
@@ -195,6 +219,19 @@ def filter_lmp_locations(
         df (pandas.DataFrame): DataFrame to filter
         locations: "ALL" or list of locations to filter "Location" column by
     """
+    if is_polars(df):
+        import polars as pl
+
+        if location_type != "ALL" and location_type is not None:
+            if isinstance(location_type, str):
+                location_type = [location_type]
+            df = df.filter(pl.col("Location Type").is_in(location_type))
+
+        if locations != "ALL" and locations is not None:
+            df = df.filter(pl.col("Location").is_in(locations))
+
+        return df
+
     if location_type != "ALL" and location_type is not None:
         if isinstance(location_type, str):
             location_type = [location_type]
@@ -281,6 +318,25 @@ def format_interconnection_df(
     assert set(rename.keys()).issubset(queue.columns), set(
         rename.keys(),
     ) - set(queue.columns)
+
+    if is_polars(queue):
+        import polars as pl
+
+        queue = queue.rename(rename)
+        columns = _interconnection_columns.copy()
+
+        if extra:
+            for e in extra:
+                assert e in queue.columns, f"Extra column {e} does not exist"
+            columns += extra
+
+        if missing:
+            for m in missing:
+                assert m not in queue.columns, "Missing column already exists"
+                queue = queue.with_columns(pl.lit(None).alias(m))
+
+        return queue.select(columns)
+
     queue = queue.rename(columns=rename)
     columns = _interconnection_columns.copy()
 
@@ -364,7 +420,48 @@ def get_interconnection_queues() -> pd.DataFrame:
 
 def move_cols_to_front(df: pd.DataFrame, cols_to_move: list[str]) -> pd.DataFrame:
     """Move columns to front of DataFrame"""
+    if is_polars(df):
+        rest = [c for c in df.columns if c not in cols_to_move]
+        return df.select(cols_to_move + rest)
+
     cols = list(df.columns)
     for c in cols_to_move:
         cols.remove(c)
     return df[cols_to_move + cols]
+
+
+def localize_ambiguous_infer_polars(
+    df: object,
+    time_col: str,
+    tz: str,
+    group_cols: list[str] | None = None,
+) -> object:
+    """Localize a naive polars datetime column, mimicking pandas ``ambiguous="infer"``.
+
+    pandas infers ambiguous (fall-back DST) timestamps by assuming the values
+    are monotonic increasing within each group: the first occurrence of a
+    repeated wall-clock time is the pre-transition (earliest) offset and later
+    occurrences are post-transition (latest). polars has no "infer" option, so
+    we reproduce it by ranking duplicate naive timestamps within each group and
+    passing per-row "earliest"/"latest" to ``replace_time_zone``. The value is
+    ignored for non-ambiguous rows.
+    """
+    import polars as pl
+
+    sort_cols = [*group_cols, time_col] if group_cols else [time_col]
+    over_cols = [*group_cols, time_col] if group_cols else [time_col]
+
+    df = df.sort(sort_cols)
+    df = df.with_columns(
+        pl.int_range(pl.len()).over(over_cols).alias("_dup_rank"),
+    )
+    df = df.with_columns(
+        pl.when(pl.col("_dup_rank") > 0)
+        .then(pl.lit("latest"))
+        .otherwise(pl.lit("earliest"))
+        .alias("_ambiguous"),
+    )
+    df = df.with_columns(
+        pl.col(time_col).dt.replace_time_zone(tz, ambiguous=pl.col("_ambiguous")),
+    )
+    return df.drop(["_dup_rank", "_ambiguous"])

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -39,8 +39,11 @@ def concat_dataframes(dfs: list) -> object:
     Used by ``support_date_range`` to combine per-chunk results regardless of
     whether the decorated method produced pandas or polars frames.
     """
-    if dfs and is_polars(dfs[0]):
-        return pl.concat(dfs, how="vertical_relaxed")
+    if not dfs:
+        return pd.DataFrame()
+
+    if is_polars(dfs[0]):
+        return pl.concat(dfs, how="diagonal")
 
     return pd.concat(dfs).reset_index(drop=True)
 

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -458,6 +458,9 @@ def localize_ambiguous_infer_polars(
     return df.drop(["_dup_rank", "_ambiguous"])
 
 
+_ISONE_DATE_FORMAT = "%m/%d/%Y"
+
+
 def create_interval_start_from_hour_start_polars(df: pl.DataFrame) -> pl.DataFrame:
     """Build naive Interval Start from ISONE Date and Hour Ending columns."""
     return df.with_columns(
@@ -469,7 +472,7 @@ def create_interval_start_from_hour_start_polars(df: pl.DataFrame) -> pl.DataFra
         .alias("Hour Start"),
     ).with_columns(
         (
-            pl.col("Date").str.to_datetime(strict=False)
+            pl.col("Date").str.to_datetime(format=_ISONE_DATE_FORMAT, strict=False)
             + pl.duration(hours=pl.col("Hour Start"))
         ).alias("Interval Start"),
     )
@@ -501,7 +504,7 @@ def localize_interval_start_polars(
         pl.col(time_col).dt.replace_time_zone(
             tz,
             ambiguous=pl.col("_ambiguous"),
-            nonexistent="null",
+            non_existent="null",
         ),
     )
     df = df.drop(["_dup_rank", "_ambiguous"])
@@ -513,7 +516,10 @@ def localize_interval_start_polars(
         df.filter(pl.col(time_col).is_null())
         .with_columns(
             (
-                pl.col(date_col).str.to_datetime(strict=False)
+                pl.col(date_col).str.to_datetime(
+                    format=_ISONE_DATE_FORMAT,
+                    strict=False,
+                )
                 + pl.duration(hours=pl.col(hour_start_col) - 1)
             ).alias(time_col),
         )

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -456,3 +456,71 @@ def localize_ambiguous_infer_polars(
         pl.col(time_col).dt.replace_time_zone(tz, ambiguous=pl.col("_ambiguous")),
     )
     return df.drop(["_dup_rank", "_ambiguous"])
+
+
+def create_interval_start_from_hour_start_polars(df: pl.DataFrame) -> pl.DataFrame:
+    """Build naive Interval Start from ISONE Date and Hour Ending columns."""
+    return df.with_columns(
+        pl.col("Hour Ending")
+        .cast(pl.Utf8)
+        .str.replace("02X", "02")
+        .cast(pl.Int64)
+        .sub(1)
+        .alias("Hour Start"),
+    ).with_columns(
+        (
+            pl.col("Date").str.to_datetime(strict=False)
+            + pl.duration(hours=pl.col("Hour Start"))
+        ).alias("Interval Start"),
+    )
+
+
+def localize_interval_start_polars(
+    df: pl.DataFrame,
+    time_col: str,
+    tz: str,
+    group_cols: list[str] | None = None,
+    date_col: str | None = None,
+    hour_start_col: str = "Hour Start",
+) -> pl.DataFrame:
+    """Localize naive interval starts, handling ISONE DST fall-back and spring-forward."""
+    sort_cols = [*group_cols, time_col] if group_cols else [time_col]
+    over_cols = [*group_cols, time_col] if group_cols else [time_col]
+
+    df = df.sort(sort_cols)
+    df = df.with_columns(
+        pl.int_range(pl.len()).over(over_cols).alias("_dup_rank"),
+    )
+    df = df.with_columns(
+        pl.when(pl.col("_dup_rank") > 0)
+        .then(pl.lit("latest"))
+        .otherwise(pl.lit("earliest"))
+        .alias("_ambiguous"),
+    )
+    df = df.with_columns(
+        pl.col(time_col).dt.replace_time_zone(
+            tz,
+            ambiguous=pl.col("_ambiguous"),
+            nonexistent="null",
+        ),
+    )
+    df = df.drop(["_dup_rank", "_ambiguous"])
+
+    if date_col is None or df.filter(pl.col(time_col).is_null()).height == 0:
+        return df
+
+    fixed = (
+        df.filter(pl.col(time_col).is_null())
+        .with_columns(
+            (
+                pl.col(date_col).str.to_datetime(strict=False)
+                + pl.duration(hours=pl.col(hour_start_col) - 1)
+            ).alias(time_col),
+        )
+        .with_columns(
+            pl.col(time_col).dt.replace_time_zone(tz),
+        )
+    )
+
+    good = df.filter(pl.col(time_col).is_not_null())
+    return pl.concat([good, fixed], how="diagonal")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,16 @@ dependencies = [
     "filelock >=3.20.3,<4",
 ]
 
+[project.optional-dependencies]
+# Opt-in polars support. gridstatus methods default to returning pandas; pass
+# return_polars=True to an ISO to get polars frames back (requires this extra).
+# pyarrow backs the polars->pandas conversion seam used for the default return.
+polars = ["polars ~=1.38", "pyarrow >=15"]
+
 [dependency-groups]
 dev = [
+    "polars ~=1.38",
+    "pyarrow >=15",
     "pytest ~=8.3",
     "pytest-xdist ~=3.6",
     "pytest-rerunfailures ~=15.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,18 +35,12 @@ dependencies = [
     "rpds-py >= 0.30.0; python_version >= '3.14'",
     "h11 >=0.16.0,<1",
     "filelock >=3.20.3,<4",
+    "polars ~=1.38",
+    "pyarrow >=15",
 ]
-
-[project.optional-dependencies]
-# Opt-in polars support. gridstatus methods default to returning pandas; pass
-# return_polars=True to an ISO to get polars frames back (requires this extra).
-# pyarrow backs the polars->pandas conversion seam used for the default return.
-polars = ["polars ~=1.38", "pyarrow >=15"]
 
 [dependency-groups]
 dev = [
-    "polars ~=1.38",
-    "pyarrow >=15",
     "pytest ~=8.3",
     "pytest-xdist ~=3.6",
     "pytest-rerunfailures ~=15.0",

--- a/uv.lock
+++ b/uv.lock
@@ -834,6 +834,8 @@ dependencies = [
     { name = "pandas" },
     { name = "pdfplumber" },
     { name = "plotly" },
+    { name = "polars" },
+    { name = "pyarrow" },
     { name = "requests" },
     { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "setuptools" },
@@ -845,12 +847,6 @@ dependencies = [
     { name = "xlrd" },
     { name = "xmltodict" },
     { name = "zipp" },
-]
-
-[package.optional-dependencies]
-polars = [
-    { name = "polars" },
-    { name = "pyarrow" },
 ]
 
 [package.dev-dependencies]
@@ -867,9 +863,7 @@ dev = [
     { name = "nbconvert" },
     { name = "notebook" },
     { name = "pillow" },
-    { name = "polars" },
     { name = "pre-commit" },
-    { name = "pyarrow" },
     { name = "pygments" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -907,8 +901,8 @@ requires-dist = [
     { name = "pandas", specifier = "~=2.2" },
     { name = "pdfplumber", specifier = "~=0.11" },
     { name = "plotly", specifier = "~=6.0" },
-    { name = "polars", marker = "extra == 'polars'", specifier = "~=1.38" },
-    { name = "pyarrow", marker = "extra == 'polars'", specifier = ">=15" },
+    { name = "polars", specifier = "~=1.38" },
+    { name = "pyarrow", specifier = ">=15" },
     { name = "requests", specifier = ">=2.33,<3" },
     { name = "rpds-py", marker = "python_full_version >= '3.14'", specifier = ">=0.30.0" },
     { name = "setuptools", specifier = ">=78.1.1,<79" },
@@ -921,7 +915,6 @@ requires-dist = [
     { name = "xmltodict", specifier = "~=0.14" },
     { name = "zipp", specifier = "~=3.21" },
 ]
-provides-extras = ["polars"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -936,9 +929,7 @@ dev = [
     { name = "nbconvert", specifier = ">=7.17.0,<8" },
     { name = "notebook", specifier = "~=7.4" },
     { name = "pillow", specifier = ">=12.1.1,<13" },
-    { name = "polars", specifier = "~=1.38" },
     { name = "pre-commit", specifier = "~=4.2" },
-    { name = "pyarrow", specifier = ">=15" },
     { name = "pygments", specifier = ">=2.20.0,<3" },
     { name = "pytest", specifier = "~=8.3" },
     { name = "pytest-cov", specifier = "~=6.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -847,6 +847,12 @@ dependencies = [
     { name = "zipp" },
 ]
 
+[package.optional-dependencies]
+polars = [
+    { name = "polars" },
+    { name = "pyarrow" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "fonttools" },
@@ -861,7 +867,9 @@ dev = [
     { name = "nbconvert" },
     { name = "notebook" },
     { name = "pillow" },
+    { name = "polars" },
     { name = "pre-commit" },
+    { name = "pyarrow" },
     { name = "pygments" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -899,6 +907,8 @@ requires-dist = [
     { name = "pandas", specifier = "~=2.2" },
     { name = "pdfplumber", specifier = "~=0.11" },
     { name = "plotly", specifier = "~=6.0" },
+    { name = "polars", marker = "extra == 'polars'", specifier = "~=1.38" },
+    { name = "pyarrow", marker = "extra == 'polars'", specifier = ">=15" },
     { name = "requests", specifier = ">=2.33,<3" },
     { name = "rpds-py", marker = "python_full_version >= '3.14'", specifier = ">=0.30.0" },
     { name = "setuptools", specifier = ">=78.1.1,<79" },
@@ -911,6 +921,7 @@ requires-dist = [
     { name = "xmltodict", specifier = "~=0.14" },
     { name = "zipp", specifier = "~=3.21" },
 ]
+provides-extras = ["polars"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -925,7 +936,9 @@ dev = [
     { name = "nbconvert", specifier = ">=7.17.0,<8" },
     { name = "notebook", specifier = "~=7.4" },
     { name = "pillow", specifier = ">=12.1.1,<13" },
+    { name = "polars", specifier = "~=1.38" },
     { name = "pre-commit", specifier = "~=4.2" },
+    { name = "pyarrow", specifier = ">=15" },
     { name = "pygments", specifier = ">=2.20.0,<3" },
     { name = "pytest", specifier = "~=8.3" },
     { name = "pytest-cov", specifier = "~=6.1" },
@@ -2316,6 +2329,34 @@ wheels = [
 ]
 
 [[package]]
+name = "polars"
+version = "1.42.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/91/a1d7809a6d399f0aa78d4d3a4f4daf411cb97ccfe7f236c08a01be5fc8a5/polars-1.42.0.tar.gz", hash = "sha256:283ddc923e47857924fbef36580d2e98d984a47c962bae4cbce9c0ebcc98989c", size = 740984, upload-time = "2026-06-24T05:20:13.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/4d/094819d251f2248999cb722125fd4e44ee79b753fe535338cbf442fbf45d/polars-1.42.0-py3-none-any.whl", hash = "sha256:ab10cac3f2d28a6e22e22bcac69c0e51fb33cd25aee1f45105782d4fe55a3e6a", size = 836855, upload-time = "2026-06-24T05:18:18.204Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.42.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/67/20759e9abbc61910cf948f5c28986ab25ef9e8009099b469d64d6a34a478/polars_runtime_32-1.42.0.tar.gz", hash = "sha256:c927e1930881fe0bf9629d12e5d44ebd4ecef2bfa02374dfc79feaa24054394f", size = 3042711, upload-time = "2026-06-24T05:20:15.715Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/62/8b83fca67d478e4a2b88cbba2fbff4d533052938ff96d598b7915fd9d235/polars_runtime_32-1.42.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d235a5e8349797c16b70ad573fb9ddbd7f162796884bcbd25260908f8408affc", size = 53112358, upload-time = "2026-06-24T05:18:22.275Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/72/06d3d78b7e8e8d3c72ea9eee310950334d50986462b3c1d40f82972495a5/polars_runtime_32-1.42.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e7923db3bcb57e0edecde3be28629e0411414a15ef1a4c10c783ac5eadab2e1e", size = 47443757, upload-time = "2026-06-24T05:18:26.326Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/77/20241aaf919a0f63b946fb702bc14447db290ef918e2c2943ed90d50fcc1/polars_runtime_32-1.42.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42e27e2eb5909abcedb4ab4cc04ee67c5ec2b73a5640ebd8739b1b719383fa68", size = 51360855, upload-time = "2026-06-24T05:18:30.709Z" },
+    { url = "https://files.pythonhosted.org/packages/46/5c/ca14606a42628b04d82ac6ae5742ed24048bd43fbf48ae87fc4f4b9e759d/polars_runtime_32-1.42.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a3c43d4a76360bf912f8772b5ac1c23d5a8efef71408c63bba1bb0b4897a8ea", size = 57299346, upload-time = "2026-06-24T05:18:35.374Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/af/3ad0de43bbb97e91d605d7d76acb30be36269b8a8402890ab4f9892b6e26/polars_runtime_32-1.42.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:542a77b2b969e5157939bfb76cd0f372c4f42db6ccd58636fcefe0011162a418", size = 51512143, upload-time = "2026-06-24T05:18:39.771Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a5/d1133ba9d005532a6fb94544f5da09e497a8fe42c04e37c3da6faa80bd67/polars_runtime_32-1.42.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a13949abfce319de7fc4c1abee43bc9d4a4ed4d96bcc1a6037d022e4e9561d9f", size = 55214521, upload-time = "2026-06-24T05:18:43.916Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/54/0b8355ab29669560608b2864a5e54674dd78bbd48c04976607516e081107/polars_runtime_32-1.42.0-cp310-abi3-win_amd64.whl", hash = "sha256:91a07bd852c1d1ea19b3e27c974bc7b1b29ac948fdb2e785da3a6ec0f0683cad", size = 52718509, upload-time = "2026-06-24T05:18:48.202Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/b9/7c46fdbd1dbbaaf77f9512d7665609d7e4c4d8c8849edb9a16c471041075/polars_runtime_32-1.42.0-cp310-abi3-win_arm64.whl", hash = "sha256:b7c5d7721b7bb2563d72785050ac099da1e2000d412f9c72a0cfb7b07779e75d", size = 46728464, upload-time = "2026-06-24T05:18:52.505Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2383,6 +2424,63 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/bf/a34fee1d624152124fa8355c42f34195ad5fe5233ce5bb87946432047d52/pyarrow-24.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:7c2b98645d576a0b9616892ead22b64a83a5f043c5e2ca15ebcefcb5b70c80cb", size = 35076681, upload-time = "2026-04-21T08:51:46.845Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/41/64180033d7027afce12dc96d0fe1f504c6fa112190582b458acea2399530/pyarrow-24.0.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:644a246325b8c69c595ad1dd4b463eba4b0cdb731370e4a86137d433208d6147", size = 36684260, upload-time = "2026-04-21T08:51:53.642Z" },
+    { url = "https://files.pythonhosted.org/packages/57/02/9b9320e673dd8a99411fac78690f3df92f6dd6f59754c750110bca66d64e/pyarrow-24.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:3a577bd840ca83f646f0a625dbc571dba7044c43c2d1503afc378b570954345c", size = 45698566, upload-time = "2026-04-21T10:46:02.133Z" },
+    { url = "https://files.pythonhosted.org/packages/67/33/f75e91b9a64c3f33c787e263c93b871ad91b8a4a68c1d5cebddd9840e835/pyarrow-24.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:e3268e43984d0b1a185c89b4cfff282a7ead12fc93f56cfd7088bdbcbe727041", size = 48835562, upload-time = "2026-04-21T10:46:10.278Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/63/097510448e47e4091faa41c43ba92f97cecaab8f4535b56a3d149578f634/pyarrow-24.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2392d954fcb920f42d230284b677605e4e2fbb11f2821e823e642abd67fbb491", size = 49394997, upload-time = "2026-04-21T10:46:18.08Z" },
+    { url = "https://files.pythonhosted.org/packages/60/6b/c047d6222ab279024a062742d1807e2fbaf27bba88a98637299ff47b9236/pyarrow-24.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:bec9373df11544592b0ba7ec2af0e35059e5f0e7647c6183a854dedd193298f1", size = 51911424, upload-time = "2026-04-21T10:46:25.347Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ba/464cc70761c2a525d97ebd84e21c31ebd47f3ef4bdcee117009f51c46f24/pyarrow-24.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:c42ab9439498270139cc63e18847a02afe5c8b3ed9c931266533cfe378bd3591", size = 27251730, upload-time = "2026-04-21T10:46:30.913Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c9/a47ab7ece0d86cbe6678418a0fbd1ac4bb493b9184a3891dfa0e7f287ae0/pyarrow-24.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:b0e131f880cda8d04e076cee175a46fc0e8bc8b65c99c6c09dff6669335fde74", size = 35068898, upload-time = "2026-04-21T10:46:36.599Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/bc/8db86617a9a58008acf8913d6fed68ea2a46acb6de928db28d724c891a68/pyarrow-24.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:1b2fe7f9a5566401a0ef2571f197eb92358925c1f0c8dba305d6e43ea0871bb3", size = 36679915, upload-time = "2026-04-21T10:46:42.602Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8e/fb178720400ef69db251eb4a9c3ccf4af269bc1feb5055529b8fc87170d1/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0b3537c00fb8d384f15ac1e79b6eb6db04a16514c8c1d22e59a9b95c8ba42868", size = 45697931, upload-time = "2026-04-21T10:46:48.403Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/27/99c42abe8e21b44f4917f62631f3aa31404882a2c41d8a4cd5c110e13d52/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:14e31a3c9e35f1ab6356c6378f6f72830e6d2d5f1791df3774a7b097d18a6a1e", size = 48837449, upload-time = "2026-04-21T10:46:55.329Z" },
+    { url = "https://files.pythonhosted.org/packages/36/b6/333749e2666e9032891125bf9c691146e92901bece62030ac1430e2e7c88/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b7d9a514e73bc42711e6a35aaccf3587c520024fe0a25d830a1a8a27c15f4f57", size = 49395949, upload-time = "2026-04-21T10:47:01.869Z" },
+    { url = "https://files.pythonhosted.org/packages/17/25/c5201706a2dd374e8ba6ee3fd7a8c89fb7ffc16eed5217a91fd2bd7f7626/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b196eb3f931862af3fa84c2a253514d859c08e0d8fe020e07be12e75a5a9780c", size = 51912986, upload-time = "2026-04-21T10:47:09.872Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d2/4d1bbba65320b21a49678d6fbdc6ff7c649251359fdcfc03568c4136231d/pyarrow-24.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:35405aecb474e683fb36af650618fd5340ee5471fc65a21b36076a18bbc6c981", size = 27255371, upload-time = "2026-04-21T10:47:15.943Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559, upload-time = "2026-04-21T10:47:22.17Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b6/0ddf0e9b6ead3474ab087ae598c76b031fc45532bf6a63f3a553440fb258/pyarrow-24.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a", size = 36663654, upload-time = "2026-04-21T10:47:28.315Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394, upload-time = "2026-04-21T10:47:34.821Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122, upload-time = "2026-04-21T10:47:42.056Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032, upload-time = "2026-04-21T10:47:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490, upload-time = "2026-04-21T10:47:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1c/e3e72c8014ad2743ca64a701652c733cc5cbcee15c0463a32a8c55518d9e/pyarrow-24.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:295f0a7f2e242dabd513737cf076007dc5b2d59237e3eca37b05c0c6446f3826", size = 27355660, upload-time = "2026-04-21T10:48:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759, upload-time = "2026-04-21T10:48:07.258Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471, upload-time = "2026-04-21T10:48:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981, upload-time = "2026-04-21T10:48:20.201Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172, upload-time = "2026-04-21T10:48:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733, upload-time = "2026-04-21T10:48:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335, upload-time = "2026-04-21T10:48:42.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748, upload-time = "2026-04-21T10:49:42.532Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554, upload-time = "2026-04-21T10:48:48.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301, upload-time = "2026-04-21T10:48:55.181Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929, upload-time = "2026-04-21T10:49:03.676Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365, upload-time = "2026-04-21T10:49:11.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819, upload-time = "2026-04-21T10:49:21.474Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252, upload-time = "2026-04-21T10:49:31.164Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127, upload-time = "2026-04-21T10:49:37.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997, upload-time = "2026-04-21T10:49:48.796Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720, upload-time = "2026-04-21T10:49:55.858Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852, upload-time = "2026-04-21T10:50:04.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852, upload-time = "2026-04-21T10:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207, upload-time = "2026-04-21T10:50:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117, upload-time = "2026-04-21T10:50:29.14Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155, upload-time = "2026-04-21T10:51:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387, upload-time = "2026-04-21T10:50:35.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102, upload-time = "2026-04-21T10:50:42.417Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118, upload-time = "2026-04-21T10:50:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765, upload-time = "2026-04-21T10:50:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
+    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

In the spirit of POC and going one ISO at a time, a full ISONE polars migration from pandas. All ISONE `get_*` methods that return tabular data now return **polars** frames directly.

There will be a bit of a transition period where `is_polars()` type methods abound, which we can then slowly start to remove as we remove the pandas dependencies. 

- **Dependencies** — `polars ~=1.38` and `pyarrow >=15` moved to main `dependencies` (removed optional `[polars]` extra).
- **Shared infra** (`utils.py`, `decorators.py`, `base.py`):
  - `is_polars`, `concat_dataframes` (polars uses `how="diagonal"`).
  - Polars branches in `move_cols_to_front`, `filter_lmp_locations`, `format_interconnection_df`.
  - `localize_ambiguous_infer_polars` — reproduces pandas `ambiguous="infer"` DST fall-back.
  - `create_interval_start_from_hour_start_polars` + `localize_interval_start_polars` — ISONE hour-ending convention + spring-forward DST.
  - `support_date_range` concat dispatches via `utils.concat_dataframes`.
  - `_latest_lmp_from_today` / `_latest_from_today` handle polars frames.
  - Removed `ISOBase.return_polars`, `_maybe_to_pandas`, and the constructor that only existed for that flag.
- **`isone.py`** — all DataFrame-returning methods converted:
  - Load stack: `get_load`, `get_fuel_mix`, `get_btm_solar`, `get_load_forecast`, `_get_system_load`
  - Forecasts: `get_solar_forecast`, `get_wind_forecast`, `_get_solar_or_wind_forecast`
  - LMP stack: `_get_lmp`, `_get_latest_lmp`, `_process_lmp`, `get_lmp_*`
  - `get_reserve_zone_prices_designations_real_time_5_min_final`
  - `get_interconnection_queue` (pandas `read_html` at IO edge, polars thereafter)
  - Pandas kept only at network/CSV parse boundaries (`_make_request`, `pd.read_csv`, `pd.read_html`).

## Breaking change

`ISONE().get_*()` callers that expect `pd.DataFrame` must migrate to polars or call `.to_pandas()`. Other ISOs are unchanged.

## Test plan

- [x] `pytest gridstatus/tests/test_isone_polars.py` — offline mocked-IO tests for converted methods + DST utils.
- [x] `test_isone.py` / `base_test_iso.py` updated to use `_as_pandas()` for pandas-style assertions.
- [ ] Re-run integration ISONE tests (LMP, forecasts, reserve zone) against live API / VCR cassettes in CI.

## Follow-ups

Migrate other ISOs (ERCOT, MISO, PJM, CAISO per cost analysis), `isone_api` datasets, and polars-native `resample_and_interpolate` for `load_forecast`.