### PR TITLE
feat(ENG 3096): Add EIA Facility Fuel scraper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 ### Additions (New Features/Datasets)
 
+#### EIA
+* EIA Facility Fuel (EIA-923) dataset in [#912](https://github.com/gridstatus/gridstatus/pull/912)
+
 #### ERCOT
 * ERCOT Available Resource Planned Outage Capacity 7 Day and Future datasets in [#884](https://github.com/gridstatus/gridstatus/pull/884)
 

--- a/gridstatus/eia.py
+++ b/gridstatus/eia.py
@@ -683,8 +683,6 @@ class EIA:
             "data": FACILITY_FUEL_DATA_FIELDS,
             "offset": 0,
             "length": page_size,
-            # pagination breaks if not sorted because
-            # api doesn't return in stable order across requests
             "sort": [
                 {"column": col, "direction": "asc"}
                 for col in ["period", "plantCode", "fuel2002", "fuelType", "primeMover"]

--- a/gridstatus/eia.py
+++ b/gridstatus/eia.py
@@ -38,6 +38,13 @@ HENRY_HUB_NATURAL_GAS_SPOT_PRICES_PATH = "natural-gas/pri/fut"
 # Physical location of Henry Hub is Louisiana
 HENRY_HUB_TIMEZONE = "US/Central"
 
+FACILITY_FUEL_ZIP_URLS = [
+    "https://www.eia.gov/electricity/data/eia923/xls/f923_{year}.zip",
+    "https://www.eia.gov/electricity/data/eia923/xls/f923_{year}er.zip",
+    "https://www.eia.gov/electricity/data/eia923/archive/xls/f923_{year}.zip",
+    "https://www.eia.gov/electricity/data/eia923/archive/xls/f906920_{year}.zip",
+]
+
 
 class EIA:
     BASE_URL = "https://api.eia.gov/v2/"
@@ -652,6 +659,10 @@ class EIA:
 
         https://www.eia.gov/electricity/data/eia923/
 
+        The Updated At column is the Last-Modified time of the per-year EIA-923
+        zip file that contains each row's period, falling back to the fetch time
+        if the file cannot be found.
+
         Args:
             date (str or pd.Timestamp): Start month to fetch data for. Truncated
                 to the beginning of the month.
@@ -698,7 +709,10 @@ class EIA:
             logger.info(f"Fetching data from {url}")
             logger.info(f"Params: {params}")
 
-        updated_at = pd.Timestamp.utcnow().floor("s")
+        updated_at_by_year = {
+            year: self._get_facility_fuel_updated_at(year, verbose=verbose)
+            for year in range(date.year, (end or date).year + 1)
+        }
 
         raw_df, total_records = self._fetch_page(url, headers)
 
@@ -723,19 +737,50 @@ class EIA:
 
         df = pd.concat(page_dfs, ignore_index=True)
 
-        return self._handle_facility_fuel(df, updated_at=updated_at)
+        return self._handle_facility_fuel(df, updated_at_by_year=updated_at_by_year)
+
+    def _get_facility_fuel_updated_at(
+        self,
+        year: int,
+        verbose: bool = False,
+    ) -> pd.Timestamp:
+        """Get the publication time of a year of EIA-923 data from the
+        Last-Modified header of the per-year zip file on the EIA-923 page.
+
+        The zip file URL moves as the release cycle progresses (current year,
+        early release, archive, and the pre-2008 form 906/920 naming), so try
+        each known location. URLs that don't exist redirect to a landing page
+        instead of returning a 404.
+        """
+        for url_template in FACILITY_FUEL_ZIP_URLS:
+            zip_url = url_template.format(year=year)
+            response = self.session.head(zip_url, allow_redirects=False)
+
+            if response.status_code == 200 and "Last-Modified" in response.headers:
+                if verbose:
+                    logger.info(f"Using Last-Modified of {zip_url} as Updated At")
+                return pd.to_datetime(response.headers["Last-Modified"], utc=True)
+
+        logger.warning(
+            f"Could not find an EIA-923 zip file for {year}. "
+            "Using the fetch time as Updated At.",
+        )
+
+        return pd.Timestamp.utcnow().floor("s")
 
     def _handle_facility_fuel(
         self,
         df: pd.DataFrame,
-        updated_at: pd.Timestamp,
+        updated_at_by_year: dict[int, pd.Timestamp],
     ) -> pd.DataFrame:
+        periods = pd.to_datetime(df["period"], format="%Y-%m")
+
+        df.insert(0, "Period", periods.dt.date)
         df.insert(
-            0,
-            "Period",
-            pd.to_datetime(df["period"], format="%Y-%m").dt.date,
+            1,
+            "Updated At",
+            pd.to_datetime(periods.dt.year.map(updated_at_by_year), utc=True),
         )
-        df.insert(1, "Updated At", updated_at)
 
         df = df.rename(columns=FACILITY_FUEL_COLUMN_RENAMES)
 

--- a/gridstatus/eia.py
+++ b/gridstatus/eia.py
@@ -20,6 +20,10 @@ from gridstatus.eia_constants import (
     CANCELED_OR_POSTPONED_GENERATOR_COLUMNS,
     EIA_FUEL_MIX_COLUMNS,
     EIA_FUEL_TYPES,
+    FACILITY_FUEL_COLUMN_RENAMES,
+    FACILITY_FUEL_COLUMNS,
+    FACILITY_FUEL_DATA_FIELDS,
+    FACILITY_FUEL_FLOAT_COLUMNS,
     GENERATOR_FLOAT_COLUMNS,
     GENERATOR_INT_COLUMNS,
     OPERATING_GENERATOR_COLUMNS,
@@ -636,6 +640,117 @@ class EIA:
         )
 
         return data
+
+    def get_facility_fuel(
+        self,
+        date: str | pd.Timestamp,
+        end: str | pd.Timestamp = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Monthly electric power operations for individual power plants, by fuel
+        type and prime mover, as reported in the EIA-923 dataset.
+
+        https://www.eia.gov/electricity/data/eia923/
+
+        Args:
+            date (str or pd.Timestamp): Start month to fetch data for. Truncated
+                to the beginning of the month.
+            end (str or pd.Timestamp, optional): End month to fetch data for,
+                inclusive. Truncated to the beginning of the month. Defaults to
+                the start month.
+            verbose (bool, optional): Whether to print progress. Defaults to False.
+
+        Returns:
+            pd.DataFrame: DataFrame with monthly plant-level generation and fuel
+                consumption data.
+        """
+        date = utils._handle_date(date, "UTC")
+        start_str = date.strftime("%Y-%m")
+
+        end_str = start_str
+        if end is not None:
+            end = utils._handle_date(end, "UTC")
+            end_str = end.strftime("%Y-%m")
+
+        url = f"{self.BASE_URL}electricity/facility-fuel/data/"
+
+        page_size = 5000
+
+        params = {
+            "start": start_str,
+            "end": end_str,
+            "frequency": "monthly",
+            "data": FACILITY_FUEL_DATA_FIELDS,
+            "offset": 0,
+            "length": page_size,
+            # pagination breaks if not sorted because
+            # api doesn't return in stable order across requests
+            "sort": [
+                {"column": col, "direction": "asc"}
+                for col in ["period", "plantCode", "fuel2002", "fuelType", "primeMover"]
+            ],
+        }
+
+        headers = {
+            "X-Api-Key": self.api_key,
+            "X-Params": json.dumps(params),
+        }
+
+        if verbose:
+            logger.info(f"Fetching data from {url}")
+            logger.info(f"Params: {params}")
+
+        updated_at = pd.Timestamp.utcnow().floor("s")
+
+        raw_df, total_records = self._fetch_page(url, headers)
+
+        if total_records == 0:
+            raise NoDataFoundException(
+                f"No EIA facility fuel data found between {start_str} and {end_str}",
+            )
+
+        total_pages = (total_records + page_size - 1) // page_size
+
+        if verbose:
+            logger.info(f"Total records: {total_records}")
+            logger.info(f"Total pages: {total_pages}")
+
+        page_dfs = [raw_df]
+
+        for page in range(1, total_pages):
+            params["offset"] = page * page_size
+            headers["X-Params"] = json.dumps(params)
+            page_df, _ = self._fetch_page(url, headers)
+            page_dfs.append(page_df)
+
+        df = pd.concat(page_dfs, ignore_index=True)
+
+        return self._handle_facility_fuel(df, updated_at=updated_at)
+
+    def _handle_facility_fuel(
+        self,
+        df: pd.DataFrame,
+        updated_at: pd.Timestamp,
+    ) -> pd.DataFrame:
+        df.insert(
+            0,
+            "Period",
+            pd.to_datetime(df["period"], format="%Y-%m").dt.date,
+        )
+        df.insert(1, "Updated At", updated_at)
+
+        df = df.rename(columns=FACILITY_FUEL_COLUMN_RENAMES)
+
+        df["Plant Code"] = df["Plant Code"].astype("Int64")
+
+        for col in FACILITY_FUEL_FLOAT_COLUMNS:
+            df[col] = df[col].replace({"NA": None}).astype(float)
+
+        df = df.sort_values(
+            ["Period", "Plant Code", "Fuel Code", "Fuel Type", "Prime Mover"],
+        ).reset_index(drop=True)
+
+        return df[FACILITY_FUEL_COLUMNS]
 
     def get_generators(
         self,

--- a/gridstatus/eia_constants.py
+++ b/gridstatus/eia_constants.py
@@ -139,6 +139,76 @@ CANCELED_OR_POSTPONED_GENERATOR_COLUMNS = [
     "Longitude",
 ]
 
+FACILITY_FUEL_DATA_FIELDS = [
+    "average-heat-content",
+    "consumption-for-eg",
+    "consumption-for-eg-btu",
+    "generation",
+    "gross-generation",
+    "total-consumption",
+    "total-consumption-btu",
+]
+
+FACILITY_FUEL_COLUMN_RENAMES = {
+    "plantCode": "Plant Code",
+    "plantName": "Plant Name",
+    "fuel2002": "Fuel Code",
+    "fuelType": "Fuel Type",
+    "fuelTypeDescription": "Fuel Type Description",
+    "state": "Plant State",
+    "primeMover": "Prime Mover",
+    "average-heat-content": "Average Heat Content",
+    "average-heat-content-units": "Average Heat Content Units",
+    "consumption-for-eg": "Consumption for EG",
+    "consumption-for-eg-units": "Consumption for EG Units",
+    "consumption-for-eg-btu": "Consumption for EG Btu",
+    "consumption-for-eg-btu-units": "Consumption for EG Btu Units",
+    "generation": "Generation",
+    "generation-units": "Generation Units",
+    "gross-generation": "Gross Generation",
+    "gross-generation-units": "Gross Generation Units",
+    "total-consumption": "Total Consumption",
+    "total-consumption-units": "Total Consumption Units",
+    "total-consumption-btu": "Total Consumption Btu",
+    "total-consumption-btu-units": "Total Consumption Btu Units",
+}
+
+FACILITY_FUEL_COLUMNS = [
+    "Period",
+    "Updated At",
+    "Plant Code",
+    "Plant Name",
+    "Fuel Code",
+    "Fuel Type",
+    "Fuel Type Description",
+    "Plant State",
+    "Prime Mover",
+    "Average Heat Content",
+    "Average Heat Content Units",
+    "Consumption for EG",
+    "Consumption for EG Units",
+    "Consumption for EG Btu",
+    "Consumption for EG Btu Units",
+    "Generation",
+    "Generation Units",
+    "Gross Generation",
+    "Gross Generation Units",
+    "Total Consumption",
+    "Total Consumption Units",
+    "Total Consumption Btu",
+    "Total Consumption Btu Units",
+]
+
+FACILITY_FUEL_FLOAT_COLUMNS = [
+    "Average Heat Content",
+    "Consumption for EG",
+    "Consumption for EG Btu",
+    "Generation",
+    "Gross Generation",
+    "Total Consumption",
+    "Total Consumption Btu",
+]
+
 GENERATOR_FLOAT_COLUMNS = [
     "Nameplate Capacity",
     "Net Summer Capacity",

--- a/gridstatus/tests/source_specific/test_eia.py
+++ b/gridstatus/tests/source_specific/test_eia.py
@@ -10,6 +10,8 @@ from gridstatus.eia import EIA, HENRY_HUB_TIMEZONE
 from gridstatus.eia_constants import (
     CANCELED_OR_POSTPONED_GENERATOR_COLUMNS,
     EIA_FUEL_MIX_COLUMNS,
+    FACILITY_FUEL_COLUMNS,
+    FACILITY_FUEL_FLOAT_COLUMNS,
     GENERATOR_FLOAT_COLUMNS,
     GENERATOR_INT_COLUMNS,
     OPERATING_GENERATOR_COLUMNS,
@@ -449,6 +451,60 @@ def _check_generators_data(
     for col in GENERATOR_INT_COLUMNS:
         if col in df.columns:
             assert pd.api.types.is_integer_dtype(df[col])
+
+
+def _check_facility_fuel_data(
+    df: pd.DataFrame,
+    expected_periods: List[datetime.date],
+):
+    assert df.columns.tolist() == FACILITY_FUEL_COLUMNS
+
+    assert df.shape[0] > 0
+    assert sorted(df["Period"].unique()) == expected_periods
+
+    assert df["Updated At"].dtype == "datetime64[us, UTC]"
+    assert df["Updated At"].nunique() == 1
+
+    assert pd.api.types.is_integer_dtype(df["Plant Code"])
+    assert df["Plant Code"].notna().all()
+
+    for col in FACILITY_FUEL_FLOAT_COLUMNS:
+        assert pd.api.types.is_float_dtype(df[col])
+
+    assert (
+        df.duplicated(
+            subset=["Period", "Plant Code", "Fuel Code", "Fuel Type", "Prime Mover"],
+        ).sum()
+        == 0
+    )
+
+
+def test_get_facility_fuel_single_month():
+    date = "2024-01-01"
+
+    with api_vcr.use_cassette("test_get_facility_fuel_single_month_2024-01"):
+        df = EIA().get_facility_fuel(date)
+
+    _check_facility_fuel_data(
+        df,
+        expected_periods=[datetime.date(2024, 1, 1)],
+    )
+
+
+def test_get_facility_fuel_date_range():
+    start = "2023-12-01"
+    end = "2024-01-01"
+
+    with api_vcr.use_cassette("test_get_facility_fuel_date_range_2023-12_2024-01"):
+        df = EIA().get_facility_fuel(start, end=end)
+
+    _check_facility_fuel_data(
+        df,
+        expected_periods=[
+            datetime.date(2023, 12, 1),
+            datetime.date(2024, 1, 1),
+        ],
+    )
 
 
 def test_get_generators_relative_date():

--- a/gridstatus/tests/source_specific/test_eia.py
+++ b/gridstatus/tests/source_specific/test_eia.py
@@ -462,8 +462,13 @@ def _check_facility_fuel_data(
     assert df.shape[0] > 0
     assert sorted(df["Period"].unique()) == expected_periods
 
-    assert df["Updated At"].dtype == "datetime64[us, UTC]"
-    assert df["Updated At"].nunique() == 1
+    assert isinstance(df["Updated At"].dtype, pd.DatetimeTZDtype)
+    assert df["Updated At"].notna().all()
+
+    period_years = pd.to_datetime(df["Period"]).dt.year
+    for year, group in df.groupby(period_years):
+        assert group["Updated At"].nunique() == 1
+        assert (group["Updated At"].dt.year >= year).all()
 
     assert pd.api.types.is_integer_dtype(df["Plant Code"])
     assert df["Plant Code"].notna().all()


### PR DESCRIPTION
## Summary
- Adds `get_facility_fuel` scraper for EIA

### Details
Pulls monthly electric power operations for individual power plants from the EIA v2 API `electricity/facility-fuel` endpoint (Form EIA-923 data). Each row is a plant/fuel/prime-mover combination for a month and includes net and gross generation, fuel consumption in physical units and BTUs, and average heat content, along with the units columns the API provides. The data includes EIA's roll-up rows (`ALL` fuel and prime mover codes and the synthetic plant code 99999 state-fuel-level increment rows), which are kept as reported. Both `fuel2002` (as Fuel Code) and `fuelType` (as Fuel Type) are kept because a plant month can report the same 2002-era fuel code under multiple modern fuel types (for example WAT as both HYC and HPS), so the fuel type is needed to uniquely identify rows. Pagination is sequential with a stable sort to avoid the API's unstable ordering across requests. The Updated At column is the publication time of each row's period, taken from the Last-Modified header of the per-year EIA-923 zip file on the EIA-923 page (checking the current, early-release, archive, and pre-2008 form 906/920 URL locations), falling back to the fetch time if no file is found. Data is available back to 2001.

To run tests:
```bash
VCR_RECORD_MODE=all uv run pytest -vvv gridstatus/tests/ -k "eia and facility_fuel"
```