### PR TITLE
feat(ENG 4236): Add MISO Area Control Error scraper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 #### ERCOT
 * ERCOT Available Resource Planned Outage Capacity 7 Day and Future datasets in [#884](https://github.com/gridstatus/gridstatus/pull/884)
 
+#### MISO
+* MISO Area Control Error dataset via `MISO.get_area_control_error`
+
 ## v0.36.0 - April 20, 2026
 
 ### Additions (New Features/Datasets)

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -1951,6 +1951,52 @@ class MISO(ISOBase):
             .reset_index(drop=True)
         )
 
+    @support_date_range(frequency=None)
+    def get_area_control_error(
+        self,
+        date: str | pd.Timestamp = "latest",
+        end: str | pd.Timestamp = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Get the MISO Area Control Error (ACE).
+
+        Real-time system-level area control error in MW, published as instantaneous
+        observations roughly every 30 seconds. The source endpoint only serves a
+        rolling window of recent observations, so only "latest" is supported.
+
+        Args:
+            date: Only "latest" is supported.
+            end: Not supported.
+            verbose: If True, prints additional information during data retrieval.
+
+        Returns:
+            DataFrame with columns "Time" and "Area Control Error".
+        """
+        if date != "latest":
+            raise NotSupported(
+                "Only latest MISO area control error data is available. Use 'latest' "
+                "as date.",
+            )
+
+        url = "https://public-api.misoenergy.org/api/Ace"
+
+        response = self._get_json(url, verbose=verbose)
+
+        df = pd.DataFrame(response["ACE"])
+
+        df["Time"] = pd.to_datetime(
+            df["instantEST"],
+            format="%Y-%m-%d %I:%M:%S %p",
+        ).dt.tz_localize(self.default_timezone)
+
+        df["Area Control Error"] = pd.to_numeric(df["value"])
+
+        return (
+            df[["Time", "Area Control Error"]]
+            .sort_values("Time")
+            .reset_index(drop=True)
+        )
+
     @support_date_range(frequency="DAY_START")
     def get_multiday_operating_margin(
         self,

--- a/gridstatus/tests/source_specific/test_miso.py
+++ b/gridstatus/tests/source_specific/test_miso.py
@@ -1152,6 +1152,41 @@ class TestMISO(BaseTestISO):
             with pytest.raises(NotSupported):
                 self.iso.get_interchange_5_min(date)
 
+    """get_area_control_error"""
+
+    def _check_get_area_control_error(self, df):
+        assert df.columns.tolist() == [
+            "Time",
+            "Area Control Error",
+        ]
+
+        assert not df.empty
+
+        assert isinstance(df["Time"].dtype, pd.DatetimeTZDtype)
+        assert str(df["Time"].dt.tz) == str(self.iso.default_timezone)
+
+        assert df["Area Control Error"].dtype in [np.float64, np.int64]
+
+        # The source publishes instantaneous observations, so no duplicate timestamps
+        assert not df["Time"].duplicated().any()
+
+    def test_get_area_control_error_latest(self):
+        with miso_vcr.use_cassette("test_get_area_control_error_latest.yaml"):
+            df = self.iso.get_area_control_error("latest")
+            self._check_get_area_control_error(df)
+
+            # Data should be near-real-time
+            assert df["Time"].max() >= self.local_now() - pd.DateOffset(hours=3)
+
+    @pytest.mark.parametrize("date", ["2025-01-01", "today"])
+    def test_get_area_control_error_raises_error_if_not_latest(self, date):
+        cassette_name = (
+            f"test_get_area_control_error_raises_error_if_not_latest_{date}.yaml"
+        )
+        with miso_vcr.use_cassette(cassette_name):
+            with pytest.raises(NotSupported):
+                self.iso.get_area_control_error(date)
+
     """get_binding_constraints_real_time_intraday"""
 
     def _check_binding_constraints_real_time_intraday(self, df):


### PR DESCRIPTION
## Summary
- Adds `get_area_control_error` scraper for MISO

### Details
Adds `MISO.get_area_control_error`, which returns the system-level Area Control Error (ACE) in MW from the public MISO API (`https://public-api.misoenergy.org/api/Ace`). ACE is published as instantaneous observations roughly every 30 seconds. The source endpoint only serves a rolling ~2-hour window of recent observations and has no historical/date query path, so only `date="latest"` is supported (a `NotSupported` error is raised otherwise), matching the pattern used by `get_interchange_5_min`. The source `instantEST` timestamps are parsed in the MISO default EST timezone into a `Time` column, and `value` is converted to a numeric `Area Control Error` column. The returned DataFrame has columns `Time` and `Area Control Error`.

This method lives in the `MISO` class rather than `MISOAPI` because ACE comes from the public, unauthenticated `public-api.misoenergy.org` host (the same host as `get_fuel_mix`, `get_load`, and `get_interchange_5_min`), whereas `MISOAPI` is a client for the authenticated Data Exchange APIM endpoints with subscription keys and pagination that do not apply here.

To run tests:
```bash
VCR_RECORD_MODE=all uv run pytest -vvv gridstatus/tests/ -k "miso" -k "area_control_error"
```