### PR TITLE
NYISO: add capacity auction results via get_capacity_market_results (#687)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@
 #### MISO
 * MISO Area Control Error dataset via `MISO.get_area_control_error`
 
+#### NYISO
+* NYISO capacity auction results via `NYISO.get_capacity_market_results`, parsing the stable public monthly ICAP Market Report. Returns a tidy, one-row-per-(delivery month, capacity locality) DataFrame of Spot / Monthly / Strip auction clearing prices (published UCAP price and derived ICAP price, in $/kW-month), the locational EFORd translation factor, and the delivery-month cleared quantity and requirement, by NYISO capacity locality (NYCA, G-J Locality, NYC/Zone J, Long Island/Zone K). Supports `"latest"`, a single month, or a `date`/`end` range. Partially addresses [#687](https://github.com/gridstatus/gridstatus/issues/687); demand curves, masked bid data, LSE-specific obligations, settlement charges, non-delivery penalties, and scarcity-related settlement data are out of scope and left to follow-up work.
+
+### Fixes
+
+#### NYISO
+* `NYISO.get_capacity_prices` now uses shared ICAP Market Report URL resolution, including versioned, URL-encoded, and legacy `.xls` filename handling. Existing return schema is unchanged.
+
 ## v0.36.0 - April 20, 2026
 
 ### Additions (New Features/Datasets)

--- a/docs/Examples/nyiso/Capacity Prices - NYISO.ipynb
+++ b/docs/Examples/nyiso/Capacity Prices - NYISO.ipynb
@@ -471,6 +471,78 @@
     "fig.update_layout(xaxis_title=\"Date\", yaxis_title=\"Megawatts (MW)\")\n",
     "fig.show(\"svg\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Auction Results: Spot, Monthly, and Strip\n",
+    "\n",
+    "`get_capacity_prices` above returns the raw, wide \"MCP Table\" from the monthly ICAP Market Report. For a tidy, analysis-ready view use `get_capacity_market_results`, which returns one row per (delivery month, capacity locality) for a chosen auction type.\n",
+    "\n",
+    "NYISO reports capacity prices by *capacity locality* (NYCA, G-J, NYC / Zone J, Long Island / Zone K), not as 11 independent load-zone prices. Capacity clears on an Unforced Capacity (UCAP) basis, so the published clearing price is the UCAP price in $/kW-month. The ICAP-equivalent price is derived from the report's locational EFORd: `ICAP = UCAP * (1 - EFORd)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iso.get_capacity_market_results(\"latest\", auction_type=\"spot\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Fetch all three auction types for the latest delivery month and compare their clearing prices:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "latest = pd.concat(\n",
+    "    iso.get_capacity_market_results(\"latest\", auction_type=a)\n",
+    "    for a in [\"spot\", \"monthly\", \"strip\"]\n",
+    ")\n",
+    "latest[\n",
+    "    [\"Auction Type\", \"Location\", \"UCAP Clearing Price\", \"ICAP Clearing Price\"]\n",
+    "].reset_index(drop=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Retrieve a range of delivery months and plot the UCAP vs. ICAP spot clearing price for New York City (Zone J):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spot = iso.get_capacity_market_results(\n",
+    "    \"Jan 1, 2024\", end=\"Jul 1, 2024\", auction_type=\"spot\"\n",
+    ")\n",
+    "nyc = spot[spot[\"Location\"] == \"NYC (Zone J)\"]\n",
+    "\n",
+    "fig = px.line(\n",
+    "    nyc,\n",
+    "    x=\"Interval Start\",\n",
+    "    y=[\"UCAP Clearing Price\", \"ICAP Clearing Price\"],\n",
+    "    title=\"NYISO NYC (Zone J) Spot Capacity Clearing Price: UCAP vs ICAP\",\n",
+    ")\n",
+    "fig.update_layout(xaxis_title=\"Delivery Month\", yaxis_title=\"$/kW-month\")\n",
+    "fig.show(\"svg\")"
+   ]
   }
  ],
  "metadata": {

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -1,7 +1,7 @@
 import warnings
 from enum import StrEnum
 from io import BytesIO
-from typing import BinaryIO, Dict, Literal, NamedTuple
+from typing import BinaryIO, Dict, Literal, NamedTuple, cast
 
 import pandas as pd
 import requests
@@ -48,6 +48,74 @@ AS_PRICES_DAY_AHEAD_HOURLY_DATASET = "damasp"
 AS_PRICES_REAL_TIME_5_MIN_DATASET = "rtasp"
 LIMITING_CONSTRAINTS_REAL_TIME_DATASET = "LimitingConstraints"
 LIMITING_CONSTRAINTS_DAY_AHEAD_DATASET = "DAMLimitingConstraints"
+
+
+# NYISO's three Installed Capacity (ICAP) auction types. NYISO capacity is bought
+# and sold on an Unforced Capacity (UCAP) basis, so the clearing prices published
+# in the monthly ICAP Market Report are UCAP-denominated ($/kW-month).
+class CapacityAuctionType(StrEnum):
+    STRIP = "strip"  # 6-month Capability Period strip auction
+    MONTHLY = "monthly"  # voluntary forward monthly auction
+    SPOT = "spot"  # mandatory monthly spot auction (settlement price)
+
+
+# The monthly ICAP Market Report lives under a per-year document-folder id in
+# NYISO's document store (https://www.nyiso.com/documents/20142/<folder-id>/...).
+# The folder id changes every year; new years must be added here as they publish.
+CAPACITY_REPORT_YEAR_CODES: Dict[int, int] = {
+    2014: 1410927,
+    2015: 1410895,
+    2016: 1410901,
+    2017: 1410883,
+    2018: 1410889,
+    2019: 4266869,
+    2020: 10106066,
+    2021: 18170164,
+    2022: 27447313,
+    2023: 35397361,
+    2024: 42146126,
+    2025: 48997190,
+    2026: 56195933,
+}
+
+# NYISO capacity prices are published by *capacity locality* (a small set of
+# nested zones), not as 11 independent load-zone prices. The data sheets label
+# each locality with a short code; map them to descriptive, stable names for the
+# tidy output. The G-J Locality (Lower Hudson Valley) was added May 1, 2014;
+# earlier reports contain only NYCA, NYC and Long Island. Locality parsing is
+# driven by these labels (not by column position), so a report with a different
+# set of localities is handled correctly rather than mislabeled.
+CAPACITY_LOCALITY_MAP: Dict[str, str] = {
+    "NYCA": "NYCA",
+    "GHIJ": "G-J Locality",
+    "NYC": "NYC (Zone J)",
+    "LI": "Long Island (Zone K)",
+}
+
+# The report cover sheet ("ICAP Market Report") spells the localities out in full.
+# Normalized (stripped/lower-cased) label -> standardized locality name, used to
+# map each cover-sheet column to a locality by its header text rather than by a
+# fixed left-to-right order.
+COVER_LOCALITY_LABELS: Dict[str, str] = {
+    "new york control area": "NYCA",
+    "nyca": "NYCA",
+    "g-j locality": "G-J Locality",
+    "ghij": "G-J Locality",
+    "new york city": "NYC (Zone J)",
+    "long island": "Long Island (Zone K)",
+}
+
+# Sheet that carries the auction clearing prices. Report vintages before ~2019
+# use a different, single-sheet ("ICAP Market Report") layout without this sheet;
+# those are not supported by the tidy parser (a clear error is raised instead).
+CAPACITY_MCP_SHEET = "MCP Table"
+
+# auction_type argument -> column label used in the "MCP Table" sheet
+CAPACITY_AUCTION_COLUMN = {
+    "strip": "Strip",
+    "monthly": "Monthly",
+    "spot": "Spot",
+}
 
 """
 Pricing data:
@@ -1513,12 +1581,135 @@ class NYISO(ISOBase):
 
         return pd.Timestamp(last_updated_date, tz=self.default_timezone)
 
+    def _capacity_report_candidate_urls(self, date: pd.Timestamp) -> list[str]:
+        """Build the ordered list of candidate URLs for a month's ICAP Market Report.
+
+        NYISO publishes the monthly ICAP Market Report under a per-year document
+        folder, but the exact filename varies by vintage: revised reports get a
+        ``-Version-N`` suffix, some months (e.g. December 2023) use URL-encoded
+        spaces instead of hyphens, and older reports are legacy ``.xls`` files.
+        Candidates are returned most-specific-first so the newest revision wins.
+        """
+        year_code = CAPACITY_REPORT_YEAR_CODES.get(date.year)
+        if year_code is None:
+            raise ValueError(
+                f"Year {date.year} is not currently supported for capacity "
+                "reports. The NYISO document-folder id for this year is unknown; "
+                "please file an issue.",
+            )
+
+        base = f"https://www.nyiso.com/documents/20142/{year_code}"
+        month = date.month_name()
+        year = date.year
+
+        candidates = []
+        # Revised reports get a "-Version-N" suffix; a higher N supersedes lower
+        # ones. Try a wide descending range so any revision level is found before
+        # falling back to the original, unversioned filename.
+        for version in range(10, 1, -1):
+            candidates.append(
+                f"{base}/ICAP-Market-Report-{month}-{year}-Version-{version}.xlsx",
+            )
+        # Standard hyphenated filename.
+        candidates.append(f"{base}/ICAP-Market-Report-{month}-{year}.xlsx")
+        # URL-encoded "space dash space" style (e.g. December 2023).
+        candidates.append(
+            f"{base}/ICAP%20Market%20Report%20-%20{month}%20{year}.xlsx",  # noqa: E501
+        )
+        # Legacy .xls variants (older report vintages).
+        candidates.append(f"{base}/ICAP-Market-Report-{month}-{year}.xls")
+        candidates.append(
+            f"{base}/ICAP%20Market%20Report%20-%20{month}%20{year}.xls",  # noqa: E501
+        )
+        return candidates
+
+    @staticmethod
+    def _is_workbook_response(response: requests.Response) -> bool:
+        """Whether an HTTP response points to a real Excel workbook.
+
+        NYISO's document store returns a ``200`` HTML error page for some misses,
+        so a status check alone is not enough. This works for both HEAD (which has
+        no body) and GET responses by checking the ``Content-Type`` header, and
+        additionally the file's magic bytes when a body is present.
+        """
+        if response.status_code != 200:
+            return False
+        content_type = response.headers.get("Content-Type", "").lower()
+        if "html" in content_type:
+            return False
+        content = response.content
+        if content:
+            # .xlsx files are zip archives (PK); legacy .xls are OLE2 (\xd0\xcf).
+            return content[:2] in (b"PK", b"\xd0\xcf")
+        # HEAD response (no body): trust the non-HTML content type.
+        return True
+
+    def _resolve_capacity_report_url(
+        self,
+        date: pd.Timestamp,
+        verbose: bool = False,
+    ) -> str:
+        """Return the first candidate URL that resolves to a real workbook.
+
+        Candidates are probed with cheap ``HEAD`` requests (no body download) so
+        the wide version scan stays polite to NYISO's servers; only the resolved
+        URL is fetched in full by :meth:`_download_capacity_report`.
+        """
+        last_error: Exception | None = None
+        candidates = self._capacity_report_candidate_urls(date)
+        for url in candidates:
+            if verbose:
+                logger.info(f"Checking {url}")
+            try:
+                response = requests.head(url, timeout=60, allow_redirects=True)
+            except requests.RequestException as e:  # pragma: no cover - network
+                last_error = e
+                continue
+            if self._is_workbook_response(response):
+                return url
+
+        raise FileNotFoundError(
+            f"Could not resolve an ICAP Market Report for {date.strftime('%B %Y')}. "
+            f"Tried {len(candidates)} candidate filenames."
+            + (f" (last error: {last_error})" if last_error else ""),
+        )
+
+    def _download_capacity_report(
+        self,
+        date: pd.Timestamp,
+        verbose: bool = False,
+    ) -> tuple[pd.ExcelFile, str, pd.Timestamp | None]:
+        """Resolve and download the ICAP Market Report workbook for ``date``.
+
+        Returns a tuple of ``(ExcelFile, resolved_url, publish_time)`` where
+        ``publish_time`` is parsed from the ``Last-Modified`` header if available.
+        """
+        url = self._resolve_capacity_report_url(date, verbose=verbose)
+        if verbose:
+            logger.info(f"Requesting {url}")
+        response = requests.get(url, timeout=60)
+        response.raise_for_status()
+
+        publish_time = None
+        last_modified = response.headers.get("Last-Modified")
+        if last_modified:
+            publish_time = pd.to_datetime(last_modified, utc=True).tz_convert(
+                self.default_timezone,
+            )
+
+        return pd.ExcelFile(BytesIO(response.content)), url, publish_time
+
     def get_capacity_prices(
         self,
         date: pd.Timestamp | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
         """Pull the most recent capacity market report's market clearing prices
+
+        This returns the raw, wide "MCP Table" sheet of the monthly ICAP Market
+        Report (auction type x locality clearing prices, indexed by month). For a
+        tidy, long-format view with ICAP/UCAP prices, cleared quantities and
+        requirements, see :meth:`get_capacity_market_results`.
 
         Arguments:
             date (pandas.Timestamp): date that will be used to pull latest capacity
@@ -1533,55 +1724,333 @@ class NYISO(ISOBase):
         else:
             date = utils._handle_date(date, tz=self.default_timezone)
 
-        if date.year == 2014:
-            year_code = 1410927
-        elif date.year == 2015:
-            year_code = 1410895
-        elif date.year == 2016:
-            year_code = 1410901
-        if date.year == 2017:
-            year_code = 1410883
-        if date.year == 2018:
-            year_code = 1410889
-        if date.year == 2019:
-            year_code = 4266869
-        elif date.year == 2020:
-            year_code = 10106066
-        elif date.year == 2021:
-            year_code = 18170164
-        elif date.year == 2022:
-            year_code = 27447313
-        elif date.year == 2023:
-            year_code = 35397361
-        elif date.year == 2024:
-            year_code = 42146126
-        elif date.year == 2025:
-            year_code = 48997190
-        elif date.year == 2026:
-            year_code = 56195933
-        else:
-            raise ValueError(
-                "Year not currently supported. Please file an issue.",
-            )
-
-            # todo: it looks like the "27447313" component of the base URL changes
-            # every year but I'm not sure what the link between that and the year
-            # is...
-        capacity_market_base_url = f"https://www.nyiso.com/documents/20142/{year_code}"
-
-        url = f"{capacity_market_base_url}/ICAP-Market-Report-{date.month_name()}-{date.year}.xlsx"
-
-        # Special case
-        if date.month_name() == "December" and date.year == 2023:
-            url = f"{capacity_market_base_url}/ICAP%20Market%20Report%20-%20{date.month_name()}%20{date.year}.xlsx"
-
+        excel_file, url, _ = self._download_capacity_report(date, verbose=verbose)
         logger.info(f"Requesting {url}")
 
-        df = pd.read_excel(url, sheet_name="MCP Table", header=[0, 1])
+        # Report vintages before ~2019 use a single-sheet layout with no
+        # "MCP Table". Raise a clear error instead of a cryptic openpyxl failure.
+        if CAPACITY_MCP_SHEET not in excel_file.sheet_names:
+            raise ValueError(
+                f"The ICAP Market Report for {date.strftime('%B %Y')} does not "
+                f"contain a {CAPACITY_MCP_SHEET!r} sheet. get_capacity_prices "
+                "requires the modern MCP Table layout (reports from ~2019 onward).",
+            )
+
+        df = excel_file.parse(sheet_name=CAPACITY_MCP_SHEET, header=[0, 1])
 
         df.rename(columns={"Unnamed: 0_level_0": "", "Date": ""}, inplace=True)
         df.set_index("", inplace=True)
         return df.dropna(how="any", axis="columns")
+
+    @support_date_range(frequency="MONTH_START")
+    def get_capacity_market_results(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | None = None,
+        auction_type: Literal["spot", "monthly", "strip"] = "spot",
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Capacity auction clearing prices and cleared quantities by locality.
+
+        Parses the monthly NYISO ICAP Market Report workbook and returns a tidy,
+        one-row-per-(delivery month, capacity locality) DataFrame for the requested
+        auction type. Supports ``"latest"``, ``"today"``, a single month, or a
+        ``date``/``end`` range (one report is fetched per delivery month).
+
+        Prices are reported by **capacity locality** -- a small set of nested zones
+        (NYCA statewide, plus the G-J, NYC/Zone J and Long Island/Zone K
+        localities) -- **not** as 11 independent load-zone prices.
+
+        NYISO runs three Installed Capacity auctions and clears them on an Unforced
+        Capacity (UCAP) basis, so the published clearing price is the UCAP price in
+        ``$/kW-month`` (returned as ``UCAP Clearing Price``). The ICAP-equivalent
+        clearing price is *derived* from the locational EFORd translation factor
+        published in the same report: ``ICAP = UCAP * (1 - EFORd)``; it is ``NaN``
+        when EFORd is unavailable.
+
+        Scope: this covers only the stable, public monthly ICAP Market Report
+        auction results -- a first, scoped step toward the broader capacity-market
+        request in issue #687. It does **not** include ICAP demand curves, masked
+        bid/offer data, LSE-specific capacity obligations, settlement charges,
+        non-delivery penalties, or scarcity-related settlement data; those require
+        separate data sources and are left to follow-up work.
+
+        Arguments:
+            date: The delivery month to fetch (``"latest"``, ``"today"``, a
+                timestamp, or the start of a range).
+            end: Optional end of a delivery-month range (exclusive).
+            auction_type: One of ``"spot"`` (default), ``"monthly"`` or
+                ``"strip"``. See :class:`CapacityAuctionType`.
+            verbose: If True, log the resolved report URL(s).
+
+        Returns:
+            A DataFrame with columns:
+
+            - ``Interval Start`` / ``Interval End``: the delivery month
+              (tz-aware, ``US/Eastern``).
+            - ``Publish Time``: report publication time (from ``Last-Modified``),
+              or ``NaT`` if unavailable.
+            - ``Auction Type``: ``"Spot"`` / ``"Monthly"`` / ``"Strip"``.
+            - ``Capability Period``: ``"Summer"`` (May-Oct) or ``"Winter"``
+              (Nov-Apr).
+            - ``Location``: ``NYCA``, ``G-J Locality``, ``NYC (Zone J)`` or
+              ``Long Island (Zone K)``.
+            - ``ICAP Clearing Price`` / ``UCAP Clearing Price``: ``$/kW-month``.
+            - ``Locational EFORd``: the UCAP/ICAP translation factor.
+            - ``MW Cleared`` / ``Requirement (MW)``: the delivery-month cleared
+              position and requirement (UCAP MW) from the report Summary Table.
+              These describe the month overall, not a single auction; ``NaN`` if
+              absent from the report vintage.
+
+        Source: monthly ICAP Market Report,
+        https://www.nyiso.com/installed-capacity-market
+        """
+        auction_type = str(auction_type).lower()  # type: ignore[assignment]
+        if auction_type not in CAPACITY_AUCTION_COLUMN:
+            raise ValueError(
+                f"Invalid auction_type {auction_type!r}. Must be one of "
+                f"{list(CAPACITY_AUCTION_COLUMN)}.",
+            )
+
+        if isinstance(date, str) and date == "latest":
+            date = pd.Timestamp.now(tz=self.default_timezone)
+        # support_date_range has already resolved date to a Timestamp for every
+        # other input (single date or the start of a range chunk).
+        date = cast(pd.Timestamp, date)
+
+        month_start = pd.Timestamp(
+            year=date.year,
+            month=date.month,
+            day=1,
+            tz=self.default_timezone,
+        )
+
+        excel_file, url, publish_time = self._download_capacity_report(
+            month_start,
+            verbose=verbose,
+        )
+        if verbose:
+            logger.info(f"Parsing capacity market results from {url}")
+
+        # Report vintages before ~2019 use a single-sheet layout without the
+        # machine-readable auction tables. Fail clearly rather than emit nothing
+        # (or, worse, mislabeled rows) for those.
+        if CAPACITY_MCP_SHEET not in excel_file.sheet_names:
+            raise ValueError(
+                f"The ICAP Market Report for {month_start.strftime('%B %Y')} does "
+                f"not contain a {CAPACITY_MCP_SHEET!r} sheet. Machine-readable "
+                "auction results are only available for reports from ~2019 "
+                "onward (fully tested for 2022+).",
+            )
+
+        prices = self._parse_capacity_mcp_table(
+            excel_file,
+            month_start,
+            auction_type,
+        )
+        eford = self._parse_capacity_eford(excel_file, month_start)
+        quantities = self._parse_capacity_summary_table(excel_file, month_start)
+
+        period = "Summer" if 5 <= month_start.month <= 10 else "Winter"
+        interval_end = month_start + pd.DateOffset(months=1)
+
+        records = []
+        for location, ucap_price in prices.items():
+            eford_factor = eford.get(location)
+            icap_price = (
+                ucap_price * (1 - eford_factor)
+                if eford_factor is not None and pd.notna(ucap_price)
+                else pd.NA
+            )
+            mw_cleared, requirement = quantities.get(location, (pd.NA, pd.NA))
+            records.append(
+                {
+                    "Interval Start": month_start,
+                    "Interval End": interval_end,
+                    "Publish Time": publish_time,
+                    "Auction Type": CAPACITY_AUCTION_COLUMN[auction_type],
+                    "Capability Period": period,
+                    "Location": location,
+                    "ICAP Clearing Price": icap_price,
+                    "UCAP Clearing Price": ucap_price,
+                    "Locational EFORd": eford_factor,
+                    "MW Cleared": mw_cleared,
+                    "Requirement (MW)": requirement,
+                },
+            )
+
+        df = pd.DataFrame.from_records(records)
+        if df.empty:
+            return df
+
+        for col in [
+            "ICAP Clearing Price",
+            "UCAP Clearing Price",
+            "Locational EFORd",
+            "MW Cleared",
+            "Requirement (MW)",
+        ]:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+
+        df["Publish Time"] = pd.to_datetime(df["Publish Time"])
+
+        return df.sort_values(["Interval Start", "Location"]).reset_index(drop=True)
+
+    def _capacity_locality_columns(
+        self,
+        raw: pd.DataFrame,
+    ) -> dict[int, str]:
+        """Map each data column index to a standardized locality name.
+
+        The workbook data sheets put the locality short code (``NYCA``, ``GHIJ``,
+        ``NYC``, ``LI``) in the first (merged) header row, which we forward-fill
+        across the columns that belong to each locality.
+        """
+        locality_row = raw.iloc[0].ffill()
+        mapping = {}
+        for col, label in locality_row.items():
+            name = CAPACITY_LOCALITY_MAP.get(str(label).strip())
+            if name is not None:
+                mapping[col] = name
+        return mapping
+
+    @staticmethod
+    def _capacity_month_mask(series: pd.Series, month_start: pd.Timestamp) -> pd.Series:
+        """Boolean mask selecting rows whose date is in ``month_start``'s month."""
+        parsed = pd.to_datetime(series, errors="coerce")
+        return (parsed.dt.year == month_start.year) & (
+            parsed.dt.month == month_start.month
+        )
+
+    def _parse_capacity_mcp_table(
+        self,
+        excel_file: pd.ExcelFile,
+        month_start: pd.Timestamp,
+        auction_type: str,
+    ) -> dict[str, float]:
+        """Extract {locality: UCAP clearing price} for one month and auction."""
+        raw = excel_file.parse("MCP Table", header=None)
+        locality_cols = self._capacity_locality_columns(raw)
+        field_row = raw.iloc[1].astype(str).str.strip()
+        auction_label = CAPACITY_AUCTION_COLUMN[auction_type]
+
+        data = raw.iloc[2:]
+        mask = self._capacity_month_mask(data.iloc[:, 0], month_start)
+        if not mask.any():
+            return {}
+        row = data[mask].iloc[0]
+
+        prices = {}
+        for col, location in locality_cols.items():
+            if field_row.get(col) == auction_label:
+                prices[location] = row[col]
+        return prices
+
+    def _parse_capacity_summary_table(
+        self,
+        excel_file: pd.ExcelFile,
+        month_start: pd.Timestamp,
+    ) -> dict[str, tuple[float, float]]:
+        """Extract {locality: (MW Cleared, Requirement)} for one delivery month."""
+        if "Summary Table" not in excel_file.sheet_names:
+            return {}
+        raw = excel_file.parse("Summary Table", header=None)
+        locality_cols = self._capacity_locality_columns(raw)
+        field_row = raw.iloc[1].astype(str).str.strip()
+
+        data = raw.iloc[2:]
+        mask = self._capacity_month_mask(data.iloc[:, 0], month_start)
+        if not mask.any():
+            return {}
+        row = data[mask].iloc[0]
+
+        quantities: dict[str, list[float]] = {
+            loc: [pd.NA, pd.NA] for loc in locality_cols.values()
+        }
+        for col, location in locality_cols.items():
+            field = field_row.get(col)
+            if field == "MW Cleared":
+                quantities[location][0] = row[col]
+            elif field == "Requirements":
+                quantities[location][1] = row[col]
+        return {loc: (vals[0], vals[1]) for loc, vals in quantities.items()}
+
+    def _parse_capacity_eford(
+        self,
+        excel_file: pd.ExcelFile,
+        month_start: pd.Timestamp,
+    ) -> dict[str, float]:
+        """Extract {locality: Locational EFORd} from the report cover sheet.
+
+        The cover sheet ("ICAP Market Report") has three columns per locality
+        (current month, prior month, delta). Rather than assume a fixed
+        left-to-right locality order -- which would mislabel reports that contain a
+        different set of localities (e.g. pre-May-2014 reports, which predate the
+        G-J Locality and carry only NYCA, NYC and Long Island) -- each
+        current-month column is mapped to a locality by the spelled-out header
+        text in its own column group. Returns an empty dict if the layout can't be
+        found; localities whose label is missing are simply omitted (never guessed).
+        """
+        if "ICAP Market Report" not in excel_file.sheet_names:
+            return {}
+        cover = excel_file.parse("ICAP Market Report", header=None)
+
+        # Row holding the "Locational EFORd" values.
+        eford_row_idx = None
+        for i in range(len(cover)):
+            label = str(cover.iloc[i, 1]).strip().lower()
+            if label.startswith("locational eford"):
+                eford_row_idx = i
+                break
+        if eford_row_idx is None:
+            return {}
+
+        # Column -> standardized locality name, from the spelled-out cover labels.
+        label_columns: dict[int, str] = {}
+        for i in range(len(cover)):
+            for col in cover.columns:
+                key = str(cover.iloc[i, col]).strip().lower()
+                if key in COVER_LOCALITY_LABELS:
+                    label_columns.setdefault(col, COVER_LOCALITY_LABELS[key])
+
+        # Current-month value columns: those whose date header is the delivery
+        # month (each locality group also has a prior-month and delta column).
+        current_cols: list[int] = []
+        for i in range(len(cover)):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                parsed = pd.to_datetime(cover.iloc[i], errors="coerce")
+            cols = [
+                c
+                for c in cover.columns
+                if pd.notna(parsed[c])
+                and parsed[c].year == month_start.year
+                and parsed[c].month == month_start.month
+            ]
+            if cols:
+                current_cols = sorted(cols)
+                break
+        if not current_cols:
+            return {}
+
+        eford = {}
+        for col in current_cols:
+            # The locality label sits within this column's 3-wide group
+            # (current, prior, delta), i.e. at col, col+1 or col+2.
+            location = next(
+                (
+                    label_columns[c]
+                    for c in (col, col + 1, col + 2)
+                    if c in label_columns
+                ),
+                None,
+            )
+            if location is None:
+                continue
+            value = cover.iloc[eford_row_idx, col]
+            if pd.notna(value):
+                eford[location] = float(value)
+        return eford
 
     @support_date_range(frequency="DAY_START")
     def get_as_prices_day_ahead_hourly(

--- a/gridstatus/tests/source_specific/test_nyiso.py
+++ b/gridstatus/tests/source_specific/test_nyiso.py
@@ -15,6 +15,20 @@ nyiso_vcr = setup_vcr(
 )
 
 
+class _FakeExcelFile:
+    """Minimal stand-in for pd.ExcelFile for offline capacity-parsing tests."""
+
+    def __init__(self, sheets: dict[str, pd.DataFrame]):
+        self._sheets = sheets
+
+    @property
+    def sheet_names(self) -> list[str]:
+        return list(self._sheets)
+
+    def parse(self, sheet_name: str, header=None) -> pd.DataFrame:
+        return self._sheets[sheet_name]
+
+
 class TestNYISO(BaseTestISO):
     iso = NYISO()
 
@@ -38,6 +52,198 @@ class TestNYISO(BaseTestISO):
             df = self.iso.get_capacity_prices(date=date, verbose=True)
             assert not df.empty, "DataFrame came back empty"
             # TODO: missing report: https://github.com/gridstatus/gridstatus/issues/309
+
+    """get_capacity_market_results"""
+
+    CAPACITY_MARKET_RESULTS_COLUMNS = [
+        "Interval Start",
+        "Interval End",
+        "Publish Time",
+        "Auction Type",
+        "Capability Period",
+        "Location",
+        "ICAP Clearing Price",
+        "UCAP Clearing Price",
+        "Locational EFORd",
+        "MW Cleared",
+        "Requirement (MW)",
+    ]
+
+    # The four capacity localities present in modern (2014+) reports.
+    CAPACITY_LOCALITIES = {
+        "NYCA",
+        "G-J Locality",
+        "NYC (Zone J)",
+        "Long Island (Zone K)",
+    }
+
+    def _check_capacity_market_results(self, df, auction_type):
+        assert not df.empty, "DataFrame came back empty"
+        assert df.columns.tolist() == self.CAPACITY_MARKET_RESULTS_COLUMNS
+
+        self._check_time_columns(
+            df,
+            instant_or_interval="interval",
+            skip_column_named_time=True,
+        )
+
+        # delivery month intervals
+        assert (
+            df["Interval End"] == df["Interval Start"] + pd.DateOffset(months=1)
+        ).all()
+
+        assert (df["Auction Type"].str.lower() == auction_type).all()
+        assert set(df["Capability Period"]).issubset({"Summer", "Winter"})
+
+        # all four modern localities are present for every delivery month
+        for _, group in df.groupby("Interval Start"):
+            assert self.CAPACITY_LOCALITIES.issubset(set(group["Location"]))
+
+        for col in [
+            "ICAP Clearing Price",
+            "UCAP Clearing Price",
+            "Locational EFORd",
+            "MW Cleared",
+            "Requirement (MW)",
+        ]:
+            assert df[col].dtype == "float64"
+
+        # both ICAP and UCAP clearing prices are available for every locality
+        assert df["UCAP Clearing Price"].notna().all()
+        assert df["ICAP Clearing Price"].notna().all()
+
+    @pytest.mark.parametrize("auction_type", ["spot", "monthly", "strip"])
+    def test_get_capacity_market_results_auction_types(self, auction_type):
+        with nyiso_vcr.use_cassette(
+            f"test_get_capacity_market_results_{auction_type}_2025-01-01.yaml",
+        ):
+            df = self.iso.get_capacity_market_results(
+                "Jan 1, 2025",
+                auction_type=auction_type,
+                verbose=True,
+            )
+
+        self._check_capacity_market_results(df, auction_type)
+        assert (
+            df["Interval Start"]
+            == pd.Timestamp("2025-01-01", tz=self.iso.default_timezone)
+        ).all()
+        # January is in the Winter Capability Period (Nov-Apr)
+        assert (df["Capability Period"] == "Winter").all()
+
+    def test_get_capacity_market_results_historical_values(self):
+        # Values hand-checked against the published April 2022 ICAP Market Report,
+        # "MCP Table" sheet (April 2022 delivery month, Spot columns):
+        # https://www.nyiso.com/documents/20142/27447313/ICAP-Market-Report-April-2022.xlsx
+        with nyiso_vcr.use_cassette(
+            "test_get_capacity_market_results_spot_2022-04-01.yaml",
+        ):
+            df = self.iso.get_capacity_market_results(
+                "April 1, 2022",
+                auction_type="spot",
+            )
+
+        self._check_capacity_market_results(df, "spot")
+
+        ucap = df.set_index("Location")["UCAP Clearing Price"]
+        assert ucap["NYCA"] == 0.76
+        assert ucap["NYC (Zone J)"] == 0.76
+        assert ucap["Long Island (Zone K)"] == 1.81
+
+        # ICAP is derived from the published Locational EFORd (NYCA = 0.084):
+        # ICAP = UCAP * (1 - EFORd)
+        icap = df.set_index("Location")["ICAP Clearing Price"]
+        assert icap["NYCA"] == pytest.approx(0.76 * (1 - 0.084))
+
+    def test_get_capacity_market_results_date_range(self):
+        # Range spans the Nov -> Dec 2023 boundary. The December 2023 report uses a
+        # non-standard, URL-encoded filename (see PR #633), exercising the URL
+        # resolution fallback across the month boundary.
+        with nyiso_vcr.use_cassette(
+            "test_get_capacity_market_results_spot_2023-11-01_2024-01-01.yaml",
+        ):
+            df = self.iso.get_capacity_market_results(
+                "Nov 1, 2023",
+                end="Jan 1, 2024",
+                auction_type="spot",
+            )
+
+        self._check_capacity_market_results(df, "spot")
+        # end is exclusive, so November and December 2023 delivery months
+        months = set(df["Interval Start"].dt.strftime("%Y-%m"))
+        assert months == {"2023-11", "2023-12"}
+
+    @pytest.mark.parametrize("date", ["April 1, 2022", "Jan 1, 2025"])
+    def test_get_capacity_market_results_schema_stability(self, date):
+        # Same schema must parse cleanly across older and newer report vintages.
+        with nyiso_vcr.use_cassette(
+            f"test_get_capacity_market_results_spot_"
+            f"{pd.Timestamp(date).strftime('%Y-%m-%d')}.yaml",
+        ):
+            df = self.iso.get_capacity_market_results(date, auction_type="spot")
+
+        self._check_capacity_market_results(df, "spot")
+
+    def test_get_capacity_market_results_invalid_auction_type(self):
+        with pytest.raises(ValueError):
+            self.iso.get_capacity_market_results(
+                "Jan 1, 2025",
+                auction_type="annual",
+            )
+
+    def test_capacity_eford_pre_2014_locality_labels(self):
+        # Pre-May-2014 reports predate the G-J Locality and contain only NYCA,
+        # NYC and Long Island. EFORd parsing must map each column to a locality by
+        # its spelled-out header text, not by a fixed 4-locality column order, so
+        # a 3-locality report is not mislabeled (which would shift NYC -> G-J etc.).
+        rows = [[None] * 11 for _ in range(9)]
+        rows[3][4] = "New York Control Area"
+        rows[5][7] = "New York City"
+        rows[5][10] = "Long Island"
+        month = pd.Timestamp("2014-03-01")
+        prior = pd.Timestamp("2014-02-01")
+        for current_col in (3, 6, 9):
+            rows[6][current_col] = month
+            rows[6][current_col + 1] = prior
+        rows[8][1] = "Locational EFORd"
+        rows[8][3], rows[8][6], rows[8][9] = 0.05, 0.03, 0.07
+
+        fake = _FakeExcelFile({"ICAP Market Report": pd.DataFrame(rows)})
+        eford = self.iso._parse_capacity_eford(fake, month)
+
+        assert eford == {
+            "NYCA": 0.05,
+            "NYC (Zone J)": 0.03,
+            "Long Island (Zone K)": 0.07,
+        }
+        assert "G-J Locality" not in eford
+
+    def test_get_capacity_market_results_unsupported_vintage_raises(self):
+        # Report vintages before ~2019 use a single-sheet layout with no
+        # "MCP Table"; the parser must raise clearly rather than emit empty or
+        # mislabeled rows.
+        iso = NYISO()
+        fake = _FakeExcelFile({"ICAP Market Report": pd.DataFrame()})
+        iso._download_capacity_report = lambda date, verbose=False: (
+            fake,
+            "local",
+            pd.NaT,
+        )
+        with pytest.raises(ValueError, match="MCP Table"):
+            iso.get_capacity_market_results("June 1, 2016", auction_type="spot")
+
+    def test_get_capacity_prices_unsupported_vintage_raises(self):
+        # Pre-~2019 reports (e.g. the 2017/2018 single-sheet .xls files) lack the
+        # "MCP Table" sheet; get_capacity_prices must raise clearly.
+        iso = NYISO()
+        fake = _FakeExcelFile({"ICAP Market Report": pd.DataFrame()})
+        iso._download_capacity_report = lambda date, verbose=False: (
+            fake,
+            "local",
+            pd.NaT,
+        )
+        with pytest.raises(ValueError, match="MCP Table"):
+            iso.get_capacity_prices(pd.Timestamp("2017-05-01"))
 
     """get_fuel_mix"""
 


### PR DESCRIPTION
## Summary

Adds `NYISO.get_capacity_market_results()`, a tidy parser for the stable public auction-results portion of NYISO's monthly ICAP Market Report.

This partially addresses #687 by adding machine-readable Spot, Monthly, and Strip capacity auction clearing prices by NYISO capacity locality.

## Details

`get_capacity_market_results(date, end=None, auction_type="spot", verbose=False)` supports `"latest"`, a single month, or a `date`/`end` range.

It returns one row per delivery month and capacity locality, with:

- Interval Start
- Interval End
- Publish Time
- Auction Type
- Capability Period
- Location
- ICAP Clearing Price
- UCAP Clearing Price
- Locational EFORd
- MW Cleared
- Requirement (MW)

The localities are NYCA, G-J Locality, NYC / Zone J, and Long Island / Zone K.

NYISO clears capacity on a UCAP basis, so UCAP Clearing Price is the published clearing price. ICAP Clearing Price is derived from the report's Locational EFORd:

`ICAP = UCAP × (1 - EFORd)`

MW Cleared and Requirement (MW) come from the report summary table and describe the delivery month/locality overall. They are not auction-specific cleared quantities.

## Refactor / Fix

Moves ICAP Market Report URL resolution into shared helpers used by both `get_capacity_market_results()` and `get_capacity_prices()`.

The resolver handles:

- versioned report filenames
- URL-encoded filenames
- legacy .xls report filenames

`get_capacity_prices()` keeps its existing return schema, while improving report-resolution behavior across older report vintages.

## Scope

This PR intentionally focuses on the public monthly ICAP Market Report data.

Other parts of #687 appear to require separate sources and follow-up work, including:

- masked ICAP bid/offer archives
- demand curve parameter data
- participant-specific obligations
- settlement charges
- non-delivery penalties
- scarcity-related settlement data

Those are not included here.

## Testing

Adds tests for:

- Spot, Monthly, and Strip auction types
- April 2022 values checked against the published report
- a Nov–Dec 2023 range that exercises filename fallback behavior
- schema stability across report vintages
- invalid auction_type
- pre-2014 locality handling so reports without G-J are not mislabeled
- unsupported older single-sheet vintages now raise a clear error instead of failing cryptically

`ruff` passes locally.
