### PR TITLE
feat(ENG-4238): Add date-range support for PJM emergency postings

### DIFF
--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -3778,7 +3778,7 @@ class PJM(ISOBase):
             .reset_index(drop=True)
         )
 
-    @support_date_range(frequency="YEAR_START")
+    @support_date_range(frequency=None)
     def get_emergency_postings(
         self,
         date: str | pd.Timestamp,

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -3781,69 +3781,44 @@ class PJM(ISOBase):
     def get_emergency_postings(
         self,
         url: str | None = None,
-        start: str | pd.Timestamp | None = None,
-        stop: str | pd.Timestamp | None = None,
+        date: str | pd.Timestamp | None = None,
+        end: str | pd.Timestamp | None = None,
     ) -> pd.DataFrame:
         """
         Retrieves PJM emergency procedure postings.
 
-        When ``start`` or ``stop`` is provided, uses the public REST endpoint
-        documented in the PJM CLI user guide. Otherwise, triggers the public
-        "Export To XML" button on the guest dashboard (current ~3-day window).
+        When ``date`` is provided, uses the public REST endpoint documented in
+        the PJM CLI user guide. Otherwise, triggers the public "Export To XML"
+        button on the guest dashboard (current ~3-day window).
 
         The XML contains Publish Time, Canceled Time, proper UTC start/end
         timestamps, and individual Region elements (one DataFrame row per
         message-region pair).
         """
-        if start is not None or stop is not None:
-            if url is not None:
-                raise ValueError(
-                    "Cannot pass url with start/stop; use the REST date range instead.",
-                )
-            xml_bytes = self._fetch_emergency_postings_rest(start=start, stop=stop)
+        if date is not None:
+            start = pd.Timestamp(date)
+            params = {
+                "start": f"{start.month:02d}-{start.day:02d}-{start.year}",
+            }
+            if end is not None:
+                stop = pd.Timestamp(end)
+                params["stop"] = f"{stop.month:02d}-{stop.day:02d}-{stop.year}"
+
+            logger.info(
+                f"GET emergency postings REST from {EMERGENCY_POSTINGS_PUBLIC_REST_URL} with params {params}...",
+            )
+            response = requests.get(
+                EMERGENCY_POSTINGS_PUBLIC_REST_URL,
+                params=params,
+                headers={"User-Agent": "Mozilla/5.0 (compatible; gridstatus)"},
+                timeout=REQUEST_TIMEOUT,
+            )
+            response.raise_for_status()
+            xml_bytes = response.content
         else:
             fetch_url = url or EMERGENCY_POSTINGS_GUEST_DASHBOARD_URL
             xml_bytes = self._fetch_emergency_xml(fetch_url)
         return self._parse_emergency_xml(xml_bytes)
-
-    @staticmethod
-    def _format_emergency_postings_date(
-        value: str | pd.Timestamp,
-    ) -> str:
-        ts = pd.Timestamp(value)
-        return f"{ts.month:02d}-{ts.day:02d}-{ts.year}"
-
-    def _fetch_emergency_postings_rest(
-        self,
-        start: str | pd.Timestamp | None,
-        stop: str | pd.Timestamp | None,
-    ) -> bytes:
-        params: dict[str, str] = {}
-        if start is not None:
-            params["start"] = self._format_emergency_postings_date(start)
-        if stop is not None:
-            params["stop"] = self._format_emergency_postings_date(stop)
-
-        logger.info(
-            "GET emergency postings REST from %s with params %s...",
-            EMERGENCY_POSTINGS_PUBLIC_REST_URL,
-            params,
-        )
-        response = requests.get(
-            EMERGENCY_POSTINGS_PUBLIC_REST_URL,
-            params=params,
-            headers={"User-Agent": "Mozilla/5.0 (compatible; gridstatus)"},
-            timeout=REQUEST_TIMEOUT,
-        )
-        response.raise_for_status()
-
-        content_type = response.headers.get("Content-Type", "")
-        if "xml" not in content_type:
-            raise NoDataFoundException(
-                f"Expected XML response but got Content-Type: {content_type}",
-            )
-
-        return response.content
 
     def _fetch_emergency_xml(self, url: str) -> bytes:
         session = requests.Session()

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -3781,7 +3781,7 @@ class PJM(ISOBase):
     @support_date_range(frequency="YEAR_START")
     def get_emergency_postings(
         self,
-        date: str | pd.Timestamp = "latest",
+        date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
@@ -3801,6 +3801,9 @@ class PJM(ISOBase):
                 EMERGENCY_POSTINGS_GUEST_DASHBOARD_URL,
             )
             return self._parse_emergency_xml(xml_bytes)
+
+        if end is None:
+            end = date
 
         logger.info(
             f"GET emergency postings REST from {EMERGENCY_POSTINGS_PUBLIC_REST_URL}...",
@@ -3889,7 +3892,21 @@ class PJM(ISOBase):
                 )
 
         if not rows:
-            raise NoDataFoundException("No emergency procedure messages found in XML")
+            return pd.DataFrame(
+                columns=[
+                    "Message ID",
+                    "Applicable Start",
+                    "Applicable End",
+                    "Publish Time",
+                    "Message Type",
+                    "Priority",
+                    "Region",
+                    "Effective Start",
+                    "Effective End",
+                    "Canceled Time",
+                    "Emergency Message",
+                ],
+            )
 
         df = pd.DataFrame(rows)
         for col in (

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -3778,47 +3778,44 @@ class PJM(ISOBase):
             .reset_index(drop=True)
         )
 
+    @support_date_range(frequency="YEAR_START")
     def get_emergency_postings(
         self,
-        url: str | None = None,
-        date: str | pd.Timestamp | None = None,
+        date: str | pd.Timestamp = "latest",
         end: str | pd.Timestamp | None = None,
+        verbose: bool = False,
     ) -> pd.DataFrame:
         """
         Retrieves PJM emergency procedure postings.
 
-        When ``date`` is provided, uses the public REST endpoint documented in
-        the PJM CLI user guide. Otherwise, triggers the public "Export To XML"
-        button on the guest dashboard (current ~3-day window).
+        When ``date`` is ``"latest"``, triggers the public "Export To XML" button
+        on the guest dashboard (current ~3-day window). Otherwise, uses the
+        public REST endpoint documented in the PJM CLI user guide.
 
         The XML contains Publish Time, Canceled Time, proper UTC start/end
         timestamps, and individual Region elements (one DataFrame row per
         message-region pair).
         """
-        if date is not None:
-            start = pd.Timestamp(date)
-            params = {
-                "start": f"{start.month:02d}-{start.day:02d}-{start.year}",
-            }
-            if end is not None:
-                stop = pd.Timestamp(end)
-                params["stop"] = f"{stop.month:02d}-{stop.day:02d}-{stop.year}"
+        if date == "latest":
+            xml_bytes = self._fetch_emergency_xml(
+                EMERGENCY_POSTINGS_GUEST_DASHBOARD_URL,
+            )
+            return self._parse_emergency_xml(xml_bytes)
 
-            logger.info(
-                f"GET emergency postings REST from {EMERGENCY_POSTINGS_PUBLIC_REST_URL} with params {params}...",
-            )
-            response = requests.get(
-                EMERGENCY_POSTINGS_PUBLIC_REST_URL,
-                params=params,
-                headers={"User-Agent": "Mozilla/5.0 (compatible; gridstatus)"},
-                timeout=REQUEST_TIMEOUT,
-            )
-            response.raise_for_status()
-            xml_bytes = response.content
-        else:
-            fetch_url = url or EMERGENCY_POSTINGS_GUEST_DASHBOARD_URL
-            xml_bytes = self._fetch_emergency_xml(fetch_url)
-        return self._parse_emergency_xml(xml_bytes)
+        logger.info(
+            f"GET emergency postings REST from {EMERGENCY_POSTINGS_PUBLIC_REST_URL}...",
+        )
+        response = requests.get(
+            EMERGENCY_POSTINGS_PUBLIC_REST_URL,
+            params={
+                "start": date.strftime("%m-%d-%Y"),
+                "stop": end.strftime("%m-%d-%Y"),
+            },
+            headers={"User-Agent": "Mozilla/5.0 (compatible; gridstatus)"},
+            timeout=REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+        return self._parse_emergency_xml(response.content)
 
     def _fetch_emergency_xml(self, url: str) -> bytes:
         session = requests.Session()

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -3796,6 +3796,10 @@ class PJM(ISOBase):
         message-region pair).
         """
         if start is not None or stop is not None:
+            if url is not None:
+                raise ValueError(
+                    "Cannot pass url with start/stop; use the REST date range instead.",
+                )
             xml_bytes = self._fetch_emergency_postings_rest(start=start, stop=stop)
         else:
             fetch_url = url or EMERGENCY_POSTINGS_GUEST_DASHBOARD_URL

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -24,6 +24,7 @@ from gridstatus.lmp_config import lmp_config
 from gridstatus.pjm_constants import (
     DEFAULT_RETRIES,
     EMERGENCY_POSTINGS_GUEST_DASHBOARD_URL,
+    EMERGENCY_POSTINGS_PUBLIC_REST_URL,
     HUB_NODE_IDS,
     LOCATION_TYPES,
     PRICE_NODE_IDS,
@@ -3777,22 +3778,68 @@ class PJM(ISOBase):
             .reset_index(drop=True)
         )
 
-    def get_emergency_postings(self, url: str | None = None) -> pd.DataFrame:
+    def get_emergency_postings(
+        self,
+        url: str | None = None,
+        start: str | pd.Timestamp | None = None,
+        stop: str | pd.Timestamp | None = None,
+    ) -> pd.DataFrame:
         """
-        Retrieves PJM emergency procedure postings by triggering the public
-        "Export To XML" button on the guest dashboard.
+        Retrieves PJM emergency procedure postings.
 
-        Two-step flow (no credentials required):
-          1. GET the guest dashboard to obtain a session cookie and JSF ViewState.
-          2. POST ``frmButtons:lnkDownload`` to download the XML export.
+        When ``start`` or ``stop`` is provided, uses the public REST endpoint
+        documented in the PJM CLI user guide. Otherwise, triggers the public
+        "Export To XML" button on the guest dashboard (current ~3-day window).
 
         The XML contains Publish Time, Canceled Time, proper UTC start/end
         timestamps, and individual Region elements (one DataFrame row per
         message-region pair).
         """
-        fetch_url = url or EMERGENCY_POSTINGS_GUEST_DASHBOARD_URL
-        xml_bytes = self._fetch_emergency_xml(fetch_url)
+        if start is not None or stop is not None:
+            xml_bytes = self._fetch_emergency_postings_rest(start=start, stop=stop)
+        else:
+            fetch_url = url or EMERGENCY_POSTINGS_GUEST_DASHBOARD_URL
+            xml_bytes = self._fetch_emergency_xml(fetch_url)
         return self._parse_emergency_xml(xml_bytes)
+
+    @staticmethod
+    def _format_emergency_postings_date(
+        value: str | pd.Timestamp,
+    ) -> str:
+        ts = pd.Timestamp(value)
+        return f"{ts.month:02d}-{ts.day:02d}-{ts.year}"
+
+    def _fetch_emergency_postings_rest(
+        self,
+        start: str | pd.Timestamp | None,
+        stop: str | pd.Timestamp | None,
+    ) -> bytes:
+        params: dict[str, str] = {}
+        if start is not None:
+            params["start"] = self._format_emergency_postings_date(start)
+        if stop is not None:
+            params["stop"] = self._format_emergency_postings_date(stop)
+
+        logger.info(
+            "GET emergency postings REST from %s with params %s...",
+            EMERGENCY_POSTINGS_PUBLIC_REST_URL,
+            params,
+        )
+        response = requests.get(
+            EMERGENCY_POSTINGS_PUBLIC_REST_URL,
+            params=params,
+            headers={"User-Agent": "Mozilla/5.0 (compatible; gridstatus)"},
+            timeout=REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+
+        content_type = response.headers.get("Content-Type", "")
+        if "xml" not in content_type:
+            raise NoDataFoundException(
+                f"Expected XML response but got Content-Type: {content_type}",
+            )
+
+        return response.content
 
     def _fetch_emergency_xml(self, url: str) -> bytes:
         session = requests.Session()

--- a/gridstatus/pjm_constants.py
+++ b/gridstatus/pjm_constants.py
@@ -5,6 +5,10 @@ EMERGENCY_POSTINGS_GUEST_DASHBOARD_URL: str = (
     "https://emergencyprocedures.pjm.com/ep/pages/dashboard.jsf"
 )
 
+EMERGENCY_POSTINGS_PUBLIC_REST_URL: str = (
+    "https://emergencyprocedures.pjm.com/ep/rest/public/posting"
+)
+
 # Timeout for API requests in seconds (connect, read)
 CONNECT_TIMEOUT_SECONDS = 10
 READ_TIMEOUT_SECONDS = 15

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -3258,8 +3258,8 @@ class TestPJM(BaseTestISO):
             return_value=mock_response,
         ) as mock_get:
             df = self.iso.get_emergency_postings(
-                start="2016-01-01",
-                stop="2016-12-31",
+                date="2016-01-01",
+                end="2016-12-31",
             )
 
         mock_get.assert_called_once()
@@ -3269,16 +3269,6 @@ class TestPJM(BaseTestISO):
         }
         assert len(df) == 1
         assert df["Message ID"].iloc[0] == 1
-
-    def test_get_emergency_postings_rejects_url_with_date_range(self):
-        with pytest.raises(
-            ValueError,
-            match="Cannot pass url with start/stop",
-        ):
-            self.iso.get_emergency_postings(
-                url="https://example.test/dashboard.jsf",
-                start="2016-01-01",
-            )
 
     """get_voltage_limits"""
 

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -3246,6 +3246,30 @@ class TestPJM(BaseTestISO):
             == "frmButtons:lnkDownload"
         )
 
+    def test_get_emergency_postings_rest_date_range(self):
+        mock_response = mock.Mock()
+        mock_response.content = self.SAMPLE_XML
+        mock_response.status_code = 200
+        mock_response.headers = {"Content-Type": "application/xml"}
+        mock_response.raise_for_status = mock.Mock()
+
+        with mock.patch(
+            "gridstatus.pjm.requests.get",
+            return_value=mock_response,
+        ) as mock_get:
+            df = self.iso.get_emergency_postings(
+                start="2016-01-01",
+                stop="2016-12-31",
+            )
+
+        mock_get.assert_called_once()
+        assert mock_get.call_args.kwargs["params"] == {
+            "start": "01-01-2016",
+            "stop": "12-31-2016",
+        }
+        assert len(df) == 1
+        assert df["Message ID"].iloc[0] == 1
+
     """get_voltage_limits"""
 
     def _check_voltage_limits(self, df):

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -3270,6 +3270,16 @@ class TestPJM(BaseTestISO):
         assert len(df) == 1
         assert df["Message ID"].iloc[0] == 1
 
+    def test_get_emergency_postings_rejects_url_with_date_range(self):
+        with pytest.raises(
+            ValueError,
+            match="Cannot pass url with start/stop",
+        ):
+            self.iso.get_emergency_postings(
+                url="https://example.test/dashboard.jsf",
+                start="2016-01-01",
+            )
+
     """get_voltage_limits"""
 
     def _check_voltage_limits(self, df):

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -3266,6 +3266,27 @@ class TestPJM(BaseTestISO):
         assert len(df) == 1
         assert df["Message ID"].iloc[0] == 1
 
+    def test_get_emergency_postings_rest_empty(self):
+        empty_xml = (
+            b'<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            b"<ns2:EmergencyProcedures "
+            b'xmlns:ns2="http://www.pjm.com/external/schemas/emergencyprocedures/v1"/>'
+        )
+        mock_response = mock.Mock()
+        mock_response.content = empty_xml
+        mock_response.status_code = 200
+        mock_response.headers = {"Content-Type": "application/xml"}
+        mock_response.raise_for_status = mock.Mock()
+
+        with mock.patch(
+            "gridstatus.pjm.requests.get",
+            return_value=mock_response,
+        ):
+            df = self.iso.get_emergency_postings(date="2026-01-01")
+
+        assert df.empty
+        assert df.columns.tolist() == self.expected_emergency_postings_cols
+
     """get_voltage_limits"""
 
     def _check_voltage_limits(self, df):

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -3184,9 +3184,7 @@ class TestPJM(BaseTestISO):
             self.SAMPLE_XML,
         )
         with mock.patch("gridstatus.pjm.requests.Session", return_value=mock_session):
-            df = self.iso.get_emergency_postings(
-                url="https://example.test/dashboard.jsf",
-            )
+            df = self.iso.get_emergency_postings(date="latest")
 
         assert df.columns.tolist() == self.expected_emergency_postings_cols
         assert len(df) == 1
@@ -3223,9 +3221,7 @@ class TestPJM(BaseTestISO):
             xml,
         )
         with mock.patch("gridstatus.pjm.requests.Session", return_value=mock_session):
-            df = self.iso.get_emergency_postings(
-                url="https://example.test/dashboard.jsf",
-            )
+            df = self.iso.get_emergency_postings(date="latest")
 
         assert len(df) == 2
         assert set(df["Region"]) == {"SOUTHERN", "MIDATL"}
@@ -3237,7 +3233,7 @@ class TestPJM(BaseTestISO):
             self.SAMPLE_XML,
         )
         with mock.patch("gridstatus.pjm.requests.Session", return_value=mock_session):
-            self.iso.get_emergency_postings(url="https://example.test/dashboard.jsf")
+            self.iso.get_emergency_postings(date="latest")
 
         post_call = mock_session.post.call_args
         assert post_call.kwargs["data"]["javax.faces.ViewState"] == "123:456"


### PR DESCRIPTION
## Summary
- Adds date range support to `get_emergency_postings()` that fetch via PJM's public REST endpoint (`/ep/rest/public/posting`). Originally we found the dashboard parsing to be faster and easier, but the public rest endpoint also works. 
- Existing behavior is now called `latest`, since we can get the most recent messages via that original pathway and the downstream approach is mostly unchanged. 

## Why
The live ETL only captured recent postings because the dashboard export defaults to a rolling 2–3 day filter. Historical backfill requires querying by date range; the REST API supports this without JSF session management. This option didn't seem available when originally implemented, but is helpful for backfills. No need to boil the ocean here.

## Test plan
- [x] `uv run pytest gridstatus/tests/source_specific/test_pjm.py -k emergency -vv`
- [ ] Merge and tag; gs-etl PR depends on this rev


Made with [Cursor](https://cursor.com)