### PR TITLE
feat(ENG-3958): Full pandas-to-polars migration (all ISOs)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,7 @@ repos:
             gridstatus/decorators\.py|
             gridstatus/eia\.py|
             gridstatus/ercot\.py|
+            gridstatus/ercot_60d_utils\.py|
             gridstatus/ercot_api/.*|
             gridstatus/gs_logging\.py|
             gridstatus/ieso\.py|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+* **All data retrieval methods now return `polars.DataFrame` instead of `pandas.DataFrame`.** This is a full migration of the library to polars for lower memory overhead and faster processing. Method signatures still accept the same date arguments (strings, `pd.Timestamp`, datetimes). To get a pandas frame, call `.to_pandas()` on any result (requires `pyarrow`). pandas remains a dependency only for IO parse edges (HTML tables, Excel workbooks, exotic CSVs) that polars cannot read directly.
 * Removed the `save_to` parameter from data retrieval methods. Data is no longer written to CSV files as it is fetched; callers should save the returned DataFrame themselves (e.g. with `df.to_csv(...)`). The `load_folder` utility remains available for loading previously saved CSV folders.
 * Removed `MISOAPI.get_medium_term_load_forecast_hourly`. Use `get_load_forecast_mid_term_by_region` instead, which fetches the mid-term load forecast by publish date across the full horizon. Use `max_offset=1` to fetch only the first forecast day after the publish date. in [#892](https://github.com/gridstatus/gridstatus/pull/892)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ caiso.get_fuel_mix("today")
 
 ### Load
 
-or the energy demand throughout the current day as a Pandas DataFrame
+or the energy demand throughout the current day as a Polars DataFrame
 
 ```{code-cell}
 caiso.get_load("today")

--- a/gridstatus/aeso/aeso.py
+++ b/gridstatus/aeso/aeso.py
@@ -4,6 +4,7 @@ import re
 from typing import Any, Literal
 
 import pandas as pd
+import polars as pl
 import requests
 from bs4 import BeautifulSoup
 from requests.exceptions import HTTPError, RequestException
@@ -104,7 +105,7 @@ class AESO:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get current load data.
 
@@ -125,20 +126,20 @@ class AESO:
 
         data = self._make_request(endpoint)
 
-        df = pd.json_normalize(data["return"]["Actual Forecast Report"])
-        df["Interval Start"] = pd.to_datetime(
-            df["begin_datetime_utc"],
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(hours=1)
-        df = df.rename(
-            columns={
-                "alberta_internal_load": "Load",
-            },
+        df = pl.DataFrame(data["return"]["Actual Forecast Report"])
+        df = df.with_columns(
+            pl.col("begin_datetime_utc")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Interval Start"),
         )
-        df["Load"] = pd.to_numeric(df["Load"], errors="coerce")
-        df = df.dropna(subset=["Load"])
-        return df[["Interval Start", "Interval End", "Load"]]
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(hours=1)).alias("Interval End"),
+        )
+        df = df.rename({"alberta_internal_load": "Load"})
+        df = df.with_columns(pl.col("Load").cast(pl.Float64, strict=False))
+        df = df.drop_nulls(subset=["Load"])
+        return df.select(["Interval Start", "Interval End", "Load"])
 
     @support_date_range(frequency=None)
     def get_load_forecast(
@@ -146,7 +147,7 @@ class AESO:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get load forecast data.
 
         The AESO publishes load forecasts daily at 7am Mountain Time. The forecast covers
@@ -169,7 +170,7 @@ class AESO:
             )
             end = publish_time + pd.Timedelta(days=13)
             df = self.get_load_forecast(date=publish_time, end=end)
-            df = df[df["Publish Time"] == publish_time]
+            df = df.filter(pl.col("Publish Time") == pl.lit(publish_time))
             return df
 
         start_date = pd.Timestamp(date).strftime("%Y-%m-%d")
@@ -182,14 +183,18 @@ class AESO:
             endpoint += f"&endDate={end_date}"
 
         data = self._make_request(endpoint)
-        df = pd.json_normalize(data["return"]["Actual Forecast Report"])
-        df["Interval Start"] = pd.to_datetime(
-            df["begin_datetime_utc"],
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(hours=1)
+        df = pl.DataFrame(data["return"]["Actual Forecast Report"])
+        df = df.with_columns(
+            pl.col("begin_datetime_utc")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Interval Start"),
+        )
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(hours=1)).alias("Interval End"),
+        )
         df = df.rename(
-            columns={
+            {
                 "alberta_internal_load": "Load",
                 "forecast_alberta_internal_load": "Load Forecast",
             },
@@ -197,33 +202,29 @@ class AESO:
 
         current_time = pd.Timestamp.now(tz=self.default_timezone)
         today_7am = current_time.floor("D") + pd.Timedelta(hours=7)
+        future_publish_time = (
+            today_7am if current_time >= today_7am else today_7am - pd.Timedelta(days=1)
+        )
+        interval_day_7am = pl.col("Interval Start").dt.truncate("1d") + pl.duration(
+            hours=7,
+        )
+        df = df.with_columns(
+            pl.when(pl.col("Interval Start") > pl.lit(current_time))
+            .then(pl.lit(future_publish_time))
+            .when(pl.col("Interval Start") >= interval_day_7am)
+            .then(interval_day_7am)
+            .otherwise(interval_day_7am - pl.duration(days=1))
+            .alias("Publish Time"),
+        )
+        df = df.with_columns(
+            pl.col("Load").cast(pl.Float64, strict=False),
+            pl.col("Load Forecast").cast(pl.Float64, strict=False),
+        )
+        return df.select(
+            ["Interval Start", "Interval End", "Publish Time", "Load", "Load Forecast"],
+        )
 
-        def get_publish_time(row: pd.Series) -> pd.Timestamp:
-            interval_day_7am = row["Interval Start"].floor("D") + pd.Timedelta(hours=7)
-            if row["Interval Start"] > current_time:
-                # NB: For future intervals, use today's 7am if after 7am, otherwise yesterday's 7am
-                return (
-                    today_7am
-                    if current_time >= today_7am
-                    else today_7am - pd.Timedelta(days=1)
-                )
-            else:
-                # NB: For historical data, use 7am on the day of the interval if after 7am,
-                # otherwise use 7am the previous day
-                return (
-                    interval_day_7am
-                    if row["Interval Start"] >= interval_day_7am
-                    else interval_day_7am - pd.Timedelta(days=1)
-                )
-
-        df["Publish Time"] = df.apply(get_publish_time, axis=1)
-        df["Load"] = pd.to_numeric(df["Load"], errors="coerce")
-        df["Load Forecast"] = pd.to_numeric(df["Load Forecast"], errors="coerce")
-        return df[
-            ["Interval Start", "Interval End", "Publish Time", "Load", "Load Forecast"]
-        ]
-
-    def get_supply_and_demand(self) -> pd.DataFrame:
+    def get_supply_and_demand(self) -> pl.DataFrame:
         """
         Get current supply and demand summary data.
 
@@ -233,39 +234,49 @@ class AESO:
         endpoint = "currentsupplydemand-api/v2/csd/summary/current"
         data = self._make_request(endpoint)
 
-        df = pd.json_normalize(data["return"])
-        df["Time"] = pd.to_datetime(
-            df["effective_datetime_utc"],
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
-
-        df = df.rename(
-            columns={
-                k: v for k, v in SUPPLY_DEMAND_COLUMN_MAPPING.items() if k in df.columns
-            },
+        return_data = data["return"]
+        exclude_keys = {"generation_data_list", "interchange_list"}
+        flat = {k: v for k, v in return_data.items() if k not in exclude_keys}
+        df = pl.DataFrame([flat])
+        df = df.with_columns(
+            pl.col("effective_datetime_utc")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Time"),
         )
 
-        if "generation_data_list" in data["return"]:
-            gen_df = pd.DataFrame(data["return"]["generation_data_list"])
-            for _, row in gen_df.iterrows():
+        rename = {
+            k: v for k, v in SUPPLY_DEMAND_COLUMN_MAPPING.items() if k in df.columns
+        }
+        df = df.rename(rename)
+
+        if "generation_data_list" in return_data:
+            gen_df = pl.DataFrame(return_data["generation_data_list"])
+            for row in gen_df.iter_rows(named=True):
                 fuel_type = row["fuel_type"].title().replace(" ", " ")
-                df[f"{fuel_type} Maximum Capability"] = row[
-                    "aggregated_maximum_capability"
-                ]
-                df[f"{fuel_type} Net Generation"] = row["aggregated_net_generation"]
-                df[f"{fuel_type} Dispatched Contingency Reserve"] = row[
-                    "aggregated_dispatched_contingency_reserve"
-                ]
+                df = df.with_columns(
+                    pl.lit(row["aggregated_maximum_capability"]).alias(
+                        f"{fuel_type} Maximum Capability",
+                    ),
+                    pl.lit(row["aggregated_net_generation"]).alias(
+                        f"{fuel_type} Net Generation",
+                    ),
+                    pl.lit(row["aggregated_dispatched_contingency_reserve"]).alias(
+                        f"{fuel_type} Dispatched Contingency Reserve",
+                    ),
+                )
 
-        if "interchange_list" in data["return"]:
-            for interchange in data["return"]["interchange_list"]:
+        if "interchange_list" in return_data:
+            for interchange in return_data["interchange_list"]:
                 path = interchange["path"].title().replace(" ", " ")
-                df[f"{path} Flow"] = interchange["actual_flow"]
+                df = df.with_columns(
+                    pl.lit(interchange["actual_flow"]).alias(f"{path} Flow"),
+                )
 
-        df = df[list(SUPPLY_DEMAND_COLUMN_MAPPING.values())]
+        df = df.select(list(SUPPLY_DEMAND_COLUMN_MAPPING.values()))
         return utils.move_cols_to_front(df, ["Time"])
 
-    def get_fuel_mix(self) -> pd.DataFrame:
+    def get_fuel_mix(self) -> pl.DataFrame:
         """
         Get current generation by fuel type.
 
@@ -276,26 +287,30 @@ class AESO:
         endpoint = "currentsupplydemand-api/v2/csd/summary/current"
         data = self._make_request(endpoint)
 
-        df = pd.json_normalize(
-            data["return"],
-            record_path="generation_data_list",
-            meta=["effective_datetime_utc"],
+        effective_datetime_utc = data["return"]["effective_datetime_utc"]
+        records = [
+            {**item, "effective_datetime_utc": effective_datetime_utc}
+            for item in data["return"]["generation_data_list"]
+        ]
+        df = pl.DataFrame(records)
+        df = df.with_columns(
+            pl.col("effective_datetime_utc")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Time"),
+            pl.col("fuel_type").str.to_titlecase().alias("fuel_type"),
         )
-        df["Time"] = pd.to_datetime(
-            df["effective_datetime_utc"],
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
-        df["fuel_type"] = df["fuel_type"].str.title()
 
         result_df = df.pivot(
+            "fuel_type",
             index="Time",
-            columns="fuel_type",
             values="aggregated_net_generation",
-        ).reset_index()
+            aggregate_function="first",
+        )
 
         return result_df
 
-    def get_interchange(self) -> pd.DataFrame:
+    def get_interchange(self) -> pl.DataFrame:
         """
         Get current interchange flows with neighboring regions.
 
@@ -306,24 +321,28 @@ class AESO:
         endpoint = "currentsupplydemand-api/v2/csd/summary/current"
         data = self._make_request(endpoint)
 
-        df = pd.json_normalize(
-            data["return"],
-            record_path="interchange_list",
-            meta=["effective_datetime_utc"],
+        effective_datetime_utc = data["return"]["effective_datetime_utc"]
+        records = [
+            {**item, "effective_datetime_utc": effective_datetime_utc}
+            for item in data["return"]["interchange_list"]
+        ]
+        df = pl.DataFrame(records)
+        df = df.with_columns(
+            pl.col("effective_datetime_utc")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Time"),
         )
-        df["Time"] = pd.to_datetime(
-            df["effective_datetime_utc"],
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
 
         df = df.pivot(
+            "path",
             index="Time",
-            columns="path",
             values="actual_flow",
-        ).reset_index()
+            aggregate_function="first",
+        )
 
         df = df.rename(
-            columns={
+            {
                 "British Columbia": "British Columbia Flow",
                 "Montana": "Montana Flow",
                 "Saskatchewan": "Saskatchewan Flow",
@@ -331,14 +350,16 @@ class AESO:
         )
 
         flow_columns = [col for col in df.columns if col != "Time"]
-        df["Net Interchange Flow"] = df[flow_columns].sum(axis=1)
+        df = df.with_columns(
+            pl.sum_horizontal([pl.col(col) for col in flow_columns]).alias(
+                "Net Interchange Flow",
+            ),
+        )
 
         cols = ["Time", "Net Interchange Flow"] + flow_columns
-        df = df[cols]
+        return df.select(cols)
 
-        return df
-
-    def get_reserves(self) -> pd.DataFrame:
+    def get_reserves(self) -> pl.DataFrame:
         """
         Get current reserve data.
 
@@ -348,14 +369,17 @@ class AESO:
         endpoint = "currentsupplydemand-api/v2/csd/summary/current"
         data = self._make_request(endpoint)
 
-        df = pd.json_normalize(data["return"])
-        df["Time"] = pd.to_datetime(
-            df["effective_datetime_utc"],
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
+        df = pl.DataFrame([data["return"]])
+        df = df.with_columns(
+            pl.col("effective_datetime_utc")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Time"),
+        )
 
-        df = df.rename(columns=RESERVES_COLUMN_MAPPING)
-        df = df[list(RESERVES_COLUMN_MAPPING.values())]
+        rename = {k: v for k, v in RESERVES_COLUMN_MAPPING.items() if k in df.columns}
+        df = df.rename(rename)
+        df = df.select(list(RESERVES_COLUMN_MAPPING.values()))
 
         return utils.move_cols_to_front(df, ["Time"])
 
@@ -366,7 +390,7 @@ class AESO:
         pool_participant_id: str | None = None,
         operating_status: str | None = None,
         asset_type: str | None = None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get list of assets in the AESO system.
 
@@ -395,15 +419,15 @@ class AESO:
             endpoint += "?" + "&".join(params)
 
         data = self._make_request(endpoint)
-        df = pd.json_normalize(data["return"])
+        df = pl.DataFrame(data["return"])
 
-        if df.empty:
-            return pd.DataFrame(columns=list(ASSET_LIST_COLUMN_MAPPING.values()))
+        if df.is_empty():
+            return pl.DataFrame(
+                schema=dict.fromkeys(ASSET_LIST_COLUMN_MAPPING.values(), pl.String),
+            )
 
-        df = df.rename(columns=ASSET_LIST_COLUMN_MAPPING)
-        df = df[list(ASSET_LIST_COLUMN_MAPPING.values())]
-
-        return df
+        df = df.rename(ASSET_LIST_COLUMN_MAPPING)
+        return df.select(list(ASSET_LIST_COLUMN_MAPPING.values()))
 
     @support_date_range(frequency=None)
     def get_pool_price(
@@ -411,7 +435,7 @@ class AESO:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get pool price data.
 
@@ -428,7 +452,7 @@ class AESO:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get pool price data.
 
@@ -444,7 +468,7 @@ class AESO:
         start_date: str,
         end_date: str | None = None,
         actual_or_forecast: Literal["actual", "forecast"] = "actual",
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get pool price data.
 
@@ -458,14 +482,18 @@ class AESO:
         if end_date:
             endpoint += f"&endDate={end_date}"
         data = self._make_request(endpoint)
-        df = pd.json_normalize(data["return"]["Pool Price Report"])
-        df["Interval Start"] = pd.to_datetime(
-            df["begin_datetime_utc"],
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(hours=1)
+        df = pl.DataFrame(data["return"]["Pool Price Report"])
+        df = df.with_columns(
+            pl.col("begin_datetime_utc")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Interval Start"),
+        )
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(hours=1)).alias("Interval End"),
+        )
         df = df.rename(
-            columns={
+            {
                 "pool_price": "Pool Price",
                 "forecast_pool_price": "Forecast Pool Price",
                 "rolling_30day_avg": "Rolling 30 Day Average Pool Price",
@@ -473,42 +501,39 @@ class AESO:
         )
 
         if actual_or_forecast == "actual":
-            df["Pool Price"] = pd.to_numeric(df["Pool Price"], errors="coerce")
-            df = df[df["Pool Price"].notna()]
-            return df[
+            df = df.with_columns(pl.col("Pool Price").cast(pl.Float64, strict=False))
+            df = df.filter(pl.col("Pool Price").is_not_null())
+            return df.select(
                 [
                     "Interval Start",
                     "Interval End",
                     "Pool Price",
                     "Rolling 30 Day Average Pool Price",
-                ]
-            ]
+                ],
+            )
         else:
-            df["Forecast Pool Price"] = pd.to_numeric(
-                df["Forecast Pool Price"],
-                errors="coerce",
+            df = df.with_columns(
+                pl.col("Forecast Pool Price").cast(pl.Float64, strict=False),
             )
             # NB: Publish times are a bit opaque from AESO, so we calculate a best estimate here.
             # Forecast pool price is provided for current and next two hours, updated every 5 minutes.
             # For future intervals: use request time floored to 5 minutes
             # For past/current intervals: use 5 minutes before interval start
             request_time = pd.Timestamp.now(tz=self.default_timezone)
-            df["Publish Time"] = df.apply(
-                lambda row: (
-                    request_time.floor("5min")
-                    if row["Interval Start"] > request_time
-                    else row["Interval Start"] - pd.Timedelta(minutes=5)
-                ),
-                axis=1,
+            df = df.with_columns(
+                pl.when(pl.col("Interval Start") > pl.lit(request_time))
+                .then(pl.lit(request_time.floor("5min")))
+                .otherwise(pl.col("Interval Start") - pl.duration(minutes=5))
+                .alias("Publish Time"),
             )
-            return df[
+            return df.select(
                 [
                     "Interval Start",
                     "Interval End",
                     "Publish Time",
                     "Forecast Pool Price",
-                ]
-            ]
+                ],
+            )
 
     @support_date_range(frequency=None)
     def get_daily_average_pool_price(
@@ -516,7 +541,7 @@ class AESO:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get daily average pool price data with on-peak and off-peak breakdowns.
 
@@ -530,88 +555,57 @@ class AESO:
             return self.get_daily_average_pool_price(date="today")
 
         hourly_df = self._get_pool_price_data(date, end, actual_or_forecast="actual")
-        hourly_df["Is On Peak"] = hourly_df["Interval End"].dt.hour.isin(range(8, 24))
-        hourly_df["Pool Price"] = pd.to_numeric(
-            hourly_df["Pool Price"],
-            errors="coerce",
-        )
-        hourly_df["Rolling 30 Day Average Pool Price"] = pd.to_numeric(
-            hourly_df["Rolling 30 Day Average Pool Price"],
-            errors="coerce",
-        )
-
-        agg_dict = {
-            "Pool Price": "mean",
-            "Is On Peak": lambda x: x.sum(),
-        }
-
-        daily_df = (
-            hourly_df.groupby(hourly_df["Interval Start"].dt.date)
-            .agg(agg_dict)
-            .reset_index()
+        hourly_df = hourly_df.with_columns(
+            pl.col("Interval End")
+            .dt.hour()
+            .is_in(list(range(8, 24)))
+            .alias(
+                "Is On Peak",
+            ),
+            pl.col("Pool Price").cast(pl.Float64, strict=False),
+            pl.col("Rolling 30 Day Average Pool Price").cast(pl.Float64, strict=False),
         )
 
-        # NB: 30 rolling average is already an average, so this just passes
-        # through the 23:00:00 value for each day, which is what the ETS system shows
+        daily_df = hourly_df.group_by(
+            pl.col("Interval Start").dt.date().alias("date"),
+        ).agg(
+            pl.col("Pool Price").mean().alias("Daily Average"),
+        )
+
         daily_30day_avg = (
-            hourly_df[hourly_df["Interval Start"].dt.hour == 23]
-            .groupby(hourly_df["Interval Start"].dt.date)
-            .agg({"Rolling 30 Day Average Pool Price": "first"})
-            .reset_index()
-        )
-        daily_30day_avg = daily_30day_avg.rename(
-            columns={"Rolling 30 Day Average Pool Price": "30 Day Average"},
-        )
-
-        daily_averages = []
-        for _, day_row in daily_df.iterrows():
-            day_date = day_row["Interval Start"]
-            day_hourly = hourly_df[hourly_df["Interval Start"].dt.date == day_date]
-
-            on_peak_prices = day_hourly[day_hourly["Is On Peak"]]["Pool Price"]
-            daily_on_peak_avg = (
-                on_peak_prices.mean() if not on_peak_prices.empty else None
+            hourly_df.filter(pl.col("Interval Start").dt.hour() == 23)
+            .group_by(pl.col("Interval Start").dt.date().alias("date"))
+            .agg(
+                pl.col("Rolling 30 Day Average Pool Price")
+                .first()
+                .alias("30 Day Average"),
             )
-
-            off_peak_prices = day_hourly[~day_hourly["Is On Peak"]]["Pool Price"]
-            daily_off_peak_avg = (
-                off_peak_prices.mean() if not off_peak_prices.empty else None
-            )
-
-            daily_averages.append(
-                {
-                    "date": day_date,
-                    "Daily On Peak Average": daily_on_peak_avg,
-                    "Daily Off Peak Average": daily_off_peak_avg,
-                },
-            )
-
-        daily_avg_df = pd.DataFrame(daily_averages)
-
-        result_df = daily_df.merge(
-            daily_avg_df,
-            left_on="Interval Start",
-            right_on="date",
-            how="left",
         )
 
-        result_df = result_df.merge(
-            daily_30day_avg,
-            left_on="Interval Start",
-            right_on="Interval Start",
-            how="left",
+        daily_on_peak = (
+            hourly_df.filter(pl.col("Is On Peak"))
+            .group_by(pl.col("Interval Start").dt.date().alias("date"))
+            .agg(pl.col("Pool Price").mean().alias("Daily On Peak Average"))
         )
 
-        result_df["Interval Start"] = pd.to_datetime(
-            result_df["Interval Start"],
-        ).dt.tz_localize(self.default_timezone)
-        result_df["Interval End"] = result_df["Interval Start"] + pd.Timedelta(days=1)
+        daily_off_peak = (
+            hourly_df.filter(~pl.col("Is On Peak"))
+            .group_by(pl.col("Interval Start").dt.date().alias("date"))
+            .agg(pl.col("Pool Price").mean().alias("Daily Off Peak Average"))
+        )
 
-        result_df = result_df.rename(
-            columns={
-                "Pool Price": "Daily Average",
-                "Rolling 30 Day Average Pool Price": "30 Day Average",
-            },
+        result_df = daily_df.join(daily_on_peak, on="date", how="left")
+        result_df = result_df.join(daily_off_peak, on="date", how="left")
+        result_df = result_df.join(daily_30day_avg, on="date", how="left")
+
+        result_df = result_df.with_columns(
+            pl.col("date")
+            .cast(pl.Datetime)
+            .dt.replace_time_zone(self.default_timezone)
+            .alias("Interval Start"),
+        )
+        result_df = result_df.with_columns(
+            (pl.col("Interval Start") + pl.duration(days=1)).alias("Interval End"),
         )
 
         price_columns = [
@@ -620,24 +614,21 @@ class AESO:
             "Daily Off Peak Average",
             "30 Day Average",
         ]
-        for col in price_columns:
-            if col in result_df.columns:
-                result_df[col] = result_df[col].round(2)
+        round_exprs = [
+            pl.col(col).round(2) for col in price_columns if col in result_df.columns
+        ]
+        result_df = result_df.with_columns(round_exprs)
 
-        return (
-            result_df[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Daily Average",
-                    "Daily On Peak Average",
-                    "Daily Off Peak Average",
-                    "30 Day Average",
-                ]
-            ]
-            .sort_values("Interval Start")
-            .reset_index(drop=True)
-        )
+        return result_df.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "Daily Average",
+                "Daily On Peak Average",
+                "Daily Off Peak Average",
+                "30 Day Average",
+            ],
+        ).sort("Interval Start")
 
     @support_date_range(frequency=None)
     def get_system_marginal_price(
@@ -645,7 +636,7 @@ class AESO:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get system marginal price data.
 
@@ -662,84 +653,95 @@ class AESO:
         if end_date:
             endpoint += f"&endDate={end_date}"
         data = self._make_request(endpoint)
-        df = pd.json_normalize(data["return"]["System Marginal Price Report"])
+        df = pl.DataFrame(data["return"]["System Marginal Price Report"])
 
-        df["Interval Start"] = pd.to_datetime(
-            df["begin_datetime_utc"],
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
-        df["Interval End"] = pd.to_datetime(
-            df["end_datetime_utc"],
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
+        df = df.with_columns(
+            pl.col("begin_datetime_utc")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Interval Start"),
+            pl.col("end_datetime_utc")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Interval End"),
+        )
 
         # NB: The latest value that the AESO API returns always has an interval that ends at 23:59 of the current day.
         # We want to set the interval end to 1 minute after the interval start to make it consistent with the other intervals
         # and make the forward filling easier.
         # Example: If the latest interval start is 2025-06-12 23:00:00,
         # the interval end will be changed from 2025-06-12 23:59:00 to 2025-06-12 23:01:00.
-        mask = df["Interval End"].dt.strftime("%H:%M") == "23:59"
-        df.loc[mask, "Interval End"] = df.loc[mask, "Interval Start"] + pd.Timedelta(
-            minutes=1,
+        df = df.with_columns(
+            pl.when(pl.col("Interval End").dt.strftime("%H:%M") == "23:59")
+            .then(pl.col("Interval Start") + pl.duration(minutes=1))
+            .otherwise(pl.col("Interval End"))
+            .alias("Interval End"),
         )
 
         df = df.rename(
-            columns={
+            {
                 "system_marginal_price": "System Marginal Price",
                 "volume": "Volume",
             },
         )
-        df["System Marginal Price"] = pd.to_numeric(
-            df["System Marginal Price"],
-            errors="coerce",
+        df = df.with_columns(
+            pl.col("System Marginal Price").cast(pl.Float64, strict=False),
+            pl.col("Volume").cast(pl.Float64, strict=False),
         )
-        df["Volume"] = pd.to_numeric(df["Volume"], errors="coerce")
-        df = df.sort_values(by="Interval Start")
+        df = df.sort("Interval Start")
 
         # NB: Add current time as final interval if needed, but only for today's data
         current_time = pd.Timestamp.now(tz=self.default_timezone)
         today_start = current_time.floor("D")
-        if (
-            df["Interval Start"].min().floor("D") == today_start
-            and df["Interval End"].max() < current_time
-        ):
-            last_row = df.iloc[-1].copy()
-            last_row["Interval Start"] = df["Interval End"].max()
-            last_row["Interval End"] = current_time.floor("min")
-            df = pd.concat([df, pd.DataFrame([last_row])], ignore_index=True)
+        min_start = pd.Timestamp(df.select(pl.col("Interval Start").min()).item())
+        max_end = pd.Timestamp(df.select(pl.col("Interval End").max()).item())
+        if min_start.floor("D") == today_start and max_end < current_time:
+            last_row = df.tail(1).with_columns(
+                pl.lit(max_end).alias("Interval Start"),
+                pl.lit(current_time.floor("min")).alias("Interval End"),
+            )
+            df = pl.concat([df, last_row])
 
-        start_time = df["Interval Start"].min()
-        end_time = pd.Timestamp(end) if end else df["Interval End"].max()
+        start_time = pd.Timestamp(df.select(pl.col("Interval Start").min()).item())
+        end_time = (
+            pd.Timestamp(end)
+            if end
+            else pd.Timestamp(
+                df.select(pl.col("Interval End").max()).item(),
+            )
+        )
 
-        all_minutes = pd.date_range(
+        all_minutes = pl.datetime_range(
             start=start_time,
             end=end_time,
-            freq="1min",
-            tz=self.default_timezone,
-            inclusive="left",
+            interval="1m",
+            time_zone=self.default_timezone,
+            closed="left",
+            eager=True,
         )
 
-        result_df = pd.DataFrame({"Interval Start": all_minutes})
-        result_df["Interval End"] = result_df["Interval Start"] + pd.Timedelta(
-            minutes=1,
+        result_df = pl.DataFrame({"Interval Start": all_minutes})
+        result_df = result_df.with_columns(
+            (pl.col("Interval Start") + pl.duration(minutes=1)).alias("Interval End"),
         )
 
-        result_df = pd.merge_asof(
-            result_df,
-            df[["Interval Start", "System Marginal Price", "Volume"]],
+        result_df = result_df.sort("Interval Start").join_asof(
+            df.select(["Interval Start", "System Marginal Price", "Volume"]).sort(
+                "Interval Start",
+            ),
             on="Interval Start",
-            direction="backward",
+            strategy="backward",
         )
 
-        return result_df[
-            ["Interval Start", "Interval End", "System Marginal Price", "Volume"]
-        ]
+        return result_df.select(
+            ["Interval Start", "Interval End", "System Marginal Price", "Volume"],
+        )
 
     def get_unit_status(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get current unit status data for all assets in the AESO system.
 
         Returns:
@@ -759,19 +761,22 @@ class AESO:
         endpoint = "currentsupplydemand-api/v1/csd/generation/assets/current"
         data = self._make_request(endpoint)
 
-        df = pd.json_normalize(
-            data["return"],
-            record_path="asset_list",
-            meta=["last_updated_datetime_utc"],
+        last_updated = data["return"]["last_updated_datetime_utc"]
+        records = [
+            {**item, "last_updated_datetime_utc": last_updated}
+            for item in data["return"]["asset_list"]
+        ]
+        df = pl.DataFrame(records)
+
+        df = df.with_columns(
+            pl.col("last_updated_datetime_utc")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Time"),
         )
 
-        df["Time"] = pd.to_datetime(
-            df["last_updated_datetime_utc"],
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
-
         df = df.rename(
-            columns={
+            {
                 "asset": "Asset",
                 "fuel_type": "Fuel Type",
                 "sub_fuel_type": "Sub Fuel Type",
@@ -786,10 +791,11 @@ class AESO:
             "Net Generation",
             "Dispatched Contingency Reserve",
         ]
-        for col in numeric_columns:
-            df[col] = pd.to_numeric(df[col], errors="coerce")
+        df = df.with_columns(
+            [pl.col(col).cast(pl.Float64, strict=False) for col in numeric_columns],
+        )
 
-        return df[
+        return df.select(
             [
                 "Time",
                 "Asset",
@@ -798,8 +804,8 @@ class AESO:
                 "Maximum Capability",
                 "Net Generation",
                 "Dispatched Contingency Reserve",
-            ]
-        ]
+            ],
+        )
 
     @support_date_range(frequency="31D")
     def get_generator_outages_hourly(
@@ -807,7 +813,7 @@ class AESO:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get hourly generator outage data.
 
@@ -896,57 +902,55 @@ class AESO:
                 }
                 rows.append(row)
 
-        df = pd.DataFrame(rows)
+        df = pl.DataFrame(rows)
 
         current_time = pd.Timestamp.now(tz=self.default_timezone).floor("h")
-        df["Publish Time"] = df.apply(
-            lambda row: (
-                current_time
-                if row["Interval Start"] > current_time
-                else row["Interval Start"] - pd.Timedelta(hours=1)
-            ),
-            axis=1,
+        df = df.with_columns(
+            pl.when(pl.col("Interval Start") > pl.lit(current_time))
+            .then(pl.lit(current_time))
+            .otherwise(pl.col("Interval Start") - pl.duration(hours=1))
+            .alias("Publish Time"),
         )
 
         # NB: Pivot the data to get the by-fuel type outage.
-        df_pivot = df.pivot_table(
+        df_pivot = df.pivot(
+            "Sub Fuel Type",
             index=["Interval Start", "Interval End", "Publish Time"],
-            columns=["Sub Fuel Type"],
             values="Operating Outage",
-            aggfunc="sum",
-        ).reset_index()
+            aggregate_function="sum",
+        )
 
         # NB: Sum the operational outage by fuel type to get the total outage.
-        df_pivot["Total Outage"] = df_pivot[
-            [
-                col
-                for col in df_pivot.columns
-                if col
-                not in [
-                    "Interval Start",
-                    "Interval End",
-                    "Publish Time",
-                    "Mothball Outage",
-                    "Total Outage",
-                ]
+        pivot_value_cols = [
+            col
+            for col in df_pivot.columns
+            if col
+            not in [
+                "Interval Start",
+                "Interval End",
+                "Publish Time",
+                "Mothball Outage",
+                "Total Outage",
             ]
-        ].sum(axis=1)
+        ]
+        df_pivot = df_pivot.with_columns(
+            pl.sum_horizontal([pl.col(col) for col in pivot_value_cols]).alias(
+                "Total Outage",
+            ),
+        )
 
         # NB: Create the summed mothball outage and merge it back in.
-        mbo_df = (
-            df.groupby(["Interval Start", "Interval End", "Publish Time"])[
-                "Mothball Outage"
-            ]
-            .sum()
-            .reset_index()
+        mbo_df = df.group_by(["Interval Start", "Interval End", "Publish Time"]).agg(
+            pl.col("Mothball Outage").sum().alias("Mothball Outage"),
         )
-        df_pivot = pd.merge(
-            df_pivot,
+        df_pivot = df_pivot.join(
             mbo_df,
             on=["Interval Start", "Interval End", "Publish Time"],
             how="left",
         )
-        df_pivot["Mothball Outage"] = df_pivot["Mothball Outage"].fillna(0)
+        df_pivot = df_pivot.with_columns(
+            pl.col("Mothball Outage").fill_null(0),
+        )
 
         df_pivot = utils.move_cols_to_front(
             df_pivot,
@@ -974,15 +978,51 @@ class AESO:
 
         for col in expected_columns:
             if col not in df_pivot.columns:
-                df_pivot[col] = 0
+                df_pivot = df_pivot.with_columns(pl.lit(0).alias(col))
 
-        return df_pivot[expected_columns]
+        return df_pivot.select(expected_columns)
+
+    def _format_transmission_outages(
+        self,
+        df: pl.DataFrame,
+        publish_datetime: pd.Timestamp,
+    ) -> pl.DataFrame:
+        df = df.with_columns(
+            pl.col("From")
+            .str.to_datetime(format="%d-%b-%y %H:%M", strict=False)
+            .dt.replace_time_zone(self.default_timezone)
+            .alias("Interval Start"),
+            pl.col("To")
+            .str.to_datetime(format="%d-%b-%y %H:%M", strict=False)
+            .dt.replace_time_zone(self.default_timezone)
+            .alias("Interval End"),
+            pl.lit(publish_datetime).alias("Publish Time"),
+        )
+        df = df.rename(
+            {
+                "Owner": "Transmission Owner",
+                "Date/Time Comments": "Date Time Comments",
+            },
+        )
+        return df.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "Publish Time",
+                "Transmission Owner",
+                "Type",
+                "Element",
+                "Scheduled Activity",
+                "Date Time Comments",
+                "Interconnection",
+            ],
+        )
 
     def get_transmission_outages(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get transmission outages data.
 
@@ -1015,40 +1055,8 @@ class AESO:
                 publish_datetime = pd.to_datetime(f"{publish_date} {publish_time}")
                 publish_datetime = publish_datetime.tz_localize(self.default_timezone)
 
-            df = pd.read_csv(csv_url)
-
-            df["Interval Start"] = pd.to_datetime(
-                df["From"],
-                format="%d-%b-%y %H:%M",
-            ).dt.tz_localize(self.default_timezone)
-            df["Interval End"] = pd.to_datetime(
-                df["To"],
-                format="%d-%b-%y %H:%M",
-            ).dt.tz_localize(self.default_timezone)
-            df["Publish Time"] = publish_datetime
-
-            df = df.rename(
-                columns={
-                    "Owner": "Transmission Owner",
-                    "Date/Time Comments": "Date Time Comments",
-                },
-            )
-
-            df = df[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Publish Time",
-                    "Transmission Owner",
-                    "Type",
-                    "Element",
-                    "Scheduled Activity",
-                    "Date Time Comments",
-                    "Interconnection",
-                ]
-            ]
-
-            return df
+            df = pl.read_csv(csv_url)
+            return self._format_transmission_outages(df, publish_datetime)
 
         else:
             # NB: For historical data, we need to navigate backwards through Previous Version links
@@ -1188,49 +1196,22 @@ class AESO:
             all_dfs = []
             for csv_url, publish_datetime in historical_files:
                 try:
-                    df_hist = pd.read_csv(csv_url, on_bad_lines="skip")
-                    df_hist["Interval Start"] = pd.to_datetime(
-                        df_hist["From"],
-                        format="%d-%b-%y %H:%M",
-                    ).dt.tz_localize(self.default_timezone)
-                    df_hist["Interval End"] = pd.to_datetime(
-                        df_hist["To"],
-                        format="%d-%b-%y %H:%M",
-                    ).dt.tz_localize(self.default_timezone)
-                    df_hist["Publish Time"] = publish_datetime
-
-                    df_hist = df_hist.rename(
-                        columns={
-                            "Owner": "Transmission Owner",
-                            "Date/Time Comments": "Date Time Comments",
-                        },
+                    df_hist = utils.read_csv_exotic_via_pandas(
+                        csv_url,
+                        on_bad_lines="skip",
                     )
-
-                    df_hist = df_hist[
-                        [
-                            "Interval Start",
-                            "Interval End",
-                            "Publish Time",
-                            "Transmission Owner",
-                            "Type",
-                            "Element",
-                            "Scheduled Activity",
-                            "Date Time Comments",
-                            "Interconnection",
-                        ]
-                    ]
-
-                    all_dfs.append(df_hist)
+                    all_dfs.append(
+                        self._format_transmission_outages(df_hist, publish_datetime),
+                    )
                 except Exception as e:
                     logger.error(f"Error accessing {csv_url}: {e}")
                     continue
 
             if all_dfs:
-                df = pd.concat(all_dfs, ignore_index=True)
-                df = df.sort_values("Publish Time", ascending=False).reset_index(
-                    drop=True,
+                return utils.concat_dataframes(all_dfs).sort(
+                    "Publish Time",
+                    descending=True,
                 )
-                return df
 
     def _generate_csv_url(self, csv_href: str) -> str:
         csv_href = csv_href.replace("\\", "/")
@@ -1251,7 +1232,7 @@ class AESO:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get 12-hour wind forecast data.
 
@@ -1276,7 +1257,7 @@ class AESO:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get 7-day wind forecast data.
 
@@ -1312,7 +1293,7 @@ class AESO:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get 12-hour solar forecast data.
 
@@ -1337,7 +1318,7 @@ class AESO:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get 7-day solar forecast data.
 
@@ -1373,7 +1354,7 @@ class AESO:
         term: Literal["shortterm", "longterm"],
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get wind or solar forecast data from AESO CSV reports.
 
@@ -1389,45 +1370,53 @@ class AESO:
         url = f"http://ets.aeso.ca/Market/Reports/Manual/Operations/prodweb_reports/wind_solar_forecast/{forecast_type}_rpt_{term}.csv"
 
         try:
-            df = pd.read_csv(url)
+            df = pl.read_csv(url)
         except Exception as e:
             raise RequestException(
                 f"Failed to fetch {forecast_type} forecast data: {str(e)}",
             )
 
-        df["Interval Start"] = pd.to_datetime(
-            df["Forecast Transaction Date"],
-            format="%Y-%m-%d %H:%M",
-        ).dt.tz_localize(self.default_timezone, ambiguous="infer")
-
-        interval_length = (
-            pd.Timedelta(minutes=10) if term == "shortterm" else pd.Timedelta(hours=1)
+        df = df.with_columns(
+            pl.col("Forecast Transaction Date")
+            .str.to_datetime(format="%Y-%m-%d %H:%M", strict=False)
+            .alias("Interval Start"),
         )
-        df["Interval End"] = df["Interval Start"] + interval_length
+        df = utils.localize_ambiguous_infer_polars(
+            df,
+            "Interval Start",
+            self.default_timezone,
+        )
+
+        interval_duration = (
+            pl.duration(minutes=10) if term == "shortterm" else pl.duration(hours=1)
+        )
+        df = df.with_columns(
+            (pl.col("Interval Start") + interval_duration).alias("Interval End"),
+        )
 
         # NB: Since the forecasts are published every 10 minutes for shortterm and every 1 hour for longterm,
         # we can calculate the publish time based on the presence of actuals values.
         # For past forecasted intervals (intervals with an actual value), we know the most recent forecast was published just before each interval.
         # For future forecasted values, the publish time for all of them is set to the first interval that has no actual value, since
         # that's when the forecast was last published.
-        first_interval_without_actual = df[df["Actual"].isna()]
-        if not first_interval_without_actual.empty:
-            forecast_publish_time = first_interval_without_actual[
-                "Interval Start"
-            ].min()
-            df["Publish Time"] = df.apply(
-                lambda row: (
-                    forecast_publish_time
-                    if pd.isna(row["Actual"])
-                    else row["Interval Start"] - interval_length
-                ),
-                axis=1,
+        first_interval_without_actual = df.filter(pl.col("Actual").is_null())
+        if first_interval_without_actual.height > 0:
+            forecast_publish_time = first_interval_without_actual.select(
+                pl.col("Interval Start").min(),
+            ).item()
+            df = df.with_columns(
+                pl.when(pl.col("Actual").is_null())
+                .then(pl.lit(forecast_publish_time))
+                .otherwise(pl.col("Interval Start") - interval_duration)
+                .alias("Publish Time"),
             )
         else:
-            df["Publish Time"] = df["Interval Start"] - interval_length
+            df = df.with_columns(
+                (pl.col("Interval Start") - interval_duration).alias("Publish Time"),
+            )
 
         df = df.rename(
-            columns={
+            {
                 "Min": "Minimum Generation Forecast",
                 "Most Likely": "Most Likely Generation Forecast",
                 "Max": "Maximum Generation Forecast",
@@ -1448,11 +1437,13 @@ class AESO:
             "Maximum Generation Percentage",
         ]
 
-        for col in numeric_columns:
-            if col in df.columns:
-                df[col] = pd.to_numeric(df[col], errors="coerce")
-        df.sort_values("Interval Start").reset_index(drop=True)
-        return df[
+        cast_exprs = [
+            pl.col(col).cast(pl.Float64, strict=False)
+            for col in numeric_columns
+            if col in df.columns
+        ]
+        df = df.with_columns(cast_exprs)
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -1464,15 +1455,15 @@ class AESO:
                 "Minimum Generation Percentage",
                 "Most Likely Generation Percentage",
                 "Maximum Generation Percentage",
-            ]
-        ]
+            ],
+        ).sort("Interval Start")
 
     def _get_wind_solar_forecast_historical_data(
         self,
         forecast_type: Literal["wind", "solar"],
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get historical wind or solar forecast data from AESO CSV archives.
 
@@ -1487,28 +1478,39 @@ class AESO:
         url = f"https://www.aeso.ca/assets/{forecast_type.upper()}_GEN_MAR_2023-MAR_2025-Day-ahead.csv"
 
         try:
-            df = pd.read_csv(url)
+            pdf = pd.read_csv(url)
         except Exception as e:
             raise RequestException(
                 f"Failed to fetch historical {forecast_type} forecast data: {str(e)}",
             )
 
-        forecast_prefix = forecast_type.upper()
-        df["Interval Start"] = pd.to_datetime(
-            df["FORECAST_DATE_MPT"],
+        pdf["Interval Start"] = pd.to_datetime(
+            pdf["FORECAST_DATE_MPT"],
             format="mixed",
-        ).dt.tz_localize(self.default_timezone, ambiguous="infer")
+        )
+        df = pl.from_pandas(pdf)
+        df = utils.localize_ambiguous_infer_polars(
+            df,
+            "Interval Start",
+            self.default_timezone,
+        )
 
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(hours=1)
-        df["Publish Time"] = df["Interval Start"] - pd.Timedelta(hours=24)
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(hours=1)).alias("Interval End"),
+            (pl.col("Interval Start") - pl.duration(hours=24)).alias("Publish Time"),
+        )
 
         if end:
-            df = df[(df["Interval Start"] >= date) & (df["Interval Start"] <= end)]
+            df = df.filter(
+                (pl.col("Interval Start") >= pl.lit(date))
+                & (pl.col("Interval Start") <= pl.lit(end)),
+            )
         else:
-            df = df[df["Interval Start"] >= date]
+            df = df.filter(pl.col("Interval Start") >= pl.lit(date))
 
+        forecast_prefix = forecast_type.upper()
         df = df.rename(
-            columns={
+            {
                 f"{forecast_prefix}_MIN": "Minimum Generation Forecast",
                 f"{forecast_prefix}_OPT": "Most Likely Generation Forecast",
                 f"{forecast_prefix}_MAX": "Maximum Generation Forecast",
@@ -1523,39 +1525,40 @@ class AESO:
             f"Total {forecast_type.capitalize()} Capacity",
         ]
 
-        for col in numeric_columns:
-            if col in df.columns:
-                df[col] = pd.to_numeric(df[col], errors="coerce")
+        cast_exprs = [
+            pl.col(col).cast(pl.Float64, strict=False)
+            for col in numeric_columns
+            if col in df.columns
+        ]
+        df = df.with_columns(cast_exprs)
 
         capacity_col = f"Total {forecast_type.capitalize()} Capacity"
-        df["Minimum Generation Percentage"] = (
-            df["Minimum Generation Forecast"] / df[capacity_col]
-        ) * 100
-        df["Most Likely Generation Percentage"] = (
-            df["Most Likely Generation Forecast"] / df[capacity_col]
-        ) * 100
-        df["Maximum Generation Percentage"] = (
-            df["Maximum Generation Forecast"] / df[capacity_col]
-        ) * 100
-
-        return (
-            df[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Publish Time",
-                    "Minimum Generation Forecast",
-                    "Most Likely Generation Forecast",
-                    "Maximum Generation Forecast",
-                    f"Total {forecast_type.capitalize()} Capacity",
-                    "Minimum Generation Percentage",
-                    "Most Likely Generation Percentage",
-                    "Maximum Generation Percentage",
-                ]
-            ]
-            .sort_values("Interval Start")
-            .reset_index(drop=True)
+        df = df.with_columns(
+            (pl.col("Minimum Generation Forecast") / pl.col(capacity_col) * 100).alias(
+                "Minimum Generation Percentage",
+            ),
+            (
+                pl.col("Most Likely Generation Forecast") / pl.col(capacity_col) * 100
+            ).alias("Most Likely Generation Percentage"),
+            (pl.col("Maximum Generation Forecast") / pl.col(capacity_col) * 100).alias(
+                "Maximum Generation Percentage",
+            ),
         )
+
+        return df.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "Publish Time",
+                "Minimum Generation Forecast",
+                "Most Likely Generation Forecast",
+                "Maximum Generation Forecast",
+                f"Total {forecast_type.capitalize()} Capacity",
+                "Minimum Generation Percentage",
+                "Most Likely Generation Percentage",
+                "Maximum Generation Percentage",
+            ],
+        ).sort("Interval Start")
 
     @support_date_range(frequency=None)
     def get_wind_hourly(
@@ -1563,7 +1566,7 @@ class AESO:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get actual wind generation data with hourly intervals.
 
@@ -1597,7 +1600,7 @@ class AESO:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get actual solar generation data with hourly intervals.
 
@@ -1631,7 +1634,7 @@ class AESO:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get actual wind generation data with 10-minute intervals.
 
@@ -1654,7 +1657,7 @@ class AESO:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get actual solar generation data with 10-minute intervals.
 
@@ -1675,7 +1678,7 @@ class AESO:
         self,
         generation_type: Literal["wind", "solar"],
         forecast_type: Literal["shortterm", "longterm"] = "shortterm",
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get actual wind or solar generation data from AESO CSV reports with 10-minute or hourly intervals.
 
@@ -1689,27 +1692,37 @@ class AESO:
         url = f"http://ets.aeso.ca/Market/Reports/Manual/Operations/prodweb_reports/wind_solar_forecast/{generation_type}_rpt_{forecast_type}.csv"
 
         try:
-            df = pd.read_csv(url)
+            df = pl.read_csv(url)
         except Exception as e:
             raise RequestException(
                 f"Failed to fetch {generation_type} generation data: {str(e)}",
             )
 
-        df["Interval Start"] = pd.to_datetime(
-            df["Forecast Transaction Date"],
-            format="%Y-%m-%d %H:%M",
-        ).dt.tz_localize(self.default_timezone, ambiguous="infer")
+        df = df.with_columns(
+            pl.col("Forecast Transaction Date")
+            .str.to_datetime(format="%Y-%m-%d %H:%M", strict=False)
+            .alias("Interval Start"),
+        )
+        df = utils.localize_ambiguous_infer_polars(
+            df,
+            "Interval Start",
+            self.default_timezone,
+        )
 
-        if forecast_type == "shortterm":
-            df["Interval End"] = df["Interval Start"] + pd.Timedelta(minutes=10)
-        else:
-            df["Interval End"] = df["Interval Start"] + pd.Timedelta(hours=1)
+        interval_duration = (
+            pl.duration(minutes=10)
+            if forecast_type == "shortterm"
+            else pl.duration(hours=1)
+        )
+        df = df.with_columns(
+            (pl.col("Interval Start") + interval_duration).alias("Interval End"),
+        )
 
         # NB: Only include rows with actual generation data
-        df = df[df["Actual"].notna()].copy()
+        df = df.filter(pl.col("Actual").is_not_null())
 
         df = df.rename(
-            columns={
+            {
                 "Actual": "Actual Generation",
                 "MCR": f"Total {generation_type.capitalize()} Capacity",
             },
@@ -1720,29 +1733,28 @@ class AESO:
             f"Total {generation_type.capitalize()} Capacity",
         ]
 
-        for col in numeric_columns:
-            if col in df.columns:
-                df[col] = pd.to_numeric(df[col], errors="coerce")
+        cast_exprs = [
+            pl.col(col).cast(pl.Float64, strict=False)
+            for col in numeric_columns
+            if col in df.columns
+        ]
+        df = df.with_columns(cast_exprs)
 
-        return (
-            df[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Actual Generation",
-                    f"Total {generation_type.capitalize()} Capacity",
-                ]
-            ]
-            .sort_values("Interval Start")
-            .reset_index(drop=True)
-        )
+        return df.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "Actual Generation",
+                f"Total {generation_type.capitalize()} Capacity",
+            ],
+        ).sort("Interval Start")
 
     def _get_wind_solar_actual_historical_data(
         self,
         generation_type: Literal["wind", "solar"],
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get historical wind or solar generation data from AESO CSV archives with hourly intervals.
 
@@ -1757,27 +1769,38 @@ class AESO:
         url = f"https://www.aeso.ca/assets/{generation_type.upper()}_GEN_MAR_2023-MAR_2025-Day-ahead.csv"
 
         try:
-            df = pd.read_csv(url)
+            pdf = pd.read_csv(url)
         except Exception as e:
             raise RequestException(
                 f"Failed to fetch historical {generation_type} generation data: {str(e)}",
             )
 
-        generation_prefix = generation_type.upper()
-        df["Interval Start"] = pd.to_datetime(
-            df["FORECAST_DATE_MPT"],
+        pdf["Interval Start"] = pd.to_datetime(
+            pdf["FORECAST_DATE_MPT"],
             format="mixed",
-        ).dt.tz_localize(self.default_timezone, ambiguous="infer")
+        )
+        df = pl.from_pandas(pdf)
+        df = utils.localize_ambiguous_infer_polars(
+            df,
+            "Interval Start",
+            self.default_timezone,
+        )
 
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(hours=1)
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(hours=1)).alias("Interval End"),
+        )
 
         if end:
-            df = df[(df["Interval Start"] >= date) & (df["Interval Start"] <= end)]
+            df = df.filter(
+                (pl.col("Interval Start") >= pl.lit(date))
+                & (pl.col("Interval Start") <= pl.lit(end)),
+            )
         else:
-            df = df[df["Interval Start"] >= date]
+            df = df.filter(pl.col("Interval Start") >= pl.lit(date))
 
+        generation_prefix = generation_type.upper()
         df = df.rename(
-            columns={
+            {
                 f"{generation_prefix}_ACTUAL": "Actual Generation",
                 f"{generation_prefix}_MCR": f"Total {generation_type.capitalize()} Capacity",
             },
@@ -1788,19 +1811,18 @@ class AESO:
             f"Total {generation_type.capitalize()} Capacity",
         ]
 
-        for col in numeric_columns:
-            if col in df.columns:
-                df[col] = pd.to_numeric(df[col], errors="coerce")
+        cast_exprs = [
+            pl.col(col).cast(pl.Float64, strict=False)
+            for col in numeric_columns
+            if col in df.columns
+        ]
+        df = df.with_columns(cast_exprs)
 
-        return (
-            df[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Actual Generation",
-                    f"Total {generation_type.capitalize()} Capacity",
-                ]
-            ]
-            .sort_values("Interval Start")
-            .reset_index(drop=True)
-        )
+        return df.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "Actual Generation",
+                f"Total {generation_type.capitalize()} Capacity",
+            ],
+        ).sort("Interval Start")

--- a/gridstatus/base.py
+++ b/gridstatus/base.py
@@ -3,7 +3,6 @@ from enum import Enum, StrEnum
 from typing import BinaryIO
 
 import pandas as pd
-import polars as pl
 import requests
 
 from gridstatus.gs_logging import logger
@@ -91,11 +90,6 @@ _interconnection_columns = [
     "Withdrawal Comment",
     "Actual Completion Date",
 ]
-
-
-def _is_polars(obj: object) -> bool:
-    """Return whether ``obj`` is a polars DataFrame."""
-    return isinstance(obj, pl.DataFrame)
 
 
 class ISOBase:
@@ -187,42 +181,22 @@ class ISOBase:
             **kwargs,
         )
 
-        if _is_polars(lmp_df):
-            col_order = lmp_df.columns
-            # Special case to handle PJM 5 min LMPs
-            grouper_column_name = (
-                "Location" if "Location" in col_order else "Location Id"
-            )
-            # Assume sorted in ascending order; maintain_order keeps the last
-            # row per group, matching pandas groupby().last().
-            latest_df = lmp_df.group_by(
-                grouper_column_name,
-                maintain_order=True,
-            ).last()
-            return latest_df.select(col_order)
-
-        col_order = lmp_df.columns.tolist()
-
+        col_order = lmp_df.columns
         # Special case to handle PJM 5 min LMPs
         grouper_column_name = "Location" if "Location" in col_order else "Location Id"
-
-        # Assume sorted in ascending order
-        latest_df = lmp_df.groupby(grouper_column_name).last().reset_index()
-        latest_df = latest_df[col_order]
-        return latest_df
+        # Assume sorted in ascending order; maintain_order keeps the last
+        # row per group, matching pandas groupby().last().
+        latest_df = lmp_df.group_by(
+            grouper_column_name,
+            maintain_order=True,
+        ).last()
+        return latest_df.select(col_order)
 
     def _latest_from_today(self, method, *args, **kwargs):
         data = method(date="today", *args, **kwargs)
 
-        if _is_polars(data):
-            row = data.tail(1).to_dicts()[0]
-            return {k.lower(): v for k, v in row.items()}
-
-        latest = data.iloc[-1]
-
-        latest.index = latest.index.str.lower()
-
-        return latest.to_dict()
+        row = data.tail(1).to_dicts()[0]
+        return {k.lower(): v for k, v in row.items()}
 
 
 class GridStatus:

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -4,12 +4,14 @@ import re
 import time
 import warnings
 import xml.etree.ElementTree as ElementTree
+from datetime import datetime
 from typing import Literal
 from zipfile import ZipFile
 
 import numpy as np
 import pandas as pd
 import pdfplumber
+import polars as pl
 import requests
 from tabulate import tabulate
 from termcolor import colored
@@ -58,16 +60,35 @@ def _determine_lmp_frequency(args: dict) -> str:
 
 
 def _collapse_group_to_array(
-    df: pd.DataFrame,
+    df: pl.DataFrame,
     group_cols: list[str],
-) -> pd.DataFrame:
+) -> pl.DataFrame:
     """Collapse multiple rows with different Group values into a single row
     with a Groups list column. The non-group columns must be identical across
     groups for a given combination of group_cols."""
-    df = df.groupby(group_cols, as_index=False, sort=False).agg(
-        Groups=("Group", lambda x: sorted(x.dropna().astype(int).tolist())),
+    return (
+        df.group_by(group_cols, maintain_order=True)
+        .agg(
+            pl.col("Group")
+            .filter(pl.col("Group").is_not_nan())
+            .drop_nulls()
+            .cast(pl.Int64)
+            .sort()
+            .implode()
+            .alias("_groups"),
+        )
+        .with_columns(
+            pl.col("_groups")
+            .map_elements(
+                lambda groups: groups.to_list()
+                if isinstance(groups, pl.Series)
+                else list(groups),
+                return_dtype=pl.Object,
+            )
+            .alias("Groups"),
+        )
+        .drop("_groups")
     )
-    return df
 
 
 def _determine_oasis_frequency(args: dict) -> str:
@@ -86,8 +107,8 @@ def _get_historical(
     date: str | pd.Timestamp,
     column: str,
     verbose: bool = False,
-) -> pd.DataFrame:
-    """Get the historical data file from CAISO given a data series name, formats, and returns a pandas dataframe.
+) -> pl.DataFrame:
+    """Get the historical data file from CAISO given a data series name, formats, and returns a polars dataframe.
 
     Args:
         file (str): The name of the data we are wanting, which is equivalent to the file to get from CAISO
@@ -96,7 +117,7 @@ def _get_historical(
         verbose (bool, optional): Whether to print out the URL being fetched, defaults to False
 
     Returns:
-        pd.DataFrame: A pandas dataframe of the data
+        pl.DataFrame: A polars dataframe of the data
     """
     # NOTE: The cache buster is necessary because CAISO will serve cached data from cloudfront on the same url if the url has not changed.
     cache_buster = int(pd.Timestamp.now(tz=CAISO.default_timezone).timestamp())
@@ -108,18 +129,11 @@ def _get_historical(
         url: str = f"{HISTORY_BASE}/{date_str}/{file}.csv?_={cache_buster}"
         latest = False
     logger.info(f"Fetching URL: {url}")
-    df = pd.read_csv(url)
+    pdf = pd.read_csv(url)
+    pdf = pdf.dropna(subset=["Time"])
+    pdf = pdf.dropna(subset=pdf.columns[1:], how="all")
+    df = pl.from_pandas(pdf)
 
-    # sometimes there are extra rows at the end, so this lets us ignore them
-    df = df.dropna(subset=["Time"])
-
-    # drop every column after Time where values
-    # are all null. this happens during spring DST
-    # change and caiso keeps the non-existent hour
-    # but has nulls for all other columns
-    df = df.dropna(subset=df.columns[1:], how="all")
-
-    # for the latest data, we want to check if the data is actually from the previous day and update the date accordingly
     if latest:
         latest_file_time = caiso_utils.check_latest_value_time(df, column)
         current_caiso_time = pd.Timestamp.now(tz=CAISO.default_timezone)
@@ -127,24 +141,31 @@ def _get_historical(
         if latest_file_time > current_caiso_time:
             date = date - pd.Timedelta(days=1)
 
-    df["Time"] = df["Time"].apply(
-        caiso_utils.make_timestamp,
-        today=date,
-        timezone=CAISO.default_timezone,
+    def _apply_make_timestamp(time_str: str) -> pd.Timestamp:
+        return caiso_utils.make_timestamp(
+            time_str,
+            today=date,
+            timezone=CAISO.default_timezone,
+        )
+
+    df = df.with_columns(
+        pl.col("Time")
+        .map_elements(
+            _apply_make_timestamp,
+            return_dtype=pl.Datetime(time_zone=CAISO.default_timezone),
+        )
+        .alias("Time"),
     )
 
-    # sometimes returns midnight, which is technically the next day
-    # to be careful, let's check if that is the case before dropping
-    if df.iloc[-1]["Time"].hour == 0:
-        df = df.iloc[:-1]
+    if df[-1, "Time"].hour == 0:
+        df = df.head(df.height - 1)
 
-    # insert interval start/end columns
-    df.insert(1, "Interval Start", df["Time"])
-
-    # be careful if this is ever not 5 minutes
-    df.insert(2, "Interval End", df["Time"] + pd.Timedelta(minutes=5))
-
-    return df
+    value_cols = [c for c in df.columns if c != "Time"]
+    df = df.with_columns(
+        pl.col("Time").alias("Interval Start"),
+        (pl.col("Time") + pl.duration(minutes=5)).alias("Interval End"),
+    )
+    return df.select(["Time", "Interval Start", "Interval End", *value_cols])
 
 
 def _caiso_handle_start_end(
@@ -264,7 +285,7 @@ class CAISO(ISOBase):
         raw_data: bool = True,
         sleep: int = 5,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Return data from OASIS for a given dataset
 
         Args:
@@ -285,7 +306,7 @@ class CAISO(ISOBase):
             ValueError: if parameter value is not supported for dataset
 
         Returns:
-            pd.DataFrame: A DataFrame of data from OASIS
+            pl.DataFrame: A DataFrame of data from OASIS
         """
 
         # deepcopy to avoid modifying original
@@ -341,7 +362,7 @@ class CAISO(ISOBase):
                 logger.warning(f"No data for {date} to {end}")
             else:
                 logger.warning(f"No data for {date}")
-            return pd.DataFrame()
+            return pl.DataFrame()
 
         return df
 
@@ -354,7 +375,7 @@ class CAISO(ISOBase):
         verbose: bool = False,
         sleep: int = 5,
         max_retries: int = 3,
-    ) -> pd.DataFrame | None:
+    ) -> pl.DataFrame | None:
         start, end = _caiso_handle_start_end(start, end)
         config = copy.deepcopy(config)
         config["startdatetime"] = start
@@ -400,22 +421,45 @@ class CAISO(ISOBase):
         z = ZipFile(io.BytesIO(r.content))
 
         # parse and concat all files
-        dfs = []
+        dfs: list[pl.DataFrame] = []
         logger.debug(f"Found {len(z.namelist())} files: {z.namelist()}")
         for f in z.namelist():
             logger.debug(f"Parsing file: {f}")
-            df = pd.read_csv(z.open(f))
-            dfs.append(df)
+            pdf = pd.read_csv(z.open(f))
+            dfs.append(pl.from_pandas(pdf))
 
-        df = pd.concat(dfs)
+        df = pl.concat(dfs, how="diagonal_relaxed")
+
+        float_cols = [
+            c
+            for c in df.columns
+            if c in {"PRC", "MW", "VALUE", "MARGINAL_CLEARING_PRICE"}
+            or c.endswith("_PRICE")
+        ]
+        if float_cols:
+            df = df.with_columns(
+                *[pl.col(c).cast(pl.Float64, strict=False) for c in float_cols],
+            )
 
         # if col ends in _GMT, then try to parse as UTC
         for col in df.columns:
             if col.endswith("_GMT"):
-                df[col] = pd.to_datetime(
-                    df[col],
-                    utc=True,
-                )
+                dtype = df.schema[col]
+                if dtype in (pl.Utf8, pl.String):
+                    df = df.with_columns(
+                        pl.col(col)
+                        .str.to_datetime(time_unit="us", time_zone="UTC")
+                        .alias(col),
+                    )
+                elif isinstance(dtype, pl.Datetime):
+                    if dtype.time_zone is None:
+                        df = df.with_columns(
+                            pl.col(col).dt.replace_time_zone("UTC").alias(col),
+                        )
+                    elif dtype.time_zone != "UTC":
+                        df = df.with_columns(
+                            pl.col(col).dt.convert_time_zone("UTC").alias(col),
+                        )
 
         # handle different column names
         # across different datasets
@@ -436,31 +480,30 @@ class CAISO(ISOBase):
         for col in start_cols:
             if col in df.columns:
                 start_col = col
-                df = df.sort_values(by=start_col)
+                df = df.sort(col)
                 break
         for col in end_cols:
             if col in df.columns:
                 end_col = col
                 break
 
-        if not raw_data and start_col in df.columns:
-            df[start_col] = df[start_col].dt.tz_convert(
-                CAISO.default_timezone,
-            )
-
-            df[end_col] = df[end_col].dt.tz_convert(
-                CAISO.default_timezone,
-            )
-
-            df.rename(
-                columns={
+        if not raw_data and start_col is not None and start_col in df.columns:
+            df = df.with_columns(
+                pl.col(start_col).dt.convert_time_zone(CAISO.default_timezone),
+                pl.col(end_col).dt.convert_time_zone(CAISO.default_timezone),
+            ).rename(
+                {
                     start_col: "Interval Start",
                     end_col: "Interval End",
                 },
-                inplace=True,
             )
-
-            df.insert(0, "Time", df["Interval Start"])
+            df = df.with_columns(pl.col("Interval Start").alias("Time"))
+            other_cols = [
+                c
+                for c in df.columns
+                if c not in {"Time", "Interval Start", "Interval End"}
+            ]
+            df = df.select(["Time", "Interval Start", "Interval End", *other_cols])
 
         # avoid rate limiting
         time.sleep(sleep)
@@ -474,7 +517,7 @@ class CAISO(ISOBase):
         start: str | pd.Timestamp | None = None,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get fuel mix in 5 minute intervals for a provided day.
 
         Args:
@@ -491,7 +534,7 @@ class CAISO(ISOBase):
         """
         if date == "latest":
             mix = self.get_fuel_mix("today", verbose=verbose)
-            return mix.tail(1).reset_index(drop=True)
+            return mix.tail(1)
 
         return self._get_historical_fuel_mix(date, verbose=verbose)
 
@@ -499,12 +542,12 @@ class CAISO(ISOBase):
         self,
         date: str | pd.Timestamp,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         df = _get_historical("fuelsource", date, column="Solar", verbose=verbose)
 
         # rename some inconsistent columns names to standardize across dates
         df = df.rename(
-            columns={
+            {
                 "Small hydro": "Small Hydro",
                 "Natural gas": "Natural Gas",
                 "Large hydro": "Large Hydro",
@@ -515,8 +558,12 @@ class CAISO(ISOBase):
         # maybe better way to do this in case there are other cases
         # where there are all na rows
         # ignore Time, Interval Start, Interval End columns
-        subset = set(df.columns) - set(["Time", "Interval Start", "Interval End"])
-        df = df.dropna(axis=0, how="all", subset=subset)
+        subset = [
+            c for c in df.columns if c not in {"Time", "Interval Start", "Interval End"}
+        ]
+        df = df.filter(
+            ~pl.all_horizontal(pl.col(c).is_null() for c in subset),
+        )
 
         return df
 
@@ -526,7 +573,7 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Return load at a previous date in 5 minute intervals"""
 
         if date == "latest":
@@ -538,12 +585,12 @@ class CAISO(ISOBase):
         self,
         date: str | pd.Timestamp,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         df = _get_historical("demand", date, column="Current demand", verbose=verbose)
 
-        df = df[["Time", "Interval Start", "Interval End", "Current demand"]]
-        df = df.rename(columns={"Current demand": "Load"})
-        df = df.dropna(subset=["Load"])
+        df = df.select(["Time", "Interval Start", "Interval End", "Current demand"])
+        df = df.rename({"Current demand": "Load"})
+        df = df.filter(pl.col("Load").is_not_null())
         return df
 
     @support_date_range(frequency="DAY_START")
@@ -552,7 +599,7 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Seven-day resource adequacy outlook in 5-minute intervals.
 
         Source: ``/outlook/history/{{yyyymmdd}}/rtm_forecast_7day.csv`` (historical)
@@ -572,7 +619,7 @@ class CAISO(ISOBase):
         publish_day = utils._handle_date(date, self.default_timezone).normalize()
         raw = self._fetch_rtm_forecast_7day_csv(publish_day, verbose=verbose)
         df = self._parse_rtm_forecast_7day_csv(raw, publish_day)
-        if df.empty:
+        if df.is_empty():
             raise NoDataFoundException(
                 f"No seven-day resource adequacy outlook data found for {publish_day.date()}",
             )
@@ -582,7 +629,7 @@ class CAISO(ISOBase):
         self,
         date: pd.Timestamp,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         tz = self.default_timezone
         file_stem = "rtm_forecast_7day"
         cache_buster = int(pd.Timestamp.now(tz=tz).timestamp())
@@ -596,7 +643,7 @@ class CAISO(ISOBase):
         try:
             r = requests.get(url, timeout=120)
             r.raise_for_status()
-            return pd.read_csv(io.StringIO(r.text))
+            return pl.from_pandas(pd.read_csv(io.StringIO(r.text)))
 
         except ValueError as e:
             raise NoDataFoundException(
@@ -605,26 +652,35 @@ class CAISO(ISOBase):
 
     def _parse_rtm_forecast_7day_csv(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         publish_day_pt: pd.Timestamp,
-    ) -> pd.DataFrame:
-        df = df.dropna(subset=["Time"])
+    ) -> pl.DataFrame:
+        df = df.filter(pl.col("Time").is_not_null())
         value_cols = [c for c in df.columns if c != "Time"]
-        df = df.dropna(subset=value_cols, how="all")
-        interval_end = pd.to_datetime(df["Time"], format="%m/%d/%Y %H:%M")
-        interval_end = interval_end.dt.tz_localize(
-            self.default_timezone,
-            ambiguous=True,
-            nonexistent="shift_forward",
+        df = df.filter(
+            ~pl.all_horizontal(pl.col(c).is_null() for c in value_cols),
         )
-        df = df.copy()
-        df["Interval End"] = interval_end
-        df = df.dropna(subset=["Interval End"])
-        df["Interval Start"] = df["Interval End"] - pd.Timedelta(minutes=5)
+        df = df.with_columns(
+            pl.col("Time")
+            .str.to_datetime(format="%m/%d/%Y %H:%M")
+            .alias("_interval_end_naive"),
+        )
+        df = utils.localize_shift_forward_polars(
+            df,
+            "_interval_end_naive",
+            self.default_timezone,
+        )
+        df = df.filter(pl.col("_interval_end_naive").is_not_null())
         publish_ts = publish_day_pt.tz_convert(self.default_timezone).normalize()
-        df["Publish Time"] = publish_ts
+        df = df.with_columns(
+            pl.col("_interval_end_naive").alias("Interval End"),
+            (pl.col("_interval_end_naive") - pl.duration(minutes=5)).alias(
+                "Interval Start",
+            ),
+            pl.lit(publish_ts).alias("Publish Time"),
+        )
         df = df.rename(
-            columns={
+            {
                 "Day-ahead demand forecast": "Day Ahead Demand Forecast",
                 "Day-ahead net demand forecast": "Day Ahead Net Demand Forecast",
                 "Resource adequacy capacity forecast": "Resource Adequacy Capacity Forecast",
@@ -634,8 +690,21 @@ class CAISO(ISOBase):
                 "Resource adequacy credits": "Resource Adequacy Credits",
             },
         )
-        df = df.drop(columns=["Time"])
-        df = df[
+        numeric_cols = [
+            "Demand",
+            "Net Demand",
+            "Day Ahead Demand Forecast",
+            "Day Ahead Net Demand Forecast",
+            "Resource Adequacy Capacity Forecast",
+            "Net Resource Adequacy Capacity Forecast",
+            "Reserve Requirement",
+            "Reserve Requirement Forecast",
+            "Resource Adequacy Credits",
+        ]
+        df = df.with_columns(
+            [pl.col(col).cast(pl.Float64, strict=False) for col in numeric_cols],
+        )
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -649,26 +718,8 @@ class CAISO(ISOBase):
                 "Reserve Requirement",
                 "Reserve Requirement Forecast",
                 "Resource Adequacy Credits",
-            ]
-        ]
-        numeric_cols = [
-            "Demand",
-            "Net Demand",
-            "Day Ahead Demand Forecast",
-            "Day Ahead Net Demand Forecast",
-            "Resource Adequacy Capacity Forecast",
-            "Net Resource Adequacy Capacity Forecast",
-            "Reserve Requirement",
-            "Reserve Requirement Forecast",
-            "Resource Adequacy Credits",
-        ]
-        for col in numeric_cols:
-            df[col] = pd.to_numeric(df[col], errors="coerce").astype("float64")
-        df = df.sort_values(
-            by=["Interval Start", "Publish Time"],
-            kind="mergesort",
-        ).reset_index(drop=True)
-        return df
+            ],
+        ).sort(["Interval Start", "Publish Time"])
 
     # Deprecated in favor of the vintage-based functions, e.g. get_load_forecast_5_min
     @support_date_range(frequency="31D")
@@ -677,14 +728,13 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "today" or date == "latest":
             date = pd.Timestamp.now(tz=self.default_timezone).normalize()
         df = self.get_load_forecast_day_ahead(date, end=end)
-        df["Time"] = df["Interval Start"]
-        df = df[df["TAC Area Name"] == "CA ISO-TAC"]
-        df = df.drop(columns=["TAC Area Name"])
-        return df
+        df = df.with_columns(pl.col("Interval Start").alias("Time"))
+        df = df.filter(pl.col("TAC Area Name") == "CA ISO-TAC")
+        return df.drop("TAC Area Name")
 
     @support_date_range(frequency="31D")
     def get_load_forecast_5_min(
@@ -693,7 +743,7 @@ class CAISO(ISOBase):
         end: str | pd.Timestamp | None = None,
         sleep: int = 4,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Returns 5-minute load forecast from the Real-Time Market
 
         Arguments:
@@ -704,7 +754,7 @@ class CAISO(ISOBase):
             verbose (bool): print verbose output. Defaults to False.
 
         Returns:
-            pd.DataFrame: DataFrame with load forecast data
+            pl.DataFrame: DataFrame with load forecast data
         """
         df = self.get_oasis_dataset(
             dataset="demand_forecast",
@@ -717,25 +767,24 @@ class CAISO(ISOBase):
         )
 
         df = df.rename(
-            columns={"MW": "Load Forecast", "TAC_AREA_NAME": "TAC Area Name"},
+            {"MW": "Load Forecast", "TAC_AREA_NAME": "TAC Area Name"},
         )
 
-        df["Publish Time"] = df["Interval Start"] - pd.Timedelta(
-            minutes=2.5,
+        df = df.with_columns(
+            (pl.col("Interval Start") - pl.duration(minutes=2, seconds=30)).alias(
+                "Publish Time",
+            ),
         )
 
-        df.sort_values(by="Interval Start", inplace=True)
-        df = df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
                 "Publish Time",
                 "TAC Area Name",
                 "Load Forecast",
-            ]
-        ]
-
-        return df
+            ],
+        ).sort("Interval Start")
 
     @support_date_range(frequency="31D")
     def get_load_forecast_15_min(
@@ -744,7 +793,7 @@ class CAISO(ISOBase):
         end: str | pd.Timestamp | None = None,
         sleep: int = 4,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Returns 15-minute load forecast from the Real-Time Pre-Dispatch Market
 
         Arguments:
@@ -755,7 +804,7 @@ class CAISO(ISOBase):
             verbose (bool): print verbose output. Defaults to False.
 
         Returns:
-            pd.DataFrame: DataFrame with load forecast data
+            pl.DataFrame: DataFrame with load forecast data
         """
         df = self.get_oasis_dataset(
             dataset="demand_forecast",
@@ -767,25 +816,24 @@ class CAISO(ISOBase):
             params={"market_run_id": "RTM", "execution_type": "RTPD"},
         )
         df = df.rename(
-            columns={"MW": "Load Forecast", "TAC_AREA_NAME": "TAC Area Name"},
+            {"MW": "Load Forecast", "TAC_AREA_NAME": "TAC Area Name"},
         )
 
-        df["Publish Time"] = df["Interval Start"] - pd.Timedelta(
-            minutes=22.5,
+        df = df.with_columns(
+            (pl.col("Interval Start") - pl.duration(minutes=22, seconds=30)).alias(
+                "Publish Time",
+            ),
         )
 
-        df.sort_values(by="Interval Start", inplace=True)
-        df = df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
                 "Publish Time",
                 "TAC Area Name",
                 "Load Forecast",
-            ]
-        ]
-
-        return df
+            ],
+        ).sort("Interval Start")
 
     @support_date_range(frequency="31D")
     def get_load_forecast_day_ahead(
@@ -794,7 +842,7 @@ class CAISO(ISOBase):
         end: str | pd.Timestamp | None = None,
         sleep: int = 4,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Returns hourly day-ahead load forecast
 
         Arguments:
@@ -805,7 +853,7 @@ class CAISO(ISOBase):
             verbose (bool): print verbose output. Defaults to False.
 
         Returns:
-            pd.DataFrame: DataFrame with load forecast data
+            pl.DataFrame: DataFrame with load forecast data
         """
         df = self.get_oasis_dataset(
             dataset="demand_forecast",
@@ -818,22 +866,19 @@ class CAISO(ISOBase):
         )
 
         df = df.rename(
-            columns={"MW": "Load Forecast", "TAC_AREA_NAME": "TAC Area Name"},
+            {"MW": "Load Forecast", "TAC_AREA_NAME": "TAC Area Name"},
         )
         df = self._add_load_forecast_publish_time(df, day_offset=1)
-        df.sort_values(by="Interval Start", inplace=True)
 
-        df = df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
                 "Publish Time",
                 "TAC Area Name",
                 "Load Forecast",
-            ]
-        ]
-
-        return df
+            ],
+        ).sort("Interval Start")
 
     @support_date_range(frequency="31D")
     def get_load_forecast_two_day_ahead(
@@ -842,7 +887,7 @@ class CAISO(ISOBase):
         end: str | pd.Timestamp | None = None,
         sleep: int = 4,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Returns hourly two-day-ahead load forecast
 
         Arguments:
@@ -853,7 +898,7 @@ class CAISO(ISOBase):
             verbose (bool): print verbose output. Defaults to False.
 
         Returns:
-            pd.DataFrame: DataFrame with load forecast data
+            pl.DataFrame: DataFrame with load forecast data
         """
         df = self.get_oasis_dataset(
             dataset="demand_forecast",
@@ -866,23 +911,20 @@ class CAISO(ISOBase):
         )
 
         df = df.rename(
-            columns={"MW": "Load Forecast", "TAC_AREA_NAME": "TAC Area Name"},
+            {"MW": "Load Forecast", "TAC_AREA_NAME": "TAC Area Name"},
         )
 
         df = self._add_load_forecast_publish_time(df, day_offset=2)
-        df.sort_values(by="Interval Start", inplace=True)
 
-        df = df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
                 "Publish Time",
                 "TAC Area Name",
                 "Load Forecast",
-            ]
-        ]
-
-        return df
+            ],
+        ).sort("Interval Start")
 
     @support_date_range(frequency="31D")
     def get_load_forecast_seven_day_ahead(
@@ -891,7 +933,7 @@ class CAISO(ISOBase):
         end: str | pd.Timestamp | None = None,
         sleep: int = 4,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Returns hourly seven-day-ahead load forecast
 
         Arguments:
@@ -902,7 +944,7 @@ class CAISO(ISOBase):
             verbose (bool): print verbose output. Defaults to False.
 
         Returns:
-            pd.DataFrame: DataFrame with load forecast data
+            pl.DataFrame: DataFrame with load forecast data
         """
         df = self.get_oasis_dataset(
             dataset="demand_forecast",
@@ -915,51 +957,54 @@ class CAISO(ISOBase):
         )
 
         df = df.rename(
-            columns={"MW": "Load Forecast", "TAC_AREA_NAME": "TAC Area Name"},
+            {"MW": "Load Forecast", "TAC_AREA_NAME": "TAC Area Name"},
         )
 
         df = self._add_load_forecast_publish_time(df, day_offset=7)
-        df.sort_values(by="Interval Start", inplace=True)
 
-        df = df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
                 "Publish Time",
                 "TAC Area Name",
                 "Load Forecast",
-            ]
-        ]
+            ],
+        ).sort("Interval Start")
 
-        return df
-
-    def _add_load_forecast_publish_time(self, df: pd.DataFrame, day_offset: int):
+    def _add_load_forecast_publish_time(
+        self,
+        df: pl.DataFrame,
+        day_offset: int,
+    ) -> pl.DataFrame:
         """Adds a publish time to the load forecast data
 
         Args:
-            df (pd.DataFrame): load forecast data
+            df (pl.DataFrame): load forecast data
             day_offset (int): number of days before the forecast date that it was published
 
         Returns:
-            pd.DataFrame: load forecast data with publish time
+            pl.DataFrame: load forecast data with publish time
         """
-        df["date"] = df["Interval Start"].dt.date
-        unique_dates = sorted(df["date"].unique())
+        df = df.with_columns(pl.col("Interval Start").dt.date().alias("date"))
+        unique_dates = sorted(df["date"].unique().to_list())
 
         # All daily forecasts are published at the same time each day, 9:10 AM PT
         # http://oasis.caiso.com/mrioasis/logon.do > Atlas Reference > Publications > OASIS Publications Schedule
-        for forecast_date in unique_dates:
-            publish_time = (
+        publish_time_map = {
+            forecast_date: (
                 pd.Timestamp(forecast_date, tz=self.default_timezone)
                 - pd.Timedelta(days=day_offset)
             ).replace(
                 hour=9,
                 minute=10,
             )
-            df.loc[df["date"] == forecast_date, "Publish Time"] = publish_time
-
-        df = df.drop(columns=["date"])
-        return df
+            for forecast_date in unique_dates
+        }
+        df = df.with_columns(
+            pl.col("date").replace_strict(publish_time_map).alias("Publish Time"),
+        )
+        return df.drop("date")
 
     @support_date_range(frequency="31D")
     def get_load_hourly(
@@ -968,7 +1013,7 @@ class CAISO(ISOBase):
         end: str | pd.Timestamp | None = None,
         sleep: int = 4,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Returns actual load values
 
         Arguments:
@@ -979,7 +1024,7 @@ class CAISO(ISOBase):
             verbose (bool): print verbose output. Defaults to False.
 
         Returns:
-            pd.DataFrame: DataFrame with actual load data
+            pl.DataFrame: DataFrame with actual load data
         """
         df = self.get_oasis_dataset(
             dataset="demand_forecast",
@@ -992,27 +1037,24 @@ class CAISO(ISOBase):
         )
 
         df = df.rename(
-            columns={"MW": "Load", "TAC_AREA_NAME": "TAC Area Name"},
+            {"MW": "Load", "TAC_AREA_NAME": "TAC Area Name"},
         )
 
-        df.sort_values(by="Interval Start", inplace=True)
-        df = df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
                 "TAC Area Name",
                 "Load",
-            ]
-        ]
-
-        return df
+            ],
+        ).sort("Interval Start")
 
     def get_renewables_hourly(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get wind and solar hourly actuals from CAISO.
 
         Args:
@@ -1021,7 +1063,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame of wind and solar hourly actuals
+            pl.DataFrame: A DataFrame of wind and solar hourly actuals
         """
         if date == "latest":
             return self.get_renewables_hourly("today")
@@ -1040,7 +1082,7 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Return DAM renewable forecast in hourly intervals
 
         Data at: http://oasis.caiso.com/mrioasis/logon.do  at System Demand >
@@ -1069,38 +1111,35 @@ class CAISO(ISOBase):
 
     def _process_renewables_hourly(
         self,
-        data: pd.DataFrame,
+        data: pl.DataFrame,
         current_time: pd.Timestamp | None = None,
         publish_time_offset_from_day_start: pd.Timedelta | None = None,
-    ):
-        df = data[
+    ) -> pl.DataFrame:
+        df = data.select(
             [
                 "Interval Start",
                 "Interval End",
                 "TRADING_HUB",
                 "RENEWABLE_TYPE",
                 "MW",
-            ]
-        ]
+            ],
+        )
 
         # Totals across all trading hubs for each renewable type at each interval
         totals = (
-            df.groupby(
-                ["RENEWABLE_TYPE", "Interval Start", "Interval End"],
-            )["MW"]
-            .sum()
-            .reset_index()
+            df.group_by(["RENEWABLE_TYPE", "Interval Start", "Interval End"])
+            .agg(pl.col("MW").sum())
+            .with_columns(pl.lit("CAISO").alias("TRADING_HUB"))
+            .select(df.columns)
         )
 
-        totals["TRADING_HUB"] = "CAISO"
+        df = pl.concat([df, totals])
 
-        df = pd.concat([df, totals])
-
-        df = df.pivot_table(
-            columns=["RENEWABLE_TYPE"],
+        df = df.pivot(
             index=["Interval Start", "Interval End", "TRADING_HUB"],
+            on="RENEWABLE_TYPE",
             values="MW",
-        ).reset_index()
+        )
 
         if publish_time_offset_from_day_start:
             df = self._add_forecast_publish_time(
@@ -1113,7 +1152,7 @@ class CAISO(ISOBase):
 
             df = utils.move_cols_to_front(
                 df.rename(
-                    columns={
+                    {
                         "TRADING_HUB": "Location",
                         "Solar": "Solar MW",
                         "Wind": "Wind MW",
@@ -1122,34 +1161,25 @@ class CAISO(ISOBase):
                 ["Interval Start", "Interval End", "Publish Time", "Location"],
             )
 
-            df.columns.name = None
+            return df.sort(["Interval Start", "Publish Time", "Location"])
 
-            return df.sort_values(
-                ["Interval Start", "Publish Time", "Location"],
-            ).reset_index(drop=True)
+        df = utils.move_cols_to_front(
+            df.rename(
+                {
+                    "TRADING_HUB": "Location",
+                },
+            ),
+            ["Interval Start", "Interval End", "Location"],
+        )
 
-        else:
-            df = utils.move_cols_to_front(
-                df.rename(
-                    columns={
-                        "TRADING_HUB": "Location",
-                    },
-                ),
-                ["Interval Start", "Interval End", "Location"],
-            )
-
-            df.columns.name = None
-
-            return df.sort_values(
-                ["Interval Start", "Location"],
-            ).reset_index(drop=True)
+        return df.sort(["Interval Start", "Location"])
 
     def _add_forecast_publish_time(
         self,
-        data: pd.DataFrame,
+        data: pl.DataFrame,
         current_time: pd.Timestamp,
         publish_time_offset_from_day_start: pd.Timedelta | None = None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Labels forecasts with a publish time.
 
         The logic is:
@@ -1182,46 +1212,57 @@ class CAISO(ISOBase):
             # publish time offset
 
         # Default to existing DAM behavior for backward compatibility
-        data["Publish Time"] = np.where(
-            data["Interval Start"].dt.date > future_forecasts_publish_time.date(),
-            future_forecasts_publish_time,
-            data["Interval Start"].apply(
-                lambda x: x.floor("D").replace(
-                    hour=hour_offset,
-                    minute=minute_offset,
+        def _past_publish_time(interval_start: datetime | pd.Timestamp) -> pd.Timestamp:
+            ts = pd.Timestamp(interval_start)
+            return ts.floor("D").replace(
+                hour=hour_offset,
+                minute=minute_offset,
+            ) - pd.Timedelta(days=1)
+
+        return data.with_columns(
+            pl.when(
+                pl.col("Interval Start").dt.date()
+                > future_forecasts_publish_time.date(),
+            )
+            .then(pl.lit(future_forecasts_publish_time))
+            .otherwise(
+                pl.col("Interval Start").map_elements(
+                    _past_publish_time,
+                    return_dtype=pl.Datetime(time_zone=self.default_timezone),
                 ),
             )
-            - pd.Timedelta(days=1),
+            .alias("Publish Time"),
         )
-
-        return data
 
     def _handle_renewables_forecast(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         publish_time_offset: pd.Timedelta,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         df = df.rename(
-            columns={
+            {
                 "TRADING_HUB": "Location",
                 "RENEWABLE_TYPE": "Renewable Type",
             },
         )
 
-        df = df.pivot_table(
+        df = df.pivot(
             index=[
                 "Interval Start",
                 "Interval End",
                 "Location",
             ],
-            columns="Renewable Type",
+            on="Renewable Type",
             values="MW",
-            aggfunc="first",
-        ).reset_index()
+            aggregate_function="first",
+        )
 
-        df.columns.name = None
-        df["Publish Time"] = df["Interval Start"] - publish_time_offset
-        return df[
+        offset_secs = int(publish_time_offset.total_seconds())
+        return df.with_columns(
+            (pl.col("Interval Start") - pl.duration(seconds=offset_secs)).alias(
+                "Publish Time",
+            ),
+        ).select(
             [
                 "Interval Start",
                 "Interval End",
@@ -1229,15 +1270,15 @@ class CAISO(ISOBase):
                 "Location",
                 "Solar",
                 "Wind",
-            ]
-        ]
+            ],
+        )
 
     def get_renewables_forecast_hasp(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get solar and wind generation HASP hourly data from CAISO.
 
         Args:
@@ -1247,7 +1288,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame of solar and wind generation HASP hourly data
+            pl.DataFrame: A DataFrame of solar and wind generation HASP hourly data
         """
         if date == "latest":
             try:
@@ -1276,7 +1317,7 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get RTD renewable forecast from CAISO.
 
         Args:
@@ -1285,7 +1326,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame of RTD renewable forecast
+            pl.DataFrame: A DataFrame of RTD renewable forecast
         """
         if date == "latest":
             return self.get_renewables_forecast_rtd(
@@ -1309,7 +1350,7 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get RTPD renewable forecast from CAISO.
 
         Args:
@@ -1318,7 +1359,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame of RTPD renewable forecast
+            pl.DataFrame: A DataFrame of RTPD renewable forecast
         """
         if date == "latest":
             return self.get_renewables_forecast_rtpd(
@@ -1343,7 +1384,7 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Day-ahead, hourly, BAA-level wind and solar forecasts for balancing
         areas participating in the extended day-ahead market (EDAM).
 
@@ -1362,37 +1403,31 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched. Defaults to False.
 
         Returns:
-            pandas.DataFrame: hourly EDAM wind and solar forecasts by BAA
+            pl.DataFrame: hourly EDAM wind and solar forecasts by BAA
         """
         rows = self._fetch_edam_wind_solar_forecast_xml(
             date=date,
             end=end,
             verbose=verbose,
         )
-        df = pd.DataFrame(rows)
-        df["Solar"] = pd.to_numeric(df["Solar"])
-        df["Wind"] = pd.to_numeric(df["Wind"])
-        df["Interval Start"] = df["Interval Start"].dt.tz_convert(
-            self.default_timezone,
-        )
-        df["Interval End"] = df["Interval End"].dt.tz_convert(
-            self.default_timezone,
+        df = pl.DataFrame(rows)
+        df = df.with_columns(
+            pl.col("Solar").cast(pl.Float64, strict=False),
+            pl.col("Wind").cast(pl.Float64, strict=False),
+            pl.col("Interval Start").dt.convert_time_zone(self.default_timezone),
+            pl.col("Interval End").dt.convert_time_zone(self.default_timezone),
         )
 
-        return (
-            df[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Publish Time",
-                    "BAA",
-                    "Solar",
-                    "Wind",
-                ]
-            ]
-            .sort_values(["Interval Start", "BAA"])
-            .reset_index(drop=True)
-        )
+        return df.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "Publish Time",
+                "BAA",
+                "Solar",
+                "Wind",
+            ],
+        ).sort(["Interval Start", "BAA"])
 
     def _fetch_edam_wind_solar_forecast_xml(
         self,
@@ -1453,7 +1488,7 @@ class CAISO(ISOBase):
 
         return rows
 
-    def get_pnodes(self, verbose: bool = False) -> pd.DataFrame:
+    def get_pnodes(self, verbose: bool = False) -> pl.DataFrame:
         start = utils._handle_date("today")
 
         df = self.get_oasis_dataset(
@@ -1464,7 +1499,7 @@ class CAISO(ISOBase):
         )
 
         df = df.rename(
-            columns={
+            {
                 "APNODE_ID": "Aggregate PNode ID",
                 "PNODE_ID": "PNode ID",
             },
@@ -1506,7 +1541,7 @@ class CAISO(ISOBase):
                 avoid hitting rate limit in regular usage. Defaults to 5 seconds.
 
         Returns:
-            pandas.DataFrame: A DataFrame of pricing data
+            pl.DataFrame: A DataFrame of pricing data
         """
         if date == "latest":
             return self._latest_lmp_from_today(market=market, locations=locations)
@@ -1567,20 +1602,20 @@ class CAISO(ISOBase):
             verbose=verbose,
         )
 
-        if df.empty:
+        if df.is_empty():
             raise NoDataFoundException(
                 f"No data found for start date: {date} and end date: {end}",
             )
 
-        df = df.pivot_table(
+        df = df.pivot(
             index=["Time", "Interval Start", "Interval End", "NODE"],
-            columns="LMP_TYPE",
+            on="LMP_TYPE",
             values=PRICE_COL,
-            aggfunc="first",
+            aggregate_function="first",
         )
 
-        df = df.reset_index().rename(
-            columns={
+        df = df.rename(
+            {
                 "NODE": "Location",
                 "LMP": "LMP",
                 "MCE": "Energy",
@@ -1590,28 +1625,25 @@ class CAISO(ISOBase):
             },
         )
 
-        df["Market"] = market.value
-        df["Location Type"] = "Node"
+        df = df.with_columns(
+            pl.lit(market.value).alias("Market"),
+            pl.lit("Node").alias("Location Type"),
+        )
 
         # if -APND in location then "APND" Location Type
 
-        df.loc[
-            df["Location"].str.endswith("-APND"),
-            "Location Type",
-        ] = "AP Node"
+        df = df.with_columns(
+            pl.when(pl.col("Location").str.ends_with("-APND"))
+            .then(pl.lit("AP Node"))
+            .when(pl.col("Location").is_in(self.trading_hub_locations))
+            .then(pl.lit("Trading Hub"))
+            .when(pl.col("Location").str.starts_with("DLAP_"))
+            .then(pl.lit("DLAP"))
+            .otherwise(pl.col("Location Type"))
+            .alias("Location Type"),
+        )
 
-        df.loc[
-            df["Location"].isin(self.trading_hub_locations),
-            "Location Type",
-        ] = "Trading Hub"
-
-        # if starts with "DLAP_" then "DLAP" Location Type
-        df.loc[
-            df["Location"].str.startswith("DLAP_"),
-            "Location Type",
-        ] = "DLAP"
-
-        df = df[
+        return df.select(
             [
                 "Time",
                 "Interval Start",
@@ -1624,16 +1656,8 @@ class CAISO(ISOBase):
                 "Congestion",
                 "Loss",
                 "GHG",
-            ]
-        ]
-
-        # data = utils.filter_lmp_locations(df, locations=location_filter)
-        data = df
-
-        # clean up pivot name in header
-        data.columns.name = None
-
-        return data
+            ],
+        )
 
     @lmp_config(
         supports={
@@ -1677,7 +1701,7 @@ class CAISO(ISOBase):
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         sleep: int = 5,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get real-time 5-minute LMPs for all nodes."""
         return self._get_lmp(
             date,
@@ -1694,7 +1718,7 @@ class CAISO(ISOBase):
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         sleep: int = 5,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get real-time 15-minute LMPs for all nodes."""
         return self._get_lmp(
             date,
@@ -1711,7 +1735,7 @@ class CAISO(ISOBase):
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         sleep: int = 5,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get day-ahead hourly LMPs for all nodes."""
         return self._get_lmp(
             date,
@@ -1728,7 +1752,7 @@ class CAISO(ISOBase):
         end: str | pd.Timestamp | None = None,
         sleep: int = 4,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Return CAISO price corrections (OASIS ``PRC_CORR_GRP`` summary).
 
         CAISO reprices an operating day when it detects an error in published
@@ -1756,7 +1780,7 @@ class CAISO(ISOBase):
                 False.
 
         Returns:
-            pandas.DataFrame: one row per corrected interval with columns
+            pl.DataFrame: one row per corrected interval with columns
             ``Trade Date`` (the corrected operating day), ``Hour Ending``,
             ``Interval``, ``Market`` (e.g. ``DAM``, ``RTD``, ``RTPD``),
             ``Affected Area``, ``Correction Method``, ``Correction Count``,
@@ -1776,7 +1800,7 @@ class CAISO(ISOBase):
 
         result = self._parse_price_corrections(raw)
 
-        if result.empty:
+        if result.is_empty():
             raise NoDataFoundException(
                 f"No CAISO price corrections for trade dates between {date} and {end}",
             )
@@ -1790,7 +1814,7 @@ class CAISO(ISOBase):
         end: pd.Timestamp | None = None,
         sleep: int = 4,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Fetch the ``PRC_CORR_GRP`` summary for one trade date; the decorator
         iterates and concatenates a range. A "no data" response (the group is
         not generated for the date yet, or a transient rate limit) is retried,
@@ -1812,53 +1836,59 @@ class CAISO(ISOBase):
                 contents = archive.read(archive.namelist()[0])
                 # A data response is a CSV; "no data" is an XML error document.
                 if b"ERR_CODE" not in contents[:600]:
-                    return pd.read_csv(io.BytesIO(contents))
+                    return pl.from_pandas(pd.read_csv(io.BytesIO(contents)))
             time.sleep(sleep)
 
-        return pd.DataFrame()
+        return pl.DataFrame()
 
-    def _parse_price_corrections(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _parse_price_corrections(self, df: pl.DataFrame) -> pl.DataFrame:
         """Rename and type the ``PRC_CORR_GRP`` columns, dropping the placeholder
         rows that mark market/method combinations with no correction for the day.
         """
-        if df.empty:
+        if df.is_empty():
             return df
 
-        df = df[df["CORRECTION_REASON"] != PRICE_CORRECTION_NO_RECORDS_REASON]
-        if df.empty:
-            return df
-
-        def to_pacific(column: pd.Series) -> pd.Series:
-            return pd.to_datetime(column).dt.tz_localize(
-                self.default_timezone,
-                ambiguous=True,
-                nonexistent="shift_forward",
-            )
-
-        result = pd.DataFrame(
-            {
-                "Trade Date": to_pacific(df["TRADE_DATE"]),
-                "Hour Ending": df["HOUR_ENDING"].astype("Int64"),
-                "Interval": df["INTERVAL"].astype("Int64"),
-                "Market": df["MARKET"],
-                "Affected Area": df["AFFECTED_AREA"],
-                "Correction Method": df["CORRECTION_METHOD"],
-                "Correction Count": df["CORRECTION_COUNT"].astype("Int64"),
-                "Energy Type": df["ENERGY_TYPECODE"],
-                "Correction Reason": df["CORRECTION_REASON"],
-                "Report Generated": to_pacific(df["REPORT_GENERATED"]),
-            },
+        df = df.filter(
+            pl.col("CORRECTION_REASON") != PRICE_CORRECTION_NO_RECORDS_REASON,
         )
-        return result.sort_values(
-            ["Trade Date", "Market", "Hour Ending", "Interval"],
-        ).reset_index(drop=True)
+        if df.is_empty():
+            return df
+
+        df = df.with_columns(
+            pl.col("TRADE_DATE").str.to_datetime().alias("_trade_date_naive"),
+            pl.col("REPORT_GENERATED")
+            .str.to_datetime()
+            .alias("_report_generated_naive"),
+        )
+        df = utils.localize_shift_forward_polars(
+            df,
+            "_trade_date_naive",
+            self.default_timezone,
+        )
+        df = utils.localize_shift_forward_polars(
+            df,
+            "_report_generated_naive",
+            self.default_timezone,
+        )
+        return df.select(
+            pl.col("_trade_date_naive").alias("Trade Date"),
+            pl.col("HOUR_ENDING").cast(pl.Int64).alias("Hour Ending"),
+            pl.col("INTERVAL").cast(pl.Int64).alias("Interval"),
+            pl.col("MARKET").alias("Market"),
+            pl.col("AFFECTED_AREA").alias("Affected Area"),
+            pl.col("CORRECTION_METHOD").alias("Correction Method"),
+            pl.col("CORRECTION_COUNT").cast(pl.Int64).alias("Correction Count"),
+            pl.col("ENERGY_TYPECODE").alias("Energy Type"),
+            pl.col("CORRECTION_REASON").alias("Correction Reason"),
+            pl.col("_report_generated_naive").alias("Report Generated"),
+        ).sort(["Trade Date", "Market", "Hour Ending", "Interval"])
 
     @support_date_range(frequency="DAY_START")
     def get_storage(
         self,
         date: str | pd.Timestamp,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Return storage charging or discharging for today in 5 minute intervals
 
         Negative means charging, positive means discharging
@@ -1881,12 +1911,12 @@ class CAISO(ISOBase):
         # _get_historical sometimes returns as float
         # because during DST switch there are nans
         # in the data that get dropped
-        df[list(rename.keys())] = df[rename.keys()].astype(int)
-
-        df = df.rename(
-            columns=rename,
+        df = df.with_columns(
+            [pl.col(col).cast(pl.Int64) for col in rename.keys()],
         )
-        df = df[
+
+        df = df.rename(rename)
+        return df.select(
             [
                 "Time",
                 "Interval Start",
@@ -1894,10 +1924,8 @@ class CAISO(ISOBase):
                 "Supply",
                 "Stand-alone Batteries",
                 "Hybrid Batteries",
-            ]
-        ]
-
-        return df
+            ],
+        )
 
     @support_date_range(frequency="31D")
     def get_gas_prices(
@@ -1921,7 +1949,7 @@ class CAISO(ISOBase):
                 all fuel regions.
 
         Returns:
-            pandas.DataFrame: A DataFrame of gas prices
+            pl.DataFrame: A DataFrame of gas prices
         """
 
         if isinstance(fuel_region_id, list):
@@ -1939,31 +1967,22 @@ class CAISO(ISOBase):
         )
 
         df = df.rename(
-            columns={
+            {
                 "FUEL_REGION_ID": "Fuel Region Id",
                 "PRC": "Price",
             },
         )
-        df = (
-            df.sort_values("Time")
-            .sort_values(
-                ["Fuel Region Id", "Time"],
-            )
-            .reset_index(drop=True)
-        )
-
-        df = df[
+        return df.select(
             [
                 "Time",
                 "Interval Start",
                 "Interval End",
                 "Fuel Region Id",
                 "Price",
-            ]
-        ]
-        return df
+            ],
+        ).sort(["Fuel Region Id", "Time"])
 
-    def get_fuel_regions(self, verbose: bool = False) -> pd.DataFrame:
+    def get_fuel_regions(self, verbose: bool = False) -> pl.DataFrame:
         """Retrieves the (mostly static) list of fuel regions with associated data.
         This file can be joined to the gas prices on Fuel Region Id"""
         url = (
@@ -1976,11 +1995,11 @@ class CAISO(ISOBase):
         response.raise_for_status()
 
         # Only want the "GPI_Fuel_Region" sheet
-        return pd.read_excel(
+        return utils.read_excel_via_pandas(
             io.BytesIO(response.content),
             sheet_name="GPI_Fuel_Region",
         ).rename(
-            columns={
+            {
                 "Fuel Region": "Fuel Region Id",
                 "Cap & Trade Credit": "Cap and Trade Credit",
             },
@@ -2012,47 +2031,59 @@ class CAISO(ISOBase):
         )
 
         df = df.rename(
-            columns={
+            {
                 "GHG_PRC_IDX": "GHG Allowance Price",
             },
         )
 
-        df = df[
+        return df.select(
             [
                 "Time",
                 "Interval Start",
                 "Interval End",
                 "GHG Allowance Price",
-            ]
-        ]
+            ],
+        )
 
-        return df
-
-    def get_raw_interconnection_queue(self, verbose: bool = False) -> pd.DataFrame:
+    def get_raw_interconnection_queue(self, verbose: bool = False) -> io.BytesIO:
         url = "http://www.caiso.com/PublishedDocuments/PublicQueueReport.xlsx"
 
         logger.info(f"Downloading interconnection queue from {url}")
         response = requests.get(url)
         return utils.get_response_blob(response)
 
-    def get_interconnection_queue(self, verbose: bool = False) -> pd.DataFrame:
+    def get_interconnection_queue(self, verbose: bool = False) -> pl.DataFrame:
         raw_data = self.get_raw_interconnection_queue(verbose)
 
-        sheets = pd.read_excel(raw_data, skiprows=3, sheet_name=None)
-
-        # remove legend at the bottom
-        queued_projects = sheets["Grid GenerationQueue"][:-8]
-        completed_projects = sheets["Completed Generation Projects"][:-2]
-        withdrawn_projects = sheets["Withdrawn Generation Projects"][:-2].rename(
-            columns={"Project Name - Confidential": "Project Name"},
+        sheets = utils.read_excel_via_pandas(
+            raw_data,
+            skiprows=3,
+            sheet_name=None,
+            dtype=str,
         )
 
-        queue = pd.concat(
+        # remove legend at the bottom
+        queued_projects = sheets["Grid GenerationQueue"].head(
+            sheets["Grid GenerationQueue"].height - 8,
+        )
+        completed_projects = sheets["Completed Generation Projects"].head(
+            sheets["Completed Generation Projects"].height - 2,
+        )
+        withdrawn_projects = (
+            sheets["Withdrawn Generation Projects"]
+            .head(
+                sheets["Withdrawn Generation Projects"].height - 2,
+            )
+            .rename({"Project Name - Confidential": "Project Name"})
+        )
+
+        queue = pl.concat(
             [queued_projects, completed_projects, withdrawn_projects],
+            how="diagonal_relaxed",
         )
 
         queue = queue.rename(
-            columns={
+            {
                 "Interconnection Request\nReceive Date": (
                     "Interconnection Request Receive Date"
                 ),
@@ -2076,9 +2107,19 @@ class CAISO(ISOBase):
         )
 
         type_columns = ["Type-1", "Type-2", "Type-3"]
-        queue["Generation Type"] = queue[type_columns].apply(
-            lambda x: " + ".join(x.dropna()),
-            axis=1,
+
+        def _join_generation_types(row: dict) -> str:
+            parts = [
+                str(row[col])
+                for col in type_columns
+                if row.get(col) is not None and str(row[col]) != "nan"
+            ]
+            return " + ".join(parts)
+
+        queue = queue.with_columns(
+            pl.struct(type_columns)
+            .map_elements(_join_generation_types, return_dtype=pl.Utf8)
+            .alias("Generation Type"),
         )
 
         rename = {
@@ -2140,7 +2181,7 @@ class CAISO(ISOBase):
         self,
         date: str | pd.Timestamp,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Return curtailment data for a given date.
 
         Note:
@@ -2186,7 +2227,7 @@ class CAISO(ISOBase):
         if pdf is None:
             raise ValueError(f"Could not find curtailment PDF for {date}")
 
-        tables = []
+        tables: list[pl.DataFrame] = []
         header = None
         with pdfplumber.open(pdf) as pdf_doc:
             for page in pdf_doc.pages:
@@ -2198,17 +2239,19 @@ class CAISO(ISOBase):
                     # First page - get header and data
                     if any("FUEL TYPE" in str(col) for col in table[0]):
                         header = table[0]
-                        df = pd.DataFrame(table[1:], columns=header)
-                        tables.append(df)
+                        tables.append(
+                            pl.from_pandas(pd.DataFrame(table[1:], columns=header)),
+                        )
                     # Subsequent pages - use saved header
                     elif header is not None:
-                        df = pd.DataFrame(table, columns=header)
-                        tables.append(df)
+                        tables.append(
+                            pl.from_pandas(pd.DataFrame(table, columns=header)),
+                        )
 
         if len(tables) == 0:
             raise ValueError("No tables found")
 
-        df = pd.concat(tables).reset_index(drop=True)
+        df = pl.concat(tables, how="diagonal")
 
         rename = {
             "DATE": "Date",
@@ -2223,27 +2266,38 @@ class CAISO(ISOBase):
             "CURTAILED\rMW": "Curtailment (MW)",
         }
 
-        df = df.rename(columns=rename)
+        df = df.rename({k: v for k, v in rename.items() if k in df.columns})
 
         # convert from hour ending to hour beginning
-        df["Hour"] = df["Hour"].astype(int) - 1
-        df["Time"] = df["Hour"].apply(
-            lambda x, date=date: date + pd.Timedelta(hours=x),
+        def _hour_to_time(hour: int) -> pd.Timestamp:
+            return date + pd.Timedelta(hours=int(hour))
+
+        df = df.with_columns(
+            pl.col("Hour").cast(pl.Int64).sub(1).alias("Hour"),
         )
-
-        df["Interval Start"] = df["Time"]
-        df["Interval End"] = df["Time"] + pd.Timedelta(hours=1)
-
-        df = df.drop(columns=["Date", "Hour"])
-
-        df["Fuel Type"] = df["Fuel Type"].map(
-            {
-                "SOLR": "Solar",
-                "WIND": "Wind",
-            },
+        df = df.with_columns(
+            pl.col("Hour")
+            .map_elements(
+                _hour_to_time,
+                return_dtype=pl.Datetime(time_zone=self.default_timezone),
+            )
+            .alias("Time"),
         )
-
-        df = df[
+        df = df.with_columns(
+            pl.col("Time").alias("Interval Start"),
+            (pl.col("Time") + pl.duration(hours=1)).alias("Interval End"),
+        )
+        df = df.drop("Date", "Hour")
+        df = df.with_columns(
+            pl.col("Fuel Type").replace({"SOLR": "Solar", "WIND": "Wind"}),
+        )
+        df = df.with_columns(
+            [
+                pl.when(pl.col(col) == "").then(None).otherwise(pl.col(col)).alias(col)
+                for col in ["Curtailment (MWh)", "Curtailment (MW)"]
+            ],
+        )
+        return df.select(
             [
                 "Time",
                 "Interval Start",
@@ -2253,33 +2307,28 @@ class CAISO(ISOBase):
                 "Fuel Type",
                 "Curtailment (MWh)",
                 "Curtailment (MW)",
-            ]
-        ]
-        df = df.replace("", np.nan)
-        return df
+            ],
+        )
 
     def _pivot_aggregated_generation_outages(
         self,
-        df: pd.DataFrame,
-    ) -> pd.DataFrame:
-        df = df.copy()
-        df["Fuel Category"] = df["Fuel Category"].replace(
-            {"Not Avail": "Not Available"},
+        df: pl.DataFrame,
+    ) -> pl.DataFrame:
+        df = df.with_columns(
+            pl.col("Fuel Category").replace({"Not Avail": "Not Available"}),
         )
 
-        df = df.pivot_table(
+        df = df.pivot(
             index=[
                 "Interval Start",
                 "Interval End",
                 "Publish Time",
                 "Trading Hub",
             ],
-            columns="Fuel Category",
+            on="Fuel Category",
             values="MW",
-            aggfunc="first",
-        ).reset_index()
-
-        df.columns.name = None
+            aggregate_function="first",
+        )
 
         for column in [
             "Aggregated",
@@ -2289,15 +2338,19 @@ class CAISO(ISOBase):
             "Thermal",
         ]:
             if column not in df.columns:
-                df[column] = np.nan
+                df = df.with_columns(pl.lit(None).cast(pl.Float64).alias(column))
 
-        component_sum = df[["Hydro", "Not Available", "Renewable", "Thermal"]].sum(
-            axis=1,
-            min_count=1,
+        component_sum = pl.sum_horizontal(
+            "Hydro",
+            "Not Available",
+            "Renewable",
+            "Thermal",
         )
-        df["Aggregated"] = df["Aggregated"].combine_first(component_sum)
+        df = df.with_columns(
+            pl.coalesce("Aggregated", component_sum).alias("Aggregated"),
+        )
 
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -2308,8 +2361,8 @@ class CAISO(ISOBase):
                 "Not Available",
                 "Renewable",
                 "Thermal",
-            ]
-        ]
+            ],
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_aggregated_generation_outages(
@@ -2318,7 +2371,7 @@ class CAISO(ISOBase):
         end: str | pd.Timestamp | None = None,
         sleep: int = 4,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Return hourly aggregated generator outages by trading hub.
 
         Outage MW is reported with an ``Aggregated`` hub-total column plus
@@ -2340,7 +2393,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with one row per
+            pl.DataFrame: A DataFrame with one row per
             (Interval Start, Publish Time, Trading Hub), with outage MW by
             fuel category in separate columns.
         """
@@ -2353,27 +2406,26 @@ class CAISO(ISOBase):
             verbose=verbose,
         )
 
-        if df.empty:
+        if df.is_empty():
             return df
 
-        df["Publish Time"] = pd.to_datetime(
-            df["REPORT_DATE_GMT"],
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
+        df = df.with_columns(
+            pl.col("REPORT_DATE_GMT")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Publish Time"),
+        )
 
         df = df.rename(
-            columns={
+            {
                 "FUEL_CATEGORY": "Fuel Category",
                 "TRADING_HUB": "Trading Hub",
             },
         )
 
-        df["MW"] = pd.to_numeric(df["MW"])
+        df = df.with_columns(pl.col("MW").cast(pl.Float64, strict=False))
 
-        return (
-            self._pivot_aggregated_generation_outages(df)
-            .sort_values(["Interval Start", "Trading Hub"])
-            .reset_index(drop=True)
+        return self._pivot_aggregated_generation_outages(df).sort(
+            ["Interval Start", "Trading Hub"],
         )
 
     @support_date_range(frequency="DAY_START")
@@ -2384,7 +2436,7 @@ class CAISO(ISOBase):
         market: str = "DAM",
         sleep: int = 4,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Return AS prices for a given date for each region
 
         Arguments:
@@ -2398,7 +2450,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame of AS prices
+            pl.DataFrame: A DataFrame of AS prices
         """
 
         params = {
@@ -2415,8 +2467,11 @@ class CAISO(ISOBase):
             raw_data=False,
         )
 
+        if df.is_empty():
+            return df
+
         df = df.rename(
-            columns={
+            {
                 "ANC_REGION": "Region",
                 "MARKET_RUN_ID": "Market",
             },
@@ -2430,9 +2485,9 @@ class CAISO(ISOBase):
             "RU": "Regulation Up",
             "SR": "Spinning Reserves",
         }
-        df["ANC_TYPE"] = df["ANC_TYPE"].map(as_type_map)
+        df = df.with_columns(pl.col("ANC_TYPE").replace(as_type_map))
 
-        df = df.pivot_table(
+        df = df.pivot(
             index=[
                 "Time",
                 "Interval Start",
@@ -2440,15 +2495,20 @@ class CAISO(ISOBase):
                 "Region",
                 "Market",
             ],
-            columns="ANC_TYPE",
+            on="ANC_TYPE",
             values="MW",
-        ).reset_index()
+        )
 
-        df = df.fillna(0)
-
-        df.columns.name = None
-
-        return df
+        value_cols = sorted(
+            c
+            for c in df.columns
+            if c not in {"Time", "Interval Start", "Interval End", "Region", "Market"}
+        )
+        return df.with_columns(
+            [pl.col(c).fill_null(0) for c in value_cols],
+        ).select(
+            ["Time", "Interval Start", "Interval End", "Region", "Market", *value_cols],
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_ir_rc_prices(
@@ -2457,7 +2517,7 @@ class CAISO(ISOBase):
         end: str | pd.Timestamp | None = None,
         sleep: int = 4,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Return day-ahead nodal Imbalance Reserve and Reliability Capacity prices.
 
         The Marginal Clearing Price for Reliability Capacity (RCU/RCD) is comprised
@@ -2473,7 +2533,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame of IR/RC prices with one row per
+            pl.DataFrame: A DataFrame of IR/RC prices with one row per
             (Interval Start, Location, Product). Earliest available date is
             May 1, 2026.
         """
@@ -2498,7 +2558,7 @@ class CAISO(ISOBase):
         ]
 
         df = df.rename(
-            columns={
+            {
                 "NODE": "Location",
                 "PRODUCT": "Product",
                 "MARGINAL_CLEARING_PRICE": "MCP",
@@ -2508,58 +2568,49 @@ class CAISO(ISOBase):
             },
         )
 
-        df = df[columns]
+        return df.select(columns).sort(["Interval Start", "Location", "Product"])
 
-        df = df.sort_values(
-            ["Interval Start", "Location", "Product"],
-        ).reset_index(drop=True)
-
-        return df
-
-    def _parse_ir_rc_requirements_awards(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _parse_ir_rc_requirements_awards(self, df: pl.DataFrame) -> pl.DataFrame:
         df = df.rename(
-            columns={
+            {
                 "BAA_GRP_ID": "BAA",
                 "PRODUCT_TYPE": "Product",
             },
         )
 
-        df = df.melt(
-            id_vars=[
+        df = df.unpivot(
+            index=[
                 "Interval Start",
                 "Interval End",
                 "BAA",
                 "Product",
             ],
-            value_vars=["REQ_MW", "AGG_AWD_MW"],
-            var_name="Type",
+            on=["REQ_MW", "AGG_AWD_MW"],
+            variable_name="Type",
             value_name="MW",
         )
 
-        df["Type"] = df["Type"].map(
-            {
-                "REQ_MW": "Requirement",
-                "AGG_AWD_MW": "Award",
-            },
+        df = df.with_columns(
+            pl.col("Type").replace(
+                {
+                    "REQ_MW": "Requirement",
+                    "AGG_AWD_MW": "Award",
+                },
+            ),
+            pl.col("MW").cast(pl.Float64, strict=False),
         )
+        df = df.filter(pl.col("MW").is_not_null())
 
-        df["MW"] = pd.to_numeric(df["MW"], errors="coerce")
-        df = df.dropna(subset=["MW"])
-
-        columns = [
-            "Interval Start",
-            "Interval End",
-            "BAA",
-            "Product",
-            "Type",
-            "MW",
-        ]
-
-        return (
-            df[columns]
-            .sort_values(["Interval Start", "BAA", "Product", "Type"])
-            .reset_index(drop=True)
-        )
+        return df.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "BAA",
+                "Product",
+                "Type",
+                "MW",
+            ],
+        ).sort(["Interval Start", "BAA", "Product", "Type"])
 
     @support_date_range(frequency="DAY_START")
     def get_ir_rc_requirements_awards_dam(
@@ -2568,7 +2619,7 @@ class CAISO(ISOBase):
         end: str | pd.Timestamp | None = None,
         sleep: int = 4,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Return day-ahead hourly Imbalance Reserve requirements and
         Imbalance Reserve and Reliability Capacity awards by BAA.
 
@@ -2581,7 +2632,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with one row per
+            pl.DataFrame: A DataFrame with one row per
             (Interval Start, BAA, Product, Type). Earliest available date is
             May 1, 2026.
         """
@@ -2604,7 +2655,7 @@ class CAISO(ISOBase):
         end: str | pd.Timestamp | None = None,
         sleep: int = 4,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Return two-day-ahead hourly Imbalance Reserve requirements by BAA.
 
         Arguments:
@@ -2616,7 +2667,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with one row per
+            pl.DataFrame: A DataFrame with one row per
             (Interval Start, BAA, Product, Type). Earliest available date is
             May 1, 2026.
         """
@@ -2639,7 +2690,7 @@ class CAISO(ISOBase):
         end: str | pd.Timestamp | None = None,
         sleep: int = 4,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Return three-day-ahead hourly Imbalance Reserve requirements by BAA.
 
         Arguments:
@@ -2651,7 +2702,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with one row per
+            pl.DataFrame: A DataFrame with one row per
             (Interval Start, BAA, Product, Type). Earliest available date is
             May 1, 2026.
         """
@@ -2673,7 +2724,7 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Return curtailed non-operational generator report for a given date.
            Earliest available date is June 17, 2021.
 
@@ -2684,7 +2735,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame of curtailed non-operational generator report
+            pl.DataFrame: A DataFrame of curtailed non-operational generator report
 
         Notes:
             Column glossary:
@@ -2736,47 +2787,67 @@ class CAISO(ISOBase):
             usecols="B:M",
             sheet_name="PREV_DAY_OUTAGES",
             engine="openpyxl",
+            dtype=str,
         )
-        first_col = test_parse[test_parse.columns[0]]
-        outage_mrid_index = first_col[first_col == "OUTAGE MRID"].index[0] + 1
+        first_col = test_parse.columns[0]
+        outage_mrid_index = (
+            test_parse.index[test_parse[first_col] == "OUTAGE MRID"].tolist()[0] + 1
+        )
+
+        content_io.seek(0)
 
         # load again, but skip rows up to outage mrid
-        df = pd.read_excel(
+        pdf = pd.read_excel(
             content_io,
             usecols="B:M",
             skiprows=outage_mrid_index,
             sheet_name="PREV_DAY_OUTAGES",
             engine="openpyxl",
         )
+        pdf = pdf.dropna(axis=1, how="all")
+        df = pl.from_pandas(pdf)
 
         # drop columns where the name is nan
         # artifact of the excel file
-        df = df.dropna(axis=1, how="all")
+        non_null_cols = [
+            c for c in df.columns if not (isinstance(c, float) and np.isnan(c))
+        ]
+        df = df.select(non_null_cols)
 
         # published day after
         publish_time = date.normalize() + pd.DateOffset(days=1)
-        df.insert(0, "Publish Time", publish_time)
+        df = df.with_columns(pl.lit(publish_time).alias("Publish Time"))
+        df = utils.move_cols_to_front(df, ["Publish Time"])
 
-        df["CURTAILMENT START DATE TIME"] = pd.to_datetime(
-            df["CURTAILMENT START DATE TIME"],
-        ).dt.tz_localize(self.default_timezone, ambiguous=True)
-        df["CURTAILMENT END DATE TIME"] = pd.to_datetime(
-            df["CURTAILMENT END DATE TIME"],
-        ).dt.tz_localize(self.default_timezone, ambiguous=True)
+        df = df.with_columns(
+            pl.col("CURTAILMENT START DATE TIME").alias("_curtailment_start_naive"),
+            pl.col("CURTAILMENT END DATE TIME").alias("_curtailment_end_naive"),
+        )
+        df = utils.localize_ambiguous_infer_polars(
+            df,
+            "_curtailment_start_naive",
+            self.default_timezone,
+        )
+        df = utils.localize_ambiguous_infer_polars(
+            df,
+            "_curtailment_end_naive",
+            self.default_timezone,
+        )
 
         # only some dates have this
         if "OUTAGE STATUS" in df.columns:
-            df = df.drop(columns=["OUTAGE STATUS"])
+            df = df.drop("OUTAGE STATUS")
 
+        df = df.drop(["CURTAILMENT START DATE TIME", "CURTAILMENT END DATE TIME"])
         df = df.rename(
-            columns={
+            {
                 "OUTAGE MRID": "Outage MRID",
                 "RESOURCE NAME": "Resource Name",
                 "RESOURCE ID": "Resource ID",
                 "OUTAGE TYPE": "Outage Type",
                 "NATURE OF WORK": "Nature of Work",
-                "CURTAILMENT START DATE TIME": "Curtailment Start Time",
-                "CURTAILMENT END DATE TIME": "Curtailment End Time",
+                "_curtailment_start_naive": "Curtailment Start Time",
+                "_curtailment_end_naive": "Curtailment End Time",
                 "CURTAILMENT MW": "Curtailment MW",
                 "RESOURCE PMAX MW": "Resource PMAX MW",
                 "NET QUALIFYING CAPACITY MW": "Net Qualifying Capacity MW",
@@ -2784,21 +2855,39 @@ class CAISO(ISOBase):
         )
 
         # if there are duplicates, set trce
-        if df.duplicated(subset=["Outage MRID", "Curtailment Start Time"]).any():
+        if df.select(
+            pl.struct(["Outage MRID", "Curtailment Start Time"]).is_duplicated().any(),
+        ).item():
             # drop where start and end are the same and end time isnt null
             # this appears to fix
-            df = df[
+            df = df.filter(
                 ~(
-                    (df["Curtailment Start Time"] == df["Curtailment End Time"])
-                    & (df["Curtailment End Time"].notnull())
-                )
-            ]
+                    (pl.col("Curtailment Start Time") == pl.col("Curtailment End Time"))
+                    & pl.col("Curtailment End Time").is_not_null()
+                ),
+            )
 
-            assert not df.duplicated(
-                subset=["Outage MRID", "Curtailment Start Time"],
-            ).any(), "There are still duplicates"
+            assert not df.select(
+                pl.struct(["Outage MRID", "Curtailment Start Time"])
+                .is_duplicated()
+                .any(),
+            ).item(), "There are still duplicates"
 
-        return df
+        return df.select(
+            [
+                "Publish Time",
+                "Outage MRID",
+                "Resource Name",
+                "Resource ID",
+                "Outage Type",
+                "Nature of Work",
+                "Curtailment Start Time",
+                "Curtailment End Time",
+                "Curtailment MW",
+                "Resource PMAX MW",
+                "Net Qualifying Capacity MW",
+            ],
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_tie_flows_real_time(
@@ -2806,7 +2895,7 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Return real time tie flow data.
 
         Args:
@@ -2816,7 +2905,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched. Defaults to False.
 
         Returns:
-            pd.DataFrame: A DataFrame of real time tie flow data
+            pl.DataFrame: A DataFrame of real time tie flow data
         """
         if date == "latest":
             date = pd.Timestamp.utcnow().round("5min")
@@ -2837,7 +2926,7 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             date = pd.Timestamp.utcnow().round("15min")
             end = date + pd.Timedelta(minutes=15)
@@ -2852,53 +2941,63 @@ class CAISO(ISOBase):
 
         return self._process_tie_flows_data(df)
 
-    def _process_tie_flows_data(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _process_tie_flows_data(self, df: pl.DataFrame) -> pl.DataFrame:
         df = df.drop(
-            columns=[
-                "Time",
-                "DATA_ITEM",
-                "OPR_DT",
-                "OPR_HR",
-                "OPR_INTERVAL",
-                "OASIS_REC_STAT",
-                "UPD_DATE",
-                "UPD_BY",
-                "GROUP",
-                # Same as FROM_BAA
-                "BAA_GRP_ID",
-            ],
-        ).rename(columns={"MARKET_TYPE": "MARKET", "VALUE": "MW"})
+            "Time",
+            "DATA_ITEM",
+            "OPR_DT",
+            "OPR_HR",
+            "OPR_INTERVAL",
+            "OASIS_REC_STAT",
+            "UPD_DATE",
+            "UPD_BY",
+            "GROUP",
+            "BAA_GRP_ID",
+        ).rename({"MARKET_TYPE": "MARKET", "VALUE": "MW"})
 
         # Multiply imports by -1 to match convention of imports being negative
-        df["MW"] = np.where(df["DIRECTION"] == "I", df["MW"] * -1, df["MW"])
+        df = df.with_columns(
+            pl.when(pl.col("DIRECTION") == "I")
+            .then(pl.col("MW") * -1)
+            .otherwise(pl.col("MW"))
+            .alias("MW"),
+        )
 
         # Sum MW by Interval Start, TIE_NAME, FROM_BAA, TO_BAA so we can remove
         # the direction column
-        df = (
-            df.groupby(
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "TIE_NAME",
-                    "FROM_BAA",
-                    "TO_BAA",
-                    "MARKET",
-                ],
-            )["MW"]
-            .sum()
-            .reset_index()
-        )
+        df = df.group_by(
+            [
+                "Interval Start",
+                "Interval End",
+                "TIE_NAME",
+                "FROM_BAA",
+                "TO_BAA",
+                "MARKET",
+            ],
+        ).agg(pl.col("MW").sum())
 
-        df.columns = df.columns.map(
-            lambda x: x.title()
-            .replace("_", " ")
-            .replace("Baa", "BAA")
-            .replace("Mw", "MW"),
-        )
+        rename_map = {
+            "Interval Start": "Interval Start",
+            "Interval End": "Interval End",
+            "TIE_NAME": "Tie Name",
+            "FROM_BAA": "From BAA",
+            "TO_BAA": "To BAA",
+            "MARKET": "Market",
+            "MW": "MW",
+        }
+        df = df.rename(rename_map)
 
         # Create an identifier column (separated by hyphens because some of the tie
         # names have underscores in them) to use for indexing
-        df["Interface ID"] = df["Tie Name"] + "-" + df["From BAA"] + "-" + df["To BAA"]
+        df = df.with_columns(
+            (
+                pl.col("Tie Name")
+                + pl.lit("-")
+                + pl.col("From BAA")
+                + pl.lit("-")
+                + pl.col("To BAA")
+            ).alias("Interface ID"),
+        )
 
         df = utils.move_cols_to_front(
             df,
@@ -2914,9 +3013,7 @@ class CAISO(ISOBase):
             ],
         )
 
-        return df.sort_values(
-            ["Interval Start", "Interface ID"],
-        )
+        return df.sort(["Interval Start", "Interface ID"])
 
     @support_date_range(frequency="31D")
     def get_as_procurement(
@@ -2926,7 +3023,7 @@ class CAISO(ISOBase):
         market: str = "DAM",
         sleep: int = 4,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get ancillary services procurement data from CAISO.
 
         Args:
@@ -2938,7 +3035,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame of ancillary services data
+            pl.DataFrame: A DataFrame of ancillary services data
         """
 
         assert market in ["DAM", "RTM"], "market must be DAM or RTM"
@@ -2955,8 +3052,11 @@ class CAISO(ISOBase):
             raw_data=False,
         )
 
+        if df.is_empty():
+            return df
+
         df = df.rename(
-            columns={
+            {
                 "ANC_REGION": "Region",
                 "MARKET_RUN_ID": "Market",
             },
@@ -2970,19 +3070,21 @@ class CAISO(ISOBase):
             "RU": "Regulation Up",
             "SR": "Spinning Reserves",
         }
-        df["ANC_TYPE"] = df["ANC_TYPE"].map(as_type_map)
-
         result_type_map = {
             "AS_BUY_MW": "Procured (MW)",
             "AS_SELF_MW": "Self-Provided (MW)",
             "AS_MW": "Total (MW)",
             "AS_COST": "Total Cost",
         }
-        df["RESULT_TYPE"] = df["RESULT_TYPE"].map(result_type_map)
+        df = df.with_columns(
+            pl.col("ANC_TYPE").replace(as_type_map).alias("ANC_TYPE"),
+            pl.col("RESULT_TYPE").replace(result_type_map).alias("RESULT_TYPE"),
+        )
+        df = df.with_columns(
+            (pl.col("ANC_TYPE") + pl.lit(" ") + pl.col("RESULT_TYPE")).alias("column"),
+        )
 
-        df["column"] = df["ANC_TYPE"] + " " + df["RESULT_TYPE"]
-
-        df = df.pivot_table(
+        df = df.pivot(
             index=[
                 "Time",
                 "Interval Start",
@@ -2990,20 +3092,20 @@ class CAISO(ISOBase):
                 "Region",
                 "Market",
             ],
-            columns="column",
+            on="column",
             values="MW",
-        ).reset_index()
+        )
 
-        df.columns.name = None
-
-        return df
+        index_cols = ["Time", "Interval Start", "Interval End", "Region", "Market"]
+        value_cols = sorted(c for c in df.columns if c not in index_cols)
+        return df.select([*index_cols, *value_cols])
 
     def get_lmp_scheduling_point_tie_real_time_5_min(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get LMP scheduling point tie combination 5-min data from CAISO.
 
         Args:
@@ -3013,7 +3115,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame of LMP scheduling point tie combination 5-min data
+            pl.DataFrame: A DataFrame of LMP scheduling point tie combination 5-min data
         """
         if date == "latest":
             return self.get_lmp_scheduling_point_tie_real_time_5_min(
@@ -3039,7 +3141,7 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             return self.get_lmp_scheduling_point_tie_real_time_15_min(
                 pd.Timestamp.now(tz=self.default_timezone),
@@ -3064,7 +3166,7 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             try:
                 df = self.get_lmp_scheduling_point_tie_day_ahead_hourly(
@@ -3095,7 +3197,7 @@ class CAISO(ISOBase):
 
     def _handle_lmp_scheduling_point_tie_combination(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         dataset_name: Literal[
             "Day Ahead Hourly",
             "Real Time 15 Min",
@@ -3103,20 +3205,20 @@ class CAISO(ISOBase):
         ],
         date: str | pd.Timestamp | None = None,
         end: str | pd.Timestamp | None = None,
-    ) -> pd.DataFrame:
-        if df.empty:
+    ) -> pl.DataFrame:
+        if df.is_empty():
             raise NoDataFoundException(
                 f"No data found for LMP Scheduling Point Tie Combination {dataset_name} for start date: {date} and end date: {end}",
             )
         df = df.rename(
-            columns={
+            {
                 "NODE": "Node",
                 "TIE": "Tie",
                 "MARKET_RUN_ID": "Market",
             },
         )
 
-        df = df.pivot_table(
+        df = df.pivot(
             index=[
                 "Interval Start",
                 "Interval End",
@@ -3124,14 +3226,13 @@ class CAISO(ISOBase):
                 "Tie",
                 "Market",
             ],
-            columns="LMP_TYPE",
+            on="LMP_TYPE",
             values="PRC",
-            aggfunc="first",
-        ).reset_index()
+            aggregate_function="first",
+        )
 
-        df.columns.name = None
         df = df.rename(
-            columns={
+            {
                 "MCE": "Energy",
                 "MCC": "Congestion",
                 "MCL": "Loss",
@@ -3139,8 +3240,9 @@ class CAISO(ISOBase):
             },
         )
 
-        df["Location"] = df["Node"] + " " + df["Tie"]
-        return df[
+        return df.with_columns(
+            (pl.col("Node") + pl.lit(" ") + pl.col("Tie")).alias("Location"),
+        ).select(
             [
                 "Interval Start",
                 "Interval End",
@@ -3153,15 +3255,15 @@ class CAISO(ISOBase):
                 "Congestion",
                 "Loss",
                 "GHG",
-            ]
-        ]
+            ],
+        )
 
     def get_lmp_hasp_15_min(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get LMP HASP 15-min data from CAISO.
 
         Args:
@@ -3171,7 +3273,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame of LMP HASP 15-min data
+            pl.DataFrame: A DataFrame of LMP HASP 15-min data
         """
         if date == "latest":
             return self.get_lmp_hasp_15_min(
@@ -3185,38 +3287,33 @@ class CAISO(ISOBase):
             verbose=verbose,
             raw_data=False,
         )
-        if df.empty:
+        if df.is_empty():
             raise NoDataFoundException(
                 f"No data found for LMP HASP 15-min for start date: {date} and end date: {end}",
             )
 
         return self._handle_lmp_hasp_15_min(df)
 
-    def _handle_lmp_hasp_15_min(self, df: pd.DataFrame) -> pd.DataFrame:
-        df = df.rename(
-            columns={"NODE": "Location"},
-        )
-        df = df.pivot_table(
+    def _handle_lmp_hasp_15_min(self, df: pl.DataFrame) -> pl.DataFrame:
+        df = df.rename({"NODE": "Location"})
+        df = df.pivot(
             index=[
                 "Interval Start",
                 "Interval End",
                 "Location",
             ],
-            columns="LMP_TYPE",
-            values="MW",  # NB: This is likely a mistake from CAISO, should probably be PRC
-            aggfunc="first",
-        ).reset_index()
-
-        df.columns.name = None
-        df = df.rename(
-            columns={
+            on="LMP_TYPE",
+            values="MW",
+            aggregate_function="first",
+        )
+        return df.rename(
+            {
                 "MCE": "Energy",
                 "MCC": "Congestion",
                 "MCL": "Loss",
                 "MGHG": "GHG",
             },
-        )
-        return df[
+        ).select(
             [
                 "Interval Start",
                 "Interval End",
@@ -3226,8 +3323,8 @@ class CAISO(ISOBase):
                 "Congestion",
                 "Loss",
                 "GHG",
-            ]
-        ]
+            ],
+        )
 
     @support_date_range(frequency="31D")
     def get_nomogram_branch_shadow_prices_day_ahead_hourly(
@@ -3235,7 +3332,7 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Returns hourly day-ahead nomogram/branch shadow price forecast.
 
         Args:
@@ -3245,7 +3342,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched.
 
         Returns:
-            pandas.DataFrame: A DataFrame with the shadow price forecast
+            pl.DataFrame: A DataFrame with the shadow price forecast
         """
         if date == "latest":
             return self.get_nomogram_branch_shadow_prices_day_ahead_hourly(
@@ -3262,7 +3359,7 @@ class CAISO(ISOBase):
         )
 
         df = df.rename(
-            columns={
+            {
                 "NOMOGRAM_ID": "Location",
                 "PRC": "Price",
                 "NOMOGRAM_ID_XML": "Nomogram ID XML",
@@ -3283,7 +3380,7 @@ class CAISO(ISOBase):
         ]
         df = _collapse_group_to_array(df, group_cols)
 
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -3293,15 +3390,15 @@ class CAISO(ISOBase):
                 "Constraint Cause",
                 "Price",
                 "Groups",
-            ]
-        ]
+            ],
+        )
 
     def get_nomogram_branch_shadow_prices_hasp_hourly(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Returns nomogram/branch shadow price HASP hourly data from CAISO.
 
         Args:
@@ -3311,7 +3408,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched.
 
         Returns:
-            pandas.DataFrame: A DataFrame with the shadow price HASP data
+            pl.DataFrame: A DataFrame with the shadow price HASP data
         """
         if date == "latest":
             return self.get_nomogram_branch_shadow_prices_hasp_hourly(
@@ -3328,7 +3425,7 @@ class CAISO(ISOBase):
         )
 
         df = df.rename(
-            columns={
+            {
                 "NOMOGRAM_ID": "Location",
                 "PRC": "Price",
                 "NOMOGRAM_ID_XML": "Nomogram ID XML",
@@ -3349,7 +3446,7 @@ class CAISO(ISOBase):
         ]
         df = _collapse_group_to_array(df, group_cols)
 
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -3359,15 +3456,15 @@ class CAISO(ISOBase):
                 "Constraint Cause",
                 "Price",
                 "Groups",
-            ]
-        ]
+            ],
+        )
 
     def get_nomogram_branch_shadow_price_forecast_15_min(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Returns 15-minute nomogram/branch shadow price forecast from the Real-Time Pre-Dispatch Market.
 
         Args:
@@ -3377,7 +3474,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched.
 
         Returns:
-            pandas.DataFrame: A DataFrame with the shadow price forecast
+            pl.DataFrame: A DataFrame with the shadow price forecast
         """
         if date == "latest":
             return self.get_nomogram_branch_shadow_price_forecast_15_min(
@@ -3394,7 +3491,7 @@ class CAISO(ISOBase):
         )
 
         df = df.rename(
-            columns={
+            {
                 "NOMOGRAM_ID": "Location",
                 "PRC": "Price",
                 "NOMOGRAM_ID_XML": "Nomogram ID XML",
@@ -3415,7 +3512,7 @@ class CAISO(ISOBase):
         ]
         df = _collapse_group_to_array(df, group_cols)
 
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -3425,15 +3522,15 @@ class CAISO(ISOBase):
                 "Constraint Cause",
                 "Price",
                 "Groups",
-            ]
-        ]
+            ],
+        )
 
     def get_interval_nomogram_branch_shadow_prices_real_time_5_min(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get 5-min nomogram/branch shadow prices from CAISO.
 
         Args:
@@ -3443,7 +3540,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched.
 
         Returns:
-            pandas.DataFrame: A DataFrame with the shadow prices
+            pl.DataFrame: A DataFrame with the shadow prices
         """
         if date == "latest":
             return self.get_interval_nomogram_branch_shadow_prices_real_time_5_min(
@@ -3459,7 +3556,7 @@ class CAISO(ISOBase):
         )
 
         df = df.rename(
-            columns={
+            {
                 "NOMOGRAM_ID": "Location",
                 "PRC": "Price",
                 "MARKET_RUN_ID": "Market Run ID",
@@ -3478,7 +3575,7 @@ class CAISO(ISOBase):
         ]
         df = _collapse_group_to_array(df, group_cols)
 
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -3487,15 +3584,15 @@ class CAISO(ISOBase):
                 "Constraint Cause",
                 "Price",
                 "Groups",
-            ]
-        ]
+            ],
+        )
 
     def get_intertie_constraint_shadow_prices_real_time_5_min(
         self,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get 5-min intertie constraint shadow prices from CAISO.
 
         Args:
@@ -3505,7 +3602,7 @@ class CAISO(ISOBase):
             verbose (bool, optional): print out url being fetched.
 
         Returns:
-            pandas.DataFrame: A DataFrame with the intertie constraint shadow prices
+            pl.DataFrame: A DataFrame with the intertie constraint shadow prices
         """
         if date == "latest":
             return self.get_intertie_constraint_shadow_prices_real_time_5_min(
@@ -3521,7 +3618,7 @@ class CAISO(ISOBase):
         )
 
         df = df.rename(
-            columns={
+            {
                 "TI_ID": "TI ID",
                 "TI_DIRECTION": "TI Direction",
                 "MARKET_RUN_ID": "Market Run ID",
@@ -3542,7 +3639,7 @@ class CAISO(ISOBase):
         ]
         df = _collapse_group_to_array(df, group_cols)
 
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -3552,8 +3649,8 @@ class CAISO(ISOBase):
                 "Constraint Cause",
                 "Shadow Price",
                 "Groups",
-            ]
-        ]
+            ],
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_curtailment(
@@ -3561,7 +3658,7 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Return curtailment data for a given date
 
         Arguments:
@@ -3573,7 +3670,7 @@ class CAISO(ISOBase):
             verbose: print out url being fetched. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame of curtailment data
+            pl.DataFrame: A DataFrame of curtailment data
         """
         if date == "latest":
             # Latest available curtailment data is usually the previous day because
@@ -3592,21 +3689,31 @@ class CAISO(ISOBase):
             ("wind_curtailment_maximum_hourly", "Wind", "MW"),
         ]
 
-        melted_dfs = {}
+        melted_dfs: dict[str, pl.DataFrame] = {}
         for df_key, fuel_type, unit in fuel_configs:
             # Melt from a wide format to a long format
-            df = dataframes[df_key].melt(
-                id_vars=["Interval Start", "Interval End"],
-                var_name="Curtailment Type",
+            value_cols = [
+                c
+                for c in dataframes[df_key].columns
+                if c not in {"Interval Start", "Interval End"}
+            ]
+            df = dataframes[df_key].unpivot(
+                index=["Interval Start", "Interval End"],
+                on=value_cols,
+                variable_name="Curtailment Type",
                 value_name=f"Curtailment {unit}",
             )
 
             # Curtailment Type format is "Curtailment Type Curtailment Reason MW/MWH"
             # Split it into two columns: Curtailment Type and Curtailment Reason
-            curtailment_parts = df["Curtailment Type"].str.split(" ")
-            df["Curtailment Type"] = curtailment_parts.str[0]
-            df["Curtailment Reason"] = curtailment_parts.str[1]
-            df["Fuel Type"] = fuel_type
+            df = df.with_columns(
+                pl.col("Curtailment Type").str.split(" ").alias("_parts"),
+            )
+            df = df.with_columns(
+                pl.col("_parts").list.get(0).alias("Curtailment Type"),
+                pl.col("_parts").list.get(1).alias("Curtailment Reason"),
+                pl.lit(fuel_type).alias("Fuel Type"),
+            ).drop("_parts")
 
             melted_dfs[f"{fuel_type} {unit}"] = df
 
@@ -3619,28 +3726,31 @@ class CAISO(ISOBase):
             "Fuel Type",
         ]
 
-        solar_df = melted_dfs["Solar MWH"].merge(
+        solar_df = melted_dfs["Solar MWH"].join(
             melted_dfs["Solar MW"],
             on=merge_cols,
-            how="outer",
+            how="full",
+            coalesce=True,
         )
-        wind_df = melted_dfs["Wind MWH"].merge(
+        wind_df = melted_dfs["Wind MWH"].join(
             melted_dfs["Wind MW"],
             on=merge_cols,
-            how="outer",
+            how="full",
+            coalesce=True,
         )
 
         return (
-            pd.concat([solar_df, wind_df])
-            .reindex(columns=merge_cols + ["Curtailment MWH", "Curtailment MW"])
-            .sort_values(merge_cols)
-            .reset_index(drop=True)
+            pl.concat([solar_df, wind_df], how="diagonal")
+            .select(
+                merge_cols + ["Curtailment MWH", "Curtailment MW"],
+            )
+            .sort(merge_cols)
         )
 
     def get_caiso_renewables_report(
         self,
         date: pd.Timestamp,
-    ) -> dict[str, pd.DataFrame]:
+    ) -> dict[str, pl.DataFrame]:
         """
         Fetches the CAISO daily renewable report for a given date and extracts data from
         all the charts into wide dataframes.
@@ -3722,9 +3832,22 @@ class CAISO(ISOBase):
                     )
                 data[col_name] = values
 
-            dataframes[df_name] = pd.DataFrame(data)
+            dataframes[df_name] = pl.DataFrame(data)
 
         return dataframes
+
+    def _load_daily_energy_storage_report(
+        self,
+        date: str | pd.Timestamp,
+        verbose: bool = False,
+    ) -> tuple[str, pd.Timestamp]:
+        if date == "latest":
+            raise NotSupported()
+        return daily_energy_storage.load_daily_energy_storage_report(
+            date=date,
+            tz=self.default_timezone,
+            verbose=verbose,
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_storage_awards_fmm(
@@ -3732,13 +3855,9 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Energy and ancillary services awards for storage in the FMM (15-minute)."""
-        html, rs = daily_energy_storage.load_daily_energy_storage_report(
-            date=date,
-            tz=self.default_timezone,
-            verbose=verbose,
-        )
+        html, rs = self._load_daily_energy_storage_report(date=date, verbose=verbose)
         return daily_energy_storage.build_storage_awards_fmm(html, rs)
 
     @support_date_range(frequency="DAY_START")
@@ -3747,13 +3866,9 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Energy and AS awards for storage in the IFM (energy at 5-minute, AS hourly)."""
-        html, rs = daily_energy_storage.load_daily_energy_storage_report(
-            date=date,
-            tz=self.default_timezone,
-            verbose=verbose,
-        )
+        html, rs = self._load_daily_energy_storage_report(date=date, verbose=verbose)
         return daily_energy_storage.build_storage_awards_ifm(html, rs)
 
     @support_date_range(frequency="DAY_START")
@@ -3762,13 +3877,9 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Energy awards for storage in RTD (5-minute)."""
-        html, rs = daily_energy_storage.load_daily_energy_storage_report(
-            date=date,
-            tz=self.default_timezone,
-            verbose=verbose,
-        )
+        html, rs = self._load_daily_energy_storage_report(date=date, verbose=verbose)
         return daily_energy_storage.build_storage_awards_rtd(html, rs)
 
     @support_date_range(frequency="DAY_START")
@@ -3777,13 +3888,9 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """RUC energy awards to storage (5-minute)."""
-        html, rs = daily_energy_storage.load_daily_energy_storage_report(
-            date=date,
-            tz=self.default_timezone,
-            verbose=verbose,
-        )
+        html, rs = self._load_daily_energy_storage_report(date=date, verbose=verbose)
         return daily_energy_storage.build_storage_energy_awards_ruc(html, rs)
 
     @support_date_range(frequency="DAY_START")
@@ -3792,13 +3899,9 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """FMM energy bid-in capacity by price bin (15-minute)."""
-        html, rs = daily_energy_storage.load_daily_energy_storage_report(
-            date=date,
-            tz=self.default_timezone,
-            verbose=verbose,
-        )
+        html, rs = self._load_daily_energy_storage_report(date=date, verbose=verbose)
         return daily_energy_storage.build_storage_energy_bids_fmm(html, rs)
 
     @support_date_range(frequency="DAY_START")
@@ -3807,13 +3910,9 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """IFM energy bid-in capacity by price bin (hourly)."""
-        html, rs = daily_energy_storage.load_daily_energy_storage_report(
-            date=date,
-            tz=self.default_timezone,
-            verbose=verbose,
-        )
+        html, rs = self._load_daily_energy_storage_report(date=date, verbose=verbose)
         return daily_energy_storage.build_storage_energy_bids_ifm(html, rs)
 
     @support_date_range(frequency="DAY_START")
@@ -3822,13 +3921,9 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """State of charge for storage in the FMM (15-minute, standalone resources)."""
-        html, rs = daily_energy_storage.load_daily_energy_storage_report(
-            date=date,
-            tz=self.default_timezone,
-            verbose=verbose,
-        )
+        html, rs = self._load_daily_energy_storage_report(date=date, verbose=verbose)
         return daily_energy_storage.build_storage_soc_fmm(html, rs)
 
     @support_date_range(frequency="DAY_START")
@@ -3837,13 +3932,9 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Hourly IFM and RUC state of charge (see ``build_storage_soc_hourly``)."""
-        html, rs = daily_energy_storage.load_daily_energy_storage_report(
-            date=date,
-            tz=self.default_timezone,
-            verbose=verbose,
-        )
+        html, rs = self._load_daily_energy_storage_report(date=date, verbose=verbose)
         return daily_energy_storage.build_storage_soc_hourly(html, rs)
 
     @support_date_range(frequency="DAY_START")
@@ -3852,13 +3943,9 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """State of charge for storage in RTD (5-minute, standalone resources)."""
-        html, rs = daily_energy_storage.load_daily_energy_storage_report(
-            date=date,
-            tz=self.default_timezone,
-            verbose=verbose,
-        )
+        html, rs = self._load_daily_energy_storage_report(date=date, verbose=verbose)
         return daily_energy_storage.build_storage_soc_rtd(html, rs)
 
     def get_system_load_and_resource_schedules_day_ahead(
@@ -3866,7 +3953,7 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get CAISO System Load and Resource Schedules Day-Ahead data from CAISO."""
         if date == "latest":
             # DAM data should be available 1 day in the future after 13:00 PT
@@ -3892,7 +3979,7 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get CAISO System Load and Resource Schedules HASP data from CAISO."""
         if date == "latest":
             return self.get_system_load_and_resource_schedules_hasp(
@@ -3911,7 +3998,7 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get CAISO System Load and Resource Schedules Real Time data from CAISO."""
         if date == "latest":
             return self.get_system_load_and_resource_schedules_real_time_5_min(
@@ -3930,7 +4017,7 @@ class CAISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get CAISO System Load and Resource Schedules RUC data from CAISO."""
         if date == "latest":
             return self.get_system_load_and_resource_schedules_ruc(
@@ -3959,15 +4046,24 @@ class CAISO(ISOBase):
             raw_data=False,
         )
 
+        if df.is_empty():
+            return df
+
         df = df.pivot(
-            columns=["SCHEDULE"],
             index=["Interval Start", "Interval End", "TAC_ZONE_NAME"],
+            on="SCHEDULE",
             values="MW",
         )
 
-        # Remove the multi-level columns
-        df.columns = df.columns.get_level_values(0)
+        df = df.rename({"TAC_ZONE_NAME": "TAC Name"})
 
-        df = df.reset_index().rename(columns={"TAC_ZONE_NAME": "TAC Name"})
-
-        return df.sort_values(["Interval Start", "TAC Name"])
+        schedule_cols = sorted(
+            c
+            for c in df.columns
+            if c not in {"Interval Start", "Interval End", "TAC Name"}
+        )
+        return df.select(
+            ["Interval Start", "Interval End", "TAC Name", *schedule_cols],
+        ).sort(
+            ["Interval Start", "TAC Name"],
+        )

--- a/gridstatus/caiso/caiso_utils.py
+++ b/gridstatus/caiso/caiso_utils.py
@@ -1,9 +1,14 @@
 import pandas as pd
+import polars as pl
 
 
 # NOTE: Currently the gridstatus.CAISO.default_timezone is in the caiso.py file, which imports caiso_utils.py and thus
 # it can't be set to the value without causing a circular import, which is why they are hardcoded here.
-def make_timestamp(time_str: str, today: pd.Timestamp, timezone: str = "US/Pacific"):
+def make_timestamp(
+    time_str: str,
+    today: pd.Timestamp,
+    timezone: str = "US/Pacific",
+) -> pd.Timestamp:
     hour, minute = map(int, time_str.split(":"))
     ts = pd.Timestamp(
         year=today.year,
@@ -16,18 +21,19 @@ def make_timestamp(time_str: str, today: pd.Timestamp, timezone: str = "US/Pacif
     return ts
 
 
-def check_latest_value_time(df: pd.DataFrame, column: str):
+def check_latest_value_time(df: pl.DataFrame, column: str) -> pd.Timestamp:
     """Check if the latest value time is from the previous day and update the date accordingly
 
     Args:
-        df (pd.DataFrame): DataFrame to check
+        df (pl.DataFrame): DataFrame to check
         column (str): Column to check
 
     Returns:
         pd.Timestamp: Latest time
     """
     current_local_date = pd.Timestamp.now(tz="US/Pacific").date()
-    latest_time_str = df.loc[df[column].last_valid_index(), "Time"]
+    non_null = df.filter(pl.col(column).is_not_null())
+    latest_time_str = non_null[-1, "Time"]
     latest_time = make_timestamp(
         latest_time_str,
         today=current_local_date,

--- a/gridstatus/caiso/daily_energy_storage.py
+++ b/gridstatus/caiso/daily_energy_storage.py
@@ -13,6 +13,7 @@ import math
 from typing import Any
 
 import pandas as pd
+import polars as pl
 import requests
 
 from gridstatus import utils
@@ -171,12 +172,9 @@ def _interval_index(
     report_start: pd.Timestamp,
     n: int,
     minutes: int,
-) -> tuple[pd.Series, pd.Series]:
+) -> tuple[list[pd.Timestamp], list[pd.Timestamp]]:
     if n <= 0:
-        return (
-            pd.Series(dtype="datetime64[ns, US/Pacific]"),
-            pd.Series(dtype="datetime64[ns, US/Pacific]"),
-        )
+        return [], []
     starts = pd.date_range(
         start=report_start,
         periods=n,
@@ -184,7 +182,7 @@ def _interval_index(
         tz=report_start.tz,
     )
     ends = starts + pd.Timedelta(minutes=minutes)
-    return starts, ends
+    return list(starts), list(ends)
 
 
 def _long_energy_awards(
@@ -193,7 +191,7 @@ def _long_energy_awards(
     values_hybrid: list[Any],
     minutes: int,
     product: str | None = "Energy",
-) -> pd.DataFrame:
+) -> pl.DataFrame:
     n = min(len(values_standalone), len(values_hybrid))
     if n == 0:
         cols = ["Interval Start", "Interval End", "Type", "MW"]
@@ -205,45 +203,45 @@ def _long_energy_awards(
                 "Type",
                 "MW",
             ]
-        return pd.DataFrame(columns=cols)
+        return pl.DataFrame(schema={c: pl.Null for c in cols})
     starts, ends = _interval_index(report_start, n, minutes)
     if product is not None:
-        standalone_rows = pd.DataFrame(
+        standalone_rows = pl.DataFrame(
             {
                 "Interval Start": starts,
                 "Interval End": ends,
-                "Product": product,
-                "Type": "Standalone",
+                "Product": [product] * n,
+                "Type": ["Standalone"] * n,
                 "MW": values_standalone[:n],
             },
         )
-        hybrid_rows = pd.DataFrame(
+        hybrid_rows = pl.DataFrame(
             {
                 "Interval Start": starts,
                 "Interval End": ends,
-                "Product": product,
-                "Type": "Hybrid",
+                "Product": [product] * n,
+                "Type": ["Hybrid"] * n,
                 "MW": values_hybrid[:n],
             },
         )
     else:
-        standalone_rows = pd.DataFrame(
+        standalone_rows = pl.DataFrame(
             {
                 "Interval Start": starts,
                 "Interval End": ends,
-                "Type": "Standalone",
+                "Type": ["Standalone"] * n,
                 "MW": values_standalone[:n],
             },
         )
-        hybrid_rows = pd.DataFrame(
+        hybrid_rows = pl.DataFrame(
             {
                 "Interval Start": starts,
                 "Interval End": ends,
-                "Type": "Hybrid",
+                "Type": ["Hybrid"] * n,
                 "MW": values_hybrid[:n],
             },
         )
-    return pd.concat([standalone_rows, hybrid_rows], ignore_index=True)
+    return pl.concat([standalone_rows, hybrid_rows])
 
 
 def _long_as_awards(
@@ -251,8 +249,8 @@ def _long_as_awards(
     series_map: dict[str, tuple[str, str]],
     minutes: int,
     html: str,
-) -> pd.DataFrame:
-    parts: list[pd.DataFrame] = []
+) -> pl.DataFrame:
+    parts: list[pl.DataFrame] = []
     for var_name, (product, type_label) in series_map.items():
         vals = _parse_js_array(html, var_name)
         n = len(vals)
@@ -260,27 +258,27 @@ def _long_as_awards(
             continue
         starts, ends = _interval_index(report_start, n, minutes)
         parts.append(
-            pd.DataFrame(
+            pl.DataFrame(
                 {
                     "Interval Start": starts,
                     "Interval End": ends,
-                    "Product": product,
-                    "Type": type_label,
+                    "Product": [product] * n,
+                    "Type": [type_label] * n,
                     "MW": vals,
                 },
             ),
         )
     if not parts:
-        return pd.DataFrame(
-            columns=[
-                "Interval Start",
-                "Interval End",
-                "Product",
-                "Type",
-                "MW",
-            ],
+        return pl.DataFrame(
+            schema={
+                "Interval Start": pl.Null,
+                "Interval End": pl.Null,
+                "Product": pl.Null,
+                "Type": pl.Null,
+                "MW": pl.Null,
+            },
         )
-    return pd.concat(parts, ignore_index=True)
+    return pl.concat(parts)
 
 
 def _hybrid_bid_var_names(order: list[tuple[str, str]]) -> list[tuple[str, str]]:
@@ -363,51 +361,51 @@ def _bid_stack_to_df(
     minutes: int,
     operation: str,
     type_label: str,
-) -> pd.DataFrame:
+) -> pl.DataFrame:
     lengths: list[int] = []
     for var_name, _ in var_order:
         vals = _parse_js_array(html, var_name)
         lengths.append(len(vals))
     n = min(lengths) if lengths else 0
     if n == 0:
-        return pd.DataFrame(
-            columns=[
-                "Interval Start",
-                "Interval End",
-                "Bid Range",
-                "Operation",
-                "Type",
-                "MW",
-            ],
+        return pl.DataFrame(
+            schema={
+                "Interval Start": pl.Null,
+                "Interval End": pl.Null,
+                "Bid Range": pl.Null,
+                "Operation": pl.Null,
+                "Type": pl.Null,
+                "MW": pl.Null,
+            },
         )
     starts, ends = _interval_index(report_start, n, minutes)
-    rows = []
+    rows: list[pl.DataFrame] = []
     for var_name, bid_range in var_order:
         vals = _parse_js_array(html, var_name)
         rows.append(
-            pd.DataFrame(
+            pl.DataFrame(
                 {
                     "Interval Start": starts,
                     "Interval End": ends,
-                    "Bid Range": bid_range,
-                    "Operation": operation,
-                    "Type": type_label,
+                    "Bid Range": [bid_range] * n,
+                    "Operation": [operation] * n,
+                    "Type": [type_label] * n,
                     "MW": vals[:n],
                 },
             ),
         )
     if not rows:
-        return pd.DataFrame(
-            columns=[
-                "Interval Start",
-                "Interval End",
-                "Bid Range",
-                "Operation",
-                "Type",
-                "MW",
-            ],
+        return pl.DataFrame(
+            schema={
+                "Interval Start": pl.Null,
+                "Interval End": pl.Null,
+                "Bid Range": pl.Null,
+                "Operation": pl.Null,
+                "Type": pl.Null,
+                "MW": pl.Null,
+            },
         )
-    return pd.concat(rows, ignore_index=True)
+    return pl.concat(rows)
 
 
 def _downsample_5min_to_15min(values: list[float]) -> list[float]:
@@ -433,7 +431,7 @@ def _downsample_5min_to_60min(values: list[float]) -> list[float]:
 def build_storage_awards_fmm(
     html: str,
     report_start: pd.Timestamp,
-) -> pd.DataFrame:
+) -> pl.DataFrame:
     energy_standalone = _downsample_5min_to_15min(
         _parse_js_array(html, "tot_energy_rtpd"),
     )
@@ -469,7 +467,7 @@ def build_storage_awards_fmm(
         15,
         html,
     )
-    return pd.concat([energy, as_standalone, as_hybrid], ignore_index=True).sort_values(
+    return pl.concat([energy, as_standalone, as_hybrid]).sort(
         ["Interval Start", "Product", "Type"],
     )
 
@@ -477,7 +475,7 @@ def build_storage_awards_fmm(
 def build_storage_awards_ifm(
     html: str,
     report_start: pd.Timestamp,
-) -> pd.DataFrame:
+) -> pl.DataFrame:
     energy_standalone = _downsample_5min_to_60min(
         _parse_js_array(html, "tot_energy_ifm"),
     )
@@ -513,7 +511,7 @@ def build_storage_awards_ifm(
         60,
         html,
     )
-    return pd.concat([energy, as_standalone, as_hybrid], ignore_index=True).sort_values(
+    return pl.concat([energy, as_standalone, as_hybrid]).sort(
         ["Interval Start", "Product", "Type"],
     )
 
@@ -521,7 +519,7 @@ def build_storage_awards_ifm(
 def build_storage_awards_rtd(
     html: str,
     report_start: pd.Timestamp,
-) -> pd.DataFrame:
+) -> pl.DataFrame:
     energy_standalone = _parse_js_array(html, "tot_energy_rtd")
     energy_hybrid = _parse_js_array(html, "tot_energy_hybrid_rtd")
     return _long_energy_awards(
@@ -530,13 +528,13 @@ def build_storage_awards_rtd(
         energy_hybrid,
         5,
         product=None,
-    ).sort_values(["Interval Start", "Type"])
+    ).sort(["Interval Start", "Type"])
 
 
 def build_storage_energy_awards_ruc(
     html: str,
     report_start: pd.Timestamp,
-) -> pd.DataFrame:
+) -> pl.DataFrame:
     energy_standalone = _parse_js_array(html, "tot_energy_ruc")
     energy_hybrid = _parse_js_array(html, "tot_energy_hybrid_ruc")
     return _long_energy_awards(
@@ -545,13 +543,13 @@ def build_storage_energy_awards_ruc(
         energy_hybrid,
         5,
         product=None,
-    ).sort_values(["Interval Start", "Type"])
+    ).sort(["Interval Start", "Type"])
 
 
 def build_storage_soc_hourly(
     html: str,
     report_start: pd.Timestamp,
-) -> pd.DataFrame:
+) -> pl.DataFrame:
     """Hourly IFM and RUC SOC from ``tot_charge_ifm`` and ``tot_charge_ruc``.
 
     The HTML arrays use a 5-minute index (typically 288 points) but IFM and
@@ -564,93 +562,91 @@ def build_storage_soc_hourly(
     n_pairs = min(len(ifm_soc_series), len(ruc_soc_series))
     n_hours = n_pairs // 12
     if n_hours == 0:
-        return pd.DataFrame(
-            columns=[
-                "Interval Start",
-                "Interval End",
-                "SOC",
-                "Schedule",
-            ],
+        return pl.DataFrame(
+            schema={
+                "Interval Start": pl.Null,
+                "Interval End": pl.Null,
+                "SOC": pl.Null,
+                "Schedule": pl.Null,
+            },
         )
     ifm_vals = [ifm_soc_series[i * 12] for i in range(n_hours)]
     ruc_vals = [ruc_soc_series[i * 12] for i in range(n_hours)]
     starts, ends = _interval_index(report_start, n_hours, 60)
-    df_ifm = pd.DataFrame(
+    df_ifm = pl.DataFrame(
         {
             "Interval Start": starts,
             "Interval End": ends,
             "SOC": ifm_vals,
-            "Schedule": "IFM",
+            "Schedule": ["IFM"] * n_hours,
         },
     )
-    df_ruc = pd.DataFrame(
+    df_ruc = pl.DataFrame(
         {
             "Interval Start": starts,
             "Interval End": ends,
             "SOC": ruc_vals,
-            "Schedule": "RUC",
+            "Schedule": ["RUC"] * n_hours,
         },
     )
-    return pd.concat([df_ifm, df_ruc], ignore_index=True).sort_values(
-        ["Interval Start", "Schedule"],
-    )
+    return pl.concat([df_ifm, df_ruc]).sort(["Interval Start", "Schedule"])
 
 
 def build_storage_soc_fmm(
     html: str,
     report_start: pd.Timestamp,
-) -> pd.DataFrame:
+) -> pl.DataFrame:
     standalone_soc_series = _parse_js_array(html, "tot_charge_rtpd")
     n = len(standalone_soc_series)
     if n == 0:
-        return pd.DataFrame(
-            columns=[
-                "Interval Start",
-                "Interval End",
-                "SOC",
-            ],
+        return pl.DataFrame(
+            schema={
+                "Interval Start": pl.Null,
+                "Interval End": pl.Null,
+                "SOC": pl.Null,
+            },
         )
     starts, ends = _interval_index(report_start, n, 5)
-    return pd.DataFrame(
+    return pl.DataFrame(
         {
             "Interval Start": starts,
             "Interval End": ends,
             "SOC": standalone_soc_series,
         },
-    ).sort_values(["Interval Start"])
+    ).sort(["Interval Start"])
 
 
 def build_storage_soc_rtd(
     html: str,
     report_start: pd.Timestamp,
-) -> pd.DataFrame:
+) -> pl.DataFrame:
     standalone_soc_series = _parse_js_array(html, "tot_charge_rtd")
     n = len(standalone_soc_series)
     if n == 0:
-        return pd.DataFrame(
-            columns=[
-                "Interval Start",
-                "Interval End",
-                "SOC",
-            ],
+        return pl.DataFrame(
+            schema={
+                "Interval Start": pl.Null,
+                "Interval End": pl.Null,
+                "SOC": pl.Null,
+            },
         )
     starts, ends = _interval_index(report_start, n, 5)
-    return pd.DataFrame(
+    return pl.DataFrame(
         {
             "Interval Start": starts,
             "Interval End": ends,
             "SOC": standalone_soc_series,
         },
-    ).sort_values(["Interval Start"])
+    ).sort(["Interval Start"])
 
 
 def build_storage_energy_bids_fmm(
     html: str,
     report_start: pd.Timestamp,
-) -> pd.DataFrame:
+) -> pl.DataFrame:
     hybrid_pos = _hybrid_bid_var_names(BID_RTPD_RANGE_ORDER)
     hybrid_neg = _hybrid_bid_var_names(BID_RTPD_NEG_ORDER)
-    parts: list[pd.DataFrame] = [
+    parts: list[pl.DataFrame] = [
         _bid_stack_to_df(
             report_start,
             html,
@@ -684,7 +680,7 @@ def build_storage_energy_bids_fmm(
             "Hybrid",
         ),
     ]
-    return pd.concat(parts, ignore_index=True).sort_values(
+    return pl.concat(parts).sort(
         ["Interval Start", "Bid Range", "Operation", "Type"],
     )
 
@@ -692,10 +688,10 @@ def build_storage_energy_bids_fmm(
 def build_storage_energy_bids_ifm(
     html: str,
     report_start: pd.Timestamp,
-) -> pd.DataFrame:
+) -> pl.DataFrame:
     hybrid_pos = _hybrid_bid_var_names(BID_IFM_RANGE_ORDER)
     hybrid_neg = _hybrid_bid_var_names(BID_IFM_NEG_ORDER)
-    parts: list[pd.DataFrame] = [
+    parts: list[pl.DataFrame] = [
         _bid_stack_to_df(
             report_start,
             html,
@@ -729,6 +725,6 @@ def build_storage_energy_bids_ifm(
             "Hybrid",
         ),
     ]
-    return pd.concat(parts, ignore_index=True).sort_values(
+    return pl.concat(parts).sort(
         ["Interval Start", "Bid Range", "Operation", "Type"],
     )

--- a/gridstatus/eia.py
+++ b/gridstatus/eia.py
@@ -885,8 +885,14 @@ def _handle_time(df: pl.DataFrame, frequency: str = "1h") -> pl.DataFrame:
         raise NotImplementedError(f"Unsupported frequency: {frequency}")
 
     value_cols = [col for col in df.columns if col != "period"]
+    # EIA hourly periods are hour-terminated strings ("2026-07-08T05"), which
+    # polars cannot parse without a minute component, so pad before parsing.
     df = df.with_columns(
-        pl.col("period").str.to_datetime(time_zone="UTC").alias("Interval End"),
+        pl.when(pl.col("period").str.len_chars() == 13)
+        .then(pl.col("period") + ":00")
+        .otherwise(pl.col("period"))
+        .str.to_datetime(time_zone="UTC")
+        .alias("Interval End"),
     )
     df = df.with_columns(
         (pl.col("Interval End") - duration).alias("Interval Start"),

--- a/gridstatus/eia.py
+++ b/gridstatus/eia.py
@@ -10,6 +10,7 @@ from zipfile import BadZipFile
 
 import numpy as np
 import pandas as pd
+import polars as pl
 import requests
 from bs4 import BeautifulSoup
 from tqdm import tqdm
@@ -48,7 +49,7 @@ class EIA:
 
         """
         if api_key is None:
-            api_key = os.environ.get("EIA_API_KEY")
+            api_key = os.getenv("EIA_API_KEY")
         self.api_key = api_key
 
         if api_key is None:
@@ -98,7 +99,7 @@ class EIA:
         except requests.exceptions.HTTPError as err:
             raise err
         response = data.json()["response"]
-        df = pd.DataFrame(response["data"])
+        df = pl.DataFrame(response["data"])
         return df, int(response["total"])
 
     def _facet_handler(self, facets):
@@ -230,9 +231,9 @@ class EIA:
 
                 page_dfs = [future.result() for future in futures]
 
-            raw_df = pd.concat([raw_df, *page_dfs], ignore_index=True)
+            raw_df = utils.concat_dataframes([raw_df, *page_dfs])
 
-        df = raw_df.copy()
+        df = raw_df
 
         if dataset in DATASET_CONFIG:
             df = DATASET_CONFIG[dataset]["handler"](df)
@@ -289,22 +290,12 @@ class EIA:
             url = grid_monitor["URL"]
             if verbose:
                 logger.info(f"Fetching data from {url}")
-            df = pd.read_excel(url, sheet_name="Published Hourly Data")
 
             rename = {
                 "Demand forecast": "Demand Forecast",
                 "Net generation": "Net Generation",
                 "Total interchange": "Total Interchange",
             }
-
-            df = df.rename(columns=rename)
-
-            df["Area Id"] = grid_monitor["ID"]
-            df["Area Type"] = grid_monitor["Type"]
-            df["Area Name"] = grid_monitor["Name"]
-
-            df.insert(0, "Interval End", pd.to_datetime(df["UTC time"], utc=True))
-            df.insert(0, "Interval Start", df["Interval End"] - pd.Timedelta("1h"))
 
             cols = [
                 "Interval Start",
@@ -342,9 +333,24 @@ class EIA:
                 "CO2 Emissions Intensity for Consumed Electricity",
             ]
 
-            df = df[cols]
+            def process(pdf: pd.DataFrame) -> pd.DataFrame:
+                pdf = pdf.rename(columns=rename)
+                pdf["Area Id"] = grid_monitor["ID"]
+                pdf["Area Type"] = grid_monitor["Type"]
+                pdf["Area Name"] = grid_monitor["Name"]
+                pdf.insert(0, "Interval End", pd.to_datetime(pdf["UTC time"], utc=True))
+                pdf.insert(
+                    0,
+                    "Interval Start",
+                    pdf["Interval End"] - pd.Timedelta("1h"),
+                )
+                return pdf[cols]
 
-            return df
+            return utils.read_excel_via_pandas(
+                url,
+                sheet_name="Published Hourly Data",
+                process=process,
+            )
 
         # Set the number of workers you want
         futures = []
@@ -362,7 +368,7 @@ class EIA:
 
         # Combine all the dataframes (assuming you want to do this)
         all_dfs = [future.result() for future in futures]
-        df = pd.concat(all_dfs, ignore_index=True)
+        df = pl.concat(all_dfs, how="diagonal")
 
         return df
 
@@ -381,17 +387,8 @@ class EIA:
 
         url = "https://www.eia.gov/todayinenergy/prices.php"
 
-        df_petrol = pd.DataFrame(columns=["product", "area", "price", "percent_change"])
-        df_ng = pd.DataFrame(
-            columns=[
-                "region",
-                "natural_gas_price",
-                "natural_gas_percent_change",
-                "electricity_price",
-                "electricity_percent_change",
-                "spark_spread",
-            ],
-        )
+        petrol_rows: list[dict[str, object]] = []
+        ng_rows: list[dict[str, object]] = []
 
         def contains_wholesale_petroleum(text):
             return text and "Wholesale Spot Petroleum Prices" in text
@@ -429,30 +426,36 @@ class EIA:
                         direction = float(
                             s1.find_next_sibling("td", class_=directions).text,
                         )
-                        df_petrol.loc[len(df_petrol)] = (
-                            text,
-                            s2,
-                            float(d1) if d1 != "NA" else np.nan,
-                            float(direction) if direction != "NA" else np.nan,
+                        petrol_rows.append(
+                            {
+                                "product": text,
+                                "area": s2,
+                                "price": float(d1) if d1 != "NA" else np.nan,
+                                "percent_change": (
+                                    float(direction) if direction != "NA" else np.nan
+                                ),
+                            },
                         )
                     else:
                         for i in range(rowspan_sum, rowspan + rowspan_sum):
                             s2_elements = parent.select("td.s2")
                             d1_elements = parent.select("td.d1")
                             direction_elements = parent.find_all(class_=directions)
-                            df_petrol.loc[len(df_petrol)] = (
-                                text,
-                                s2_elements[i].text,
-                                (
-                                    float(d1_elements[i].text)
-                                    if d1_elements[i].text != "NA"
-                                    else np.nan
-                                ),
-                                (
-                                    float(direction_elements[i].text)
-                                    if direction_elements[i].text != "NA"
-                                    else np.nan
-                                ),
+                            petrol_rows.append(
+                                {
+                                    "product": text,
+                                    "area": s2_elements[i].text,
+                                    "price": (
+                                        float(d1_elements[i].text)
+                                        if d1_elements[i].text != "NA"
+                                        else np.nan
+                                    ),
+                                    "percent_change": (
+                                        float(direction_elements[i].text)
+                                        if direction_elements[i].text != "NA"
+                                        else np.nan
+                                    ),
+                                },
                             )
 
                     rowspan_sum += rowspan
@@ -462,11 +465,15 @@ class EIA:
                     direction = float(
                         s1.find_next_sibling("td", class_=directions).text,
                     )
-                    df_petrol.loc[len(df_petrol)] = (
-                        text,
-                        s2,
-                        float(d1) if d1 != "NA" else np.nan,
-                        float(direction) if direction != "NA" else np.nan,
+                    petrol_rows.append(
+                        {
+                            "product": text,
+                            "area": s2,
+                            "price": float(d1) if d1 != "NA" else np.nan,
+                            "percent_change": (
+                                float(direction) if direction != "NA" else np.nan
+                            ),
+                        },
                     )
 
             natural_gas_spots = soup.select_one(
@@ -476,37 +483,42 @@ class EIA:
             for s1 in natural_gas_spots.select("td.s1"):
                 price_siblings = s1.find_next_siblings("td", class_="d1")
                 direction_siblings = s1.find_next_siblings("td", class_=directions)
-                df_ng.loc[len(df_ng)] = (
-                    s1.text,
-                    (
-                        float(price_siblings[0].text)
-                        if price_siblings[0].text != "NA"
-                        else np.nan
-                    ),
-                    (
-                        float(direction_siblings[0].text)
-                        if direction_siblings[0].text != "NA"
-                        else np.nan
-                    ),
-                    (
-                        float(price_siblings[1].text)
-                        if price_siblings[1].text != "NA"
-                        else np.nan
-                    ),
-                    (
-                        float(direction_siblings[1].text)
-                        if direction_siblings[1].text != "NA"
-                        else np.nan
-                    ),
-                    (
-                        float(price_siblings[2].text)
-                        if price_siblings[2].text != "NA"
-                        else np.nan
-                    ),
+                ng_rows.append(
+                    {
+                        "region": s1.text,
+                        "natural_gas_price": (
+                            float(price_siblings[0].text)
+                            if price_siblings[0].text != "NA"
+                            else np.nan
+                        ),
+                        "natural_gas_percent_change": (
+                            float(direction_siblings[0].text)
+                            if direction_siblings[0].text != "NA"
+                            else np.nan
+                        ),
+                        "electricity_price": (
+                            float(price_siblings[1].text)
+                            if price_siblings[1].text != "NA"
+                            else np.nan
+                        ),
+                        "electricity_percent_change": (
+                            float(direction_siblings[1].text)
+                            if direction_siblings[1].text != "NA"
+                            else np.nan
+                        ),
+                        "spark_spread": (
+                            float(price_siblings[2].text)
+                            if price_siblings[2].text != "NA"
+                            else np.nan
+                        ),
+                    },
                 )
 
-        df_ng["date"] = pd.to_datetime(close_date)
-        df_petrol["date"] = pd.to_datetime(close_date)
+        close_date_ts = pd.to_datetime(close_date)
+        df_petrol = pl.DataFrame(petrol_rows).with_columns(
+            pl.lit(close_date_ts).alias("date"),
+        )
+        df_ng = pl.DataFrame(ng_rows).with_columns(pl.lit(close_date_ts).alias("date"))
 
         df_ng = utils.move_cols_to_front(df_ng, cols_to_move=["date"])
         df_petrol = utils.move_cols_to_front(df_petrol, cols_to_move=["date"])
@@ -586,25 +598,39 @@ class EIA:
             else:
                 pass
 
-        weekly_spots = pd.DataFrame(spot_prices)
-        weekly_spots = weekly_spots.loc[weekly_spots["week_ending_date"] != "change"]
-        weekly_spots["week_ending_date"] = weekly_spots["week_ending_date"].map(
-            pd.to_datetime,
+        weekly_spots = pl.DataFrame(spot_prices)
+        weekly_spots = weekly_spots.filter(pl.col("week_ending_date") != "change")
+        weekly_spots = weekly_spots.with_columns(
+            pl.col("week_ending_date").str.to_datetime(),
         )
-        weekly_spots = pd.merge(
-            weekly_spots.drop_duplicates("week_ending_date", keep="first"),
-            weekly_spots.drop_duplicates("week_ending_date", keep="last"),
+        price_cols = [col for col in weekly_spots.columns if col != "week_ending_date"]
+        weekly_spots_first = weekly_spots.unique(
+            subset=["week_ending_date"],
+            keep="first",
+        ).rename({col: f"{col}_short_ton" for col in price_cols})
+        weekly_spots_last = weekly_spots.unique(
+            subset=["week_ending_date"],
+            keep="last",
+        ).rename({col: f"{col}_mmbtu" for col in price_cols})
+        weekly_spots = weekly_spots_first.join(
+            weekly_spots_last,
             on="week_ending_date",
-            suffixes=("_short_ton", "_mmbtu"),
+            how="inner",
         )
 
-        coal_exports = pd.DataFrame(coal_exports)
-        coal_exports["delivery_month"] = coal_exports["delivery_month"].map(
-            lambda x: datetime.datetime.strptime(str(x), "%Y%m"),
+        coal_exports = pl.DataFrame(coal_exports)
+        coal_exports = coal_exports.with_columns(
+            pl.col("delivery_month")
+            .cast(pl.Utf8)
+            .str.strptime(pl.Datetime, "%Y%m")
+            .alias("delivery_month"),
         )
-        coke_exports = pd.DataFrame(coke_exports)
-        coke_exports["delivery_month"] = coke_exports["delivery_month"].map(
-            lambda x: datetime.datetime.strptime(str(x), "%Y%m"),
+        coke_exports = pl.DataFrame(coke_exports)
+        coke_exports = coke_exports.with_columns(
+            pl.col("delivery_month")
+            .cast(pl.Utf8)
+            .str.strptime(pl.Datetime, "%Y%m")
+            .alias("delivery_month"),
         )
 
         return {
@@ -642,7 +668,7 @@ class EIA:
         date: str | datetime.datetime,
         end: str | datetime.datetime = None,
         verbose: bool = False,
-    ) -> Dict[str, pd.DataFrame]:
+    ) -> Dict[str, pl.DataFrame]:
         date = utils._handle_date(date, "UTC")
         month_name = date.strftime("%B").lower()
         year = date.year
@@ -676,18 +702,27 @@ class EIA:
         # column to determine the rows to skip. For the footer, we drop NAs while
         # processing the data
         skiprows = 1
-        shared_args = {"skiprows": skiprows, "skipfooter": 1}
-        operating_data = file.parse("Operating", **shared_args)
+        operating_data = _parse_generator_sheet(file, "Operating", skiprows)
 
         if operating_data.columns[0] == "Unnamed: 0":
-            operating_data.columns = operating_data.iloc[0].values
-            operating_data = operating_data.iloc[1:]
+            operating_pdf = operating_data.to_pandas()
+            operating_pdf.columns = operating_pdf.iloc[0].values
+            operating_pdf = operating_pdf.iloc[1:]
+            for col in operating_pdf.columns:
+                if operating_pdf[col].dtype == object:
+                    operating_pdf[col] = operating_pdf[col].map(
+                        lambda value: None if pd.isna(value) else str(value),
+                    )
+            operating_data = pl.from_pandas(operating_pdf)
             skiprows = 2
-            shared_args.update({"skiprows": skiprows})
 
-        planned_data = file.parse("Planned", **shared_args)
-        retired_data = file.parse("Retired", **shared_args)
-        canceled_or_postponed_data = file.parse("Canceled or Postponed", **shared_args)
+        planned_data = _parse_generator_sheet(file, "Planned", skiprows)
+        retired_data = _parse_generator_sheet(file, "Retired", skiprows)
+        canceled_or_postponed_data = _parse_generator_sheet(
+            file,
+            "Canceled or Postponed",
+            skiprows,
+        )
 
         return {
             key: self._handle_generator_data(
@@ -717,38 +752,45 @@ class EIA:
 
     def _handle_generator_data(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         period: datetime.date,
         updated_at: datetime.datetime,
         columns: list[str],
         generator_status: str,
         verbose: bool = False,
-    ) -> pd.DataFrame:
-        df.insert(0, "Period", period)
-        df.insert(1, "Updated At", updated_at)
+    ) -> pl.DataFrame:
+        df = df.with_columns(
+            pl.lit(period).alias("Period"),
+            pl.lit(updated_at).alias("Updated At"),
+        )
+        other_cols = [col for col in df.columns if col not in ["Period", "Updated At"]]
+        df = df.select(["Period", "Updated At"] + other_cols)
 
-        df.columns = df.columns.str.strip()
+        rename_strip = {col: col.strip() for col in df.columns}
+        df = df.rename(rename_strip)
 
         cols_to_drop = [col for col in ["Google Map", "Bing Map"] if col in df.columns]
+        if cols_to_drop:
+            df = df.drop(cols_to_drop)
 
-        df = (
-            df.rename(
-                columns={
-                    "Nameplate Capacity (MW)": "Nameplate Capacity",
-                    "Net Summer Capacity (MW)": "Net Summer Capacity",
-                    "Net Winter Capacity (MW)": "Net Winter Capacity",
-                    "Nameplate Energy Capacity (MWh)": "Nameplate Energy Capacity",
-                    "DC Net Capacity (MW)": "DC Net Capacity",
-                    "Planned Derate of Summer Capacity (MW)": "Planned Derate of Summer Capacity",
-                    "Planned Uprate of Summer Capacity (MW)": "Planned Uprate of Summer Capacity",
-                },
-            )
-            .drop(
-                columns=cols_to_drop,
-            )
-            # Dropna values to remove extra footer rows
-            .dropna(subset=["Plant ID"])
-        )
+        rename_map = {
+            "Nameplate Capacity (MW)": "Nameplate Capacity",
+            "Net Summer Capacity (MW)": "Net Summer Capacity",
+            "Net Winter Capacity (MW)": "Net Winter Capacity",
+            "Nameplate Energy Capacity (MWh)": "Nameplate Energy Capacity",
+            "DC Net Capacity (MW)": "DC Net Capacity",
+            "Planned Derate of Summer Capacity (MW)": "Planned Derate of Summer Capacity",
+            "Planned Uprate of Summer Capacity (MW)": "Planned Uprate of Summer Capacity",
+        }
+        existing_rename = {
+            old_name: new_name
+            for old_name, new_name in rename_map.items()
+            if old_name in df.columns
+        }
+        if existing_rename:
+            df = df.rename(existing_rename)
+
+        df = df.drop_nulls(subset=["Plant ID"])
 
         # Older files may not have all the columns. These are the columns we want to
         # fill with np.nan if they don't exist.
@@ -768,48 +810,91 @@ class EIA:
                     logger.warning(
                         f"Column {col} not found in data for {generator_status} generators. Adding and filling with np.nan values.",  # noqa
                     )
-                df[col] = np.nan
+                df = df.with_columns(pl.lit(None).cast(pl.Float64).alias(col))
 
         for col in GENERATOR_FLOAT_COLUMNS:
-            if col in df.columns and df[col].dtype == "object":
-                df[col] = (
-                    df[col].astype(str).str.strip().replace({"": np.nan}).astype(float)
+            if col in df.columns and df.schema[col] == pl.Utf8:
+                df = df.with_columns(
+                    pl.col(col)
+                    .cast(pl.Utf8)
+                    .str.strip_chars()
+                    .replace("", None)
+                    .replace("nan", None)
+                    .replace("None", None)
+                    .cast(pl.Float64, strict=False)
+                    .alias(col),
                 )
 
         for col in GENERATOR_INT_COLUMNS:
-            if col in df.columns and (
-                df[col].dtype == "object" or df[col].dtype == "float"
-            ):
-                df[col] = (
-                    df[col]
-                    .astype(str)
-                    .str.strip()
-                    .str.replace(".0", "")
-                    .replace({"": None, "nan": None})
-                    .astype("Int64")
+            if col not in df.columns:
+                continue
+            if df.schema[col] == pl.Utf8:
+                df = df.with_columns(
+                    pl.col(col)
+                    .cast(pl.Utf8)
+                    .str.strip_chars()
+                    .str.replace(".0", "", literal=True)
+                    .replace("", None)
+                    .replace("nan", None)
+                    .cast(pl.Int64, strict=False)
+                    .alias(col),
+                )
+            elif df.schema[col] in (pl.Float64, pl.Float32):
+                df = df.with_columns(
+                    pl.col(col).cast(pl.Int64, strict=False).alias(col),
                 )
 
-        null_generator_id_rows = df.loc[df["Generator ID"].isnull()]
+        null_generator_id_rows = df.filter(pl.col("Generator ID").is_null())
 
-        # There are some rows with null Generator IDs. We drop these rows
-        if not null_generator_id_rows.empty:
+        if null_generator_id_rows.height > 0:
             logger.warning(
                 f"Found rows with null Generator Ids for {generator_status} "
                 + f"power plants. {null_generator_id_rows}",
             )
-            df = df.dropna(subset=["Generator ID"])
+            df = df.drop_nulls(subset=["Generator ID"])
 
-        return df[columns]
-
-
-def _handle_time(df, frequency="1h"):
-    df.insert(0, "Interval End", pd.to_datetime(df["period"], utc=True))
-    df.insert(0, "Interval Start", df["Interval End"] - pd.Timedelta(frequency))
-    df = df.drop("period", axis=1)
-    return df
+        return df.select(columns)
 
 
-def _handle_region_data(df):
+def _parse_generator_sheet(
+    file: pd.ExcelFile,
+    sheet_name: str,
+    skiprows: int,
+) -> pl.DataFrame:
+    def process(pdf: pd.DataFrame) -> pd.DataFrame:
+        for col in pdf.columns:
+            if pdf[col].dtype == object:
+                pdf[col] = pdf[col].map(
+                    lambda value: None if pd.isna(value) else str(value),
+                )
+        return pdf
+
+    return utils.read_excel_via_pandas(
+        file,
+        sheet_name=sheet_name,
+        skiprows=skiprows,
+        skipfooter=1,
+        engine="openpyxl",
+        process=process,
+    )
+
+
+def _handle_time(df: pl.DataFrame, frequency: str = "1h") -> pl.DataFrame:
+    duration = pl.duration(hours=1)
+    if frequency != "1h":
+        raise NotImplementedError(f"Unsupported frequency: {frequency}")
+
+    value_cols = [col for col in df.columns if col != "period"]
+    df = df.with_columns(
+        pl.col("period").str.to_datetime(time_zone="UTC").alias("Interval End"),
+    )
+    df = df.with_columns(
+        (pl.col("Interval End") - duration).alias("Interval Start"),
+    )
+    return df.select(["Interval Start", "Interval End"] + value_cols)
+
+
+def _handle_region_data(df: pl.DataFrame) -> pl.DataFrame:
     df = _handle_time(df, frequency="1h")
 
     df = df.rename(
@@ -819,41 +904,40 @@ def _handle_region_data(df):
             "respondent-name": "Respondent Name",
             "type": "Type",
         },
-        axis=1,
     )
 
-    # ['TI', 'NG', 'DF', 'D']
-    df["Type"] = df["Type"].map(
-        {
-            "D": "Load",
-            "TI": "Total Interchange",
-            "NG": "Net Generation",
-            "DF": "Load Forecast",
-        },
+    df = df.with_columns(
+        pl.col("Type")
+        .replace(
+            {
+                "D": "Load",
+                "TI": "Total Interchange",
+                "NG": "Net Generation",
+                "DF": "Load Forecast",
+            },
+        )
+        .alias("Type"),
+        pl.col("MW").cast(pl.Float64),
     )
 
-    df["MW"] = df["MW"].astype(float)
+    df = df.filter(pl.col("Type").is_not_null())
 
-    df = df[df["Type"].notna()]
-
-    # pivot on Type
     df = df.pivot(
+        on="Type",
         index=["Interval Start", "Interval End", "Respondent", "Respondent Name"],
-        columns="Type",
         values="MW",
-    ).reset_index()
+        aggregate_function="first",
+    )
 
-    df.columns.name = None
-
-    # fix after pivot
-    for col in ["Load", "Net Generation", "Load Forecast", "Total Interchange"]:
+    float_cols = ["Load", "Net Generation", "Load Forecast", "Total Interchange"]
+    for col in float_cols:
         if col in df.columns:
-            df[col] = df[col].astype(float)
+            df = df.with_columns(pl.col(col).cast(pl.Float64))
 
     return df
 
 
-def _handle_region_sub_ba_data(df):
+def _handle_region_sub_ba_data(df: pl.DataFrame) -> pl.DataFrame:
     """electricity/rto/region-sub-ba-data"""
     df = _handle_time(df, frequency="1h")
 
@@ -865,10 +949,9 @@ def _handle_region_sub_ba_data(df):
             "parent": "BA",
             "parent-name": "BA Name",
         },
-        axis=1,
     )
 
-    df = df[
+    return df.select(
         [
             "Interval Start",
             "Interval End",
@@ -877,15 +960,11 @@ def _handle_region_sub_ba_data(df):
             "Subregion",
             "Subregion Name",
             "MW",
-        ]
-    ]
-
-    df = df.sort_values(["Interval Start", "Subregion"])
-
-    return df
+        ],
+    ).sort(["Interval Start", "Subregion"])
 
 
-def _handle_rto_interchange(df):
+def _handle_rto_interchange(df: pl.DataFrame) -> pl.DataFrame:
     """electricity/rto/interchange-data"""
     df = _handle_time(df, frequency="1h")
     df = df.rename(
@@ -896,9 +975,8 @@ def _handle_rto_interchange(df):
             "fromba-name": "From BA Name",
             "toba-name": "To BA Name",
         },
-        axis=1,
     )
-    df = df[
+    return df.select(
         [
             "Interval Start",
             "Interval End",
@@ -907,15 +985,11 @@ def _handle_rto_interchange(df):
             "To BA",
             "To BA Name",
             "MW",
-        ]
-    ]
-
-    df = df.sort_values(["Interval Start", "From BA"])
-
-    return df
+        ],
+    ).sort(["Interval Start", "From BA"])
 
 
-def _handle_fuel_type_data(df):
+def _handle_fuel_type_data(df: pl.DataFrame) -> pl.DataFrame:
     """electricity/rto/fuel-type-data"""
     df = _handle_time(df, frequency="1h")
 
@@ -925,77 +999,73 @@ def _handle_fuel_type_data(df):
             "respondent": "Respondent",
             "respondent-name": "Respondent Name",
         },
-        axis=1,
     )
 
-    df["MW"] = df["MW"].astype(float)
-
-    # The raw data will sometimes have case-sensitive duplicates
-    # (e.g. "Pumped Storage","Pumped storage"). We can handle that through the pivot
-    # table by summing the duplicates across case-insensitive names.
-    df["type-name"] = df["type-name"].str.lower()
-
-    # These columns are grouped together by EIA as confirmed by inspection of the EIA
-    # fuel mix graphs. https://www.eia.gov/electricity/gridmonitor/expanded-view/electric_overview/US48/US48/GenerationByEnergySource-4/edit # noqa
-    df["type-name"] = df["type-name"].replace(
-        {
-            "battery": "battery storage",
-            "solar battery": "solar with integrated battery storage",
-            "unknown energy": "unknown energy storage",
-            "unknown": "other",
-        },
+    df = df.with_columns(
+        pl.col("MW").cast(pl.Float64),
+        pl.col("type-name").str.to_lowercase().alias("type-name"),
     )
 
-    # Pivot on fuel type
-    df = df.pivot_table(
+    df = df.with_columns(
+        pl.col("type-name")
+        .replace(
+            {
+                "battery": "battery storage",
+                "solar battery": "solar with integrated battery storage",
+                "unknown energy": "unknown energy storage",
+                "unknown": "other",
+            },
+        )
+        .alias("type-name"),
+    )
+
+    df = df.pivot(
+        on="type-name",
         index=["Interval Start", "Interval End", "Respondent", "Respondent Name"],
-        columns="type-name",
         values="MW",
-        aggfunc="sum",
-    ).reset_index()
+        aggregate_function="sum",
+    )
 
-    df.columns.name = None
-
-    df.columns = df.columns.str.title()
+    fixed_cols = ["Interval Start", "Interval End", "Respondent", "Respondent Name"]
+    rename_map = {col: col.title() for col in df.columns if col not in fixed_cols}
+    df = df.rename(rename_map)
 
     for col in EIA_FUEL_TYPES:
         if col not in df.columns:
-            # This has to be np.nan not pd.NA because we are converting to float
-            df[col] = np.nan
+            df = df.with_columns(pl.lit(None).cast(pl.Float64).alias(col))
 
-    fixed_cols = ["Interval Start", "Interval End", "Respondent", "Respondent Name"]
     fuel_mix_cols = [col for col in df.columns if col not in fixed_cols]
+    df = df.with_columns([pl.col(col).cast(pl.Float64) for col in fuel_mix_cols])
 
-    df[fuel_mix_cols] = df[fuel_mix_cols].astype(float)
+    df = df.select(fixed_cols + sorted(fuel_mix_cols))
 
-    # Set final column order with title case
-    df = df[fixed_cols + sorted(fuel_mix_cols)]
-
-    # Find any unknown columns and log them
     unknown_columns = set(df.columns) - set(EIA_FUEL_MIX_COLUMNS)
 
     if unknown_columns:
         logger.warning(f"Unknown columns found in fuel type data: {unknown_columns}")
 
-    df = df.sort_values(["Interval Start", "Respondent"])
-
-    return df
+    return df.sort(["Interval Start", "Respondent"])
 
 
-def _handle_henry_hub_natural_gas_spot_prices(df):
+def _handle_henry_hub_natural_gas_spot_prices(df: pl.DataFrame) -> pl.DataFrame:
     # The other EIA datasets use "period" as the "Interval End" but that is not correct
     # for this dataset because that would put the data one day ahead of how the EIA
     # shows it here: https://www.eia.gov/dnav/ng/hist/rngwhhdD.htm
     # We use the HENRY_HUB_TIMEZONE because the spot prices are based on delivery
     # at Henry Hub in Louisiana. However, this dataset also includes futures prices,
     # where are based on the NYMEX, so US/Central might not be correct for these prices.
-    df["Interval Start"] = pd.to_datetime(df["period"]).dt.tz_localize(
-        HENRY_HUB_TIMEZONE,
+    df = df.with_columns(
+        pl.col("period")
+        .str.to_datetime()
+        .dt.replace_time_zone(HENRY_HUB_TIMEZONE)
+        .alias("Interval Start"),
     )
-    df["Interval End"] = df["Interval Start"] + pd.Timedelta("1d")
+    df = df.with_columns(
+        (pl.col("Interval Start") + pl.duration(days=1)).alias("Interval End"),
+    )
 
     df = df.rename(
-        columns={
+        {
             "area-name": "area_name",
             "product-name": "fuel_type",
             "process-name": "price_type",
@@ -1004,12 +1074,13 @@ def _handle_henry_hub_natural_gas_spot_prices(df):
         },
     )
 
-    df = df.replace({"NA": pd.NA})
-    df["price"] = df["price"].astype(float)
+    df = df.with_columns(
+        pl.col("price").replace("NA", None).cast(pl.Float64, strict=False),
+    )
 
     df = utils.move_cols_to_front(df, ["Interval Start", "Interval End"])
 
-    return df.sort_values(["Interval Start", "area_name", "series"])
+    return df.sort(["Interval Start", "area_name", "series"])
 
 
 DATASET_CONFIG = {

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -3889,7 +3889,7 @@ class Ercot(ISOBase):
 
         return pl.from_pandas(df)
 
-    def _parse_html_table(self, html_content: bytes) -> pl.DataFrame:
+    def _parse_html_table(self, html_content: bytes) -> pd.DataFrame:
         logger.info("Parsing HTML table")
         soup = BeautifulSoup(html_content, "html.parser")
 

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -9,6 +9,7 @@ from zipfile import ZipFile
 
 import numpy as np
 import pandas as pd
+import polars as pl
 import pytz
 import requests
 import tqdm
@@ -460,7 +461,7 @@ class Ercot(ISOBase):
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Returns status of grid"""
         if date != "latest":
             raise NotSupported()
@@ -492,7 +493,7 @@ class Ercot(ISOBase):
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get energy storage resources.
         Always returns data from previous and current day"""
         url = self.BASE + "/energy-storage-resources.json"
@@ -529,13 +530,13 @@ class Ercot(ISOBase):
         )
 
         df = df.sort_values("Time").reset_index(drop=True)
-        return df
+        return pl.from_pandas(df)
 
     def get_fuel_mix(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get fuel mix 5 minute intervals
 
         Arguments:
@@ -545,7 +546,7 @@ class Ercot(ISOBase):
             verbose(bool): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with columns; Time and columns for each fuel \
+            polars.DataFrame: A DataFrame with columns; Time and columns for each fuel \
                 type
         """
         data = self._get_fuel_mix(date, verbose=verbose)
@@ -563,20 +564,22 @@ class Ercot(ISOBase):
 
         mix = pd.concat(dfs)
 
-        return self._handle_fuel_mix(
-            date,
-            mix,
-            [
-                "Time",
-                "Coal and Lignite",
-                "Hydro",
-                "Nuclear",
-                "Power Storage",
-                "Solar",
-                "Wind",
-                "Natural Gas",
-                "Other",
-            ],
+        return pl.from_pandas(
+            self._handle_fuel_mix(
+                date,
+                mix,
+                [
+                    "Time",
+                    "Coal and Lignite",
+                    "Hydro",
+                    "Nuclear",
+                    "Power Storage",
+                    "Solar",
+                    "Wind",
+                    "Natural Gas",
+                    "Other",
+                ],
+            ),
         )
 
     def _get_fuel_mix(
@@ -627,7 +630,7 @@ class Ercot(ISOBase):
         self,
         date: str | datetime.datetime | pd.Timestamp,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """The fuel mix with gen, hsl, and seasonal capacity for each fuel type."""
         data = self._get_fuel_mix(date, verbose=verbose)
 
@@ -653,36 +656,38 @@ class Ercot(ISOBase):
 
         mix = mix.drop(columns=cols_to_drop)
 
-        return self._handle_fuel_mix(
-            date,
-            mix,
-            [
-                "Time",
-                "Coal and Lignite Gen",
-                "Coal and Lignite HSL",
-                "Coal and Lignite Seasonal Capacity",
-                "Hydro Gen",
-                "Hydro HSL",
-                "Hydro Seasonal Capacity",
-                "Nuclear Gen",
-                "Nuclear HSL",
-                "Nuclear Seasonal Capacity",
-                "Power Storage Gen",
-                "Power Storage HSL",
-                "Power Storage Seasonal Capacity",
-                "Solar Gen",
-                "Solar HSL",
-                "Solar Seasonal Capacity",
-                "Wind Gen",
-                "Wind HSL",
-                "Wind Seasonal Capacity",
-                "Natural Gas Gen",
-                "Natural Gas HSL",
-                "Natural Gas Seasonal Capacity",
-                "Other Gen",
-                "Other HSL",
-                "Other Seasonal Capacity",
-            ],
+        return pl.from_pandas(
+            self._handle_fuel_mix(
+                date,
+                mix,
+                [
+                    "Time",
+                    "Coal and Lignite Gen",
+                    "Coal and Lignite HSL",
+                    "Coal and Lignite Seasonal Capacity",
+                    "Hydro Gen",
+                    "Hydro HSL",
+                    "Hydro Seasonal Capacity",
+                    "Nuclear Gen",
+                    "Nuclear HSL",
+                    "Nuclear Seasonal Capacity",
+                    "Power Storage Gen",
+                    "Power Storage HSL",
+                    "Power Storage Seasonal Capacity",
+                    "Solar Gen",
+                    "Solar HSL",
+                    "Solar Seasonal Capacity",
+                    "Wind Gen",
+                    "Wind HSL",
+                    "Wind Seasonal Capacity",
+                    "Natural Gas Gen",
+                    "Natural Gas HSL",
+                    "Natural Gas Seasonal Capacity",
+                    "Other Gen",
+                    "Other HSL",
+                    "Other Seasonal Capacity",
+                ],
+            ),
         )
 
     @support_date_range("DAY_START")
@@ -691,7 +696,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get load for a date
 
         Arguments:
@@ -703,7 +708,9 @@ class Ercot(ISOBase):
         if utils.is_today(date, tz=self.default_timezone):
             df = self._get_todays_outlook_non_forecast(date, verbose=verbose)
             df = df.rename(columns={"demand": "Load"})
-            return df[["Time", "Interval Start", "Interval End", "Load"]]
+            return pl.from_pandas(
+                df[["Time", "Interval Start", "Interval End", "Load"]],
+            )
 
         elif utils.is_within_last_days(
             date,
@@ -713,7 +720,9 @@ class Ercot(ISOBase):
             df = self._get_forecast_zone_load_html(date, verbose).rename(
                 columns={"TOTAL": "Load"},
             )
-            return df[["Time", "Interval Start", "Interval End", "Load"]]
+            return pl.from_pandas(
+                df[["Time", "Interval Start", "Interval End", "Load"]],
+            )
 
         else:
             raise NotSupported()
@@ -723,7 +732,7 @@ class Ercot(ISOBase):
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get hourly load for ERCOT weather zones
 
         Arguments:
@@ -751,7 +760,7 @@ class Ercot(ISOBase):
                 verbose=verbose,
             )
 
-            df = self.read_doc(doc_info, verbose=verbose)
+            df = self.read_doc(doc_info, verbose=verbose).to_pandas()
 
         # Clean up columns to match load_forecast_by_weather_zone
         df.columns = df.columns.map(lambda x: x.replace("_", " ").title())
@@ -771,14 +780,14 @@ class Ercot(ISOBase):
             + ["System Total"],
         )
 
-        return df
+        return pl.from_pandas(df)
 
     @support_date_range("DAY_START")
     def get_load_by_forecast_zone(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get hourly load for ERCOT forecast zones
 
         Arguments:
@@ -805,8 +814,8 @@ class Ercot(ISOBase):
                 verbose=verbose,
             )
 
-            df = self.read_doc(doc_info, verbose=verbose)
-        return df
+            df = self.read_doc(doc_info, verbose=verbose).to_pandas()
+        return pl.from_pandas(df)
 
     def _get_forecast_zone_load_html(
         self,
@@ -883,7 +892,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get historical hourly load data from ERCOT's load archives.
 
         Downloads zip files from https://www.ercot.com/gridinfo/load/load_hist
@@ -908,7 +917,7 @@ class Ercot(ISOBase):
     def _download_post_settlements_load_file(
         self,
         year: int,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Download and parse ERCOT historical load data for a specific year."""
 
         page_url = "https://www.ercot.com/gridinfo/load/load_hist"
@@ -935,12 +944,12 @@ class Ercot(ISOBase):
             df = pd.read_excel(io.BytesIO(response.content))
         df = self._process_post_settlements_load_data(df)
 
-        return df
+        return pl.from_pandas(df)
 
     def _process_post_settlements_load_data(
         self,
         df: pd.DataFrame,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         df.columns = df.columns.str.strip()
 
         # Not all of these columns are in all of the files,
@@ -1074,7 +1083,9 @@ class Ercot(ISOBase):
             "ERCOT",
         ]
         df = df.dropna(subset=["Interval Start", "Interval End"])
-        return df[expected_columns].sort_values("Interval Start").reset_index(drop=True)
+        return pl.from_pandas(
+            df[expected_columns].sort_values("Interval Start").reset_index(drop=True),
+        )
 
     def _get_supply_demand_json(self) -> dict:
         url = self.BASE + "/supply-demand.json"
@@ -1138,7 +1149,7 @@ class Ercot(ISOBase):
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         forecast_type: ERCOTSevenDayLoadForecastReport = ERCOTSevenDayLoadForecastReport.BY_FORECAST_ZONE,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Returns load forecast of specified forecast type.
 
         If date range provided, returns all hourly reports published within.
@@ -1189,9 +1200,9 @@ class Ercot(ISOBase):
 
             all_df.append(df)
 
-        df = pd.concat(all_df)
+        df = pl.concat(all_df, how="diagonal_relaxed")
 
-        df = df.sort_values("Publish Time")
+        df = df.sort("Publish Time")
 
         return df
 
@@ -1200,12 +1211,12 @@ class Ercot(ISOBase):
         doc: Document,
         forecast_type: ERCOTSevenDayLoadForecastReport,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Function to handle the different types of load forecast parsing.
 
         """
-        df = self.read_doc(doc, verbose=verbose)
+        df = self.read_doc(doc, verbose=verbose).to_pandas()
 
         df["Publish Time"] = doc.publish_date
 
@@ -1227,7 +1238,7 @@ class Ercot(ISOBase):
 
         df = utils.move_cols_to_front(df, cols_to_move)
 
-        return df
+        return pl.from_pandas(df)
 
     @support_date_range(frequency=None)
     def get_load_forecast_by_model(
@@ -1235,7 +1246,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Seven-Day Load Forecast by Model and Weather Zone.
 
         Forecasted hourly demand by Model and Weather Zone as reported by ERCOT.
@@ -1248,14 +1259,14 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with load forecast by model data
+            polars.DataFrame: A DataFrame with load forecast by model data
 
         Source:
             https://www.ercot.com/mp/data-products/data-product-details?id=NP3-565-CD
         """
 
-        def handle_doc(doc: Document, verbose: bool = False) -> pd.DataFrame:
-            df = self.read_doc(doc, verbose=verbose)
+        def handle_doc(doc: Document, verbose: bool = False) -> pl.DataFrame:
+            df = self.read_doc(doc, verbose=verbose).to_pandas()
             df["Publish Time"] = doc.publish_date
             return self._handle_load_forecast_by_model(df)
 
@@ -1268,7 +1279,7 @@ class Ercot(ISOBase):
             verbose=verbose,
         )
 
-        return df[LOAD_FORECAST_BY_MODEL_COLUMNS].sort_values(
+        return df.select(LOAD_FORECAST_BY_MODEL_COLUMNS).sort(
             ["Interval Start", "Publish Time", "Model"],
         )
 
@@ -1276,7 +1287,7 @@ class Ercot(ISOBase):
         self,
         df: pd.DataFrame,
         publish_time: pd.Timestamp | None = None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Handle parsing of load forecast by model data.
 
         Arguments:
@@ -1295,46 +1306,46 @@ class Ercot(ISOBase):
         # Convert In Use Flag to boolean
         df["In Use Flag"] = df["In Use Flag"] == "Y"
 
-        return df
+        return pl.from_pandas(df)
 
     def get_capacity_committed(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = "latest",
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the actual committed capacity (the amount of power available from
         generating units that were on-line or providing operating reserves).
 
         Data is ephemeral and does not support past days.
         """
-        data = self._get_capacity_dataset(verbose=verbose)
+        data = self._get_capacity_dataset(verbose=verbose).to_pandas()
 
-        return (
+        return pl.from_pandas(
             data.loc[
                 # Actual values
                 data["forecast"] == 0,
                 ["Interval Start", "Interval End", "capacity"],
             ]
             .rename(columns={"capacity": "Capacity"})
-            .reset_index(drop=True)
+            .reset_index(drop=True),
         )
 
     def get_capacity_forecast(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = "latest",
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the forecasted committed capacity (Committed Capacity) and the
         forecasted available capacity (Available Capacity) for the current day.
 
         Data is ephemeral and does not support past days.
         """
-        data = self._get_capacity_dataset(verbose=verbose)
+        data = self._get_capacity_dataset(verbose=verbose).to_pandas()
 
         # Forecast values
-        return (
+        return pl.from_pandas(
             data.loc[
                 data["forecast"] == 1,
                 [
@@ -1351,10 +1362,10 @@ class Ercot(ISOBase):
                     "available": "Available Capacity",
                 },
             )
-            .reset_index(drop=True)
+            .reset_index(drop=True),
         )
 
-    def _get_capacity_dataset(self, verbose: bool = False) -> pd.DataFrame:
+    def _get_capacity_dataset(self, verbose: bool = False) -> pl.DataFrame:
         supply_demand_json = self._get_supply_demand_json()
 
         data = pd.DataFrame(supply_demand_json["data"])
@@ -1371,22 +1382,24 @@ class Ercot(ISOBase):
         ).dt.tz_convert(self.default_timezone)
         data["Interval End"] = data["Interval Start"] + pd.Timedelta(minutes=5)
 
-        return data[
-            [
-                "Interval Start",
-                "Interval End",
-                "Publish Time",
-                "capacity",
-                "forecast",
-                "available",
-            ]
-        ].sort_values("Interval Start")
+        return pl.from_pandas(
+            data[
+                [
+                    "Interval Start",
+                    "Interval End",
+                    "Publish Time",
+                    "capacity",
+                    "forecast",
+                    "available",
+                ]
+            ].sort_values("Interval Start"),
+        )
 
     def get_available_seasonal_capacity_forecast(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = "latest",
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the forecasted demand (Load Forecast) and the forecasted available
         seasonal capacity (Available Capacity) for the next 6 days.
@@ -1420,7 +1433,7 @@ class Ercot(ISOBase):
             "Publish Time",
         ] = self._get_update_timestamp_from_supply_demand_json(supply_demand_json)
 
-        return (
+        return pl.from_pandas(
             data[
                 [
                     "Interval Start",
@@ -1437,10 +1450,10 @@ class Ercot(ISOBase):
                 },
             )
             .sort_values("Interval Start")
-            .reset_index(drop=True)
+            .reset_index(drop=True),
         )
 
-    def get_rtm_spp(self, year: int, verbose: bool = False) -> pd.DataFrame:
+    def get_rtm_spp(self, year: int, verbose: bool = False) -> pl.DataFrame:
         """Get Historical RTM Settlement Point Prices(SPPs)
             for each of the Hubs and Load Zones
 
@@ -1475,14 +1488,14 @@ class Ercot(ISOBase):
             )
 
         df["Delivery Interval"] = df["Delivery Interval"].astype("Int64")
-        df = self.parse_doc(df, verbose=verbose)
+        df = self.parse_doc(df, verbose=verbose).to_pandas()
         return self._finalize_spp_df(
             df,
             market=Markets.REAL_TIME_15_MIN,
             verbose=verbose,
         )
 
-    def get_dam_spp(self, year: int, verbose: bool = False) -> pd.DataFrame:
+    def get_dam_spp(self, year: int, verbose: bool = False) -> pl.DataFrame:
         """Get Historical DAM Settlement Point Prices(SPPs)
         for each of the Hubs and Load Zones
 
@@ -1504,7 +1517,7 @@ class Ercot(ISOBase):
         all_sheets = pd.read_excel(x, sheet_name=None)
         df = pd.concat(all_sheets.values())
         # filter where DSTFlag == 10
-        df = self.parse_doc(df, verbose=verbose)
+        df = self.parse_doc(df, verbose=verbose).to_pandas()
         return self._finalize_spp_df(
             df,
             market=Markets.DAY_AHEAD_HOURLY,
@@ -1755,7 +1768,7 @@ class Ercot(ISOBase):
 
         return df
 
-    def get_interconnection_queue(self, verbose: bool = False) -> pd.DataFrame:
+    def get_interconnection_queue(self, verbose: bool = False) -> pl.DataFrame:
         """
         Get interconnection queue for ERCOT
 
@@ -1835,7 +1848,14 @@ class Ercot(ISOBase):
             missing=missing,
         )
 
-        return queue
+        for col in queue.columns[queue.dtypes == "object"]:
+            has_datetimes = queue[col].map(
+                lambda v: isinstance(v, (pd.Timestamp, datetime.datetime)),
+            )
+            if has_datetimes.any():
+                queue[col] = queue[col].where(~has_datetimes, queue[col].astype(str))
+
+        return pl.from_pandas(queue)
 
     @support_date_range(frequency=None)
     def _get_lmp(
@@ -1844,7 +1864,7 @@ class Ercot(ISOBase):
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         location_type: str = SETTLEMENT_POINT_LOCATION_TYPE,  # TODO: support 'ALL'
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get LMP data for ERCOT normally produced by SCED every five minutes
 
         Can specify the location type to return "electrical bus"
@@ -1888,7 +1908,7 @@ class Ercot(ISOBase):
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         location_type: str = SETTLEMENT_POINT_LOCATION_TYPE,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Deprecated. Use the per-dataset methods instead:
         :meth:`get_lmp_by_settlement_point`, :meth:`get_lmp_by_bus`.
         """
@@ -1910,7 +1930,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get real-time SCED LMPs by settlement point (every five minutes)."""
         return self._get_lmp(
             date,
@@ -1924,7 +1944,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get real-time SCED LMPs by electrical bus (every five minutes)."""
         return self._get_lmp(
             date,
@@ -1938,23 +1958,23 @@ class Ercot(ISOBase):
         docs: list[Document],
         verbose: bool = False,
         sced: bool = True,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         df = self.read_docs(
             docs,
             parse=False,
             # need to return a DF that works with the
             # logic in rest of function
-            empty_df=pd.DataFrame(
-                columns=[
-                    "SCEDTimestamp",
-                    "RepeatedHourFlag",
-                    "Location",
-                    "Location Type",
-                    "LMP",
-                ],
+            empty_df=pl.DataFrame(
+                schema={
+                    "SCEDTimestamp": pl.Null,
+                    "RepeatedHourFlag": pl.Null,
+                    "Location": pl.Null,
+                    "Location Type": pl.Null,
+                    "LMP": pl.Null,
+                },
             ),
             verbose=verbose,
-        )
+        ).to_pandas()
 
         return self._handle_lmp_df(df, verbose=verbose, sced=sced)
 
@@ -1963,11 +1983,17 @@ class Ercot(ISOBase):
         df: pd.DataFrame,
         verbose: bool = False,
         sced: bool = True,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
+        if isinstance(df, pl.DataFrame):
+            df = df.to_pandas()
         df = self._handle_sced_timestamp(df=df, verbose=verbose)
+        if isinstance(df, pl.DataFrame):
+            df = df.to_pandas()
 
         if "SettlementPoint" in df.columns:
             df = self._handle_settlement_point_name_and_type(df, verbose=verbose)
+            if isinstance(df, pl.DataFrame):
+                df = df.to_pandas()
         elif "ElectricalBus" in df.columns:
             # do same thing as settlement point but for electrical bus
             df = df.rename(
@@ -2003,7 +2029,7 @@ class Ercot(ISOBase):
             ],
         ).reset_index(drop=True)
 
-        return df
+        return pl.from_pandas(df)
 
     @support_date_range(frequency=None)
     def get_lmp_by_bus_dam(
@@ -2011,7 +2037,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Day-Ahead Market (DAM) LMPs by Electrical Bus
 
         Returns hourly Locational Marginal Prices per electrical bus from the
@@ -2027,7 +2053,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with day-ahead LMPs by electrical bus
+            polars.DataFrame: A DataFrame with day-ahead LMPs by electrical bus
         """
         # DAM data is published the day before delivery
         publish_date = date.normalize() - pd.DateOffset(days=1)
@@ -2051,9 +2077,11 @@ class Ercot(ISOBase):
 
         df = self.read_docs(
             docs,
-            empty_df=pd.DataFrame(columns=self._lmp_by_bus_dam_cols),
+            empty_df=pl.DataFrame(
+                schema={c: pl.Null for c in self._lmp_by_bus_dam_cols},
+            ),
             verbose=verbose,
-        )
+        ).to_pandas()
 
         return self._handle_lmp_by_bus_dam_df(df)
 
@@ -2066,7 +2094,7 @@ class Ercot(ISOBase):
         "LMP",
     ]
 
-    def _handle_lmp_by_bus_dam_df(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _handle_lmp_by_bus_dam_df(self, df: pd.DataFrame) -> pl.DataFrame:
         if df.empty:
             raise NoDataFoundException("No DAM LMP by bus data found")
 
@@ -2086,7 +2114,7 @@ class Ercot(ISOBase):
             ]
         ]
 
-        return df.sort_values("Interval Start").reset_index(drop=True)
+        return pl.from_pandas(df.sort_values("Interval Start").reset_index(drop=True))
 
     @lmp_config(
         supports={
@@ -2103,7 +2131,7 @@ class Ercot(ISOBase):
         locations: list = "ALL",
         location_type: str = "ALL",
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get SPP data for ERCOT
 
         Supported Markets:
@@ -2159,19 +2187,19 @@ class Ercot(ISOBase):
 
         df = self.read_docs(
             docs,
-            empty_df=pd.DataFrame(
-                columns=[
-                    "Time",
-                    "Interval Start",
-                    "Interval End",
-                    "Location",
-                    "Location Type",
-                    "Market",
-                    "SPP",
-                ],
+            empty_df=pl.DataFrame(
+                schema={
+                    "Time": pl.Null,
+                    "Interval Start": pl.Null,
+                    "Interval End": pl.Null,
+                    "Location": pl.Null,
+                    "Location Type": pl.Null,
+                    "Market": pl.Null,
+                    "SPP": pl.Null,
+                },
             ),
             verbose=verbose,
-        )
+        ).to_pandas()
 
         return self._finalize_spp_df(
             df,
@@ -2186,6 +2214,8 @@ class Ercot(ISOBase):
         df: pd.DataFrame,
         verbose: bool = False,
     ) -> pd.DataFrame:
+        if isinstance(df, pl.DataFrame):
+            df = df.to_pandas()
         df = df.rename(
             columns={
                 "SettlementPoint": "Location",
@@ -2196,7 +2226,7 @@ class Ercot(ISOBase):
         )
 
         # todo is this needed if we are defaulting to resource node?
-        mapping_df = self._get_settlement_point_mapping(verbose=verbose)
+        mapping_df = self._get_settlement_point_mapping(verbose=verbose).to_pandas()
         resource_node = mapping_df["RESOURCE_NODE"].dropna().unique()
 
         # Create boolean masks for each location type
@@ -2249,7 +2279,7 @@ class Ercot(ISOBase):
         locations: list = None,
         location_type: str = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         df = self._handle_settlement_point_name_and_type(df, verbose=verbose)
 
         df["Market"] = market.value
@@ -2282,7 +2312,7 @@ class Ercot(ISOBase):
         df = df.sort_values(by="Interval Start")
         df = df.reset_index(drop=True)
 
-        return df
+        return pl.from_pandas(df)
 
     @support_date_range(frequency="DAY_START")
     def get_as_prices(
@@ -2290,7 +2320,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get ancillary service clearing prices in hourly intervals in Day Ahead Market
 
         Arguments:
@@ -2303,7 +2333,7 @@ class Ercot(ISOBase):
 
         Returns:
 
-            pandas.DataFrame: A DataFrame with prices for "Non-Spinning Reserves", \
+            polars.DataFrame: A DataFrame with prices for "Non-Spinning Reserves", \
                 "Regulation Up", "Regulation Down", "Responsive Reserves", \
                 "ERCOT Contingency Reserve Service"
         """
@@ -2322,14 +2352,14 @@ class Ercot(ISOBase):
 
         logger.info(f"Downloading {doc_info.url}")
 
-        doc = self.read_doc(doc_info, verbose=verbose)
+        doc = self.read_doc(doc_info, verbose=verbose).to_pandas()
 
         df = self._finalize_as_price_df(
             doc,
             pivot=True,
         )
 
-        return df
+        return pl.from_pandas(df)
 
     @support_date_range(frequency=None)
     def get_mcpc_dam(
@@ -2337,7 +2367,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Market Clearing Prices for Capacity (MCPC) from the Day-Ahead Market
 
         Returns hourly MCPC per ancillary service type in long format.
@@ -2352,7 +2382,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with columns: Interval Start,
+            polars.DataFrame: A DataFrame with columns: Interval Start,
                 Interval End, AS Type, MCPC
         """
         # DAM data is published the day before delivery
@@ -2377,9 +2407,9 @@ class Ercot(ISOBase):
 
         df = self.read_docs(
             docs,
-            empty_df=pd.DataFrame(columns=self._mcpc_dam_cols),
+            empty_df=pl.DataFrame(schema={c: pl.Null for c in self._mcpc_dam_cols}),
             verbose=verbose,
-        )
+        ).to_pandas()
 
         return self._handle_mcpc_dam_df(df)
 
@@ -2390,7 +2420,7 @@ class Ercot(ISOBase):
         "MCPC",
     ]
 
-    def _handle_mcpc_dam_df(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _handle_mcpc_dam_df(self, df: pd.DataFrame) -> pl.DataFrame:
         if df.empty:
             raise NoDataFoundException("No DAM MCPC data found")
 
@@ -2398,10 +2428,10 @@ class Ercot(ISOBase):
         df = df.drop(columns=["Time"], errors="ignore")
         df["MCPC"] = pd.to_numeric(df["MCPC"], errors="coerce")
 
-        return (
+        return pl.from_pandas(
             df[["Interval Start", "Interval End", "AS Type", "MCPC"]]
             .sort_values(["Interval Start", "AS Type"])
-            .reset_index(drop=True)
+            .reset_index(drop=True),
         )
 
     @support_date_range(frequency=None)
@@ -2410,7 +2440,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Day-Ahead Market Shadow Prices
 
         Returns shadow prices for binding transmission constraints from the
@@ -2426,7 +2456,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with day-ahead market shadow prices
+            polars.DataFrame: A DataFrame with day-ahead market shadow prices
         """
         # DAM data is published the day before delivery
         publish_date = date.normalize() - pd.DateOffset(days=1)
@@ -2450,9 +2480,11 @@ class Ercot(ISOBase):
 
         df = self.read_docs(
             docs,
-            empty_df=pd.DataFrame(columns=self._shadow_prices_dam_cols),
+            empty_df=pl.DataFrame(
+                schema={c: pl.Null for c in self._shadow_prices_dam_cols},
+            ),
             verbose=verbose,
-        )
+        ).to_pandas()
 
         return self._handle_shadow_prices_dam_df(df)
 
@@ -2509,7 +2541,7 @@ class Ercot(ISOBase):
         "To Station kV",
     ]
 
-    def _handle_shadow_prices_dam_df(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _handle_shadow_prices_dam_df(self, df: pd.DataFrame) -> pl.DataFrame:
         if df.empty:
             raise NoDataFoundException("No DAM shadow prices data found")
 
@@ -2556,9 +2588,11 @@ class Ercot(ISOBase):
         df = df.drop(columns=["Delivery Time", "Time"], errors="ignore")
         df = df[output_cols]
 
-        return df.sort_values(
-            ["Interval Start", "Constraint ID"],
-        ).reset_index(drop=True)
+        return pl.from_pandas(
+            df.sort_values(
+                ["Interval Start", "Constraint ID"],
+            ).reset_index(drop=True),
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_as_plan(
@@ -2566,7 +2600,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Ancillary Service requirements by type and quantity for each hour of the
         current day plus the next 6 days
 
@@ -2579,7 +2613,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with prices for ECRS, NSPIN, REGDN, REGUP, RRS
+            polars.DataFrame: A DataFrame with prices for ECRS, NSPIN, REGDN, REGUP, RRS
         """
         doc_info = self._get_document(
             report_type_id=DAM_ANCILLARY_SERVICE_PLAN_RTID,
@@ -2590,12 +2624,14 @@ class Ercot(ISOBase):
 
         logger.info(f"Downloading {doc_info.url}")
 
-        doc = self.read_doc(doc_info, verbose=verbose).drop(columns=["Time"])
+        doc = (
+            self.read_doc(doc_info, verbose=verbose).to_pandas().drop(columns=["Time"])
+        )
         doc["Publish Time"] = doc_info.publish_date
 
         return self._handle_as_plan(doc)
 
-    def _handle_as_plan(self, doc: Document) -> pd.DataFrame:
+    def _handle_as_plan(self, doc: Document) -> pl.DataFrame:
         df = doc.pivot(
             index=["Interval Start", "Interval End", "Publish Time"],
             columns="AncillaryType",
@@ -2680,7 +2716,7 @@ class Ercot(ISOBase):
         Returns:
             dict: dictionary with keys "sced_load_resource", "sced_gen_resource",
                 "sced_smne", and (when available) "sced_esr", "sced_eoc_updates",
-                "sced_resource_as_offers", mapping to pandas.DataFrame objects
+                "sced_resource_as_offers", mapping to polars.DataFrame objects
         """
 
         report_date = date + pd.DateOffset(days=60)
@@ -2746,6 +2782,11 @@ class Ercot(ISOBase):
             )
             if resource_as_offers is not None:
                 data[SCED_RESOURCE_AS_OFFERS_KEY] = resource_as_offers
+
+        data = {
+            key: pl.from_pandas(value) if isinstance(value, pd.DataFrame) else value
+            for key, value in data.items()
+        }
 
         return data
 
@@ -2818,7 +2859,7 @@ class Ercot(ISOBase):
             df: pd.DataFrame,
             time_col: str,
             is_interval_end: bool = False,
-        ) -> pd.DataFrame:
+        ) -> pl.DataFrame:
             df[time_col] = pd.to_datetime(df[time_col])
 
             if "Repeated Hour Flag" in df.columns:
@@ -2872,7 +2913,7 @@ class Ercot(ISOBase):
                 interval_end,
             )
 
-            return df
+            return pl.from_pandas(df)
 
         def localize_sced_timestamp(df: pd.DataFrame) -> pd.DataFrame:
             """Localize SCED Timestamp without adding Interval Start/End."""
@@ -2906,14 +2947,14 @@ class Ercot(ISOBase):
             )
             gen_resource = process_sced_gen(gen_resource, output_format=output_format)
             smne = smne.rename(
-                columns={
+                {
                     "Resource Code": "Resource Name",
                 },
             )
             if esr is not None:
                 esr = process_sced_esr(esr, output_format=output_format)
             if as_offer_updates is not None:
-                as_offer_updates = self.parse_doc(as_offer_updates)
+                as_offer_updates = self.parse_doc(as_offer_updates).to_pandas()
                 as_offer_updates = process_sced_as_offer_updates_in_op_hour(
                     as_offer_updates,
                 )
@@ -2938,6 +2979,11 @@ class Ercot(ISOBase):
         if resource_as_offers is not None:
             result[SCED_RESOURCE_AS_OFFERS_KEY] = resource_as_offers
 
+        result = {
+            key: pl.from_pandas(value) if isinstance(value, pd.DataFrame) else value
+            for key, value in result.items()
+        }
+
         return result
 
     def _get_esr_correction_data(
@@ -2946,7 +2992,7 @@ class Ercot(ISOBase):
         process: bool = False,
         verbose: bool = False,
         output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
-    ) -> pd.DataFrame | None:
+    ) -> pd.DataFrame | pl.DataFrame | None:
         """Fetch ESR data from the supplemental correction file for specific dates.
 
         The ESR supplemental correction file was published on Feb 5, 2026 and contains
@@ -3126,7 +3172,7 @@ class Ercot(ISOBase):
         process: bool = False,
         verbose: bool = False,
         output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
-    ) -> pd.DataFrame | None:
+    ) -> pd.DataFrame | pl.DataFrame | None:
         """Fetch SCED Resource AS Offers data from the supplemental file for
         data dates Dec 5, 2025 through Feb 2, 2026.
 
@@ -3231,7 +3277,7 @@ class Ercot(ISOBase):
         - "dam_as_only_awards" (when available, starting 2025-12-06)
         - "dam_as_only_offers" (when available, starting 2025-12-06)
 
-        and values as pandas.DataFrame objects
+        and values as polars.DataFrame objects
 
         The date passed in should be the report date. Since reports are delayed by 60
         days, the passed date should not be fewer than 60 days in the past.
@@ -3327,7 +3373,7 @@ class Ercot(ISOBase):
             # weird that these files dont have this column like all other ERCOT files
             # add so we can parse
             doc["DSTFlag"] = "N"
-            data[key] = self.parse_doc(doc, verbose=verbose)
+            data[key] = self.parse_doc(doc, verbose=verbose).to_pandas()
 
         if process:
             file_to_function = {
@@ -3371,13 +3417,18 @@ class Ercot(ISOBase):
                     else:
                         data[file_name] = process_func(data[file_name])
 
+        data = {
+            key: pl.from_pandas(value) if isinstance(value, pd.DataFrame) else value
+            for key, value in data.items()
+        }
+
         return data
 
     def get_sara(
         self,
         url: str = "https://www.ercot.com/files/docs/2023/05/05/SARA_Summer2023_Revised.xlsx",
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Parse SARA data from url.
 
         Seasonal Assessment of Resource Adequacy for the ERCOT Region (SARA)
@@ -3419,7 +3470,7 @@ class Ercot(ISOBase):
         for col in category_cols:
             df[col] = df[col].astype("category")
 
-        return df
+        return pl.from_pandas(df)
 
     def _finalize_as_price_df(
         self,
@@ -3473,7 +3524,7 @@ class Ercot(ISOBase):
         self,
         date: str = "latest",
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Ancillary Service Capacity Monitor.
 
         Parses table from
@@ -3484,7 +3535,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with ancillary service capacity monitor data
+            polars.DataFrame: A DataFrame with ancillary service capacity monitor data
         """
 
         url = "https://www.ercot.com/content/cdr/html/as_capacity_monitor.html"
@@ -3492,13 +3543,13 @@ class Ercot(ISOBase):
         html_content = requests.get(url).content
         df = self._parse_html_table(html_content)
 
-        return df
+        return pl.from_pandas(df)
 
     def get_system_as_capacity_monitor(
         self,
         date: str | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get System Ancillary Service Capacity Monitor.
 
         Fetches real-time ancillary service capacity data from
@@ -3509,7 +3560,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with system AS capacity monitor data
+            polars.DataFrame: A DataFrame with system AS capacity monitor data
         """
         if date is not None and date != "latest":
             logger.warning(
@@ -3521,14 +3572,14 @@ class Ercot(ISOBase):
         json_data = self._get_json(url, verbose=verbose)
         return self._parse_system_as_capacity_monitor(json_data)
 
-    def _parse_system_as_capacity_monitor(self, json_data: dict) -> pd.DataFrame:
+    def _parse_system_as_capacity_monitor(self, json_data: dict) -> pl.DataFrame:
         """Parse JSON response from System Ancillary Service Capacity Monitor API.
 
         Arguments:
             json_data: Raw JSON response from the API
 
         Returns:
-            pandas.DataFrame: Parsed data with standardized column names
+            polars.DataFrame: Parsed data with standardized column names
         """
         key_to_column = {
             "rrcCapPfrGenEsr": "RRS Capability PFR Gen and ESR",
@@ -3615,7 +3666,7 @@ class Ercot(ISOBase):
         df = pd.DataFrame([row_data])
         df = utils.move_cols_to_front(df, ["Time"])
 
-        return df
+        return pl.from_pandas(df)
 
     OPERATIONS_MESSAGES_URL = (
         "https://www.ercot.com/services/comm/mkt_notices/opsmessages"
@@ -3628,7 +3679,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | None = None,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get operations messages from the ERCOT control room.
 
         When called without date arguments, scrapes the live page at
@@ -3645,7 +3696,7 @@ class Ercot(ISOBase):
             verbose: Print verbose output.
 
         Returns:
-            pandas.DataFrame with columns Time, Notice, Type, Status.
+            polars.DataFrame with columns Time, Notice, Type, Status.
         """
         if date is None:
             return self._fetch_operations_messages_from_url(
@@ -3670,7 +3721,7 @@ class Ercot(ISOBase):
                 f"No Wayback Machine snapshots found for {date} to {end}",
             )
 
-        frames: list[pd.DataFrame] = []
+        frames: list[pl.DataFrame] = []
         for i, ts in enumerate(snapshots):
             if i > 0:
                 time.sleep(2)
@@ -3692,23 +3743,26 @@ class Ercot(ISOBase):
                 f"Could not parse any snapshots for {date} to {end}",
             )
 
-        combined = pd.concat(frames, ignore_index=True)
+        combined = pd.concat(
+            [frame.to_pandas() for frame in frames],
+            ignore_index=True,
+        )
         combined = combined.drop_duplicates(
             subset=["Time", "Notice"],
         )
         combined = combined[(combined["Time"] >= date) & (combined["Time"] < end)]
 
-        return (
+        return pl.from_pandas(
             combined[["Time", "Notice", "Type", "Status"]]
             .sort_values("Time")
-            .reset_index(drop=True)
+            .reset_index(drop=True),
         )
 
     def _fetch_operations_messages_from_url(
         self,
         url: str,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Parse the operations messages HTML table from a URL (live or Wayback)."""
         logger.info(f"Getting operations messages from {url}")
 
@@ -3717,6 +3771,8 @@ class Ercot(ISOBase):
         except ValueError:
             dfs = pd.read_html(url, match="Date")
         df = dfs[0]
+        if isinstance(df, pl.DataFrame):
+            df = df.to_pandas()
 
         df = df.rename(
             columns={
@@ -3741,7 +3797,9 @@ class Ercot(ISOBase):
             if col not in df.columns:
                 df[col] = pd.NA
 
-        return df[expected_cols].sort_values("Time").reset_index(drop=True)
+        return pl.from_pandas(
+            df[expected_cols].sort_values("Time").reset_index(drop=True),
+        )
 
     def _get_wayback_snapshots(
         self,
@@ -3799,7 +3857,7 @@ class Ercot(ISOBase):
         self,
         date: str = "latest",
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Real-Time System Conditions.
 
         Parses table from
@@ -3810,7 +3868,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with real-time system conditions
+            polars.DataFrame: A DataFrame with real-time system conditions
         """
 
         url = "https://www.ercot.com/content/cdr/html/real_time_system_conditions.html"
@@ -3829,9 +3887,9 @@ class Ercot(ISOBase):
             },
         )
 
-        return df
+        return pl.from_pandas(df)
 
-    def _parse_html_table(self, html_content: bytes) -> pd.DataFrame:
+    def _parse_html_table(self, html_content: bytes) -> pl.DataFrame:
         logger.info("Parsing HTML table")
         soup = BeautifulSoup(html_content, "html.parser")
 
@@ -3907,7 +3965,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with hourly wind report data
+            polars.DataFrame: A DataFrame with hourly wind report data
         """
         df = self._get_hourly_report(
             start=date,
@@ -3918,7 +3976,7 @@ class Ercot(ISOBase):
             verbose=True,
         )
 
-        return df[WIND_ACTUAL_AND_FORECAST_COLUMNS].sort_values(
+        return df.select(WIND_ACTUAL_AND_FORECAST_COLUMNS).sort(
             ["Interval Start", "Publish Time"],
         )
 
@@ -3936,7 +3994,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with hourly wind report data
+            polars.DataFrame: A DataFrame with hourly wind report data
         """
         df = self._get_hourly_report(
             start=date,
@@ -3947,7 +4005,7 @@ class Ercot(ISOBase):
             verbose=True,
         )
 
-        return df[WIND_ACTUAL_AND_FORECAST_BY_GEOGRAPHICAL_REGION_COLUMNS].sort_values(
+        return df.select(WIND_ACTUAL_AND_FORECAST_BY_GEOGRAPHICAL_REGION_COLUMNS).sort(
             ["Interval Start", "Publish Time"],
         )
 
@@ -3966,7 +4024,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with hourly solar report data
+            polars.DataFrame: A DataFrame with hourly solar report data
         """
         df = self._get_hourly_report(
             start=date,
@@ -3977,7 +4035,7 @@ class Ercot(ISOBase):
             verbose=True,
         )
 
-        return df[SOLAR_ACTUAL_AND_FORECAST_COLUMNS].sort_values(
+        return df.select(SOLAR_ACTUAL_AND_FORECAST_COLUMNS).sort(
             ["Interval Start", "Publish Time"],
         )
 
@@ -4002,7 +4060,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with hourly solar report data
+            polars.DataFrame: A DataFrame with hourly solar report data
         """
         df = self._get_hourly_report(
             start=date,
@@ -4013,7 +4071,7 @@ class Ercot(ISOBase):
             verbose=True,
         )
 
-        return df[SOLAR_ACTUAL_AND_FORECAST_BY_GEOGRAPHICAL_REGION_COLUMNS].sort_values(
+        return df.select(SOLAR_ACTUAL_AND_FORECAST_BY_GEOGRAPHICAL_REGION_COLUMNS).sort(
             ["Interval Start", "Publish Time"],
         )
 
@@ -4021,8 +4079,8 @@ class Ercot(ISOBase):
         self,
         doc: Document,
         verbose: bool = False,
-    ) -> pd.DataFrame:
-        df = self.read_doc(doc, verbose=verbose)
+    ) -> pl.DataFrame:
+        df = self.read_doc(doc, verbose=verbose).to_pandas()
         df.insert(
             0,
             "Publish Time",
@@ -4033,7 +4091,7 @@ class Ercot(ISOBase):
 
         return self._rename_hourly_wind_or_solar_report(df)
 
-    def _rename_hourly_wind_or_solar_report(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _rename_hourly_wind_or_solar_report(self, df: pd.DataFrame) -> pl.DataFrame:
         df = df.rename(
             columns={
                 # on Sept 26, 2024 ercot added this column
@@ -4071,7 +4129,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the 5-minute data behind this dashboard:
         https://www.ercot.com/gridmktinfo/dashboards/generationoutages
@@ -4123,7 +4181,7 @@ class Ercot(ISOBase):
             columns=["Deliverytime", "Dstflag"],
         )
 
-        return df.sort_values("Time").reset_index(drop=True)
+        return pl.from_pandas(df.sort_values("Time").reset_index(drop=True))
 
     @support_date_range(frequency=None)
     def get_hourly_resource_outage_capacity(
@@ -4131,7 +4189,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Hourly Resource Outage Capacity report sourced
         from the Outage Scheduler (OS).
 
@@ -4151,7 +4209,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with hourly resource outage capacity data
+            polars.DataFrame: A DataFrame with hourly resource outage capacity data
         """
 
         df = self._get_hourly_report(
@@ -4168,8 +4226,8 @@ class Ercot(ISOBase):
         self,
         doc: Document,
         verbose: bool = False,
-    ) -> pd.DataFrame:
-        df = self.read_doc(doc, parse=False, verbose=verbose)
+    ) -> pl.DataFrame:
+        df = self.read_doc(doc, parse=False, verbose=verbose).to_pandas()
         # there is no DST flag column
         # and the data set ignores DST
         # so, we will default to assuming it is DST. We will also
@@ -4179,7 +4237,7 @@ class Ercot(ISOBase):
             dst_ambiguous_default=True,
             nonexistent="NaT",
             verbose=verbose,
-        )
+        ).to_pandas()
 
         df = df.dropna(subset=["Interval Start"])
 
@@ -4194,7 +4252,7 @@ class Ercot(ISOBase):
     def _handle_hourly_resource_outage_capacity_df(
         self,
         df: pd.DataFrame,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         outage_types = ["Total Resource", "Total IRR", "Total New Equip Resource"]
 
         # Earlier data doesn't have these columns
@@ -4237,7 +4295,7 @@ class Ercot(ISOBase):
                 },
             )
 
-        return df
+        return pl.from_pandas(df)
 
     @support_date_range(frequency=None)
     def get_planned_outage_capacity_7_day(
@@ -4245,7 +4303,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Hourly maximum resource capacity available for planned outages within 7
         days of the operating day, as reported by ERCOT (NP3-162-CD).
 
@@ -4259,29 +4317,25 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with hourly planned outage capacity data
+            polars.DataFrame: A DataFrame with hourly planned outage capacity data
         """
-        return (
-            self._get_hourly_report(
-                start=date,
-                end=end,
-                report_type_id=PLANNED_OUTAGE_CAPACITY_7_DAY_RTID,
-                extension="csv",
-                handle_doc=self._handle_planned_outage_capacity_7_day,
-                verbose=verbose,
-            )
-            .sort_values(["Interval Start", "Publish Time"])
-            .reset_index(drop=True)
-        )
+        return self._get_hourly_report(
+            start=date,
+            end=end,
+            report_type_id=PLANNED_OUTAGE_CAPACITY_7_DAY_RTID,
+            extension="csv",
+            handle_doc=self._handle_planned_outage_capacity_7_day,
+            verbose=verbose,
+        ).sort(["Interval Start", "Publish Time"])
 
     def _handle_planned_outage_capacity_7_day(
         self,
         doc: Document,
         verbose: bool = False,
-    ) -> pd.DataFrame:
-        df = self.read_doc(doc, parse=False, verbose=verbose)
+    ) -> pl.DataFrame:
+        df = self.read_doc(doc, parse=False, verbose=verbose).to_pandas()
         df = df.rename(columns={"OperatingDate": "DeliveryDate"})
-        df = self.parse_doc(df, verbose=verbose)
+        df = self.parse_doc(df, verbose=verbose).to_pandas()
 
         df.insert(
             0,
@@ -4297,7 +4351,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Daily maximum resource capacity available for planned outages from 7 days
         to 60 months ahead of the operating day, as reported by ERCOT (NP3-161-CD).
 
@@ -4311,27 +4365,23 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with daily planned outage capacity data
+            polars.DataFrame: A DataFrame with daily planned outage capacity data
         """
-        return (
-            self._get_hourly_report(
-                start=date,
-                end=end,
-                report_type_id=PLANNED_OUTAGE_CAPACITY_FUTURE_RTID,
-                extension="csv",
-                handle_doc=self._handle_planned_outage_capacity_future,
-                verbose=verbose,
-            )
-            .sort_values(["Interval Start", "Publish Time"])
-            .reset_index(drop=True)
-        )
+        return self._get_hourly_report(
+            start=date,
+            end=end,
+            report_type_id=PLANNED_OUTAGE_CAPACITY_FUTURE_RTID,
+            extension="csv",
+            handle_doc=self._handle_planned_outage_capacity_future,
+            verbose=verbose,
+        ).sort(["Interval Start", "Publish Time"])
 
     def _handle_planned_outage_capacity_future(
         self,
         doc: Document,
         verbose: bool = False,
-    ) -> pd.DataFrame:
-        df = self.read_doc(doc, parse=False, verbose=verbose)
+    ) -> pl.DataFrame:
+        df = self.read_doc(doc, parse=False, verbose=verbose).to_pandas()
 
         df["Interval Start"] = pd.to_datetime(
             df["OperatingDate"],
@@ -4386,7 +4436,7 @@ class Ercot(ISOBase):
     def _handle_planned_outage_capacity_df(
         self,
         df: pd.DataFrame,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if "ResourcePOLnonIRRnonPUN" in df.columns:
             column_map = self._PLANNED_OUTAGE_CAPACITY_POL_COLUMN_MAP
         else:
@@ -4398,7 +4448,7 @@ class Ercot(ISOBase):
             if column not in df.columns:
                 df[column] = pd.NA
 
-        return df[self.PLANNED_OUTAGE_CAPACITY_COLUMNS]
+        return pl.from_pandas(df[self.PLANNED_OUTAGE_CAPACITY_COLUMNS])
 
     @support_date_range(frequency=None)
     def get_unplanned_resource_outages(
@@ -4406,7 +4456,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Unplanned Resource Outages.
 
         Data published at ~5am central on the 3rd day after the day of interest. Since
@@ -4419,7 +4469,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with unplanned resource outages
+            polars.DataFrame: A DataFrame with unplanned resource outages
 
         """
         docs = self._get_documents(
@@ -4439,13 +4489,13 @@ class Ercot(ISOBase):
 
         complete_df = pd.concat(dfs, ignore_index=True)
 
-        return complete_df
+        return pl.from_pandas(complete_df)
 
     def _handle_unplanned_resource_outages_file(
         self,
         doc: Document,
         xls: ZipFile,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         as_of = pd.to_datetime(
             pd.read_excel(
                 xls,
@@ -4496,14 +4546,14 @@ class Ercot(ISOBase):
             ],
         )
 
-        return df
+        return pl.from_pandas(df)
 
     @support_date_range("DAY_START")
     def get_as_reports(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Ancillary Services Reports.
 
         Published with a 2 day delay around 3am central
@@ -4533,7 +4583,7 @@ class Ercot(ISOBase):
         file_path: str,
         verbose: bool = False,
         **kwargs,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         z = utils.get_zip_folder(file_path, verbose=verbose, **kwargs)
 
         # extract the date from the file name
@@ -4682,7 +4732,7 @@ class Ercot(ISOBase):
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Day-Ahead Market Ancillary Services Reports.
 
         Published with a 2 day delay around 3am central.
@@ -4694,7 +4744,7 @@ class Ercot(ISOBase):
             verbose: print verbose output
 
         Returns:
-            pandas.DataFrame: A DataFrame with DAM ancillary services reports
+            polars.DataFrame: A DataFrame with DAM ancillary services reports
         """
         doc = self._get_as_report_document(
             date=date,
@@ -4709,7 +4759,7 @@ class Ercot(ISOBase):
         file_path: str,
         verbose: bool = False,
         **kwargs,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Parse DAM AS reports into long format with columns:
         interval_start, interval_end, as_type, cleared, self_arranged, offer_curve
         """
@@ -4829,7 +4879,7 @@ class Ercot(ISOBase):
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get 2-Day SCED Ancillary Service Disclosure Reports.
 
         Published with a 2 day delay around 3am central.
@@ -4844,7 +4894,7 @@ class Ercot(ISOBase):
             verbose: print verbose output
 
         Returns:
-            pandas.DataFrame: A DataFrame with SCED ancillary services offers
+            polars.DataFrame: A DataFrame with SCED ancillary services offers
         """
         doc = self._get_as_report_document(
             date=date,
@@ -4852,7 +4902,9 @@ class Ercot(ISOBase):
             verbose=verbose,
         )
 
-        return self._handle_as_reports_sced_file(doc.url, verbose=verbose)
+        return pl.from_pandas(
+            self._handle_as_reports_sced_file(doc.url, verbose=verbose),
+        )
 
     def _handle_as_reports_sced_file(
         self,
@@ -4953,7 +5005,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Day-Ahead Market System Lambda
 
         File is typically published around 12:30 pm for the day ahead
@@ -4967,7 +5019,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with day-ahead market system lambda data
+            polars.DataFrame: A DataFrame with day-ahead market system lambda data
         """
         # Subtract one day since this is the day ahead market
         date = date - pd.DateOffset(days=1)
@@ -4984,8 +5036,8 @@ class Ercot(ISOBase):
         self,
         doc: Document,
         verbose: bool = False,
-    ) -> pd.DataFrame:
-        df = self.read_doc(doc, parse=True, verbose=verbose)
+    ) -> pl.DataFrame:
+        df = self.read_doc(doc, parse=True, verbose=verbose).to_pandas()
 
         # Set the publish time from the document metadata
         df["Publish Time"] = pd.to_datetime(doc.publish_date)
@@ -5002,7 +5054,7 @@ class Ercot(ISOBase):
             ],
         )
 
-        return df
+        return pl.from_pandas(df)
 
     @support_date_range(frequency=None)
     def get_sced_system_lambda(
@@ -5010,7 +5062,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get System lambda of each successful SCED
 
         Normally published every 5 minutes
@@ -5022,7 +5074,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame
+            polars.DataFrame: A DataFrame
 
         """
 
@@ -5050,13 +5102,15 @@ class Ercot(ISOBase):
 
         df = self._handle_sced_system_lambda(docs, verbose=verbose)
 
-        return df
+        return pl.from_pandas(df)
 
     def _handle_sced_timestamp(
         self,
         df: pd.DataFrame,
         verbose: bool = False,
     ) -> pd.DataFrame:
+        if isinstance(df, pl.DataFrame):
+            df = df.to_pandas()
         df = df.rename(
             columns={
                 "RepeatHourFlag": "RepeatedHourFlag",
@@ -5094,7 +5148,7 @@ class Ercot(ISOBase):
         self,
         docs: list[Document],
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         all_dfs = []
         for doc in tqdm.tqdm(
             docs,
@@ -5123,7 +5177,9 @@ class Ercot(ISOBase):
         )
 
         df.sort_values("SCED Timestamp", inplace=True)
-        return df[["Interval Start", "Interval End", "SCED Timestamp", "System Lambda"]]
+        return pl.from_pandas(
+            df[["Interval Start", "Interval End", "SCED Timestamp", "System Lambda"]],
+        )
 
     @support_date_range("DAY_START")
     def get_highest_price_as_offer_selected(
@@ -5131,7 +5187,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get the offer price and the name of the Entity submitting
         the offer for the highest-priced Ancillary Service (AS) Offer.
 
@@ -5142,7 +5198,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrameq
+            polars.DataFrame: A DataFrameq
         """
         # This report ends on 2025-12-05
         if date >= pd.Timestamp(
@@ -5168,11 +5224,13 @@ class Ercot(ISOBase):
         )
 
         # Add Time and Market columns for backwards compatibility
-        df["Time"] = df["Interval Start"]
-        df["Market"] = "dam"
+        df = df.with_columns(
+            pl.col("Interval Start").alias("Time"),
+            pl.lit("dam").alias("Market"),
+        )
 
         # Reorder columns to match old format
-        return df[
+        return df.select(
             [
                 "Time",
                 "Interval Start",
@@ -5186,8 +5244,8 @@ class Ercot(ISOBase):
                 "Offered Price",
                 "Total Offered Quantity",
                 "Offered Quantities",
-            ]
-        ]
+            ],
+        )
 
     @support_date_range("DAY_START")
     def get_highest_price_as_offer_selected_dam(
@@ -5195,7 +5253,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get the offer price and the name of the Entity submitting
         the offer for the highest-priced Ancillary Service (AS) Offer
         selected in the Day-Ahead Market (DAM).
@@ -5208,7 +5266,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with columns:
+            polars.DataFrame: A DataFrame with columns:
                 - Interval Start
                 - Interval End
                 - QSE
@@ -5234,7 +5292,7 @@ class Ercot(ISOBase):
             verbose=verbose,
         )
 
-        return (
+        return pl.from_pandas(
             df[
                 [
                     "Interval Start",
@@ -5250,7 +5308,7 @@ class Ercot(ISOBase):
                 ]
             ]
             .sort_values(["Interval Start", "AS Type", "Resource Name"])
-            .reset_index(drop=True)
+            .reset_index(drop=True),
         )
 
     @support_date_range("DAY_START")
@@ -5259,7 +5317,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get the offer price and the name of the Entity submitting
         the offer for the highest-priced Ancillary Service (AS) Offer
         selected in the Real-Time Market (SCED).
@@ -5272,7 +5330,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with columns:
+            polars.DataFrame: A DataFrame with columns:
                 - SCED Timestamp
                 - QSE
                 - DME
@@ -5296,7 +5354,7 @@ class Ercot(ISOBase):
             verbose=verbose,
         )
 
-        return (
+        return pl.from_pandas(
             df[
                 [
                     "SCED Timestamp",
@@ -5310,7 +5368,7 @@ class Ercot(ISOBase):
                 ]
             ]
             .sort_values(["SCED Timestamp", "AS Type", "Resource Name"])
-            .reset_index(drop=True)
+            .reset_index(drop=True),
         )
 
     @support_date_range("DAY_START")
@@ -5319,7 +5377,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get the bid price and name of the Load Resource submitting the
         highest-priced bid selected or dispatched by SCED for the given
         operating day.
@@ -5334,7 +5392,7 @@ class Ercot(ISOBase):
             verbose: print verbose output.
 
         Returns:
-            pandas.DataFrame with columns: Interval Start, Interval End,
+            polars.DataFrame with columns: Interval Start, Interval End,
             SCED Timestamp, QSE, DME, Load Resource,
             Highest Price Dispatched by SCED, Proxy Extension.
         """
@@ -5346,13 +5404,13 @@ class Ercot(ISOBase):
             verbose=verbose,
         )
 
-        df = self.read_doc(doc, parse=False, verbose=verbose)
+        df = self.read_doc(doc, parse=False, verbose=verbose).to_pandas()
         return self._handle_3_day_highest_price_bids_selected_sced(df)
 
     def _handle_3_day_highest_price_bids_selected_sced(
         self,
         df: pd.DataFrame,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         df = df.rename(
             columns={
                 "SCED Time Stamp": "SCED Timestamp",
@@ -5366,7 +5424,7 @@ class Ercot(ISOBase):
             errors="coerce",
         )
 
-        return (
+        return pl.from_pandas(
             df[
                 [
                     "Interval Start",
@@ -5380,7 +5438,7 @@ class Ercot(ISOBase):
                 ]
             ]
             .sort_values(["SCED Timestamp", "QSE", "DME", "Load Resource"])
-            .reset_index(drop=True)
+            .reset_index(drop=True),
         )
 
     @support_date_range("DAY_START")
@@ -5389,7 +5447,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get the offer price and name of the Generation Resource submitting
         the highest-priced offer selected by SCED for the given operating day.
 
@@ -5403,7 +5461,7 @@ class Ercot(ISOBase):
             verbose: print verbose output.
 
         Returns:
-            pandas.DataFrame with columns: Interval Start, Interval End,
+            polars.DataFrame with columns: Interval Start, Interval End,
             SCED Timestamp, QSE, DME, Generation Resource, LMP,
             Proxy Extension, Power Balance Penalty Flag.
         """
@@ -5415,13 +5473,13 @@ class Ercot(ISOBase):
             verbose=verbose,
         )
 
-        df = self.read_doc(doc, parse=False, verbose=verbose)
+        df = self.read_doc(doc, parse=False, verbose=verbose).to_pandas()
         return self._handle_3_day_highest_price_offered_sced(df)
 
     def _handle_3_day_highest_price_offered_sced(
         self,
         df: pd.DataFrame,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         df = df.rename(
             columns={
                 "SCED Time Stamp": "SCED Timestamp",
@@ -5432,7 +5490,7 @@ class Ercot(ISOBase):
 
         df["LMP"] = pd.to_numeric(df["LMP"], errors="coerce")
 
-        return (
+        return pl.from_pandas(
             df[
                 [
                     "Interval Start",
@@ -5447,7 +5505,7 @@ class Ercot(ISOBase):
                 ]
             ]
             .sort_values(["SCED Timestamp", "QSE", "DME", "Generation Resource"])
-            .reset_index(drop=True)
+            .reset_index(drop=True),
         )
 
     def _handle_highest_price_as_offer_selected_file(
@@ -5455,14 +5513,14 @@ class Ercot(ISOBase):
         doc: Document,
         market: str,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Handle the new 3-day highest price AS offer selected files
         for both DAM and SCED markets.
 
         The new files (post RTC+B) don't have a Market column,
         so we add it manually based on the market parameter.
         """
-        df = self.read_doc(doc, verbose=verbose, parse=False)
+        df = self.read_doc(doc, verbose=verbose, parse=False).to_pandas()
 
         # Determine format based on market parameter
         is_sced_format = market.lower() == "sced"
@@ -5514,7 +5572,7 @@ class Ercot(ISOBase):
             # TODO: we haven't been able to test this with an actual DST transition
             # so we may have to update this logic
             if not is_dst_end:
-                df = self.parse_doc(df)
+                df = self.parse_doc(df).to_pandas()
             else:
                 # Hours go up to 25. Assume hour 2 is CDT and hour 3 is CST
                 df["Interval Start"] = (
@@ -5557,7 +5615,7 @@ class Ercot(ISOBase):
         self,
         dam_type: str,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get DAM Price Corrections
 
@@ -5574,13 +5632,13 @@ class Ercot(ISOBase):
 
         df = self._handle_price_corrections(docs, verbose=verbose)
 
-        return df
+        return pl.from_pandas(df)
 
     def get_rtm_price_corrections(
         self,
         rtm_type: str,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get RTM Price Corrections
 
@@ -5598,12 +5656,12 @@ class Ercot(ISOBase):
 
         df = self._handle_price_corrections(docs, verbose=verbose)
 
-        return df
+        return pl.from_pandas(df)
 
     def get_mcpc_dam_price_corrections(
         self,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get Market Clearing Price for Capacity (MCPC) corrections for DAM.
 
@@ -5628,14 +5686,14 @@ class Ercot(ISOBase):
 
         df = self._handle_mcpc_price_corrections(docs, verbose=verbose)
 
-        return df
+        return pl.from_pandas(df)
 
     def _handle_price_corrections(
         self,
         docs: list[Document],
         verbose: bool = False,
-    ) -> pd.DataFrame:
-        df = self.read_docs(docs, verbose=verbose)
+    ) -> pl.DataFrame:
+        df = self.read_docs(docs, verbose=verbose).to_pandas()
 
         df = self._handle_settlement_point_name_and_type(df)
 
@@ -5666,20 +5724,20 @@ class Ercot(ISOBase):
             ]
         ]
 
-        return df
+        return pl.from_pandas(df)
 
     def _handle_mcpc_price_corrections(
         self,
         docs: list[Document],
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Handle MCPC (Market Clearing Price for Capacity) price corrections.
 
         MCPC corrections have a different structure than SPP corrections:
         - They are for ancillary services at the system level (not settlement points)
         - read_docs() already creates Interval Start/End columns
         """
-        df = self.read_docs(docs, verbose=verbose)
+        df = self.read_docs(docs, verbose=verbose).to_pandas()
 
         # Rename columns to match gridstatus conventions
         df = df.rename(
@@ -5708,7 +5766,7 @@ class Ercot(ISOBase):
             ]
         ]
 
-        return df
+        return pl.from_pandas(df)
 
     @support_date_range(frequency=None)
     def get_system_wide_actual_load(
@@ -5716,7 +5774,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get 15-minute system-wide actual load.
 
         This report is posted every hour five minutes after the hour.
@@ -5727,7 +5785,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with system actuals data
+            polars.DataFrame: A DataFrame with system actuals data
         """
         report_type_id = SYSTEM_WIDE_ACTUALS_RTID
 
@@ -5753,7 +5811,7 @@ class Ercot(ISOBase):
             self._handle_system_wide_actual_load(doc, verbose=verbose) for doc in docs
         ]
 
-        return pd.concat(all_df).sort_values("Interval Start")
+        return pl.from_pandas(pd.concat(all_df).sort_values("Interval Start"))
 
     def _handle_system_wide_actual_load(self, doc, verbose=False):
         return self.read_doc(doc, verbose=verbose)
@@ -5764,7 +5822,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Short Term System Adequacy published between date and end.
 
         Arguments:
@@ -5772,7 +5830,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with system adequacy data
+            polars.DataFrame: A DataFrame with system adequacy data
         """
         return self._get_hourly_report(
             start=date,
@@ -5787,8 +5845,8 @@ class Ercot(ISOBase):
         self,
         doc: Document,
         verbose: bool = False,
-    ) -> pd.DataFrame:
-        df = self.read_doc(doc, verbose=verbose)
+    ) -> pl.DataFrame:
+        df = self.read_doc(doc, verbose=verbose).to_pandas()
 
         df["Publish Time"] = doc.publish_date
 
@@ -5827,7 +5885,7 @@ class Ercot(ISOBase):
             },
         )
 
-        return df
+        return pl.from_pandas(df)
 
     @support_date_range(frequency=None)
     def get_real_time_adders_and_reserves(
@@ -5835,7 +5893,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Real-Time ORDC and Reliability Deployment Price Adders and
             Reserves by SCED Interval
 
@@ -5846,7 +5904,7 @@ class Ercot(ISOBase):
             end (str, datetime): end date to get data for
             verbose (bool, optional): print verbose output. Defaults to False.
         Returns:
-            pandas.DataFrame: A DataFrame with ORDC data
+            polars.DataFrame: A DataFrame with ORDC data
 
         NOTE: data only goes back 5 days
         """
@@ -5868,8 +5926,8 @@ class Ercot(ISOBase):
         self,
         docs: list[Document],
         verbose: bool = False,
-    ) -> pd.DataFrame:
-        df = self.read_docs(docs, parse=False, verbose=verbose)
+    ) -> pl.DataFrame:
+        df = self.read_docs(docs, parse=False, verbose=verbose).to_pandas()
         df = self._handle_sced_timestamp(df)
 
         df = utils.move_cols_to_front(
@@ -5879,7 +5937,7 @@ class Ercot(ISOBase):
 
         df = df.rename(columns={"SystemLambda": "System Lambda"})
 
-        return df.sort_values("SCED Timestamp")
+        return pl.from_pandas(df.sort_values("SCED Timestamp"))
 
     @support_date_range(frequency=None)
     def get_temperature_forecast_by_weather_zone(
@@ -5887,7 +5945,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get temperature forecast by weather zone in hourly intervals. Published
         once a day at 5 am central.
 
@@ -5897,7 +5955,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with temperature forecast data
+            polars.DataFrame: A DataFrame with temperature forecast data
         """
         # Set end to get a full day of published data
         if not end:
@@ -5916,11 +5974,13 @@ class Ercot(ISOBase):
         self,
         docs: list[Document],
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         # Process files in a loop to add the publish time for each doc
         df = pd.concat(
             [
-                self.read_doc(doc, verbose=verbose, parse=False).assign(
+                self.read_doc(doc, verbose=verbose, parse=False)
+                .to_pandas()
+                .assign(
                     **{"Publish Time": doc.publish_date},
                 )
                 for doc in docs
@@ -5944,7 +6004,7 @@ class Ercot(ISOBase):
             )
             df.loc[mask, "HourEnding"] = "2:00"
 
-        df = self.parse_doc(df)
+        df = self.parse_doc(df).to_pandas()
 
         df = df.drop(columns=["Time"]).rename(
             columns=self._weather_zone_column_name_mapping(),
@@ -5976,7 +6036,7 @@ class Ercot(ISOBase):
             # after the correction, the straight duplicate intervals remain, so we remove them
             df = df.drop_duplicates(subset=["Interval Start", "Publish Time"])
 
-        return df.sort_values("Interval Start")
+        return pl.from_pandas(df.sort_values("Interval Start"))
 
     def _get_document(
         self,
@@ -6145,10 +6205,10 @@ class Ercot(ISOBase):
         start: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None,
         report_type_id: int,
-        handle_doc: Callable[[Document, bool], pd.DataFrame],
+        handle_doc: Callable[[Document, bool], pl.DataFrame],
         extension: str | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if start == "latest":
             # _get_document can handle "latest"
             doc = self._get_document(
@@ -6174,15 +6234,17 @@ class Ercot(ISOBase):
         all_df = []
         for doc in docs:
             df = handle_doc(doc, verbose=verbose)
+            if isinstance(df, pd.DataFrame):
+                df = pl.from_pandas(df)
             all_df.append(df)
 
-        df = pd.concat(all_df)
+        df = pl.concat(all_df, how="diagonal_relaxed")
 
-        df = df.sort_values("Publish Time")
+        df = df.sort("Publish Time")
 
         return df
 
-    def _handle_json_data(self, df: pd.DataFrame, columns: dict) -> pd.DataFrame:
+    def _handle_json_data(self, df: pd.DataFrame, columns: dict) -> pl.DataFrame:
         df["Time"] = (
             pd.to_datetime(df["epoch"], unit="ms")
             .dt.tz_localize("UTC")
@@ -6190,7 +6252,7 @@ class Ercot(ISOBase):
         )
 
         cols_to_keep = ["Time"] + list(columns.keys())
-        return df[cols_to_keep].rename(columns=columns)
+        return pl.from_pandas(df[cols_to_keep].rename(columns=columns))
 
     def _get_settlement_points_mapping_documents(
         self,
@@ -6268,7 +6330,7 @@ class Ercot(ISOBase):
         date: pd.Timestamp | None = None,
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         docs = self._get_settlement_points_mapping_documents(date, end, verbose)
         dfs = []
         for doc in docs:
@@ -6280,13 +6342,13 @@ class Ercot(ISOBase):
             df["Publish Date"] = publish_date.date()
             cols = ["Publish Date"] + list(column_mapping.values())
             dfs.append(df[cols])
-        return pd.concat(dfs).reset_index(drop=True)
+        return pl.from_pandas(pd.concat(dfs).reset_index(drop=True))
 
-    def _get_settlement_point_mapping(self, verbose: bool = False) -> pd.DataFrame:
+    def _get_settlement_point_mapping(self, verbose: bool = False) -> pl.DataFrame:
         """Get DataFrame whose columns can help us filter out values"""
         docs = self._get_settlement_points_mapping_documents(verbose=verbose)
         df, _ = self._download_and_extract_csv(docs[0], "Settlement_Points")
-        return df
+        return pl.from_pandas(df)
 
     @support_date_range(frequency=None)
     def get_settlement_points_electrical_bus_mapping(
@@ -6294,7 +6356,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | None = None,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_settlement_points_csv(
             filename_contains="Settlement_Points",
             column_mapping={
@@ -6320,7 +6382,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | None = None,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_settlement_points_csv(
             filename_contains="CCP_Resource_Names",
             column_mapping={
@@ -6338,7 +6400,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | None = None,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_settlement_points_csv(
             filename_contains="NOIE_Mapping",
             column_mapping={
@@ -6359,7 +6421,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | None = None,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_settlement_points_csv(
             filename_contains="Resource_Node_to_Unit",
             column_mapping={
@@ -6378,7 +6440,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | None = None,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_settlement_points_csv(
             filename_contains="Hub_Name_AND_DC_Ties",
             column_mapping={
@@ -6396,7 +6458,7 @@ class Ercot(ISOBase):
         verbose: bool = False,
         request_kwargs: dict | None = None,
         read_csv_kwargs: dict | None = None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         logger.debug(f"Reading {doc.url}")
 
         if request_kwargs:
@@ -6410,17 +6472,17 @@ class Ercot(ISOBase):
             df = pd.read_csv(doc.url, compression="zip", **(read_csv_kwargs or {}))
 
         if parse:
-            df = self.parse_doc(df, verbose=verbose)
-        return df
+            return self.parse_doc(df, verbose=verbose)
+        return pl.from_pandas(df)
 
     def read_docs(
         self,
         docs: list[Document],
         parse: bool = True,
-        empty_df: pd.DataFrame | None = None,
+        empty_df: pl.DataFrame | None = None,
         verbose: bool = False,
         request_kwargs: dict | None = None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if len(docs) == 0:
             return empty_df
 
@@ -6434,7 +6496,7 @@ class Ercot(ISOBase):
                     request_kwargs=request_kwargs,
                 ),
             )
-        return pd.concat(dfs).reset_index(drop=True)
+        return pl.concat(dfs, how="diagonal_relaxed")
 
     def ambiguous_based_on_dstflag(self, df: pd.DataFrame) -> pd.Series:
         # DSTFlag is Y during the repeated hour (after the clock has been set back)
@@ -6457,7 +6519,7 @@ class Ercot(ISOBase):
         dst_ambiguous_default: str = "infer",
         verbose: bool = False,
         nonexistent: str = "raise",
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         # files sometimes have different naming conventions
         # a more elegant solution would be nice
 
@@ -6602,7 +6664,7 @@ class Ercot(ISOBase):
             if col in doc.columns:
                 doc = doc.drop(columns=[col])
 
-        return doc
+        return pl.from_pandas(doc)
 
     def _weather_zone_column_name_mapping(self) -> dict[str, str]:
         return {
@@ -6637,7 +6699,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if not end:
             end = date + pd.DateOffset(days=1)
 
@@ -6648,13 +6710,13 @@ class Ercot(ISOBase):
             published_after=date,
             verbose=verbose,
         )
-        df = self.read_docs(docs, parse=False, verbose=verbose)
+        df = self.read_docs(docs, parse=False, verbose=verbose).to_pandas()
         return self._handle_indicative_lmp_by_settlement_point(df)
 
     def _handle_indicative_lmp_by_settlement_point(
         self,
         df: pd.DataFrame,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         columns_to_rename = {
             "RTDTimestamp": "RTD Timestamp",
             "IntervalEnding": "Interval End",
@@ -6696,7 +6758,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get DAM Total Energy Purchased
 
         Arguments:
@@ -6705,7 +6767,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with DAM total energy purchased data
+            polars.DataFrame: A DataFrame with DAM total energy purchased data
         """
         # DAM data so subtract one from the date
         doc = self._get_document(
@@ -6723,9 +6785,10 @@ class Ercot(ISOBase):
         self,
         doc: Document,
         verbose: bool = False,
-    ) -> pd.DataFrame:
-        return (
+    ) -> pl.DataFrame:
+        return pl.from_pandas(
             self.read_doc(doc, verbose=verbose)
+            .to_pandas()
             .rename(
                 columns={
                     "Settlement_Point": "Location",
@@ -6737,7 +6800,7 @@ class Ercot(ISOBase):
                 columns=["Time"],
             )
             .sort_values(["Interval Start", "Location"])
-            .reset_index(drop=True)
+            .reset_index(drop=True),
         )
 
     @support_date_range(frequency="DAY_START")
@@ -6746,7 +6809,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get DAM Total Energy Sold
 
         Arguments:
@@ -6755,7 +6818,7 @@ class Ercot(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with DAM total energy sold data
+            polars.DataFrame: A DataFrame with DAM total energy sold data
         """
         # DAM data so subtract one from the date
         doc = self._get_document(
@@ -6775,7 +6838,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date > pd.Timestamp.now(
             tz=self.default_timezone,
         ) - pd.DateOffset(days=60):
@@ -6793,11 +6856,13 @@ class Ercot(ISOBase):
             date=report_date,
         )
 
-        data = self.read_doc(doc, verbose=verbose)
+        data = self.read_doc(doc, verbose=verbose).to_pandas()
 
-        return self._process_cop_adjustment_period_snapshot_60_day_data(
-            data,
-            verbose=verbose,
+        return pl.from_pandas(
+            self._process_cop_adjustment_period_snapshot_60_day_data(
+                data,
+                verbose=verbose,
+            ),
         )
 
     def _process_cop_adjustment_period_snapshot_60_day_data(
@@ -6865,7 +6930,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Market Clearing Prices for Capacity by SCED interval"""
         if end is None:
             # Assume getting data for one day
@@ -6882,20 +6947,20 @@ class Ercot(ISOBase):
             verbose=verbose,
         )
 
-        df = self.read_docs(docs, parse=False, verbose=verbose)
+        df = self.read_docs(docs, parse=False, verbose=verbose).to_pandas()
         return self._handle_mcpc_sced(df)
 
-    def _handle_mcpc_sced(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _handle_mcpc_sced(self, df: pd.DataFrame) -> pl.DataFrame:
         df = df.rename(columns={"ASType": "AS Type"})
         df = self._handle_sced_timestamp(df)
 
         df["MCPC"] = pd.to_numeric(df["MCPC"], errors="coerce")
 
-        return (
+        return pl.from_pandas(
             # Only need the SCED Timestamps
             df[["SCED Timestamp", "AS Type", "MCPC"]]
             .sort_values(["SCED Timestamp", "AS Type"])
-            .reset_index(drop=True)
+            .reset_index(drop=True),
         )
 
     # Published every 15 minutes for the past 15 minutes.
@@ -6905,7 +6970,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Market Clearing Prices for Capacity by 15-minute interval"""
         # Assume getting data for one day
         if not end:
@@ -6922,25 +6987,25 @@ class Ercot(ISOBase):
             verbose=verbose,
         )
 
-        df = self.read_docs(docs, parse=False, verbose=verbose)
+        df = self.read_docs(docs, parse=False, verbose=verbose).to_pandas()
         return self._handle_mcpc_real_time_15_min(df)
 
     def _handle_mcpc_real_time_15_min(
         self,
         df: pd.DataFrame,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         df = df.rename(
             columns={"ASType": "AS Type", "RepeatedHourFlag": "DSTFlag"},
         )
 
-        df = self.parse_doc(df)
+        df = self.parse_doc(df).to_pandas()
 
         df["MCPC"] = pd.to_numeric(df["MCPC"], errors="coerce")
 
-        return (
+        return pl.from_pandas(
             df[["Interval Start", "Interval End", "AS Type", "MCPC"]]
             .sort_values(["Interval Start", "AS Type"])
-            .reset_index(drop=True)
+            .reset_index(drop=True),
         )
 
     # Should be published once per day for today and tomorrow in the same file
@@ -6952,7 +7017,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Ancillary Service Demand Curves"""
         if end is None:
             end = date + pd.DateOffset(days=1)
@@ -6967,7 +7032,9 @@ class Ercot(ISOBase):
 
         df = pd.concat(
             [
-                self.read_doc(doc, parse=False, verbose=verbose).assign(
+                self.read_doc(doc, parse=False, verbose=verbose)
+                .to_pandas()
+                .assign(
                     **{"Publish Time": doc.publish_date},
                 )
                 for doc in docs
@@ -6976,7 +7043,7 @@ class Ercot(ISOBase):
 
         return self._handle_as_demand_curves_dam_and_sced(df)
 
-    def _handle_as_demand_curves_dam_and_sced(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _handle_as_demand_curves_dam_and_sced(self, df: pd.DataFrame) -> pl.DataFrame:
         df = df.rename(
             columns={
                 "ASType": "AS Type",
@@ -6984,12 +7051,12 @@ class Ercot(ISOBase):
                 "RepeatedHourFlag": "DSTFlag",
             },
         )
-        df = self.parse_doc(df)
+        df = self.parse_doc(df).to_pandas()
 
         for col in ["Quantity", "Price", "Demand Curve Point"]:
             df[col] = pd.to_numeric(df[col], errors="coerce")
 
-        return (
+        return pl.from_pandas(
             df[
                 [
                     "Interval Start",
@@ -7004,7 +7071,7 @@ class Ercot(ISOBase):
             .sort_values(
                 ["Interval Start", "Publish Time", "AS Type", "Demand Curve Point"],
             )
-            .reset_index(drop=True)
+            .reset_index(drop=True),
         )
 
     # Published once per DAM run (daily, ~12-2 PM Central) for the next day's
@@ -7016,7 +7083,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get DAM Aggregated Ancillary Service Offer Curve (NP4-19-CD).
 
         The DAM Aggregated Ancillary Service Demand/Offer Curve contains the
@@ -7039,25 +7106,25 @@ class Ercot(ISOBase):
             verbose=verbose,
         )
 
-        df = self.read_docs(docs, parse=False, verbose=verbose)
+        df = self.read_docs(docs, parse=False, verbose=verbose).to_pandas()
         return self._handle_dam_asdc_aggregated(df)
 
-    def _handle_dam_asdc_aggregated(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _handle_dam_asdc_aggregated(self, df: pd.DataFrame) -> pl.DataFrame:
         df = df.rename(
             columns={
                 "AncillaryType": "AS Type",
                 "RepeatedHourFlag": "DSTFlag",
             },
         )
-        df = self.parse_doc(df)
+        df = self.parse_doc(df).to_pandas()
 
         for col in ["Price", "Quantity"]:
             df[col] = pd.to_numeric(df[col], errors="coerce")
 
-        return (
+        return pl.from_pandas(
             df[["Interval Start", "Interval End", "AS Type", "Price", "Quantity"]]
             .sort_values(["Interval Start", "AS Type", "Price"])
-            .reset_index(drop=True)
+            .reset_index(drop=True),
         )
 
     # Published once per day for tomorrow
@@ -7067,7 +7134,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Projected Ancillary Service Deployment Factors"""
         if end is None:
             end = date + pd.DateOffset(days=1)
@@ -7086,8 +7153,8 @@ class Ercot(ISOBase):
         self,
         docs: list[Document],
         verbose: bool = False,
-    ) -> pd.DataFrame:
-        df = self.read_docs(docs, parse=False, verbose=verbose)
+    ) -> pl.DataFrame:
+        df = self.read_docs(docs, parse=False, verbose=verbose).to_pandas()
 
         df = df.rename(
             columns={
@@ -7097,17 +7164,17 @@ class Ercot(ISOBase):
             },
         )
 
-        df = self.parse_doc(df)
+        df = self.parse_doc(df).to_pandas()
 
         df["AS Deployment Factors"] = pd.to_numeric(
             df["AS Deployment Factors"],
             errors="coerce",
         )
 
-        return (
+        return pl.from_pandas(
             df[["Interval Start", "Interval End", "AS Type", "AS Deployment Factors"]]
             .sort_values("Interval Start")
-            .reset_index(drop=True)
+            .reset_index(drop=True),
         )
 
     # Published per WRUC run (once per day) for the next 5 days
@@ -7117,7 +7184,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Weekly RUC Ancillary Service Deployment Factors
 
         Retrieves ancillary service deployment factors used by the Weekly
@@ -7153,7 +7220,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Daily RUC Ancillary Service Deployment Factors"""
         if not end:
             end = date + pd.DateOffset(days=1)
@@ -7176,7 +7243,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Hourly RUC Ancillary Service Deployment Factors"""
         if not end:
             end = date + pd.DateOffset(days=1)
@@ -7195,8 +7262,8 @@ class Ercot(ISOBase):
         self,
         docs: list[Document],
         verbose: bool = False,
-    ) -> pd.DataFrame:
-        df = self.read_docs(docs, parse=False, verbose=verbose)
+    ) -> pl.DataFrame:
+        df = self.read_docs(docs, parse=False, verbose=verbose).to_pandas()
         df = df.rename(
             columns={
                 "RUCTimestamp": "RUC Timestamp",
@@ -7206,7 +7273,7 @@ class Ercot(ISOBase):
             },
         )
 
-        df = self.parse_doc(df)
+        df = self.parse_doc(df).to_pandas()
 
         # Parse RUC Timestamp
         df["RUC Timestamp"] = pd.to_datetime(
@@ -7218,7 +7285,7 @@ class Ercot(ISOBase):
             errors="coerce",
         )
 
-        return (
+        return pl.from_pandas(
             df[
                 [
                     "Interval Start",
@@ -7229,7 +7296,7 @@ class Ercot(ISOBase):
                 ]
             ]
             .sort_values(["Interval Start", "RUC Timestamp", "AS Type"])
-            .reset_index(drop=True)
+            .reset_index(drop=True),
         )
 
     # Published per HRUC run (every hour) for the rest of the day
@@ -7239,7 +7306,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Hourly RUC Ancillary Service Demand Curves"""
         if not end:
             end = date + pd.DateOffset(days=1)
@@ -7252,7 +7319,7 @@ class Ercot(ISOBase):
             verbose=verbose,
         )
 
-        df = self.read_docs(docs, parse=False, verbose=verbose)
+        df = self.read_docs(docs, parse=False, verbose=verbose).to_pandas()
         return self._handle_ruc_as_demand_curves(df)
 
     # Published per DRUC run (once per day) for the next day
@@ -7262,7 +7329,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Daily RUC Ancillary Service Demand Curves"""
         if not end:
             end = date + pd.DateOffset(days=1)
@@ -7275,7 +7342,7 @@ class Ercot(ISOBase):
             verbose=verbose,
         )
 
-        df = self.read_docs(docs, parse=False, verbose=verbose)
+        df = self.read_docs(docs, parse=False, verbose=verbose).to_pandas()
         return self._handle_ruc_as_demand_curves(df)
 
     # Published per WRUC run (once per day) for the next five days
@@ -7285,7 +7352,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Weekly RUC Ancillary Service Demand Curves"""
         if not end:
             end = date + pd.DateOffset(days=1)
@@ -7298,13 +7365,13 @@ class Ercot(ISOBase):
             verbose=verbose,
         )
 
-        df = self.read_docs(docs, parse=False, verbose=verbose)
+        df = self.read_docs(docs, parse=False, verbose=verbose).to_pandas()
         return self._handle_ruc_as_demand_curves(df)
 
     def _handle_ruc_as_demand_curves(
         self,
         df: pd.DataFrame,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         df = df.rename(
             columns={
                 "RUCTimeStamp": "RUC Timestamp",
@@ -7314,7 +7381,7 @@ class Ercot(ISOBase):
             },
         )
 
-        df = self.parse_doc(df)
+        df = self.parse_doc(df).to_pandas()
 
         # Parse RUC Timestamp
         df["RUC Timestamp"] = pd.to_datetime(
@@ -7324,7 +7391,7 @@ class Ercot(ISOBase):
         for col in ["Quantity", "Price", "Demand Curve Point"]:
             df[col] = pd.to_numeric(df[col], errors="coerce")
 
-        return (
+        return pl.from_pandas(
             df[
                 [
                     "Interval Start",
@@ -7339,7 +7406,7 @@ class Ercot(ISOBase):
             .sort_values(
                 ["Interval Start", "RUC Timestamp", "AS Type", "Demand Curve Point"],
             )
-            .reset_index(drop=True)
+            .reset_index(drop=True),
         )
 
     # Published per DAM run for the next day
@@ -7349,7 +7416,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get DAM Total Ancillary Services Sold"""
         date -= pd.DateOffset(days=1)
 
@@ -7360,10 +7427,10 @@ class Ercot(ISOBase):
             verbose=verbose,
         )
 
-        df = self.read_docs(docs, parse=False, verbose=verbose)
+        df = self.read_docs(docs, parse=False, verbose=verbose).to_pandas()
         return self._handle_dam_total_as_sold(df)
 
-    def _handle_dam_total_as_sold(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _handle_dam_total_as_sold(self, df: pd.DataFrame) -> pl.DataFrame:
         """Handle DAM Total Ancillary Services Sold data."""
         df = df.rename(
             columns={
@@ -7373,10 +7440,10 @@ class Ercot(ISOBase):
             },
         )
 
-        df = self.parse_doc(df)
+        df = self.parse_doc(df).to_pandas()
         df["Quantity"] = pd.to_numeric(df["Quantity"], errors="coerce")
 
-        return (
+        return pl.from_pandas(
             df[
                 [
                     "Interval Start",
@@ -7386,7 +7453,7 @@ class Ercot(ISOBase):
                 ]
             ]
             .sort_values(["Interval Start", "AS Type"])
-            .reset_index(drop=True)
+            .reset_index(drop=True),
         )
 
     # Published per RTD run for the next 55 minutes (11 intervals per file)
@@ -7396,7 +7463,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get RTD Indicative Real-Time Market Clearing Prices for Capacity"""
         if not end:
             end = date + pd.DateOffset(days=1)
@@ -7412,10 +7479,10 @@ class Ercot(ISOBase):
             verbose=verbose,
         )
 
-        df = self.read_docs(docs, parse=False, verbose=verbose)
+        df = self.read_docs(docs, parse=False, verbose=verbose).to_pandas()
         return self._handle_indicative_mcpc_rtd(df)
 
-    def _handle_indicative_mcpc_rtd(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _handle_indicative_mcpc_rtd(self, df: pd.DataFrame) -> pl.DataFrame:
         # Parse timestamps with DST handling. nonexistent= only applies to
         # spring-forward (gap when 02:00 does not exist); fall-back repeated
         # hour is handled by ambiguous= from RepeatedHourFlag.
@@ -7442,10 +7509,10 @@ class Ercot(ISOBase):
         for col in price_cols:
             df[col] = df[col].astype("float64")
 
-        return (
+        return pl.from_pandas(
             df[["Interval Start", "Interval End", "RTD Timestamp"] + price_cols]
             .sort_values(["Interval Start", "RTD Timestamp"])
-            .reset_index(drop=True)
+            .reset_index(drop=True),
         )
 
     # Published every SCED interval
@@ -7455,7 +7522,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Total Capability of Resources Available to Provide Ancillary Service"""
         if not end:
             end = date + pd.DateOffset(days=1)
@@ -7474,7 +7541,9 @@ class Ercot(ISOBase):
         # Add the publish time to deal with duplicates downstream
         df = pd.concat(
             [
-                self.read_doc(doc, parse=False, verbose=verbose).assign(
+                self.read_doc(doc, parse=False, verbose=verbose)
+                .to_pandas()
+                .assign(
                     **{"Publish Time": doc.publish_date},
                 )
                 for doc in docs
@@ -7483,7 +7552,7 @@ class Ercot(ISOBase):
 
         return self._handle_as_total_capability(df)
 
-    def _handle_as_total_capability(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _handle_as_total_capability(self, df: pd.DataFrame) -> pl.DataFrame:
         df = df.rename(
             columns={
                 "SCEDTimestamp": "SCED Timestamp",
@@ -7516,10 +7585,10 @@ class Ercot(ISOBase):
         for col in cap_cols:
             df[col] = df[col].astype(float)
 
-        return (
+        return pl.from_pandas(
             df[["SCED Timestamp", "Publish Time"] + cap_cols]
             .sort_values(["SCED Timestamp", "Publish Time"])
-            .reset_index(drop=True)
+            .reset_index(drop=True),
         )
 
     # Published every SCED interval
@@ -7529,7 +7598,7 @@ class Ercot(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Real-Time ORDC and Reliability Deployment
         Price Adders and Reserves by SCED Interval produced by SCED every five minutes.
 
@@ -7539,7 +7608,7 @@ class Ercot(ISOBase):
             verbose: print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with ORDC price adders data
+            polars.DataFrame: A DataFrame with ORDC price adders data
         """
         if not end:
             # Assume getting data for one day
@@ -7562,8 +7631,8 @@ class Ercot(ISOBase):
         self,
         docs: list[Document],
         verbose: bool = False,
-    ) -> pd.DataFrame:
-        df = self.read_docs(docs, parse=False, verbose=verbose)
+    ) -> pl.DataFrame:
+        df = self.read_docs(docs, parse=False, verbose=verbose).to_pandas()
         df = self._handle_sced_timestamp(df)
 
         df = utils.move_cols_to_front(
@@ -7572,4 +7641,4 @@ class Ercot(ISOBase):
         )
         df = df.rename(columns={"SystemLambda": "System Lambda"})
 
-        return df.sort_values("SCED Timestamp").reset_index(drop=True)
+        return pl.from_pandas(df.sort_values("SCED Timestamp").reset_index(drop=True))

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -2793,6 +2793,163 @@ class Ercot(ISOBase):
 
         return data
 
+    def _read_zip_csv_polars(self, z: ZipFile, file: str) -> pl.DataFrame:
+        # Extract to a temp file instead of reading bytes into memory so
+        # polars can mmap the CSV; keeps peak RSS at ~the final frame size
+        # rather than frame + full decompressed CSV bytes.
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+            with z.open(file) as f:
+                shutil.copyfileobj(f, tmp)
+            tmp_path = tmp.name
+        try:
+            # ERCOT CSVs quote empty fields (""), which pandas read as NaN;
+            # treating them as nulls at parse time lets polars infer numeric
+            # dtypes directly instead of leaving those columns as String,
+            # which roughly halves the read's peak memory.
+            df = pl.read_csv(
+                tmp_path,
+                infer_schema_length=None,
+                null_values=[""],
+            )
+        finally:
+            os.unlink(tmp_path)
+        # Match the pandas.read_csv dtypes: integer columns containing empty
+        # fields were float64 (with NaN) under pandas, and String columns
+        # where every non-null value parses as a number (e.g. floats written
+        # without a leading zero like "-.5") were float64 as well.
+        exprs = []
+        for col, dtype in df.schema.items():
+            if dtype == pl.Int64 and df[col].null_count() > 0:
+                exprs.append(pl.col(col).cast(pl.Float64))
+            elif dtype == pl.String:
+                parsed = df[col].cast(pl.Float64, strict=False)
+                if parsed.null_count() == df[col].null_count():
+                    exprs.append(pl.col(col).cast(pl.Float64, strict=False))
+        if exprs:
+            df = df.with_columns(exprs)
+        return df
+
+    def _localize_sced_timestamp_polars(self, df: pl.DataFrame) -> pl.DataFrame:
+        """Parse and localize the SCED Timestamp column of a raw 60-day
+        disclosure frame without adding Interval Start/End.
+
+        Repeated Hour Flag is Y during the repeated hour, so it's N during DST
+        and Y during Standard Time: N maps to the earliest (DST) offset.
+        """
+        df = df.rename({"SCED Time Stamp": "SCED Timestamp"}, strict=False)
+        # ERCOT timestamps are MM/DD/YYYY, with or without seconds. Parse with
+        # explicit formats so polars never falls back to DD/MM.
+        parsed = pl.coalesce(
+            pl.col("SCED Timestamp").str.to_datetime("%m/%d/%Y %H:%M:%S", strict=False),
+            pl.col("SCED Timestamp").str.to_datetime("%m/%d/%Y %H:%M", strict=False),
+        )
+        ambiguous = (
+            pl.when(pl.col("Repeated Hour Flag") == "N")
+            .then(pl.lit("earliest"))
+            .otherwise(pl.lit("latest"))
+        )
+        return df.with_columns(
+            parsed.dt.replace_time_zone(
+                self.default_timezone,
+                ambiguous=ambiguous,
+            ).alias("SCED Timestamp"),
+        )
+
+    def _parse_doc_polars(self, doc: pl.DataFrame) -> pl.DataFrame:
+        """Polars-native version of parse_doc() for hourly documents
+        (DeliveryDate + HourEnding, optional DSTFlag).
+
+        Files with DeliveryInterval or TimeEnding columns fall back to the
+        pandas parse_doc() since those shapes are not needed on the
+        polars-native 60-day disclosure path.
+        """
+        doc = doc.rename(
+            {
+                "deliveryDate": "DeliveryDate",
+                "Delivery Date": "DeliveryDate",
+                "DELIVERY_DATE": "DeliveryDate",
+                "OperDay": "DeliveryDate",
+                "hourEnding": "HourEnding",
+                "Hour Ending": "HourEnding",
+                "HOUR_ENDING": "HourEnding",
+                "Repeated Hour Flag": "DSTFlag",
+                "RepeatedHourFlag": "DSTFlag",
+                "Date": "DeliveryDate",
+                "DeliveryHour": "HourEnding",
+                "Delivery Hour": "HourEnding",
+                "Delivery Interval": "DeliveryInterval",
+                # fix whitespace in column name
+                "DSTFlag    ": "DSTFlag",
+            },
+            strict=False,
+        )
+
+        if "DeliveryInterval" in doc.columns or "TimeEnding" in doc.columns:
+            return self.parse_doc(doc.to_pandas())
+
+        original_cols = doc.columns
+
+        hour_beginning = (
+            pl.col("HourEnding")
+            .cast(pl.String)
+            .str.split(":")
+            .list.first()
+            .cast(pl.Int64)
+            - 1
+        )
+        naive = pl.coalesce(
+            pl.col("DeliveryDate").str.to_datetime("%m/%d/%Y", strict=False),
+            pl.col("DeliveryDate").str.to_datetime("%m/%d/%Y %H:%M:%S", strict=False),
+        ) + pl.duration(hours=hour_beginning)
+        doc = doc.with_columns(naive.alias("Interval Start"))
+
+        if "DSTFlag" in original_cols:
+            # DSTFlag is Y during the repeated hour, so it's N during DST and
+            # Y during Standard Time: N maps to the earliest (DST) offset.
+            ambiguous = (
+                pl.when(pl.col("DSTFlag") == "N")
+                .then(pl.lit("earliest"))
+                .otherwise(pl.lit("latest"))
+            )
+            # Nonexistent (spring-forward) wall times localize to null and are
+            # replaced by shifting forward an hour, matching the pandas
+            # NonExistentTimeError fallback in parse_doc().
+            localized = pl.col("Interval Start").dt.replace_time_zone(
+                self.default_timezone,
+                ambiguous=ambiguous,
+                non_existent="null",
+            )
+            shifted = (
+                pl.col("Interval Start") + pl.duration(hours=1)
+            ).dt.replace_time_zone(
+                self.default_timezone,
+                ambiguous=ambiguous,
+                non_existent="null",
+            ) - pl.duration(hours=1)
+            doc = doc.with_columns(
+                pl.coalesce(localized, shifted).alias("Interval Start"),
+            )
+        else:
+            # matches the pandas ambiguous="infer" default
+            doc = utils.localize_ambiguous_infer_polars(
+                doc,
+                time_col="Interval Start",
+                tz=self.default_timezone,
+            )
+
+        doc = doc.with_columns(
+            (pl.col("Interval Start") + pl.duration(hours=1)).alias("Interval End"),
+            pl.col("Interval Start").alias("Time"),
+        )
+        doc = doc.sort("Time", maintain_order=True)
+
+        cols_to_keep = ["Time", "Interval Start", "Interval End"] + [
+            c
+            for c in original_cols
+            if c not in ("DeliveryDate", "HourEnding", "DSTFlag")
+        ]
+        return doc.select(cols_to_keep)
+
     def _handle_60_day_sced_disclosure(
         self,
         z: ZipFile,
@@ -2841,32 +2998,7 @@ class Ercot(ISOBase):
         assert smne_file, "Could not find smne file"
 
         def read_zip_csv(file: str) -> pl.DataFrame:
-            # Extract to a temp file instead of reading bytes into memory so
-            # polars can mmap the CSV; keeps peak RSS at ~the final frame size
-            # rather than frame + full decompressed CSV bytes.
-            with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
-                with z.open(file) as f:
-                    shutil.copyfileobj(f, tmp)
-                tmp_path = tmp.name
-            try:
-                df = pl.read_csv(tmp_path, infer_schema_length=None)
-            finally:
-                os.unlink(tmp_path)
-            # ERCOT CSVs quote empty fields ("") and write floats without a
-            # leading zero (e.g. "-.5"), both of which polars leaves as String
-            # columns where pandas produced float64 (with NaN for empties).
-            # Normalize empty strings to null and cast a String column to
-            # Float64 whenever every non-empty value parses as a number,
-            # matching the pandas.read_csv behavior. Columns are replaced one
-            # at a time to keep transient memory to a single column.
-            for col, dtype in df.schema.items():
-                if dtype != pl.String:
-                    continue
-                cleaned = df[col].replace("", None)
-                parsed = cleaned.cast(pl.Float64, strict=False)
-                if parsed.null_count() == cleaned.null_count():
-                    df = df.with_columns(parsed.rename(col))
-            return df
+            return self._read_zip_csv_polars(z, file)
 
         def parse_time_col(time_col: str) -> pl.Expr:
             # ERCOT timestamps are MM/DD/YYYY, with or without seconds. Parse
@@ -2933,18 +3065,24 @@ class Ercot(ISOBase):
             )
             return utils.move_cols_to_front(df, ["Interval Start", "Interval End"])
 
-        def localize_sced_timestamp(df: pl.DataFrame) -> pl.DataFrame:
-            """Localize SCED Timestamp without adding Interval Start/End."""
-            df = df.rename({"SCED Time Stamp": "SCED Timestamp"}, strict=False)
-            return df.with_columns(
-                parse_time_col("SCED Timestamp").dt.replace_time_zone(
-                    self.default_timezone,
-                    ambiguous=repeated_hour_ambiguous,
-                ),
+        localize_sced_timestamp = self._localize_sced_timestamp_polars
+
+        if process:
+            logger.info("Processing 60 day SCED disclosure data")
+
+        # Each dataset is processed immediately after its read so the raw
+        # frame (several times larger than the processed one) is freed before
+        # the next file is read, keeping peak memory to roughly one raw frame.
+        load_resource = localize_sced_timestamp(read_zip_csv(load_resource_file))
+        if process:
+            load_resource = process_sced_load(
+                load_resource,
+                output_format=output_format,
             )
 
-        load_resource = localize_sced_timestamp(read_zip_csv(load_resource_file))
         gen_resource = localize_sced_timestamp(read_zip_csv(gen_resource_file))
+        if process:
+            gen_resource = process_sced_gen(gen_resource, output_format=output_format)
 
         # no repeated hour flag like other ERCOT data
         # likely will error on DST change
@@ -2953,15 +3091,28 @@ class Ercot(ISOBase):
             time_col="Interval Time",
             is_interval_end=True,
         )
+        if process:
+            smne = smne.rename(
+                {
+                    "Resource Code": "Resource Name",
+                },
+            )
 
         # Skip ESR from the main disclosure file if we need correction data
         esr = None
         if not skip_esr and esr_file:
             esr = localize_sced_timestamp(read_zip_csv(esr_file))
+            if process:
+                esr = process_sced_esr(esr, output_format=output_format)
 
         as_offer_updates = (
             read_zip_csv(as_offer_updates_file) if as_offer_updates_file else None
         )
+        if process and as_offer_updates is not None:
+            as_offer_updates = self._parse_doc_polars(as_offer_updates)
+            as_offer_updates = process_sced_as_offer_updates_in_op_hour(
+                as_offer_updates,
+            )
 
         # Process Resource AS Offers - has SCED Timestamp like other SCED data
         resource_as_offers = None
@@ -2969,27 +3120,7 @@ class Ercot(ISOBase):
             resource_as_offers = localize_sced_timestamp(
                 read_zip_csv(resource_as_offers_file),
             )
-
-        if process:
-            logger.info("Processing 60 day SCED disclosure data")
-            load_resource = process_sced_load(
-                load_resource,
-                output_format=output_format,
-            )
-            gen_resource = process_sced_gen(gen_resource, output_format=output_format)
-            smne = smne.rename(
-                {
-                    "Resource Code": "Resource Name",
-                },
-            )
-            if esr is not None:
-                esr = process_sced_esr(esr, output_format=output_format)
-            if as_offer_updates is not None:
-                as_offer_updates = self.parse_doc(as_offer_updates.to_pandas())
-                as_offer_updates = process_sced_as_offer_updates_in_op_hour(
-                    as_offer_updates,
-                )
-            if resource_as_offers is not None:
+            if process:
                 resource_as_offers = process_sced_resource_as_offers(
                     resource_as_offers,
                     output_format=output_format,
@@ -3023,7 +3154,7 @@ class Ercot(ISOBase):
         process: bool = False,
         verbose: bool = False,
         output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
-    ) -> pd.DataFrame | pl.DataFrame | None:
+    ) -> pl.DataFrame | None:
         """Fetch ESR data from the supplemental correction file for specific dates.
 
         The ESR supplemental correction file was published on Feb 5, 2026 and contains
@@ -3079,14 +3210,9 @@ class Ercot(ISOBase):
         if verbose:
             logger.info(f"Reading ESR correction data from {target_file}")
 
-        esr = pd.read_csv(z.open(target_file))
-
         # Localize the SCED Timestamp
-        esr = esr.rename(columns={"SCED Time Stamp": "SCED Timestamp"})
-        esr["SCED Timestamp"] = pd.to_datetime(esr["SCED Timestamp"])
-        esr["SCED Timestamp"] = esr["SCED Timestamp"].dt.tz_localize(
-            self.default_timezone,
-            ambiguous=esr["Repeated Hour Flag"] == "N",
+        esr = self._localize_sced_timestamp_polars(
+            self._read_zip_csv_polars(z, target_file),
         )
 
         if process:
@@ -3180,14 +3306,9 @@ class Ercot(ISOBase):
             if verbose:
                 logger.info(f"Reading supplemental data from {target_file}")
 
-            df = pd.read_csv(z.open(target_file))
-
             # Localize SCED Timestamp
-            df = df.rename(columns={"SCED Time Stamp": "SCED Timestamp"})
-            df["SCED Timestamp"] = pd.to_datetime(df["SCED Timestamp"])
-            df["SCED Timestamp"] = df["SCED Timestamp"].dt.tz_localize(
-                self.default_timezone,
-                ambiguous=df["Repeated Hour Flag"] == "N",
+            df = self._localize_sced_timestamp_polars(
+                self._read_zip_csv_polars(z, target_file),
             )
 
             if process:
@@ -3203,7 +3324,7 @@ class Ercot(ISOBase):
         process: bool = False,
         verbose: bool = False,
         output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
-    ) -> pd.DataFrame | pl.DataFrame | None:
+    ) -> pl.DataFrame | None:
         """Fetch SCED Resource AS Offers data from the supplemental file for
         data dates Dec 5, 2025 through Feb 2, 2026.
 
@@ -3263,16 +3384,11 @@ class Ercot(ISOBase):
                 f"Reading SCED Resource AS Offers supplemental data from {target_file}",
             )
 
-        df = pd.read_csv(z.open(target_file))
-
         # Localize SCED Timestamp (column is already named "SCED Timestamp"
         # in the supplemental file, but rename defensively in case a future
         # supplemental reverts to "SCED Time Stamp").
-        df = df.rename(columns={"SCED Time Stamp": "SCED Timestamp"})
-        df["SCED Timestamp"] = pd.to_datetime(df["SCED Timestamp"])
-        df["SCED Timestamp"] = df["SCED Timestamp"].dt.tz_localize(
-            self.default_timezone,
-            ambiguous=df["Repeated Hour Flag"] == "N",
+        df = self._localize_sced_timestamp_polars(
+            self._read_zip_csv_polars(z, target_file),
         )
 
         if process:
@@ -3397,61 +3513,57 @@ class Ercot(ISOBase):
                 if file in f:
                     files[key] = f
 
+        file_to_function = {
+            DAM_GEN_RESOURCE_KEY: process_dam_gen,
+            DAM_LOAD_RESOURCE_KEY: process_dam_load,
+            DAM_GEN_RESOURCE_AS_OFFERS_KEY: process_dam_or_gen_load_as_offers,
+            DAM_LOAD_RESOURCE_AS_OFFERS_KEY: process_dam_or_gen_load_as_offers,
+            DAM_ENERGY_ONLY_OFFER_AWARDS_KEY: process_dam_energy_only_offer_awards,
+            DAM_ENERGY_ONLY_OFFERS_KEY: process_dam_energy_only_offers,
+            DAM_PTP_OBLIGATION_BID_AWARDS_KEY: process_dam_ptp_obligation_bid_awards,  # noqa
+            DAM_PTP_OBLIGATION_BIDS_KEY: process_dam_ptp_obligation_bids,
+            DAM_ENERGY_BID_AWARDS_KEY: process_dam_energy_bid_awards,
+            DAM_ENERGY_BIDS_KEY: process_dam_energy_bids,
+            DAM_PTP_OBLIGATION_OPTION_KEY: process_dam_ptp_obligation_option,
+            DAM_PTP_OBLIGATION_OPTION_AWARDS_KEY: process_dam_ptp_obligation_option_awards,  # noqa
+            DAM_ESR_KEY: process_dam_esr,
+            DAM_ESR_AS_OFFERS_KEY: process_dam_esr_as_offers,
+            DAM_AS_ONLY_AWARDS_KEY: process_dam_as_only_awards,
+            DAM_AS_ONLY_OFFERS_KEY: process_dam_as_only_offers,
+        }
+
+        # These process functions accept output_format for curve extraction
+        supports_output_format = {
+            DAM_GEN_RESOURCE_KEY,
+            DAM_ESR_KEY,
+            DAM_ENERGY_ONLY_OFFERS_KEY,
+            DAM_ENERGY_BIDS_KEY,
+            DAM_GEN_RESOURCE_AS_OFFERS_KEY,
+            DAM_LOAD_RESOURCE_AS_OFFERS_KEY,
+            DAM_ESR_AS_OFFERS_KEY,
+            DAM_AS_ONLY_OFFERS_KEY,
+        }
+
         data = {}
 
+        # Each file is processed immediately after its read so the raw frame
+        # is freed before the next file is read, keeping peak memory to
+        # roughly one raw frame.
         for key, file in files.items():
-            doc = pd.read_csv(z.open(file))
+            doc = self._read_zip_csv_polars(z, file)
             # weird that these files dont have this column like all other ERCOT files
             # add so we can parse
-            doc["DSTFlag"] = "N"
-            data[key] = self.parse_doc(doc, verbose=verbose)
+            doc = doc.with_columns(pl.lit("N").alias("DSTFlag"))
+            doc = self._parse_doc_polars(doc)
 
-        if process:
-            file_to_function = {
-                DAM_GEN_RESOURCE_KEY: process_dam_gen,
-                DAM_LOAD_RESOURCE_KEY: process_dam_load,
-                DAM_GEN_RESOURCE_AS_OFFERS_KEY: process_dam_or_gen_load_as_offers,
-                DAM_LOAD_RESOURCE_AS_OFFERS_KEY: process_dam_or_gen_load_as_offers,
-                DAM_ENERGY_ONLY_OFFER_AWARDS_KEY: process_dam_energy_only_offer_awards,
-                DAM_ENERGY_ONLY_OFFERS_KEY: process_dam_energy_only_offers,
-                DAM_PTP_OBLIGATION_BID_AWARDS_KEY: process_dam_ptp_obligation_bid_awards,  # noqa
-                DAM_PTP_OBLIGATION_BIDS_KEY: process_dam_ptp_obligation_bids,
-                DAM_ENERGY_BID_AWARDS_KEY: process_dam_energy_bid_awards,
-                DAM_ENERGY_BIDS_KEY: process_dam_energy_bids,
-                DAM_PTP_OBLIGATION_OPTION_KEY: process_dam_ptp_obligation_option,
-                DAM_PTP_OBLIGATION_OPTION_AWARDS_KEY: process_dam_ptp_obligation_option_awards,  # noqa
-                DAM_ESR_KEY: process_dam_esr,
-                DAM_ESR_AS_OFFERS_KEY: process_dam_esr_as_offers,
-                DAM_AS_ONLY_AWARDS_KEY: process_dam_as_only_awards,
-                DAM_AS_ONLY_OFFERS_KEY: process_dam_as_only_offers,
-            }
+            if process:
+                process_func = file_to_function[key]
+                if key in supports_output_format:
+                    doc = process_func(doc, output_format=output_format)
+                else:
+                    doc = process_func(doc)
 
-            # These process functions accept output_format for curve extraction
-            supports_output_format = {
-                DAM_GEN_RESOURCE_KEY,
-                DAM_ESR_KEY,
-                DAM_ENERGY_ONLY_OFFERS_KEY,
-                DAM_ENERGY_BIDS_KEY,
-                DAM_GEN_RESOURCE_AS_OFFERS_KEY,
-                DAM_LOAD_RESOURCE_AS_OFFERS_KEY,
-                DAM_ESR_AS_OFFERS_KEY,
-                DAM_AS_ONLY_OFFERS_KEY,
-            }
-
-            for file_name, process_func in file_to_function.items():
-                if file_name in data:
-                    if file_name in supports_output_format:
-                        data[file_name] = process_func(
-                            data[file_name],
-                            output_format=output_format,
-                        )
-                    else:
-                        data[file_name] = process_func(data[file_name])
-
-        data = {
-            key: pl.from_pandas(value) if isinstance(value, pd.DataFrame) else value
-            for key, value in data.items()
-        }
+            data[key] = doc
 
         return data
 

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -1,5 +1,8 @@
 import datetime
 import io
+import os
+import shutil
+import tempfile
 import time
 import warnings
 from dataclasses import dataclass
@@ -2837,107 +2840,135 @@ class Ercot(ISOBase):
         assert gen_resource_file, "Could not find gen resource file"
         assert smne_file, "Could not find smne file"
 
-        load_resource = pd.read_csv(z.open(load_resource_file))
-        gen_resource = pd.read_csv(z.open(gen_resource_file))
-        smne = pd.read_csv(z.open(smne_file))
-        # Skip ESR from the main disclosure file if we need correction data
-        esr = None
-        if not skip_esr and esr_file:
-            esr = pd.read_csv(z.open(esr_file))
-        as_offer_updates = (
-            pd.read_csv(z.open(as_offer_updates_file))
-            if as_offer_updates_file
-            else None
-        )
-        resource_as_offers = (
-            pd.read_csv(z.open(resource_as_offers_file))
-            if resource_as_offers_file and not skip_resource_as_offers
-            else None
+        def read_zip_csv(file: str) -> pl.DataFrame:
+            # Extract to a temp file instead of reading bytes into memory so
+            # polars can mmap the CSV; keeps peak RSS at ~the final frame size
+            # rather than frame + full decompressed CSV bytes.
+            with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+                with z.open(file) as f:
+                    shutil.copyfileobj(f, tmp)
+                tmp_path = tmp.name
+            try:
+                df = pl.read_csv(tmp_path, infer_schema_length=None)
+            finally:
+                os.unlink(tmp_path)
+            # ERCOT CSVs quote empty fields ("") and write floats without a
+            # leading zero (e.g. "-.5"), both of which polars leaves as String
+            # columns where pandas produced float64 (with NaN for empties).
+            # Normalize empty strings to null and cast a String column to
+            # Float64 whenever every non-empty value parses as a number,
+            # matching the pandas.read_csv behavior. Columns are replaced one
+            # at a time to keep transient memory to a single column.
+            for col, dtype in df.schema.items():
+                if dtype != pl.String:
+                    continue
+                cleaned = df[col].replace("", None)
+                parsed = cleaned.cast(pl.Float64, strict=False)
+                if parsed.null_count() == cleaned.null_count():
+                    df = df.with_columns(parsed.rename(col))
+            return df
+
+        def parse_time_col(time_col: str) -> pl.Expr:
+            # ERCOT timestamps are MM/DD/YYYY, with or without seconds. Parse
+            # with explicit formats so polars never falls back to DD/MM.
+            return pl.coalesce(
+                pl.col(time_col).str.to_datetime("%m/%d/%Y %H:%M:%S", strict=False),
+                pl.col(time_col).str.to_datetime("%m/%d/%Y %H:%M", strict=False),
+            ).alias(time_col)
+
+        # Repeated Hour Flag is Y during the repeated hour
+        # So, it's N during DST And Y during Standard Time
+        # Pandas wants True for DST and False for Standard Time
+        # during ambiguous times
+        repeated_hour_ambiguous = (
+            pl.when(pl.col("Repeated Hour Flag") == "N")
+            .then(pl.lit("earliest"))
+            .otherwise(pl.lit("latest"))
         )
 
         def handle_time(
-            df: pd.DataFrame,
+            df: pl.DataFrame,
             time_col: str,
             is_interval_end: bool = False,
         ) -> pl.DataFrame:
-            df[time_col] = pd.to_datetime(df[time_col])
+            df = df.with_columns(parse_time_col(time_col))
 
             if "Repeated Hour Flag" in df.columns:
-                # Repeated Hour Flag is Y during the repeated hour
-                # So, it's N during DST And Y during Standard Time
-                # Pandas wants True for DST and False for Standard Time
-                # during ambiguous times
-                df[time_col] = df[time_col].dt.tz_localize(
-                    self.default_timezone,
-                    ambiguous=df["Repeated Hour Flag"] == "N",
+                df = df.with_columns(
+                    pl.col(time_col).dt.replace_time_zone(
+                        self.default_timezone,
+                        ambiguous=repeated_hour_ambiguous,
+                    ),
                 )
-                interval_start = df[time_col].dt.round(
-                    "15min",
-                    ambiguous=df["Repeated Hour Flag"] == "N",
-                )
-
             else:
                 # for SMNE data
-                df[time_col] = (
-                    df.sort_values("Interval Number", ascending=True)
-                    .groupby("Resource Code")[time_col]
-                    .transform(
-                        lambda x: x.dt.tz_localize(
-                            self.default_timezone,
-                            ambiguous="infer",
-                        ),
-                    )
+                df = utils.localize_ambiguous_infer_polars(
+                    df,
+                    time_col=time_col,
+                    tz=self.default_timezone,
+                    group_cols=["Resource Code"],
                 )
 
-                # convert to utc
-                # bc round doesn't work with dst changes
-                # without Repeated Hour Flag
-                interval_start = (
-                    df[time_col]
-                    .dt.tz_convert("utc")
-                    .dt.round("15min")
-                    .dt.tz_convert(self.default_timezone)
-                )
+            # convert to utc
+            # bc round doesn't work with dst changes
+            # without Repeated Hour Flag
+            rounded = (
+                pl.col(time_col)
+                .dt.convert_time_zone("UTC")
+                .dt.round("15m")
+                .dt.convert_time_zone(self.default_timezone)
+            )
 
-            interval_length = pd.Timedelta(minutes=15)
+            interval_length = pl.duration(minutes=15)
             if is_interval_end:
-                interval_end = interval_start
-                interval_start = interval_start - interval_length
+                interval_start = rounded - interval_length
+                interval_end = rounded
             else:
-                interval_end = interval_start + interval_length
+                interval_start = rounded
+                interval_end = rounded + interval_length
 
-            df.insert(0, "Interval Start", interval_start)
-            df.insert(
-                1,
-                "Interval End",
-                interval_end,
+            df = df.with_columns(
+                interval_start.alias("Interval Start"),
+                interval_end.alias("Interval End"),
             )
+            return utils.move_cols_to_front(df, ["Interval Start", "Interval End"])
 
-            return pl.from_pandas(df)
-
-        def localize_sced_timestamp(df: pd.DataFrame) -> pd.DataFrame:
+        def localize_sced_timestamp(df: pl.DataFrame) -> pl.DataFrame:
             """Localize SCED Timestamp without adding Interval Start/End."""
-            df = df.rename(columns={"SCED Time Stamp": "SCED Timestamp"})
-            df["SCED Timestamp"] = pd.to_datetime(df["SCED Timestamp"])
-            df["SCED Timestamp"] = df["SCED Timestamp"].dt.tz_localize(
-                self.default_timezone,
-                ambiguous=df["Repeated Hour Flag"] == "N",
+            df = df.rename({"SCED Time Stamp": "SCED Timestamp"}, strict=False)
+            return df.with_columns(
+                parse_time_col("SCED Timestamp").dt.replace_time_zone(
+                    self.default_timezone,
+                    ambiguous=repeated_hour_ambiguous,
+                ),
             )
-            return df
 
-        load_resource = localize_sced_timestamp(load_resource)
-        gen_resource = localize_sced_timestamp(gen_resource)
+        load_resource = localize_sced_timestamp(read_zip_csv(load_resource_file))
+        gen_resource = localize_sced_timestamp(read_zip_csv(gen_resource_file))
 
         # no repeated hour flag like other ERCOT data
         # likely will error on DST change
-        smne = handle_time(smne, time_col="Interval Time", is_interval_end=True)
+        smne = handle_time(
+            read_zip_csv(smne_file),
+            time_col="Interval Time",
+            is_interval_end=True,
+        )
 
-        if esr is not None:
-            esr = localize_sced_timestamp(esr)
+        # Skip ESR from the main disclosure file if we need correction data
+        esr = None
+        if not skip_esr and esr_file:
+            esr = localize_sced_timestamp(read_zip_csv(esr_file))
+
+        as_offer_updates = (
+            read_zip_csv(as_offer_updates_file) if as_offer_updates_file else None
+        )
 
         # Process Resource AS Offers - has SCED Timestamp like other SCED data
-        if resource_as_offers is not None:
-            resource_as_offers = localize_sced_timestamp(resource_as_offers)
+        resource_as_offers = None
+        if resource_as_offers_file and not skip_resource_as_offers:
+            resource_as_offers = localize_sced_timestamp(
+                read_zip_csv(resource_as_offers_file),
+            )
 
         if process:
             logger.info("Processing 60 day SCED disclosure data")
@@ -2954,7 +2985,7 @@ class Ercot(ISOBase):
             if esr is not None:
                 esr = process_sced_esr(esr, output_format=output_format)
             if as_offer_updates is not None:
-                as_offer_updates = self.parse_doc(as_offer_updates).to_pandas()
+                as_offer_updates = self.parse_doc(as_offer_updates.to_pandas())
                 as_offer_updates = process_sced_as_offer_updates_in_op_hour(
                     as_offer_updates,
                 )
@@ -3373,7 +3404,7 @@ class Ercot(ISOBase):
             # weird that these files dont have this column like all other ERCOT files
             # add so we can parse
             doc["DSTFlag"] = "N"
-            data[key] = self.parse_doc(doc, verbose=verbose).to_pandas()
+            data[key] = self.parse_doc(doc, verbose=verbose)
 
         if process:
             file_to_function = {

--- a/gridstatus/ercot_60d_utils.py
+++ b/gridstatus/ercot_60d_utils.py
@@ -554,6 +554,34 @@ def make_storage_resources(data):
     return pl.from_pandas(storage_resources)
 
 
+def extract_curve_as_pg_string_expr(mw_cols, price_cols):
+    """Polars expression version of extract_curve_as_pg_string().
+
+    Builds PG array strings like '{{100.0,25.5},{200.0,60.0}}' from paired
+    MW/price columns without leaving polars (no pandas copy of the frame).
+    """
+    pieces = [
+        pl.when(pl.col(mw).is_not_null() & pl.col(price).is_not_null()).then(
+            pl.concat_str(
+                [
+                    pl.lit("{"),
+                    pl.col(mw).round(2).cast(pl.Float64).cast(pl.String),
+                    pl.lit(","),
+                    pl.col(price).round(2).cast(pl.Float64).cast(pl.String),
+                    pl.lit("}"),
+                ],
+            ),
+        )
+        for mw, price in zip(mw_cols, price_cols)
+    ]
+    joined = pl.concat_str(pieces, separator=",", ignore_nulls=True)
+    return (
+        pl.when(joined != "")
+        .then(pl.concat_str([pl.lit("{"), joined, pl.lit("}")]))
+        .otherwise(None)
+    )
+
+
 def extract_curve_as_pg_string(df, mw_cols, price_cols):
     """Like extract_curve() but returns PG array strings directly.
 
@@ -1505,6 +1533,105 @@ def process_sced_as_offer_updates_in_op_hour(df):
     return pl.from_pandas(df)
 
 
+def _process_sced_resource_as_offers_polars(df: pl.DataFrame) -> pl.DataFrame:
+    """Polars-native version of process_sced_resource_as_offers() for the
+    PG_ARRAY_AS_STRING output format.
+
+    Mirrors the pandas logic below (suffix renames, curve-type classification,
+    per-AS-type curve extraction) while keeping the largest SCED disclosure
+    frame in polars the whole time.
+    """
+    new_to_old_suffix = {
+        "_REGUP": "_URS",
+        "_REGDN": "_DRS",
+        "_RRSPFR": "_RRSPF",
+        "_RRSUFR": "_RRSUF",
+        "_RRSFFR": "_RRSFF",
+        "_NSPIN": "_NS",
+    }
+
+    def _rename_suffix(col: str) -> str:
+        for new_suffix, old_suffix in new_to_old_suffix.items():
+            if col.endswith(new_suffix):
+                return col[: -len(new_suffix)] + old_suffix
+        return col
+
+    df = df.rename({c: _rename_suffix(c) for c in df.columns})
+
+    price_cols = [c for c in df.columns if c.startswith("PRICE")]
+    drs_cols = [c for c in price_cols if c.endswith("_DRS")]
+    ns_cols = [c for c in price_cols if c.endswith("_NS")]
+    non_drs_cols = [c for c in price_cols if not c.endswith("_DRS")]
+    non_drs_ns_ecrs_cols = [c for c in non_drs_cols if not c.endswith(("_NS", "_ECRS"))]
+
+    def _has_value(cols: list[str]) -> pl.Expr:
+        # NaN values are treated as "no value" (same as zero), matching the
+        # pandas fillna(0) behavior for ERCOT corrected files (April 4, 2026+).
+        return pl.any_horizontal(pl.col(c).fill_null(0) != 0 for c in cols)
+
+    has_drs = _has_value(drs_cols)
+    has_non_drs = _has_value(non_drs_cols)
+    has_ns = _has_value(ns_cols)
+    has_non_drs_ns_ecrs = _has_value(non_drs_ns_ecrs_cols)
+
+    df = df.with_columns(
+        pl.when(has_non_drs & has_non_drs_ns_ecrs)
+        .then(pl.lit("Online"))
+        .when(has_ns & ~has_drs & ~has_non_drs_ns_ecrs)
+        .then(pl.lit("Offline"))
+        .when(has_drs & ~has_non_drs)
+        .then(pl.lit("Regulation Down"))
+        .otherwise(pl.lit("unknown"))
+        .alias("Curve Type"),
+    )
+
+    if df["Curve Type"].eq("unknown").any():
+        raise ValueError("Unknown curve type found")
+
+    as_type_mapping = {
+        "URS": "URS Offer Curve",
+        "DRS": "DRS Offer Curve",
+        "RRSPF": "RRSPFR Offer Curve",
+        "RRSUF": "RRSUFR Offer Curve",
+        "RRSFF": "RRSFFR Offer Curve",
+        "NS": "NonSpin Offer Curve",
+        "ECRS": "ECRS Offer Curve",
+    }
+
+    qty_cols = sorted([col for col in df.columns if col.startswith("QUANTITY_MW")])
+    block_count = len(qty_cols)
+
+    if block_count == 0:
+        return df
+
+    mw_cols = [f"QUANTITY_MW{i}" for i in range(1, block_count + 1)]
+
+    curve_exprs = []
+    for as_suffix, curve_col in as_type_mapping.items():
+        as_price_cols = [f"PRICE{i}_{as_suffix}" for i in range(1, block_count + 1)]
+        as_price_cols = [c for c in as_price_cols if c in df.columns]
+
+        if not as_price_cols:
+            curve_exprs.append(pl.lit(None, dtype=pl.String).alias(curve_col))
+            continue
+
+        curve_exprs.append(
+            extract_curve_as_pg_string_expr(
+                mw_cols=mw_cols[: len(as_price_cols)],
+                price_cols=as_price_cols,
+            ).alias(curve_col),
+        )
+
+    df = df.with_columns(curve_exprs)
+
+    df = df.select(SCED_RESOURCE_AS_OFFERS_COLUMNS)
+    return df.with_columns(
+        pl.col(c).cast(pl.Categorical)
+        for c, dtype in df.schema.items()
+        if dtype == pl.String and not c.endswith("Curve")
+    )
+
+
 def process_sced_resource_as_offers(
     df,
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
@@ -1527,6 +1654,11 @@ def process_sced_resource_as_offers(
             directly, using ~3x less peak memory.
     """
     if isinstance(df, pl.DataFrame):
+        # The polars-native path avoids materializing a pandas copy of this
+        # frame (the largest in the SCED disclosure). Only the PG-string
+        # format is supported natively; the list format still needs pandas.
+        if output_format == CurveOutputFormat.PG_ARRAY_AS_STRING:
+            return _process_sced_resource_as_offers_polars(df)
         df = df.to_pandas()
     # ERCOT renamed the AS-price column suffixes in late March 2026
     # (_URS->_REGUP, _DRS->_REGDN, _NS->_NSPIN, _RRSPF->_RRSPFR,

--- a/gridstatus/ercot_60d_utils.py
+++ b/gridstatus/ercot_60d_utils.py
@@ -2,6 +2,7 @@ from enum import StrEnum
 
 import numpy as np
 import pandas as pd
+import polars as pl
 
 from gridstatus.gs_logging import setup_gs_logger
 
@@ -428,6 +429,8 @@ def _categorize_strings(df):
     Curve columns (ending in 'Curve') and 'Block Indicators' contain structured
     data (lists or serialized arrays) that should not be categorized.
     """
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     df = df.copy()
     for col in df.select_dtypes(include=["object"]).columns:
         if col.endswith("Curve") or col == "Block Indicators":
@@ -548,7 +551,7 @@ def make_storage_resources(data):
         )[cols]
     )
 
-    return storage_resources
+    return pl.from_pandas(storage_resources)
 
 
 def extract_curve_as_pg_string(df, mw_cols, price_cols):
@@ -557,6 +560,8 @@ def extract_curve_as_pg_string(df, mw_cols, price_cols):
     Returns pd.Series of strings like '{{100.0,25.5},{200.0,60.0}}'
     instead of Python list-of-lists. ~3x less peak memory.
     """
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     mw_arr = df[mw_cols].round(2).values  # (N, blocks) float64
     price_arr = df[price_cols].round(2).values
     valid = ~(np.isnan(mw_arr) | np.isnan(price_arr))
@@ -602,6 +607,8 @@ def extract_curve(
             per cell. CurveOutputFormat.PG_ARRAY_AS_STRING returns PG array strings like
             '{{mw,price},{mw,price}}' directly, using ~3x less peak memory.
     """
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     if mw_cols is None or price_cols is None:
         # Auto-detect by prefix
         mw_cols = [x for x in df.columns if x.startswith(curve_name + mw_suffix)]
@@ -636,6 +643,8 @@ def process_dam_gen(
     df,
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
 ):
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     time_cols = [
         "Interval Start",
         "Interval End",
@@ -692,10 +701,12 @@ def process_dam_gen(
     df = df[time_cols + all_cols]
 
     df = _categorize_strings(df)
-    return df
+    return pl.from_pandas(df)
 
 
 def process_dam_load(df):
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     time_cols = [
         "Time",
         "Interval Start",
@@ -742,13 +753,15 @@ def process_dam_load(df):
     )
 
     df = _categorize_strings(df)
-    return df
+    return pl.from_pandas(df)
 
 
 def process_dam_esr(
     df,
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
 ):
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     time_cols = [
         "Interval Start",
         "Interval End",
@@ -805,13 +818,15 @@ def process_dam_esr(
     df = df[time_cols + all_cols]
 
     df = _categorize_strings(df)
-    return df
+    return pl.from_pandas(df)
 
 
 def process_dam_esr_as_offers(
     df,
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
 ):
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     return process_as_offer_curves(df, output_format=output_format)
 
 
@@ -819,6 +834,8 @@ def process_dam_or_gen_load_as_offers(
     df,
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
 ):
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     if "QSE" not in df.columns:
         # after Interval End
         index = df.columns.tolist().index("Interval End") + 1
@@ -843,6 +860,8 @@ def process_as_offer_curves(
     df,
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
 ):
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     block_columns = [col for col in df.columns if col.startswith("BLOCK INDICATOR")]
     block_count = len(block_columns)
 
@@ -989,10 +1008,12 @@ def process_as_offer_curves(
     ]
 
     df = _categorize_strings(df)
-    return df
+    return pl.from_pandas(df)
 
 
 def process_dam_energy_only_offer_awards(df):
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     df = df.rename(
         columns={"Settlement Point": "Settlement Point Name", "QSE Name": "QSE"},
     )
@@ -1001,13 +1022,15 @@ def process_dam_energy_only_offer_awards(df):
         ["Interval Start", "Settlement Point Name"],
     )
     df = _categorize_strings(df)
-    return df
+    return pl.from_pandas(df)
 
 
 def process_dam_energy_only_offers(
     df,
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
 ):
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     df = df.rename(
         columns={
             "Settlement Point": "Settlement Point Name",
@@ -1030,28 +1053,34 @@ def process_dam_energy_only_offers(
         ["Interval Start", "Settlement Point Name"],
     )
     df = _categorize_strings(df)
-    return df
+    return pl.from_pandas(df)
 
 
 def process_dam_ptp_obligation_bid_awards(df):
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     df = df.rename(columns={"QSE Name": "QSE"})
 
     df = df[DAM_PTP_OBLIGATION_BID_AWARDS_COLUMNS].sort_values(
         ["Interval Start", "QSE"],
     )
     df = _categorize_strings(df)
-    return df
+    return pl.from_pandas(df)
 
 
 def process_dam_ptp_obligation_bids(df):
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     df = df.rename(columns={"QSE Name": "QSE"})
 
     df = df[DAM_PTP_OBLIGATION_BIDS_COLUMNS].sort_values(["Interval Start", "QSE"])
     df = _categorize_strings(df)
-    return df
+    return pl.from_pandas(df)
 
 
 def process_dam_energy_bid_awards(df):
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     df = df.rename(
         columns={"Settlement Point": "Settlement Point Name", "QSE Name": "QSE"},
     )
@@ -1060,13 +1089,15 @@ def process_dam_energy_bid_awards(df):
         ["Interval Start", "Settlement Point Name"],
     )
     df = _categorize_strings(df)
-    return df
+    return pl.from_pandas(df)
 
 
 def process_dam_energy_bids(
     df,
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
 ):
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     df = df.rename(
         columns={
             "Settlement Point": "Settlement Point Name",
@@ -1089,28 +1120,34 @@ def process_dam_energy_bids(
         ["Interval Start", "Settlement Point Name"],
     )
     df = _categorize_strings(df)
-    return df
+    return pl.from_pandas(df)
 
 
 def process_dam_ptp_obligation_option(df):
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     df = df.rename(columns={"QSE Name": "QSE"})
 
     df = df[DAM_PTP_OBLIGATION_OPTION_COLUMNS].sort_values(["Interval Start", "QSE"])
     df = _categorize_strings(df)
-    return df
+    return pl.from_pandas(df)
 
 
 def process_dam_ptp_obligation_option_awards(df):
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     df = df.rename(columns={"QSE Name": "QSE"})
 
     df = df[DAM_PTP_OBLIGATION_OPTION_AWARDS_COLUMNS].sort_values(
         ["Interval Start", "QSE"],
     )
     df = _categorize_strings(df)
-    return df
+    return pl.from_pandas(df)
 
 
 def process_dam_as_only_awards(df):
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     df = df.rename(
         columns={
             "QSE Name": "QSE",
@@ -1131,13 +1168,15 @@ def process_dam_as_only_awards(df):
         ["Interval Start", "QSE", "AS Type", "Offer ID"],
     )
     df = _categorize_strings(df)
-    return df
+    return pl.from_pandas(df)
 
 
 def process_dam_as_only_offers(
     df,
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
 ):
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     df = df.rename(columns={"QSE Name": "QSE"})
 
     df["Offer Curve"] = extract_curve(
@@ -1156,13 +1195,15 @@ def process_dam_as_only_offers(
         ["Interval Start", "QSE", "AS Type", "Offer ID"],
     )
     df = _categorize_strings(df)
-    return df
+    return pl.from_pandas(df)
 
 
 def process_sced_gen(
     df,
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
 ):
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     # Strip whitespace from column names
     df.columns = df.columns.str.strip()
     time_cols = [
@@ -1258,13 +1299,15 @@ def process_sced_gen(
     )
 
     df = _categorize_strings(df[SCED_GEN_RESOURCE_COLUMNS])
-    return df
+    return pl.from_pandas(df)
 
 
 def process_sced_load(
     df,
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
 ):
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     time_cols = [
         "SCED Timestamp",
     ]
@@ -1339,13 +1382,15 @@ def process_sced_load(
     )
 
     df = _categorize_strings(df[SCED_LOAD_RESOURCE_COLUMNS])
-    return df
+    return pl.from_pandas(df)
 
 
 def process_sced_esr(
     df,
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
 ):
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     time_cols = [
         "SCED Timestamp",
     ]
@@ -1443,7 +1488,7 @@ def process_sced_esr(
     )
 
     df = _categorize_strings(df[SCED_ESR_COLUMNS])
-    return df
+    return pl.from_pandas(df)
 
 
 def process_sced_as_offer_updates_in_op_hour(df):
@@ -1454,8 +1499,10 @@ def process_sced_as_offer_updates_in_op_hour(df):
 
     Expects df to already have Interval Start/End from parse_doc().
     """
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     df = _categorize_strings(df[SCED_AS_OFFER_UPDATES_IN_OP_HOUR_COLUMNS])
-    return df
+    return pl.from_pandas(df)
 
 
 def process_sced_resource_as_offers(
@@ -1479,6 +1526,8 @@ def process_sced_resource_as_offers(
             "pg_array_as_string" returns PG array strings like '{{mw,price},{mw,price}}'
             directly, using ~3x less peak memory.
     """
+    if isinstance(df, pl.DataFrame):
+        df = df.to_pandas()
     # ERCOT renamed the AS-price column suffixes in late March 2026
     # (_URS->_REGUP, _DRS->_REGDN, _NS->_NSPIN, _RRSPF->_RRSPFR,
     # _RRSUF->_RRSUFR, _RRSFF->_RRSFFR). Rename them back to the original names
@@ -1544,7 +1593,7 @@ def process_sced_resource_as_offers(
     block_count = len(qty_cols)
 
     if block_count == 0:
-        return df
+        return pl.from_pandas(df)
 
     # Extract MW column names (shared across all AS types)
     mw_cols = [f"QUANTITY_MW{i}" for i in range(1, block_count + 1)]
@@ -1576,7 +1625,7 @@ def process_sced_resource_as_offers(
         df.drop(columns=mw_cols, inplace=True, errors="ignore")
 
     df = _categorize_strings(df[SCED_RESOURCE_AS_OFFERS_COLUMNS])
-    return df
+    return pl.from_pandas(df)
 
 
 # # backup for more node names

--- a/gridstatus/ercot_60d_utils.py
+++ b/gridstatus/ercot_60d_utils.py
@@ -554,6 +554,26 @@ def make_storage_resources(data):
     return pl.from_pandas(storage_resources)
 
 
+def _categorize_strings_polars(df: pl.DataFrame) -> pl.DataFrame:
+    """Polars version of _categorize_strings(): cast String columns to
+    Categorical, skipping curve columns and Block Indicators."""
+    return df.with_columns(
+        pl.col(c).cast(pl.Categorical)
+        for c, dtype in df.schema.items()
+        if dtype == pl.String and not (c.endswith("Curve") or c == "Block Indicators")
+    )
+
+
+def _is_present(expr: pl.Expr) -> pl.Expr:
+    """Whether a numeric curve value is present: not null and not NaN.
+
+    Matches the np.isnan() checks in the pandas curve extractors, where both
+    missing fields (null) and explicit NaN values mark an absent pair.
+    """
+    value = expr.cast(pl.Float64)
+    return value.is_not_null() & value.is_not_nan()
+
+
 def extract_curve_as_pg_string_expr(mw_cols, price_cols):
     """Polars expression version of extract_curve_as_pg_string().
 
@@ -561,7 +581,9 @@ def extract_curve_as_pg_string_expr(mw_cols, price_cols):
     MW/price columns without leaving polars (no pandas copy of the frame).
     """
     pieces = [
-        pl.when(pl.col(mw).is_not_null() & pl.col(price).is_not_null()).then(
+        pl.when(
+            _is_present(pl.col(mw)) & _is_present(pl.col(price)),
+        ).then(
             pl.concat_str(
                 [
                     pl.lit("{"),
@@ -667,12 +689,53 @@ def extract_curve(
     return pd.Series(curves, index=df.index)
 
 
-def process_dam_gen(
-    df,
+def extract_curve_expr(mw_cols: list[str], price_cols: list[str]) -> pl.Expr:
+    """Polars expression version of extract_curve() for the LIST output
+    format.
+
+    Builds List(List(Float64)) cells like [[mw, price], ...] from paired
+    MW/price columns, with all-null rows becoming null cells.
+    """
+    pairs = [
+        pl.when(
+            _is_present(pl.col(mw)) & _is_present(pl.col(price)),
+        ).then(
+            pl.concat_arr(
+                [
+                    pl.col(mw).cast(pl.Float64).round(2),
+                    pl.col(price).cast(pl.Float64).round(2),
+                ],
+            ),
+        )
+        for mw, price in zip(mw_cols, price_cols)
+    ]
+    curve = pl.concat_list(pairs).list.drop_nulls()
+    return pl.when(curve.list.len() > 0).then(curve).cast(pl.List(pl.List(pl.Float64)))
+
+
+def _extract_curve_expr_by_prefix(
+    df: pl.DataFrame,
+    curve_name: str,
+    mw_suffix: str = "-MW",
+    price_suffix: str = "-Price",
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
-):
-    if isinstance(df, pl.DataFrame):
-        df = df.to_pandas()
+) -> pl.Expr | None:
+    """Prefix-detected polars version of extract_curve() supporting both
+    output formats. Returns None when the frame has no matching curve columns
+    (extract_curve() returned np.nan in that case)."""
+    mw_cols = [x for x in df.columns if x.startswith(curve_name + mw_suffix)]
+    price_cols = [x for x in df.columns if x.startswith(curve_name + price_suffix)]
+    if len(mw_cols) == 0 or len(price_cols) == 0:
+        return None
+    if output_format == CurveOutputFormat.PG_ARRAY_AS_STRING:
+        return extract_curve_as_pg_string_expr(mw_cols, price_cols)
+    return extract_curve_expr(mw_cols, price_cols)
+
+
+def process_dam_gen(
+    df: pl.DataFrame,
+    output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
+) -> pl.DataFrame:
     time_cols = [
         "Interval Start",
         "Interval End",
@@ -718,23 +781,29 @@ def process_dam_gen(
 
     curve = "QSE submitted Curve"
 
-    df[curve] = extract_curve(df, "QSE submitted Curve", output_format=output_format)
+    curve_expr = _extract_curve_expr_by_prefix(
+        df,
+        "QSE submitted Curve",
+        output_format=output_format,
+    )
+    if curve_expr is None:
+        curve_expr = pl.lit(None, dtype=pl.Float64)
+    df = df.with_columns(curve_expr.alias(curve))
 
     all_cols = resource_cols + telemetry_cols + energy_award_cols + as_cols + [curve]
 
-    for col in all_cols:
-        if col not in df.columns:
-            df[col] = np.nan
+    df = df.with_columns(
+        pl.lit(None, dtype=pl.Float64).alias(col)
+        for col in all_cols
+        if col not in df.columns
+    )
 
-    df = df[time_cols + all_cols]
+    df = df.select(time_cols + all_cols)
 
-    df = _categorize_strings(df)
-    return pl.from_pandas(df)
+    return _categorize_strings_polars(df)
 
 
-def process_dam_load(df):
-    if isinstance(df, pl.DataFrame):
-        df = df.to_pandas()
+def process_dam_load(df: pl.DataFrame) -> pl.DataFrame:
     time_cols = [
         "Time",
         "Interval Start",
@@ -766,30 +835,29 @@ def process_dam_load(df):
 
     all_cols = resource_cols + telemetry_cols + as_cols
 
-    for col in all_cols:
-        if col not in df.columns:
-            df[col] = np.nan
+    df = df.with_columns(
+        pl.lit(None, dtype=pl.Float64).alias(col)
+        for col in all_cols
+        if col not in df.columns
+    )
 
-    df = df[time_cols + all_cols]
+    df = df.select(time_cols + all_cols)
 
     # rename for consistency
     # with gen columns
     df = df.rename(
-        columns={
+        {
             "Load Resource Name": "Resource Name",
         },
     )
 
-    df = _categorize_strings(df)
-    return pl.from_pandas(df)
+    return _categorize_strings_polars(df)
 
 
 def process_dam_esr(
-    df,
+    df: pl.DataFrame,
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
-):
-    if isinstance(df, pl.DataFrame):
-        df = df.to_pandas()
+) -> pl.DataFrame:
     time_cols = [
         "Interval Start",
         "Interval End",
@@ -835,49 +903,52 @@ def process_dam_esr(
 
     curve = "QSE submitted Curve"
 
-    df[curve] = extract_curve(df, "QSE submitted Curve", output_format=output_format)
+    curve_expr = _extract_curve_expr_by_prefix(
+        df,
+        "QSE submitted Curve",
+        output_format=output_format,
+    )
+    if curve_expr is None:
+        curve_expr = pl.lit(None, dtype=pl.Float64)
+    df = df.with_columns(curve_expr.alias(curve))
 
     all_cols = resource_cols + telemetry_cols + energy_award_cols + as_cols + [curve]
 
-    for col in all_cols:
-        if col not in df.columns:
-            df[col] = np.nan
+    df = df.with_columns(
+        pl.lit(None, dtype=pl.Float64).alias(col)
+        for col in all_cols
+        if col not in df.columns
+    )
 
-    df = df[time_cols + all_cols]
+    df = df.select(time_cols + all_cols)
 
-    df = _categorize_strings(df)
-    return pl.from_pandas(df)
+    return _categorize_strings_polars(df)
 
 
 def process_dam_esr_as_offers(
-    df,
+    df: pl.DataFrame,
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
-):
-    if isinstance(df, pl.DataFrame):
-        df = df.to_pandas()
+) -> pl.DataFrame:
     return process_as_offer_curves(df, output_format=output_format)
 
 
 def process_dam_or_gen_load_as_offers(
-    df,
+    df: pl.DataFrame,
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
-):
-    if isinstance(df, pl.DataFrame):
-        df = df.to_pandas()
+) -> pl.DataFrame:
     if "QSE" not in df.columns:
         # after Interval End
-        index = df.columns.tolist().index("Interval End") + 1
-        df.insert(index, "QSE", np.nan)
+        df = df.with_columns(pl.lit(None, dtype=pl.Float64).alias("QSE"))
 
     if "DME" not in df.columns:
         # after QSE
-        index = df.columns.tolist().index("QSE") + 1
-        df.insert(index, "DME", np.nan)
+        df = df.with_columns(pl.lit(None, dtype=pl.Float64).alias("DME"))
 
     df = df.rename(
-        columns={
-            "Load Resource Name": "Resource Name",
-            "Generation Resource Name": "Resource Name",
+        {
+            old: "Resource Name"
+            for old in ("Load Resource Name", "Generation Resource Name")
+            if old in df.columns
         },
     )
 
@@ -885,11 +956,9 @@ def process_dam_or_gen_load_as_offers(
 
 
 def process_as_offer_curves(
-    df,
+    df: pl.DataFrame,
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
-):
-    if isinstance(df, pl.DataFrame):
-        df = df.to_pandas()
+) -> pl.DataFrame:
     block_columns = [col for col in df.columns if col.startswith("BLOCK INDICATOR")]
     block_count = len(block_columns)
 
@@ -936,25 +1005,48 @@ def process_as_offer_curves(
 
         ancillary_services_column_lists.append(service_columns)
 
+    group_keys = ["Interval Start", "Interval End", "Resource Name", "QSE", "DME"]
+
+    n_blocks_expr = (
+        pl.sum_horizontal(pl.col(c).is_not_null() for c in block_columns)
+        if block_columns
+        else pl.lit(0)
+    )
+    has_price_exprs = []
+    for index, column_list in enumerate(ancillary_services_column_lists):
+        price_columns = [c for c in column_list if c.startswith("PRICE")]
+        has_price_exprs.append(
+            (
+                pl.any_horizontal(pl.col(c).is_not_null() for c in price_columns)
+                if price_columns
+                else pl.lit(True)
+            ).alias(f"__has_price_{index}"),
+        )
+
+    df = df.with_columns(n_blocks_expr.alias("__n_blocks"), *has_price_exprs)
+    # Sort by the group keys with nulls last so group iteration order matches
+    # the old sorted pandas groupby; maintain_order keeps the original row
+    # order within groups.
+    df = df.sort(group_keys, nulls_last=True, maintain_order=True)
+
     constructed_data = []
 
     # Group by each interval and resource name because each resource can have multiple
     # rows at one interval. These rows represent different AS products.
-    for (interval_start, interval_end, resource_name, qse, dme), group in df.groupby(
-        # We must use dropna=False because QSE and DME may be all null
-        ["Interval Start", "Interval End", "Resource Name", "QSE", "DME"],
-        dropna=False,
-    ):
-        # Find the block list with the most non-null elements which represents the
-        # number of blocks where the resource made an offer
-        block_lists = (
-            group[block_columns].dropna(axis="columns", how="all").values.tolist()
-        )
+    # We must use dropna=False because QSE and DME may be all null (polars
+    # group_by keeps null keys by default).
+    for key, group in df.group_by(group_keys, maintain_order=True):
+        interval_start, interval_end, resource_name, qse, dme = key
 
-        max_block_list = max(
-            block_lists,
-            key=lambda x: len([elem for elem in x if not pd.isnull(elem)]),
-        )
+        # Find the block list with the most non-null elements which represents the
+        # number of blocks where the resource made an offer. Block columns that
+        # are all null within the group are dropped from the list.
+        block_row_idx = int(group["__n_blocks"].arg_max())
+        max_block_list = [
+            group[c][block_row_idx]
+            for c in block_columns
+            if group[c].null_count() < group.height
+        ]
 
         group_data = {
             "Interval Start": interval_start,
@@ -962,22 +1054,16 @@ def process_as_offer_curves(
             "QSE": qse,
             "DME": dme,
             "Resource Name": resource_name,
-            "Multi-Hour Block Flag": group["Multi-Hour Block Flag"].iloc[0],
+            "Multi-Hour Block Flag": group["Multi-Hour Block Flag"][0],
             "Block Indicators": max_block_list,
         }
 
         # Iterate through each ancillary service and extract the offer curve data
         for index, column_list in enumerate(ancillary_services_column_lists):
             # Drop rows where all prices are NaN. This should leave us with only 1 row
-            price_columns = [c for c in column_list if c.startswith("PRICE")]
+            subset = group.filter(pl.col(f"__has_price_{index}"))
 
-            subset = group[column_list + block_columns].dropna(
-                axis="rows",
-                how="all",
-                subset=price_columns,
-            )
-
-            if len(subset) > 1:
+            if subset.height > 1:
                 # We've identified an issue where
                 # there are sometimes multiple offers for the same service at the same
                 # interval. In theory this should never happen. The QUANTITY MW are
@@ -985,34 +1071,48 @@ def process_as_offer_curves(
                 # quantity. This is a temporary fix until we can figure out why this
                 # is happening.
                 logger.info(
-                    f"Found {len(subset)} rows for {resource_name}across columns "
+                    f"Found {subset.height} rows for {resource_name}across columns "
                     f"{column_list}. Taking the row with the lowest quantity",
                 )
-                subset = subset.sort_values("QUANTITY MW1").head(1)
+                subset = subset.sort("QUANTITY MW1", nulls_last=True).head(1)
 
-            # Only keep the number of block indicators that are non-null
-            keep_block_count = subset[block_columns].notna().sum().sum()
-            subset = subset.drop(columns=block_columns).loc[
-                :,
-                column_list[: keep_block_count * 2],
-            ]
-
-            if subset.empty:
+            if subset.height == 0:
                 curve = None
             else:
-                subset_values = subset.replace({np.nan: 0}).values[0]
-
-                if output_format == CurveOutputFormat.PG_ARRAY_AS_STRING:
-                    pairs = []
-                    for i in range(0, len(subset_values), 2):
-                        pairs.append(
-                            f"{{{subset_values[i]},{subset_values[i + 1]}}}",
-                        )
-                    curve = "{" + ",".join(pairs) + "}"
+                # Only keep the number of block indicators that are non-null
+                if block_columns:
+                    block_values = subset.select(block_columns).row(0)
+                    keep_block_count = sum(
+                        1 for v in block_values if v is not None and v == v
+                    )
                 else:
-                    curve = []
-                    for i in range(0, len(subset_values), 2):
-                        curve.append(subset_values[i : i + 2].tolist())
+                    keep_block_count = 0
+
+                kept_columns = column_list[: keep_block_count * 2]
+
+                if not kept_columns:
+                    curve = None
+                else:
+                    subset_values = np.asarray(
+                        [
+                            0
+                            if v is None or (isinstance(v, float) and np.isnan(v))
+                            else v
+                            for v in subset.select(kept_columns).row(0)
+                        ],
+                    )
+
+                    if output_format == CurveOutputFormat.PG_ARRAY_AS_STRING:
+                        pairs = []
+                        for i in range(0, len(subset_values), 2):
+                            pairs.append(
+                                f"{{{subset_values[i]},{subset_values[i + 1]}}}",
+                            )
+                        curve = "{" + ",".join(pairs) + "}"
+                    else:
+                        curve = []
+                        for i in range(0, len(subset_values), 2):
+                            curve.append(subset_values[i : i + 2].tolist())
 
             curve_name = f"{present_ancillary_services[index]} Offer Curve"
             group_data[curve_name] = curve
@@ -1022,7 +1122,37 @@ def process_as_offer_curves(
 
         constructed_data.append(group_data)
 
-    df = pd.DataFrame(constructed_data).replace({None: pd.NA})[
+    non_null_block_dtypes = [
+        df.schema[c] for c in block_columns if df[c].null_count() < df.height
+    ]
+    block_dtype = non_null_block_dtypes[0] if non_null_block_dtypes else pl.Null
+
+    curve_dtype = (
+        pl.String
+        if output_format == CurveOutputFormat.PG_ARRAY_AS_STRING
+        else pl.List(pl.List(pl.Float64))
+    )
+
+    # The old pandas implementation rebuilt this frame from the group keys,
+    # which pandas infers as nanosecond datetimes; pin ns to keep the output
+    # dtype identical.
+    schema = {
+        "Interval Start": pl.Datetime("ns", df.schema["Interval Start"].time_zone),
+        "Interval End": pl.Datetime("ns", df.schema["Interval End"].time_zone),
+        "QSE": df.schema["QSE"],
+        "DME": df.schema["DME"],
+        "Resource Name": df.schema["Resource Name"],
+        "Multi-Hour Block Flag": df.schema["Multi-Hour Block Flag"],
+        "Block Indicators": pl.List(block_dtype),
+    }
+    for service in all_ancillary_services:
+        schema[f"{service} Offer Curve"] = (
+            curve_dtype if service in present_ancillary_services else pl.Null
+        )
+
+    out = pl.from_dicts(constructed_data, schema=schema)
+
+    out = out.select(
         [
             "Interval Start",
             "Interval End",
@@ -1032,284 +1162,256 @@ def process_as_offer_curves(
             "Multi-Hour Block Flag",
             "Block Indicators",
         ]
-        + as_offer_curve_column_names
-    ]
-
-    df = _categorize_strings(df)
-    return pl.from_pandas(df)
-
-
-def process_dam_energy_only_offer_awards(df):
-    if isinstance(df, pl.DataFrame):
-        df = df.to_pandas()
-    df = df.rename(
-        columns={"Settlement Point": "Settlement Point Name", "QSE Name": "QSE"},
+        + as_offer_curve_column_names,
     )
 
-    df = df[DAM_ENERGY_ONLY_OFFER_AWARDS_COLUMNS].sort_values(
+    return _categorize_strings_polars(out)
+
+
+def process_dam_energy_only_offer_awards(df: pl.DataFrame) -> pl.DataFrame:
+    rename_map = {"Settlement Point": "Settlement Point Name", "QSE Name": "QSE"}
+    df = df.rename({k: v for k, v in rename_map.items() if k in df.columns})
+
+    df = df.select(DAM_ENERGY_ONLY_OFFER_AWARDS_COLUMNS).sort(
         ["Interval Start", "Settlement Point Name"],
+        nulls_last=True,
+        maintain_order=True,
     )
-    df = _categorize_strings(df)
-    return pl.from_pandas(df)
+    return _categorize_strings_polars(df)
 
 
 def process_dam_energy_only_offers(
-    df,
+    df: pl.DataFrame,
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
-):
-    if isinstance(df, pl.DataFrame):
-        df = df.to_pandas()
-    df = df.rename(
-        columns={
-            "Settlement Point": "Settlement Point Name",
-            "QSE Name": "QSE",
-            "Block/Curve indicator": "Block or Curve indicator",
-        },
-    )
+) -> pl.DataFrame:
+    rename_map = {
+        "Settlement Point": "Settlement Point Name",
+        "QSE Name": "QSE",
+        "Block/Curve indicator": "Block or Curve indicator",
+    }
+    df = df.rename({k: v for k, v in rename_map.items() if k in df.columns})
 
     curve_name = "Energy Only Offer"
 
-    df[curve_name + " Curve"] = extract_curve(
+    curve_expr = _extract_curve_expr_by_prefix(
         df,
         curve_name,
         mw_suffix=" MW",
         price_suffix=" Price",
         output_format=output_format,
     )
+    if curve_expr is None:
+        curve_expr = pl.lit(None, dtype=pl.Float64)
+    df = df.with_columns(curve_expr.alias(curve_name + " Curve"))
 
-    df = df[DAM_ENERGY_ONLY_OFFERS_COLUMNS].sort_values(
+    df = df.select(DAM_ENERGY_ONLY_OFFERS_COLUMNS).sort(
         ["Interval Start", "Settlement Point Name"],
+        nulls_last=True,
+        maintain_order=True,
     )
-    df = _categorize_strings(df)
-    return pl.from_pandas(df)
+    return _categorize_strings_polars(df)
 
 
-def process_dam_ptp_obligation_bid_awards(df):
-    if isinstance(df, pl.DataFrame):
-        df = df.to_pandas()
-    df = df.rename(columns={"QSE Name": "QSE"})
+def process_dam_ptp_obligation_bid_awards(df: pl.DataFrame) -> pl.DataFrame:
+    rename_map = {"QSE Name": "QSE"}
+    df = df.rename({k: v for k, v in rename_map.items() if k in df.columns})
 
-    df = df[DAM_PTP_OBLIGATION_BID_AWARDS_COLUMNS].sort_values(
+    df = df.select(DAM_PTP_OBLIGATION_BID_AWARDS_COLUMNS).sort(
         ["Interval Start", "QSE"],
+        nulls_last=True,
+        maintain_order=True,
     )
-    df = _categorize_strings(df)
-    return pl.from_pandas(df)
+    return _categorize_strings_polars(df)
 
 
-def process_dam_ptp_obligation_bids(df):
-    if isinstance(df, pl.DataFrame):
-        df = df.to_pandas()
-    df = df.rename(columns={"QSE Name": "QSE"})
+def process_dam_ptp_obligation_bids(df: pl.DataFrame) -> pl.DataFrame:
+    rename_map = {"QSE Name": "QSE"}
+    df = df.rename({k: v for k, v in rename_map.items() if k in df.columns})
 
-    df = df[DAM_PTP_OBLIGATION_BIDS_COLUMNS].sort_values(["Interval Start", "QSE"])
-    df = _categorize_strings(df)
-    return pl.from_pandas(df)
-
-
-def process_dam_energy_bid_awards(df):
-    if isinstance(df, pl.DataFrame):
-        df = df.to_pandas()
-    df = df.rename(
-        columns={"Settlement Point": "Settlement Point Name", "QSE Name": "QSE"},
+    df = df.select(DAM_PTP_OBLIGATION_BIDS_COLUMNS).sort(
+        ["Interval Start", "QSE"],
+        nulls_last=True,
+        maintain_order=True,
     )
+    return _categorize_strings_polars(df)
 
-    df = df[DAM_ENERGY_BID_AWARDS_COLUMNS].sort_values(
+
+def process_dam_energy_bid_awards(df: pl.DataFrame) -> pl.DataFrame:
+    rename_map = {"Settlement Point": "Settlement Point Name", "QSE Name": "QSE"}
+    df = df.rename({k: v for k, v in rename_map.items() if k in df.columns})
+
+    df = df.select(DAM_ENERGY_BID_AWARDS_COLUMNS).sort(
         ["Interval Start", "Settlement Point Name"],
+        nulls_last=True,
+        maintain_order=True,
     )
-    df = _categorize_strings(df)
-    return pl.from_pandas(df)
+    return _categorize_strings_polars(df)
 
 
 def process_dam_energy_bids(
-    df,
+    df: pl.DataFrame,
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
-):
-    if isinstance(df, pl.DataFrame):
-        df = df.to_pandas()
-    df = df.rename(
-        columns={
-            "Settlement Point": "Settlement Point Name",
-            "QSE Name": "QSE",
-            "Block/Curve indicator": "Block or Curve indicator",
-        },
-    )
+) -> pl.DataFrame:
+    rename_map = {
+        "Settlement Point": "Settlement Point Name",
+        "QSE Name": "QSE",
+        "Block/Curve indicator": "Block or Curve indicator",
+    }
+    df = df.rename({k: v for k, v in rename_map.items() if k in df.columns})
 
     curve_name = "Energy Only Bid"
 
-    df[curve_name + " Curve"] = extract_curve(
+    curve_expr = _extract_curve_expr_by_prefix(
         df,
         curve_name,
         mw_suffix=" MW",
         price_suffix=" Price",
         output_format=output_format,
     )
+    if curve_expr is None:
+        curve_expr = pl.lit(None, dtype=pl.Float64)
+    df = df.with_columns(curve_expr.alias(curve_name + " Curve"))
 
-    df = df[DAM_ENERGY_BIDS_COLUMNS].sort_values(
+    df = df.select(DAM_ENERGY_BIDS_COLUMNS).sort(
         ["Interval Start", "Settlement Point Name"],
+        nulls_last=True,
+        maintain_order=True,
     )
-    df = _categorize_strings(df)
-    return pl.from_pandas(df)
+    return _categorize_strings_polars(df)
 
 
-def process_dam_ptp_obligation_option(df):
-    if isinstance(df, pl.DataFrame):
-        df = df.to_pandas()
-    df = df.rename(columns={"QSE Name": "QSE"})
+def process_dam_ptp_obligation_option(df: pl.DataFrame) -> pl.DataFrame:
+    rename_map = {"QSE Name": "QSE"}
+    df = df.rename({k: v for k, v in rename_map.items() if k in df.columns})
 
-    df = df[DAM_PTP_OBLIGATION_OPTION_COLUMNS].sort_values(["Interval Start", "QSE"])
-    df = _categorize_strings(df)
-    return pl.from_pandas(df)
-
-
-def process_dam_ptp_obligation_option_awards(df):
-    if isinstance(df, pl.DataFrame):
-        df = df.to_pandas()
-    df = df.rename(columns={"QSE Name": "QSE"})
-
-    df = df[DAM_PTP_OBLIGATION_OPTION_AWARDS_COLUMNS].sort_values(
+    df = df.select(DAM_PTP_OBLIGATION_OPTION_COLUMNS).sort(
         ["Interval Start", "QSE"],
+        nulls_last=True,
+        maintain_order=True,
     )
-    df = _categorize_strings(df)
-    return pl.from_pandas(df)
+    return _categorize_strings_polars(df)
 
 
-def process_dam_as_only_awards(df):
-    if isinstance(df, pl.DataFrame):
-        df = df.to_pandas()
-    df = df.rename(
-        columns={
-            "QSE Name": "QSE",
-            "Quantity1_Award": "Quantity1 Award",
-            "Quantity2_Award": "Quantity2 Award",
-            "Quantity3_Award": "Quantity3 Award",
-            "Quantity4_Award": "Quantity4 Award",
-            "Quantity5_Award": "Quantity5 Award",
-            "Total_Award": "Total Award",
-        },
+def process_dam_ptp_obligation_option_awards(df: pl.DataFrame) -> pl.DataFrame:
+    rename_map = {"QSE Name": "QSE"}
+    df = df.rename({k: v for k, v in rename_map.items() if k in df.columns})
+
+    df = df.select(DAM_PTP_OBLIGATION_OPTION_AWARDS_COLUMNS).sort(
+        ["Interval Start", "QSE"],
+        nulls_last=True,
+        maintain_order=True,
+    )
+    return _categorize_strings_polars(df)
+
+
+def process_dam_as_only_awards(df: pl.DataFrame) -> pl.DataFrame:
+    rename_map = {
+        "QSE Name": "QSE",
+        "Quantity1_Award": "Quantity1 Award",
+        "Quantity2_Award": "Quantity2 Award",
+        "Quantity3_Award": "Quantity3 Award",
+        "Quantity4_Award": "Quantity4 Award",
+        "Quantity5_Award": "Quantity5 Award",
+        "Total_Award": "Total Award",
+    }
+    df = df.rename({k: v for k, v in rename_map.items() if k in df.columns})
+
+    df = df.with_columns(
+        pl.lit(None, dtype=pl.Float64).alias(col)
+        for col in DAM_AS_ONLY_AWARDS_COLUMNS
+        if col not in df.columns
     )
 
-    for col in DAM_AS_ONLY_AWARDS_COLUMNS:
-        if col not in df.columns:
-            df[col] = np.nan
-
-    df = df[DAM_AS_ONLY_AWARDS_COLUMNS].sort_values(
+    df = df.select(DAM_AS_ONLY_AWARDS_COLUMNS).sort(
         ["Interval Start", "QSE", "AS Type", "Offer ID"],
+        nulls_last=True,
+        maintain_order=True,
     )
-    df = _categorize_strings(df)
-    return pl.from_pandas(df)
+    return _categorize_strings_polars(df)
 
 
 def process_dam_as_only_offers(
-    df,
+    df: pl.DataFrame,
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
-):
-    if isinstance(df, pl.DataFrame):
-        df = df.to_pandas()
-    df = df.rename(columns={"QSE Name": "QSE"})
+) -> pl.DataFrame:
+    rename_map = {"QSE Name": "QSE"}
+    df = df.rename({k: v for k, v in rename_map.items() if k in df.columns})
 
-    df["Offer Curve"] = extract_curve(
+    curve_expr = _extract_curve_expr_by_prefix(
         df,
         "AS Only Offer",
         mw_suffix=" MW",
         price_suffix=" Price",
         output_format=output_format,
     )
+    if curve_expr is None:
+        curve_expr = pl.lit(None, dtype=pl.Float64)
+    df = df.with_columns(curve_expr.alias("Offer Curve"))
 
-    for col in DAM_AS_ONLY_OFFERS_COLUMNS:
-        if col not in df.columns:
-            df[col] = np.nan
-
-    df = df[DAM_AS_ONLY_OFFERS_COLUMNS].sort_values(
-        ["Interval Start", "QSE", "AS Type", "Offer ID"],
+    df = df.with_columns(
+        pl.lit(None, dtype=pl.Float64).alias(col)
+        for col in DAM_AS_ONLY_OFFERS_COLUMNS
+        if col not in df.columns
     )
-    df = _categorize_strings(df)
-    return pl.from_pandas(df)
+
+    df = df.select(DAM_AS_ONLY_OFFERS_COLUMNS).sort(
+        ["Interval Start", "QSE", "AS Type", "Offer ID"],
+        nulls_last=True,
+        maintain_order=True,
+    )
+    return _categorize_strings_polars(df)
+
+
+def _finalize_sced_frame(
+    df: pl.DataFrame,
+    curve_specs: list[tuple[str, str]],
+    rename_map: dict[str, str],
+    output_columns: list[str],
+    output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
+) -> pl.DataFrame:
+    """Shared tail for the SCED process functions: extract offer curves,
+    apply renames, null-fill missing columns, select the final column set,
+    and categorize strings."""
+    curve_exprs = []
+    for curve_name, out_col in curve_specs:
+        expr = _extract_curve_expr_by_prefix(
+            df,
+            curve_name,
+            output_format=output_format,
+        )
+        if expr is None:
+            expr = pl.lit(None, dtype=pl.Float64)
+        curve_exprs.append(expr.alias(out_col))
+    if curve_exprs:
+        df = df.with_columns(curve_exprs)
+
+    df = df.rename(
+        {old: new for old, new in rename_map.items() if old in df.columns},
+    )
+    df = df.with_columns(
+        pl.lit(None, dtype=pl.Float64).alias(col)
+        for col in output_columns
+        if col not in df.columns
+    )
+    return _categorize_strings_polars(df.select(output_columns))
 
 
 def process_sced_gen(
-    df,
+    df: pl.DataFrame,
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
-):
-    if isinstance(df, pl.DataFrame):
-        df = df.to_pandas()
+) -> pl.DataFrame:
     # Strip whitespace from column names
-    df.columns = df.columns.str.strip()
-    time_cols = [
-        "SCED Timestamp",
-    ]
-
-    resource_cols = ["QSE", "DME", "Resource Name", "Resource Type"]
-
-    telemetry_cols = [
-        "Telemetered Resource Status",
-        "Output Schedule",
-        "HSL",
-        "HASL",
-        "HDL",
-        "LSL",
-        "LASL",
-        "LDL",
-        "Base Point",
-        "Telemetered Net Output",
-        "Ramp Rate Up",
-        "Ramp Rate Down",
-    ]
-
-    as_cols = [
-        "Ancillary Service REGUP",
-        "Ancillary Service REGDN",
-        "Ancillary Service RRS",
-        "Ancillary Service RRSFFR",
-        "Ancillary Service NSRS",
-        "Ancillary Service ECRS",
-        "AS Capability REGUP",
-        "AS Capability REGDN",
-        "AS Capability ECRS",
-        "AS Capability NSPIN",
-        "AS Capability RRSPF",
-        "AS Capability RRSFF",
-        "AS Awards NSPIN",
-        "AS Awards RRSFFR",
-        "AS Awards RRSPFR",
-        "AS Awards RRSUFR",
-        "AS Awards ECRS",
-        "AS Awards REGUP",
-        "AS Awards REGDN",
-    ]
-
-    tpo_cols = [
-        "Start Up Cold Offer",
-        "Start Up Hot Offer",
-        "Start Up Inter Offer",
-        "Min Gen Cost",
-        "SCED TPO Offer Curve",
-    ]
-
-    sced1_offer_col = "SCED1 Offer Curve"
-    sced2_offer_col = "SCED2 Offer Curve"
-
-    df[sced1_offer_col] = extract_curve(df, "SCED1 Curve", output_format=output_format)
-    df[sced2_offer_col] = extract_curve(df, "SCED2 Curve", output_format=output_format)
-    df[tpo_cols[-1]] = extract_curve(df, "Submitted TPO", output_format=output_format)
-
-    all_cols = (
-        resource_cols
-        + telemetry_cols
-        + as_cols
-        + [sced1_offer_col, sced2_offer_col]
-        + tpo_cols
-    )
-
-    for col in all_cols:
-        if col not in df.columns:
-            df[col] = np.nan
-
-    df = df[time_cols + all_cols]
-
-    # standardized to same naming as load
-    # clean up column names
-    df = df.rename(
-        columns={
+    df = df.rename({c: c.strip() for c in df.columns if c != c.strip()})
+    return _finalize_sced_frame(
+        df,
+        curve_specs=[
+            ("SCED1 Curve", "SCED1 Offer Curve"),
+            ("SCED2 Curve", "SCED2 Offer Curve"),
+            ("Submitted TPO", "SCED TPO Offer Curve"),
+        ],
+        # standardized to same naming as load
+        # clean up column names
+        rename_map={
             "Ancillary Service RRS": "AS Responsibility for RRS",
             "Ancillary Service RRSFFR": "AS Responsibility for RRSFFR",
             "Ancillary Service NSRS": "AS Responsibility for NonSpin",
@@ -1324,81 +1426,19 @@ def process_sced_gen(
             "AS Awards REGDN": "AS Awards RegDown",
             "AS Awards NSPIN": "AS Awards NonSpin",
         },
-    )
-
-    df = _categorize_strings(df[SCED_GEN_RESOURCE_COLUMNS])
-    return pl.from_pandas(df)
-
-
-def process_sced_load(
-    df,
-    output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
-):
-    if isinstance(df, pl.DataFrame):
-        df = df.to_pandas()
-    time_cols = [
-        "SCED Timestamp",
-    ]
-
-    resource_cols = ["QSE", "DME", "Resource Name"]
-
-    telemetry_cols = [
-        "Telemetered Resource Status",
-        "Max Power Consumption",
-        "Low Power Consumption",
-        "Real Power Consumption",
-        "HASL",
-        "HDL",
-        "LASL",
-        "LDL",
-        "Base Point",
-        "Self Provided RRSFFR",
-        "Self Provided RRSUFR",
-        "Self Provided ECRS",
-        "Ramp Rate Up",
-        "Ramp Rate Down",
-    ]
-
-    as_cols = [
-        "AS Responsibility for RRS",
-        "AS Responsibility for RRSFFR",
-        "AS Responsibility for NonSpin",
-        "AS Responsibility for RegUp",
-        "AS Responsibility for RegDown",
-        "AS Responsibility for ECRS",
-        "AS Awards NSPIN",
-        "AS Awards RRSFFR",
-        "AS Awards RRSPFR",
-        "AS Awards RRSUFR",
-        "AS Awards ECRS",
-        "AS Awards REGUP",
-        "AS Awards REGDN",
-        "AS Capability NSPIN",
-        "AS Capability ECRS",
-        "AS Capability REGUP",
-        "AS Capability REGDN",
-        "AS Capability RRSPF",
-        "AS Capability RRSFF",
-        "AS Capability RRSUF",
-    ]
-
-    bid_curve_col = "SCED Bid to Buy Curve"
-
-    df[bid_curve_col] = extract_curve(
-        df,
-        "SCED Bid to Buy Curve",
+        output_columns=SCED_GEN_RESOURCE_COLUMNS,
         output_format=output_format,
     )
 
-    all_cols = resource_cols + telemetry_cols + as_cols + [bid_curve_col]
-    for col in all_cols:
-        if col not in df.columns:
-            df[col] = np.nan
 
-    df = df[time_cols + all_cols]
-
-    df = df.rename(
-        columns={
+def process_sced_load(
+    df: pl.DataFrame,
+    output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
+) -> pl.DataFrame:
+    return _finalize_sced_frame(
+        df,
+        curve_specs=[("SCED Bid to Buy Curve", "SCED Bid to Buy Curve")],
+        rename_map={
             # Rename REGUP -> RegUp, REGDN -> RegDown, NSPIN -> NonSpin
             "AS Capability REGUP": "AS Capability RegUp",
             "AS Capability REGDN": "AS Capability RegDown",
@@ -1407,98 +1447,24 @@ def process_sced_load(
             "AS Awards REGDN": "AS Awards RegDown",
             "AS Awards NSPIN": "AS Awards NonSpin",
         },
+        output_columns=SCED_LOAD_RESOURCE_COLUMNS,
+        output_format=output_format,
     )
-
-    df = _categorize_strings(df[SCED_LOAD_RESOURCE_COLUMNS])
-    return pl.from_pandas(df)
 
 
 def process_sced_esr(
-    df,
+    df: pl.DataFrame,
     output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
-):
-    if isinstance(df, pl.DataFrame):
-        df = df.to_pandas()
-    time_cols = [
-        "SCED Timestamp",
-    ]
-
-    resource_cols = ["QSE", "DME", "Resource Name", "Resource Type"]
-
-    telemetry_cols = [
-        "Output Schedule",
-        "HSL",
-        "HDL",
-        "LSL",
-        "LDL",
-        "Telemetered Resource Status",
-        "Base Point",
-        "Telemetered Net Output",
-        "Ramp Rate Up",
-        "Ramp Rate Down",
-    ]
-
-    as_cols = [
-        "AS Capability REGUP",
-        "AS Capability REGDN",
-        "AS Capability ECRS",
-        "AS Capability NSPIN",
-        "AS Capability RRSPF",
-        "AS Capability RRSFF",
-        "AS Awards NSPIN",
-        "AS Awards RRSFFR",
-        "AS Awards RRSPFR",
-        "AS Awards RRSUFR",
-        "AS Awards ECRS",
-        "AS Awards REGUP",
-        "AS Awards REGDN",
-    ]
-
+) -> pl.DataFrame:
     # SOC columns added in Feb 2026 ESR data
-    soc_cols = [
-        "State of Charge",
-        "Minimum SOC",
-        "Maximum SOC",
-    ]
-
-    tpo_cols = [
-        "Start Up Cold Offer",
-        "Start Up Hot Offer",
-        "Start Up Inter Offer",
-        "Min Gen Cost",
-        "SCED TPO Offer Curve",
-    ]
-
-    other_cols = [
-        "Bid_Type",
-        "Proxy Extension",
-    ]
-
-    sced1_offer_col = "SCED1 Offer Curve"
-    sced2_offer_col = "SCED2 Offer Curve"
-
-    df[sced1_offer_col] = extract_curve(df, "SCED1 Curve", output_format=output_format)
-    df[sced2_offer_col] = extract_curve(df, "SCED2 Curve", output_format=output_format)
-    df[tpo_cols[-1]] = extract_curve(df, "Submitted TPO", output_format=output_format)
-
-    all_cols = (
-        resource_cols
-        + [sced1_offer_col, sced2_offer_col]
-        + telemetry_cols
-        + as_cols
-        + soc_cols
-        + other_cols
-        + tpo_cols
-    )
-
-    for col in all_cols:
-        if col not in df.columns:
-            df[col] = np.nan
-
-    df = df[time_cols + all_cols]
-
-    df = df.rename(
-        columns={
+    return _finalize_sced_frame(
+        df,
+        curve_specs=[
+            ("SCED1 Curve", "SCED1 Offer Curve"),
+            ("SCED2 Curve", "SCED2 Offer Curve"),
+            ("Submitted TPO", "SCED TPO Offer Curve"),
+        ],
+        rename_map={
             # Rename REGUP -> RegUp, REGDN -> RegDown, NSPIN -> NonSpin
             "AS Capability REGUP": "AS Capability RegUp",
             "AS Capability REGDN": "AS Capability RegDown",
@@ -1513,10 +1479,9 @@ def process_sced_esr(
             "Minimum SOC": "Min SOC",
             "Maximum SOC": "Max SOC",
         },
+        output_columns=SCED_ESR_COLUMNS,
+        output_format=output_format,
     )
-
-    df = _categorize_strings(df[SCED_ESR_COLUMNS])
-    return pl.from_pandas(df)
 
 
 def process_sced_as_offer_updates_in_op_hour(df):
@@ -1527,20 +1492,37 @@ def process_sced_as_offer_updates_in_op_hour(df):
 
     Expects df to already have Interval Start/End from parse_doc().
     """
-    if isinstance(df, pl.DataFrame):
-        df = df.to_pandas()
-    df = _categorize_strings(df[SCED_AS_OFFER_UPDATES_IN_OP_HOUR_COLUMNS])
-    return pl.from_pandas(df)
+    return _categorize_strings_polars(
+        df.select(SCED_AS_OFFER_UPDATES_IN_OP_HOUR_COLUMNS),
+    )
 
 
-def _process_sced_resource_as_offers_polars(df: pl.DataFrame) -> pl.DataFrame:
-    """Polars-native version of process_sced_resource_as_offers() for the
-    PG_ARRAY_AS_STRING output format.
+def process_sced_resource_as_offers(
+    df: pl.DataFrame,
+    output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
+) -> pl.DataFrame:
+    """Process SCED Resource AS Offers data.
 
-    Mirrors the pandas logic below (suffix renames, curve-type classification,
-    per-AS-type curve extraction) while keeping the largest SCED disclosure
-    frame in polars the whole time.
+    This data contains ancillary service offer curves at the SCED timestamp level.
+    Each row has price/quantity pairs for each AS type across 6 blocks.
+
+    Source columns: PRICEn_URS, PRICEn_DRS, PRICEn_RRSPF, PRICEn_RRSUF,
+                   PRICEn_RRSFF, PRICEn_NS, PRICEn_ECRS, QUANTITY_MWn (n=1-6)
+
+    Creates offer curves for each AS type. Format depends on output_format:
+    list-of-lists like [[mw, price], ...] or PG array strings.
+
+    Args:
+        df: DataFrame with raw SCED resource AS offers data.
+        output_format: "list" (default) returns list-of-lists per cell.
+            "pg_array_as_string" returns PG array strings like '{{mw,price},{mw,price}}'
+            directly, using ~3x less peak memory.
     """
+    # ERCOT renamed the AS-price column suffixes in late March 2026
+    # (_URS->_REGUP, _DRS->_REGDN, _NS->_NSPIN, _RRSPF->_RRSPFR,
+    # _RRSUF->_RRSUFR, _RRSFF->_RRSFFR). Rename them back to the original names
+    # so the curve-type and curve-extraction logic below works unchanged for
+    # both old and new files.
     new_to_old_suffix = {
         "_REGUP": "_URS",
         "_REGDN": "_DRS",
@@ -1558,6 +1540,10 @@ def _process_sced_resource_as_offers_polars(df: pl.DataFrame) -> pl.DataFrame:
 
     df = df.rename({c: _rename_suffix(c) for c in df.columns})
 
+    # First create a curve_type column with the logic:
+    # regulation down : values only in _DRS columns and not in other columns
+    # offline: values in _NS and optionally _ECRS columns and not in other columns
+    # online : values in any column except for _DRS
     price_cols = [c for c in df.columns if c.startswith("PRICE")]
     drs_cols = [c for c in price_cols if c.endswith("_DRS")]
     ns_cols = [c for c in price_cols if c.endswith("_NS")]
@@ -1565,9 +1551,14 @@ def _process_sced_resource_as_offers_polars(df: pl.DataFrame) -> pl.DataFrame:
     non_drs_ns_ecrs_cols = [c for c in non_drs_cols if not c.endswith(("_NS", "_ECRS"))]
 
     def _has_value(cols: list[str]) -> pl.Expr:
-        # NaN values are treated as "no value" (same as zero), matching the
-        # pandas fillna(0) behavior for ERCOT corrected files (April 4, 2026+).
-        return pl.any_horizontal(pl.col(c).fill_null(0) != 0 for c in cols)
+        # Treat null and NaN values as "no value" (same as zero). ERCOT
+        # corrected files (April 4, 2026+) use NaN instead of zero for empty
+        # AS Sub-Type Offer Prices (see ERCOT notice M-B040326-01). Unlike
+        # pandas fillna(0), polars fill_null() does not fill NaN, so both are
+        # filled explicitly.
+        return pl.any_horizontal(
+            pl.col(c).cast(pl.Float64).fill_nan(0).fill_null(0) != 0 for c in cols
+        )
 
     has_drs = _has_value(drs_cols)
     has_non_drs = _has_value(non_drs_cols)
@@ -1588,127 +1579,6 @@ def _process_sced_resource_as_offers_polars(df: pl.DataFrame) -> pl.DataFrame:
     if df["Curve Type"].eq("unknown").any():
         raise ValueError("Unknown curve type found")
 
-    as_type_mapping = {
-        "URS": "URS Offer Curve",
-        "DRS": "DRS Offer Curve",
-        "RRSPF": "RRSPFR Offer Curve",
-        "RRSUF": "RRSUFR Offer Curve",
-        "RRSFF": "RRSFFR Offer Curve",
-        "NS": "NonSpin Offer Curve",
-        "ECRS": "ECRS Offer Curve",
-    }
-
-    qty_cols = sorted([col for col in df.columns if col.startswith("QUANTITY_MW")])
-    block_count = len(qty_cols)
-
-    if block_count == 0:
-        return df
-
-    mw_cols = [f"QUANTITY_MW{i}" for i in range(1, block_count + 1)]
-
-    curve_exprs = []
-    for as_suffix, curve_col in as_type_mapping.items():
-        as_price_cols = [f"PRICE{i}_{as_suffix}" for i in range(1, block_count + 1)]
-        as_price_cols = [c for c in as_price_cols if c in df.columns]
-
-        if not as_price_cols:
-            curve_exprs.append(pl.lit(None, dtype=pl.String).alias(curve_col))
-            continue
-
-        curve_exprs.append(
-            extract_curve_as_pg_string_expr(
-                mw_cols=mw_cols[: len(as_price_cols)],
-                price_cols=as_price_cols,
-            ).alias(curve_col),
-        )
-
-    df = df.with_columns(curve_exprs)
-
-    df = df.select(SCED_RESOURCE_AS_OFFERS_COLUMNS)
-    return df.with_columns(
-        pl.col(c).cast(pl.Categorical)
-        for c, dtype in df.schema.items()
-        if dtype == pl.String and not c.endswith("Curve")
-    )
-
-
-def process_sced_resource_as_offers(
-    df,
-    output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
-):
-    """Process SCED Resource AS Offers data.
-
-    This data contains ancillary service offer curves at the SCED timestamp level.
-    Each row has price/quantity pairs for each AS type across 6 blocks.
-
-    Source columns: PRICEn_URS, PRICEn_DRS, PRICEn_RRSPF, PRICEn_RRSUF,
-                   PRICEn_RRSFF, PRICEn_NS, PRICEn_ECRS, QUANTITY_MWn (n=1-6)
-
-    Creates offer curves for each AS type. Format depends on output_format:
-    list-of-lists like [[mw, price], ...] or PG array strings.
-
-    Args:
-        df: DataFrame with raw SCED resource AS offers data.
-        output_format: "list" (default) returns Python list-of-lists per cell.
-            "pg_array_as_string" returns PG array strings like '{{mw,price},{mw,price}}'
-            directly, using ~3x less peak memory.
-    """
-    if isinstance(df, pl.DataFrame):
-        # The polars-native path avoids materializing a pandas copy of this
-        # frame (the largest in the SCED disclosure). Only the PG-string
-        # format is supported natively; the list format still needs pandas.
-        if output_format == CurveOutputFormat.PG_ARRAY_AS_STRING:
-            return _process_sced_resource_as_offers_polars(df)
-        df = df.to_pandas()
-    # ERCOT renamed the AS-price column suffixes in late March 2026
-    # (_URS->_REGUP, _DRS->_REGDN, _NS->_NSPIN, _RRSPF->_RRSPFR,
-    # _RRSUF->_RRSUFR, _RRSFF->_RRSFFR). Rename them back to the original names
-    # so the curve-type and curve-extraction logic below works unchanged for
-    # both old and new files.
-    new_to_old_suffix = {
-        "_REGUP": "_URS",
-        "_REGDN": "_DRS",
-        "_RRSPFR": "_RRSPF",
-        "_RRSUFR": "_RRSUF",
-        "_RRSFFR": "_RRSFF",
-        "_NSPIN": "_NS",
-    }
-
-    def _rename_suffix(col):
-        for new_suffix, old_suffix in new_to_old_suffix.items():
-            if col.endswith(new_suffix):
-                return col[: -len(new_suffix)] + old_suffix
-        return col
-
-    df = df.rename(columns=_rename_suffix)
-
-    # First create a curve_type column with the logic:
-    # regulation down : values only in _DRS columns and not in other columns
-    # offline: values in _NS and optionally _ECRS columns and not in other columns
-    # online : values in any column except for _DRS
-    price_cols = [c for c in df.columns if c.startswith("PRICE")]
-    drs_cols = [c for c in price_cols if c.endswith("_DRS")]
-    ns_cols = [c for c in price_cols if c.endswith("_NS")]
-    non_drs_cols = [c for c in price_cols if not c.endswith("_DRS")]
-
-    # Use fillna(0) so that NaN values are treated as "no value" (same as zero).
-    # ERCOT corrected files (April 4, 2026+) use NaN instead of zero for empty
-    # AS Sub-Type Offer Prices (see ERCOT notice M-B040326-01).
-    has_drs = (df[drs_cols].fillna(0) != 0).any(axis=1)
-    has_non_drs = (df[non_drs_cols].fillna(0) != 0).any(axis=1)
-    has_ns = (df[ns_cols].fillna(0) != 0).any(axis=1)
-
-    non_drs_ns_ecrs_cols = [c for c in non_drs_cols if not c.endswith(("_NS", "_ECRS"))]
-    has_non_drs_ns_ecrs = (df[non_drs_ns_ecrs_cols].fillna(0) != 0).any(axis=1)
-
-    df["Curve Type"] = "unknown"
-    df.loc[has_drs & ~has_non_drs, "Curve Type"] = "Regulation Down"
-    df.loc[has_non_drs & has_non_drs_ns_ecrs, "Curve Type"] = "Online"
-    df.loc[has_ns & ~has_drs & ~has_non_drs_ns_ecrs, "Curve Type"] = "Offline"
-
-    if any(df["Curve Type"] == "unknown"):
-        raise ValueError("Unknown curve type found")
-
     # Map source column suffixes to output curve names
     as_type_mapping = {
         "URS": "URS Offer Curve",
@@ -1725,39 +1595,35 @@ def process_sced_resource_as_offers(
     block_count = len(qty_cols)
 
     if block_count == 0:
-        return pl.from_pandas(df)
+        return df
 
     # Extract MW column names (shared across all AS types)
     mw_cols = [f"QUANTITY_MW{i}" for i in range(1, block_count + 1)]
 
     use_pg = output_format == CurveOutputFormat.PG_ARRAY_AS_STRING
-    extract_fn = extract_curve_as_pg_string if use_pg else extract_curve
+    null_dtype = pl.String if use_pg else pl.List(pl.List(pl.Float64))
 
     # Extract curves for each AS type
+    curve_exprs = []
     for as_suffix, curve_col in as_type_mapping.items():
         as_price_cols = [f"PRICE{i}_{as_suffix}" for i in range(1, block_count + 1)]
         as_price_cols = [c for c in as_price_cols if c in df.columns]
 
         if not as_price_cols:
-            df[curve_col] = None
+            curve_exprs.append(pl.lit(None, dtype=null_dtype).alias(curve_col))
             continue
 
-        df[curve_col] = extract_fn(
-            df,
-            mw_cols=mw_cols[: len(as_price_cols)],
-            price_cols=as_price_cols,
+        extract_fn = extract_curve_as_pg_string_expr if use_pg else extract_curve_expr
+        curve_exprs.append(
+            extract_fn(
+                mw_cols=mw_cols[: len(as_price_cols)],
+                price_cols=as_price_cols,
+            ).alias(curve_col),
         )
 
-        # Free source price columns immediately to reduce peak memory
-        if use_pg:
-            df.drop(columns=as_price_cols, inplace=True, errors="ignore")
+    df = df.with_columns(curve_exprs)
 
-    # Drop shared MW columns after all extractions
-    if use_pg:
-        df.drop(columns=mw_cols, inplace=True, errors="ignore")
-
-    df = _categorize_strings(df[SCED_RESOURCE_AS_OFFERS_COLUMNS])
-    return pl.from_pandas(df)
+    return _categorize_strings_polars(df.select(SCED_RESOURCE_AS_OFFERS_COLUMNS))
 
 
 # # backup for more node names

--- a/gridstatus/ercot_api/ercot_api.py
+++ b/gridstatus/ercot_api/ercot_api.py
@@ -8,7 +8,7 @@ from typing import Dict
 from zipfile import ZipFile
 
 import pandas as pd
-import pytz
+import polars as pl
 import requests
 import requests.status_codes as status_codes
 from tqdm import tqdm
@@ -176,6 +176,8 @@ DAM_ASDC_AGGREGATED_ENDPOINT = f"/{DAM_ASDC_AGGREGATED_EMIL_ID}"
 
 ESR_ENDPOINT = "/rptesr-m/4_sec_esr_charging_mw"
 
+POST_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S%.f"
+
 
 class ErcotAPI:
     """
@@ -261,6 +263,108 @@ class ErcotAPI:
             )
 
         return end
+
+    def _from_ercot_pandas(self, df: pd.DataFrame) -> pl.DataFrame:
+        return pl.from_pandas(df, include_index=False)
+
+    def _from_ercot_pandas_objects(self, df: pd.DataFrame) -> pl.DataFrame:
+        columns: list[pl.Series] = []
+        for col in df.columns:
+            if df[col].dtype == object:
+                columns.append(pl.Series(col, df[col].tolist(), dtype=pl.Object))
+            else:
+                columns.append(pl.from_pandas(df[[col]], include_index=False)[col])
+        return pl.DataFrame(columns)
+
+    def _to_ercot_pandas(self, df: pl.DataFrame) -> pd.DataFrame:
+        return df.to_pandas()
+
+    def _parse_ercot_doc(
+        self,
+        data: pl.DataFrame,
+        dst_ambiguous_default: str = "infer",
+        verbose: bool = False,
+        nonexistent: str = "raise",
+    ) -> pl.DataFrame:
+        return self.ercot.parse_doc(
+            self._to_ercot_pandas(data),
+            dst_ambiguous_default=dst_ambiguous_default,
+            verbose=verbose,
+            nonexistent=nonexistent,
+        )
+
+    def _sort_pl(
+        self,
+        df: pl.DataFrame,
+        by: str | list[str],
+        columns: list[str] | None = None,
+    ) -> pl.DataFrame:
+        result = df.sort(by)
+        if columns is not None:
+            result = result.select(columns)
+        return result
+
+    def _publish_time_ambiguous_expr(
+        self,
+        data: pl.DataFrame,
+        raw_data: pl.DataFrame | None = None,
+    ) -> pl.Expr:
+        ambiguous = pl.lit("earliest")
+        if raw_data is not None and {"postDatetime", "_source_filename"}.issubset(
+            raw_data.columns,
+        ):
+            xhr_posts = (
+                raw_data.filter(
+                    pl.col("_source_filename").str.contains("(?i)xhr"),
+                )["postDatetime"]
+                .cast(pl.Utf8)
+                .unique()
+                .to_list()
+            )
+            xhr_cst_posts = [p for p in xhr_posts if "T01:" in str(p)]
+            if xhr_cst_posts:
+                ambiguous = (
+                    pl.when(
+                        pl.col("postDatetime").cast(pl.Utf8).is_in(xhr_cst_posts),
+                    )
+                    .then(pl.lit("latest"))
+                    .otherwise(pl.lit("earliest"))
+                )
+        return ambiguous
+
+    def _localize_publish_time(
+        self,
+        data: pl.DataFrame,
+        raw_data: pl.DataFrame | None = None,
+    ) -> pl.DataFrame:
+        has_ambiguous = (
+            data.select(pl.col("postDatetime").cast(pl.Utf8).str.contains("T01:"))
+            .to_series()
+            .any()
+        )
+        dt = pl.col("postDatetime").str.to_datetime(
+            format=POST_DATETIME_FORMAT,
+            strict=False,
+        )
+        if has_ambiguous:
+            ambiguous = self._publish_time_ambiguous_expr(data, raw_data)
+            publish_time = dt.dt.replace_time_zone(
+                self.default_timezone,
+                ambiguous=ambiguous,
+            )
+        else:
+            publish_time = dt.dt.replace_time_zone(self.default_timezone)
+        return data.with_columns(publish_time.alias("Publish Time"))
+
+    def _ambiguous_based_on_dstflag_expr(self) -> pl.Expr:
+        return (
+            pl.when(
+                pl.col("DSTFlag").cast(pl.Boolean, strict=False)
+                | (pl.col("DSTFlag") == "N"),
+            )
+            .then(pl.lit("earliest"))
+            .otherwise(pl.lit("latest"))
+        )
 
     def get_token(self):
         payload = {
@@ -379,7 +483,7 @@ class ErcotAPI:
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with hourly wind power production reports
+            pl.DataFrame: A DataFrame with hourly wind power production reports
         """
         return self._get_wind_actual_and_forecast_hourly(
             endpoint=HOURLY_WIND_POWER_PRODUCTION_ENDPOINT,
@@ -404,7 +508,7 @@ class ErcotAPI:
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with hourly wind power production reports
+            pl.DataFrame: A DataFrame with hourly wind power production reports
         """
         return self._get_wind_actual_and_forecast_hourly(
             endpoint=HOURLY_WIND_POWER_PRODUCTION_BY_GEOGRAPHICAL_REGION_ENDPOINT,
@@ -446,91 +550,28 @@ class ErcotAPI:
             verbose=verbose,
         )
 
-    def _determine_ambiguous_timezone_for_publish_time(
+    def _handle_wind_actual_and_forecast_hourly(
         self,
-        post_datetime_series: pd.Series,
-        raw_data: pd.DataFrame = None,
-    ) -> pd.Series:
-        """
-        Determines which ambiguous timestamps should be CDT vs CST for postDatetime values.
-
-        Rule: Find all unique ambiguous timestamps (1:xx AM).
-        - Timestamps associated with rows containing "xhr" in filename/source are CST
-        - All other ambiguous timestamps are CDT
-
-        Returns a boolean Series where True means CDT and False means CST for ambiguous times.
-        """
-        post_datetime_str = post_datetime_series.astype(str)
-        ambiguous_posts = sorted(
-            [p for p in post_datetime_str.unique() if "T01:" in str(p)],
+        data: pl.DataFrame,
+        columns: list[str],
+        verbose: bool = False,
+    ) -> pl.DataFrame:
+        raw_data = data.clone()
+        data = self._parse_ercot_doc(data, verbose=verbose)
+        data = data.rename(
+            {c: c.replace("_", " ") for c in data.columns},
         )
-
-        if len(ambiguous_posts) == 0:
-            return pd.Series(
-                [True] * len(post_datetime_series),
-                index=post_datetime_series.index,
-            )
-
-        result = pd.Series(
-            [True] * len(post_datetime_series),
-            index=post_datetime_series.index,
-        )
-
-        # Find CST timestamps by checking for "xhr" in filename
-        if raw_data is not None and "postDatetime" in raw_data.columns:
-            if "_source_filename" in raw_data.columns:
-                xhr_mask = (
-                    raw_data["_source_filename"]
-                    .astype(str)
-                    .str.contains("xhr", case=False, na=False)
-                )
-                if xhr_mask.any():
-                    raw_post_datetime_str = (
-                        raw_data.loc[xhr_mask, "postDatetime"].astype(str).unique()
-                    )
-                    # Mark rows in result that match these postDatetime values as CST
-                    for xhr_post in raw_post_datetime_str:
-                        if "T01:" in str(xhr_post):
-                            result[post_datetime_str == xhr_post] = False
-
-        return result
-
-    def _handle_wind_actual_and_forecast_hourly(self, data, columns, verbose=False):
-        # Store raw data before parse_doc to check for xhr in filename
-        raw_data = data.copy()
-        data = Ercot().parse_doc(data, verbose=verbose)
-
-        data.columns = data.columns.str.replace("_", " ")
-
-        try:
-            data["Publish Time"] = pd.to_datetime(data["postDatetime"]).dt.tz_localize(
-                self.default_timezone,
-            )
         # NOTE: ERCOT gives ambiguous Publish Times for the DST transition
         # Timestamps with "xhr" in filename are CST, all other ambiguous timestamps are CDT
-        except pytz.exceptions.AmbiguousTimeError:
-            ambiguous_array = self._determine_ambiguous_timezone_for_publish_time(
-                data["postDatetime"],
-                raw_data=raw_data,
-            )
-            data["Publish Time"] = pd.to_datetime(data["postDatetime"]).dt.tz_localize(
-                self.default_timezone,
-                ambiguous=ambiguous_array,
-            )
-
-        data = (
-            utils.move_cols_to_front(
-                data,
-                ["Interval Start", "Interval End", "Publish Time"],
-            )
-            .drop(columns=["Time", "postDatetime", "_source_filename"], errors="ignore")
-            .sort_values(["Interval Start", "Publish Time"])
-            .reset_index(drop=True)
+        data = self._localize_publish_time(data, raw_data=raw_data)
+        data = utils.move_cols_to_front(
+            data.drop(["Time", "postDatetime", "_source_filename"], strict=False),
+            ["Interval Start", "Interval End", "Publish Time"],
         )
-
-        data = Ercot()._rename_hourly_wind_or_solar_report(data)
-
-        return data[columns]
+        data = self._from_ercot_pandas(
+            Ercot()._rename_hourly_wind_or_solar_report(self._to_ercot_pandas(data)),
+        )
+        return data.sort(["Interval Start", "Publish Time"]).select(columns)
 
     def get_solar_actual_and_forecast_hourly(self, date, end=None, verbose=False):
         """Get Solar Power Production - Hourly Averaged Actual and Forecasted Values
@@ -541,7 +582,7 @@ class ErcotAPI:
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with hourly solar power production reports
+            pl.DataFrame: A DataFrame with hourly solar power production reports
         """
         return self._get_solar_actual_and_forecast_hourly(
             endpoint=HOURLY_SOLAR_POWER_PRODUCTION_ENDPOINT,
@@ -566,7 +607,7 @@ class ErcotAPI:
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with hourly wind power production reports
+            pl.DataFrame: A DataFrame with hourly wind power production reports
         """
         return self._get_solar_actual_and_forecast_hourly(
             endpoint=HOURLY_SOLAR_POWER_PRODUCTION_BY_GEOGRAPHICAL_REGION_ENDPOINT,
@@ -608,42 +649,28 @@ class ErcotAPI:
             verbose=verbose,
         )
 
-    def _handle_solar_actual_and_forecast_hourly(self, data, columns, verbose=False):
-        # Store raw data before parse_doc to check for xhr in filename
-        raw_data = data.copy()
-        data = Ercot().parse_doc(data, verbose=verbose)
-
-        data.columns = data.columns.str.replace("_", " ")
-
-        try:
-            data["Publish Time"] = pd.to_datetime(data["postDatetime"]).dt.tz_localize(
-                self.default_timezone,
-            )
+    def _handle_solar_actual_and_forecast_hourly(
+        self,
+        data: pl.DataFrame,
+        columns: list[str],
+        verbose: bool = False,
+    ) -> pl.DataFrame:
+        raw_data = data.clone()
+        data = self._parse_ercot_doc(data, verbose=verbose)
+        data = data.rename(
+            {c: c.replace("_", " ") for c in data.columns},
+        )
         # NOTE: ERCOT gives ambiguous Publish Times for the DST transition
         # Timestamps with "xhr" in filename are CST, all other ambiguous timestamps are CDT
-        except pytz.exceptions.AmbiguousTimeError:
-            ambiguous_array = self._determine_ambiguous_timezone_for_publish_time(
-                data["postDatetime"],
-                raw_data=raw_data,
-            )
-            data["Publish Time"] = pd.to_datetime(data["postDatetime"]).dt.tz_localize(
-                self.default_timezone,
-                ambiguous=ambiguous_array,
-            )
-
-        data = (
-            utils.move_cols_to_front(
-                data,
-                ["Interval Start", "Interval End", "Publish Time"],
-            )
-            .drop(columns=["Time", "postDatetime", "_source_filename"], errors="ignore")
-            .sort_values(["Interval Start", "Publish Time"])
-            .reset_index(drop=True)
+        data = self._localize_publish_time(data, raw_data=raw_data)
+        data = utils.move_cols_to_front(
+            data.drop(["Time", "postDatetime", "_source_filename"], strict=False),
+            ["Interval Start", "Interval End", "Publish Time"],
         )
-
-        data = Ercot()._rename_hourly_wind_or_solar_report(data)
-
-        return data[columns]
+        data = self._from_ercot_pandas(
+            Ercot()._rename_hourly_wind_or_solar_report(self._to_ercot_pandas(data)),
+        )
+        return data.sort(["Interval Start", "Publish Time"]).select(columns)
 
     @support_date_range(frequency=None)
     def get_load_forecast_by_model(
@@ -651,7 +678,7 @@ class ErcotAPI:
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Seven-Day Load Forecast by Model and Weather Zone.
 
         Forecasted hourly demand by Model and Weather Zone as reported by ERCOT.
@@ -678,31 +705,36 @@ class ErcotAPI:
             add_post_datetime=True,
         )
 
-        data = Ercot().parse_doc(data, verbose=verbose)
-
-        try:
-            publish_time = pd.to_datetime(data["postDatetime"]).dt.tz_localize(
-                self.default_timezone,
-            )
+        data = self._parse_ercot_doc(data, verbose=verbose)
+        has_ambiguous = (
+            data.select(pl.col("postDatetime").cast(pl.Utf8).str.contains("T01:"))
+            .to_series()
+            .any()
+        )
+        dt = pl.col("postDatetime").str.to_datetime(
+            format=POST_DATETIME_FORMAT,
+            strict=False,
+        )
         # The DSTFlag only applies to the Interval Start so we have to assume one way or the other in this situation.
-        except pytz.exceptions.AmbiguousTimeError:
-            publish_time = pd.to_datetime(data["postDatetime"]).dt.tz_localize(
+        if has_ambiguous:
+            publish_time = dt.dt.replace_time_zone(
                 self.default_timezone,
-                ambiguous=True,
+                ambiguous="earliest",
             )
-
-        data["Publish Time"] = publish_time
-        data = Ercot()._handle_load_forecast_by_model(data)
+        else:
+            publish_time = dt.dt.replace_time_zone(self.default_timezone)
+        data = data.with_columns(publish_time.alias("Publish Time"))
+        data = Ercot()._handle_load_forecast_by_model(self._to_ercot_pandas(data))
 
         return (
             utils.move_cols_to_front(
                 data,
                 ["Interval Start", "Interval End", "Publish Time", "Model"],
             )
-            .drop(columns=["Time", "postDatetime"], errors="ignore")
-            .sort_values(["Interval Start", "Publish Time", "Model"])
-            .reset_index(drop=True)
-        )[LOAD_FORECAST_BY_MODEL_COLUMNS]
+            .drop(["Time", "postDatetime"], strict=False)
+            .sort(["Interval Start", "Publish Time", "Model"])
+            .select(LOAD_FORECAST_BY_MODEL_COLUMNS)
+        )
 
     @support_date_range(frequency=None)
     def get_load_by_weather_zone(
@@ -710,7 +742,7 @@ class ErcotAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Actual System Load by Weather Zone.
 
         Hourly actual load by ERCOT weather zone, published once per operating
@@ -752,14 +784,14 @@ class ErcotAPI:
             )
 
         # Normalize the date column name to what Ercot.parse_doc expects.
-        data = data.rename(columns={"OperatingDay": "DeliveryDate"})
+        data = data.rename({"OperatingDay": "DeliveryDate"}, strict=False)
 
-        data = Ercot().parse_doc(data, verbose=verbose)
+        data = self._parse_ercot_doc(data, verbose=verbose)
 
         # The live API returns camelCase columns capitalized to e.g. "FarWest",
         # while the historical archive returns "FAR_WEST" — normalize both.
         data = data.rename(
-            columns={
+            {
                 "Coast": "Coast",
                 "East": "East",
                 "FarWest": "Far West",
@@ -779,6 +811,7 @@ class ErcotAPI:
                 "WEST": "West",
                 "TOTAL": "System Total",
             },
+            strict=False,
         )
 
         columns = (
@@ -789,8 +822,8 @@ class ErcotAPI:
 
         return (
             utils.move_cols_to_front(data, columns)
-            .sort_values("Interval Start")
-            .reset_index(drop=True)[columns]
+            .sort("Interval Start")
+            .select(columns)
         )
 
     @support_date_range(frequency=None)
@@ -799,7 +832,7 @@ class ErcotAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Actual System Load by Forecast Zone.
 
         Hourly actual load by ERCOT forecast zone (North, South, West, Houston),
@@ -841,21 +874,22 @@ class ErcotAPI:
             )
 
         # Normalize the date column name to what Ercot.parse_doc expects.
-        data = data.rename(columns={"OperatingDay": "DeliveryDate"})
+        data = data.rename({"OperatingDay": "DeliveryDate"}, strict=False)
 
-        data = Ercot().parse_doc(data, verbose=verbose)
+        data = self._parse_ercot_doc(data, verbose=verbose)
 
         # The live API returns capitalized columns like "North", while the
         # historical archive returns "NORTH" — normalize both to uppercase
         # to match Ercot.get_load_by_forecast_zone.
         data = data.rename(
-            columns={
+            {
                 "North": "NORTH",
                 "South": "SOUTH",
                 "West": "WEST",
                 "Houston": "HOUSTON",
                 "Total": "TOTAL",
             },
+            strict=False,
         )
 
         columns = [
@@ -871,8 +905,8 @@ class ErcotAPI:
 
         return (
             utils.move_cols_to_front(data, columns)
-            .sort_values("Interval Start")
-            .reset_index(drop=True)[columns]
+            .sort("Interval Start")
+            .select(columns)
         )
 
     def get_as_prices(
@@ -880,7 +914,7 @@ class ErcotAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Ancillary Services Prices
 
         Arguments:
@@ -890,7 +924,7 @@ class ErcotAPI:
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with ancillary services prices as the columns
+            pl.DataFrame: A DataFrame with ancillary services prices as the columns
         """
         data = self.get_mcpc_data(date, end=end, verbose=verbose)
         return self._handle_as_prices(data, verbose=verbose)
@@ -901,7 +935,7 @@ class ErcotAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             return self.get_mcpc_data("today", verbose=verbose)
 
@@ -936,18 +970,18 @@ class ErcotAPI:
 
     def _handle_as_prices(
         self,
-        data: pd.DataFrame,
+        data: pl.DataFrame,
         verbose: bool = False,
-    ) -> pd.DataFrame:
-        data = self.ercot.parse_doc(data, verbose=verbose)
-        data = self.ercot._finalize_as_price_df(data, pivot=True)
-
+    ) -> pl.DataFrame:
+        pdf = self.ercot.parse_doc(
+            self._to_ercot_pandas(data),
+            verbose=verbose,
+        ).to_pandas()
+        pdf = self.ercot._finalize_as_price_df(pdf, pivot=True)
         return (
-            data.sort_values(["Interval Start"])
-            .drop(columns=["Time"])
-            .reset_index(
-                drop=True,
-            )
+            self._from_ercot_pandas(pdf)
+            .sort("Interval Start")
+            .drop("Time", strict=False)
         )
 
     def get_mcpc_dam(
@@ -955,7 +989,7 @@ class ErcotAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Market Clearing Price for Capacity (MCPC) Day-Ahead Market
 
         Arguments:
@@ -965,7 +999,7 @@ class ErcotAPI:
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with MCPC prices in a long format (column for
+            pl.DataFrame: A DataFrame with MCPC prices in a long format (column for
              AS Type)
         """
         data = self.get_mcpc_data(date, end=end, verbose=verbose)
@@ -973,11 +1007,14 @@ class ErcotAPI:
 
     def _handle_mcpc_data(
         self,
-        data: pd.DataFrame,
+        data: pl.DataFrame,
         verbose: bool = False,
-    ) -> pd.DataFrame:
-        data = self.ercot.parse_doc(data, verbose=verbose)
-        return self.ercot._handle_mcpc_dam_df(data)
+    ) -> pl.DataFrame:
+        pdf = self.ercot.parse_doc(
+            self._to_ercot_pandas(data),
+            verbose=verbose,
+        ).to_pandas()
+        return self.ercot._handle_mcpc_dam_df(pdf)
 
     @support_date_range(frequency=None)
     def get_dam_asdc_aggregated(
@@ -985,7 +1022,7 @@ class ErcotAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get DAM Aggregated Ancillary Service Offer Curve (NP4-19-CD).
 
         Contains the aggregated offer curve (price/quantity pairs) per
@@ -1004,7 +1041,7 @@ class ErcotAPI:
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with columns Interval Start,
+            pl.DataFrame: A DataFrame with columns Interval Start,
             Interval End, AS Type, Price, and Quantity.
         """
         if date == "latest":
@@ -1021,7 +1058,7 @@ class ErcotAPI:
             verbose=verbose,
         )
 
-        return self.ercot._handle_dam_asdc_aggregated(data)
+        return self.ercot._handle_dam_asdc_aggregated(self._to_ercot_pandas(data))
 
     @support_date_range(frequency=None)
     def get_as_reports(self, date, end=None, verbose=False):
@@ -1033,7 +1070,7 @@ class ErcotAPI:
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with ancillary services reports
+            pl.DataFrame: A DataFrame with ancillary services reports
         """
         # This method is not supported starting with the file published on 2025-12-08
         # (with data for 2025-12-06)
@@ -1071,10 +1108,9 @@ class ErcotAPI:
         ]
 
         return (
-            pd.concat(dfs)
-            .reset_index(drop=True)
-            .drop(columns=["Time"])
-            .sort_values("Interval Start")
+            pl.concat(dfs, how="diagonal_relaxed")
+            .drop("Time", strict=False)
+            .sort("Interval Start")
         )
 
     @support_date_range(frequency=None)
@@ -1091,7 +1127,7 @@ class ErcotAPI:
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with DAM ancillary services reports
+            pl.DataFrame: A DataFrame with DAM ancillary services reports
         """
         if date == "latest":
             date = self.local_start_of_today() - pd.DateOffset(days=2)
@@ -1125,10 +1161,9 @@ class ErcotAPI:
         ]
 
         return (
-            pd.concat(dfs)
-            .reset_index(drop=True)
-            .drop(columns=["Time"])
-            .sort_values("Interval Start")
+            pl.concat(dfs, how="diagonal_relaxed")
+            .drop("Time", strict=False)
+            .sort("Interval Start")
         )
 
     @support_date_range(frequency=None)
@@ -1148,7 +1183,7 @@ class ErcotAPI:
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with SCED ancillary services offers
+            pl.DataFrame: A DataFrame with SCED ancillary services offers
         """
         if date == "latest":
             date = self.local_start_of_today() - pd.DateOffset(days=2)
@@ -1173,15 +1208,17 @@ class ErcotAPI:
         urls = [tup[0] for tup in links_and_posted_datetimes]
 
         dfs = [
-            self.ercot._handle_as_reports_sced_file(
-                url,
-                verbose=verbose,
-                headers=self.headers(),
+            self._from_ercot_pandas_objects(
+                self.ercot._handle_as_reports_sced_file(
+                    url,
+                    verbose=verbose,
+                    headers=self.headers(),
+                ),
             )
             for url in urls
         ]
 
-        return pd.concat(dfs).reset_index(drop=True).sort_values("SCED Timestamp")
+        return pl.concat(dfs, how="diagonal_relaxed").sort("SCED Timestamp")
 
     @support_date_range(frequency=None)
     def get_as_plan(self, date, end=None, verbose=False):
@@ -1194,7 +1231,7 @@ class ErcotAPI:
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with ancillary services plans
+            pl.DataFrame: A DataFrame with ancillary services plans
         """
         if date == "latest":
             return self.get_as_plan("today", verbose=verbose)
@@ -1210,10 +1247,9 @@ class ErcotAPI:
             verbose=verbose,
         )
 
-        df = Ercot().parse_doc(data)
-        df["Publish Time"] = pd.to_datetime(df["postDatetime"])
-
-        return Ercot()._handle_as_plan(df)
+        pdf = self.ercot.parse_doc(self._to_ercot_pandas(data))
+        pdf["Publish Time"] = pd.to_datetime(pdf["postDatetime"])
+        return self._from_ercot_pandas(Ercot()._handle_as_plan(pdf))
 
     @support_date_range(frequency=None)
     def get_lmp_by_settlement_point(self, date, end=None, verbose=False):
@@ -1226,7 +1262,7 @@ class ErcotAPI:
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with locational marginal prices
+            pl.DataFrame: A DataFrame with locational marginal prices
         """
         if date == "latest":
             return self.get_lmp_by_settlement_point("today", verbose=verbose)
@@ -1253,9 +1289,10 @@ class ErcotAPI:
                 **api_params,
             )
 
-        data = self.ercot._handle_lmp_df(df=data, verbose=verbose)
-
-        return data.sort_values(["Interval Start", "Location"]).reset_index(drop=True)
+        data = self._from_ercot_pandas(
+            self.ercot._handle_lmp_df(df=self._to_ercot_pandas(data), verbose=verbose),
+        )
+        return data.sort(["Interval Start", "Location"])
 
     @support_date_range(frequency=None)
     def get_indicative_lmp_by_settlement_point(
@@ -1263,7 +1300,7 @@ class ErcotAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if not end:
             end = self._handle_end_date(date, end, days_to_add_if_no_end=1)
 
@@ -1274,7 +1311,11 @@ class ErcotAPI:
             bulk_download=True,
             verbose=verbose,
         )
-        return self.ercot._handle_indicative_lmp_by_settlement_point(df)
+        return self._from_ercot_pandas(
+            self.ercot._handle_indicative_lmp_by_settlement_point(
+                self._to_ercot_pandas(df),
+            ),
+        )
 
     @support_date_range(frequency=None)
     def get_hourly_resource_outage_capacity(
@@ -1282,7 +1323,7 @@ class ErcotAPI:
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Hourly Resource Outage Capacity Reports. Fetches all reports
         published on the given date. Reports extend out 168 hours from the
         start of the day.
@@ -1293,7 +1334,7 @@ class ErcotAPI:
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with hourly resource outage capacity reports
+            pl.DataFrame: A DataFrame with hourly resource outage capacity reports
         """
         if date == "latest":
             return self.get_hourly_resource_outage_capacity("today", verbose=verbose)
@@ -1309,13 +1350,13 @@ class ErcotAPI:
             bulk_download=True,
         )
 
-        data["Publish Time"] = pd.to_datetime(data["postDatetime"]).dt.tz_localize(
+        pdf = self._to_ercot_pandas(data)
+        pdf["Publish Time"] = pd.to_datetime(pdf["postDatetime"]).dt.tz_localize(
             self.default_timezone,
             ambiguous="NaT",
         )
-
-        data = self.ercot.parse_doc(
-            data,
+        pdf = self.ercot.parse_doc(
+            pdf,
             # there is no DST flag column and the data set ignores DST
             # so, we will default to assuming it is DST. We will also
             # set nonexistent times to NaT and drop them
@@ -1323,17 +1364,14 @@ class ErcotAPI:
             nonexistent="NaT",
             verbose=verbose,
         ).dropna(subset=["Interval Start", "Publish Time"])
-
+        pdf = self.ercot._handle_hourly_resource_outage_capacity_df(df=pdf)
         data = utils.move_cols_to_front(
-            data,
+            self._from_ercot_pandas(pdf),
             ["Interval Start", "Interval End", "Publish Time"],
         )
-
-        return (
-            self.ercot._handle_hourly_resource_outage_capacity_df(df=data)
-            .sort_values(["Interval Start", "Publish Time"])
-            .reset_index(drop=True)
-            .drop(columns=["Time", "postDatetime"])
+        return data.sort(["Interval Start", "Publish Time"]).drop(
+            ["Time", "postDatetime"],
+            strict=False,
         )
 
     @support_date_range(frequency=None)
@@ -1345,7 +1383,7 @@ class ErcotAPI:
             date (str): the date to fetch prices for.
             end (str, optional): the end date to fetch prices for. Defaults to None.
         Returns:
-            pandas.DataFrame: A DataFrame with lmps by bus
+            pl.DataFrame: A DataFrame with lmps by bus
 
         Data from https://data.ercot.com/data-product-archive/NP6-787-CD
         """
@@ -1377,13 +1415,22 @@ class ErcotAPI:
 
         return self._handle_lmp_by_bus(data, verbose=verbose)
 
-    def _handle_lmp_by_bus(self, data, verbose=False):
-        data = self.ercot._handle_sced_timestamp(data, verbose=verbose)
-
-        data = data.rename(columns={"ElectricalBus": "Location"})
-        data["Location Type"] = ELECTRICAL_BUS_LOCATION_TYPE
-        data["Market"] = Markets.REAL_TIME_SCED.value
-
+    def _handle_lmp_by_bus(
+        self,
+        data: pl.DataFrame,
+        verbose: bool = False,
+    ) -> pl.DataFrame:
+        data = self._from_ercot_pandas(
+            self.ercot._handle_sced_timestamp(
+                self._to_ercot_pandas(data),
+                verbose=verbose,
+            ),
+        )
+        data = data.rename({"ElectricalBus": "Location"})
+        data = data.with_columns(
+            pl.lit(ELECTRICAL_BUS_LOCATION_TYPE).alias("Location Type"),
+            pl.lit(Markets.REAL_TIME_SCED.value).alias("Market"),
+        )
         data = utils.move_cols_to_front(
             data,
             [
@@ -1396,10 +1443,7 @@ class ErcotAPI:
                 "LMP",
             ],
         )
-
-        return data.sort_values(["SCED Timestamp", "Location"]).reset_index(
-            drop=True,
-        )
+        return data.sort(["SCED Timestamp", "Location"])
 
     @support_date_range(frequency=None)
     def get_lmp_by_bus_dam(self, date, end=None, verbose=False):
@@ -1429,18 +1473,19 @@ class ErcotAPI:
 
         return self.parse_dam_doc(data)
 
-    def parse_dam_doc(self, data: pd.DataFrame) -> pd.DataFrame:
-        data = self.ercot.parse_doc(
-            data.rename(
-                columns=dict(
-                    deliveryDate="DeliveryDate",
-                    hourEnding="HourEnding",
-                    busName="BusName",
+    def parse_dam_doc(self, data: pl.DataFrame) -> pl.DataFrame:
+        pdf = self.ercot.parse_doc(
+            self._to_ercot_pandas(
+                data.rename(
+                    {
+                        "deliveryDate": "DeliveryDate",
+                        "hourEnding": "HourEnding",
+                        "busName": "BusName",
+                    },
                 ),
             ),
         )
-
-        return self.ercot._handle_lmp_by_bus_dam_df(data)
+        return self._from_ercot_pandas(self.ercot._handle_lmp_by_bus_dam_df(pdf))
 
     @support_date_range(frequency=None)
     def get_shadow_prices_dam(self, date, end=None, verbose=False):
@@ -1453,7 +1498,7 @@ class ErcotAPI:
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with day-ahead market shadow prices
+            pl.DataFrame: A DataFrame with day-ahead market shadow prices
         """  # noqa
         if date == "latest":
             return self.get_shadow_prices_dam("today", verbose=verbose)
@@ -1489,9 +1534,13 @@ class ErcotAPI:
 
         return self._handle_shadow_prices_dam(data, verbose=verbose)
 
-    def _handle_shadow_prices_dam(self, data, verbose=False):
-        data = self.ercot.parse_doc(data, verbose=verbose)
-        return self.ercot._handle_shadow_prices_dam_df(data)
+    def _handle_shadow_prices_dam(
+        self,
+        data: pl.DataFrame,
+        verbose: bool = False,
+    ) -> pl.DataFrame:
+        pdf = self.ercot.parse_doc(self._to_ercot_pandas(data), verbose=verbose)
+        return self._from_ercot_pandas(self.ercot._handle_shadow_prices_dam_df(pdf))
 
     @support_date_range(frequency=None)
     def get_shadow_prices_sced(self, date, end=None, verbose=False):
@@ -1503,7 +1552,7 @@ class ErcotAPI:
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with real-time market shadow prices
+            pl.DataFrame: A DataFrame with real-time market shadow prices
         """  # noqa
         if date == "latest":
             return self.get_shadow_prices_sced("today", verbose=verbose)
@@ -1537,17 +1586,17 @@ class ErcotAPI:
 
     def _handle_shadow_prices_sced(
         self,
-        data: pd.DataFrame,
-        verbose=False,
-    ) -> pd.DataFrame:
-        data = self.ercot._handle_sced_timestamp(data, verbose=verbose)
-        data = data.rename(
-            columns=self.ercot._shadow_prices_column_name_mapper(),
+        data: pl.DataFrame,
+        verbose: bool = False,
+    ) -> pl.DataFrame:
+        pdf = self.ercot._handle_sced_timestamp(
+            self._to_ercot_pandas(data),
+            verbose=verbose,
         )
-        data = self.ercot._construct_limiting_facility_column(data)
-        # Fill all empty strings in the dataframe with NaN
-        data = data.replace("", pd.NA)
-
+        pdf = pdf.rename(columns=self.ercot._shadow_prices_column_name_mapper())
+        pdf = self.ercot._construct_limiting_facility_column(pdf)
+        pdf = pdf.replace("", pd.NA)
+        data = self._from_ercot_pandas(pdf)
         data = utils.move_cols_to_front(
             data,
             [
@@ -1560,10 +1609,7 @@ class ErcotAPI:
                 "Limiting Facility",
             ],
         )
-
-        return data.sort_values(["SCED Timestamp", "Constraint ID"]).reset_index(
-            drop=True,
-        )
+        return data.sort(["SCED Timestamp", "Constraint ID"])
 
     @support_date_range(frequency=None)
     def get_spp_real_time_15_min(self, date, end=None, verbose=False):
@@ -1575,7 +1621,7 @@ class ErcotAPI:
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with settlement point prices
+            pl.DataFrame: A DataFrame with settlement point prices
         """
         if date == "latest":
             return self.get_spp_by_settlement_point("today", verbose=verbose)
@@ -1590,17 +1636,15 @@ class ErcotAPI:
             verbose=verbose,
         )
 
-        data = Ercot().parse_doc(data, verbose=verbose)
-
-        data = Ercot()._finalize_spp_df(
-            data,
+        pdf = self.ercot.parse_doc(self._to_ercot_pandas(data), verbose=verbose)
+        pdf = Ercot()._finalize_spp_df(
+            pdf,
             market=Markets.REAL_TIME_15_MIN,
             locations="ALL",
             location_type="ALL",
             verbose=verbose,
         )
-
-        return data.sort_values(["Interval Start", "Location"]).reset_index(drop=True)
+        return self._from_ercot_pandas(pdf).sort(["Interval Start", "Location"])
 
     @support_date_range(frequency=None)
     def get_spp_day_ahead_hourly(self, date, end=None, verbose=False):
@@ -1612,7 +1656,7 @@ class ErcotAPI:
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with settlement point prices
+            pl.DataFrame: A DataFrame with settlement point prices
         """
         if date == "latest":
             return self.get_spp_day_ahead_hourly("today", verbose=verbose)
@@ -1630,17 +1674,15 @@ class ErcotAPI:
             verbose=verbose,
         )
 
-        data = Ercot().parse_doc(data, verbose=verbose)
-
-        data = Ercot()._finalize_spp_df(
-            data,
+        pdf = self.ercot.parse_doc(self._to_ercot_pandas(data), verbose=verbose)
+        pdf = Ercot()._finalize_spp_df(
+            pdf,
             market=Markets.DAY_AHEAD_HOURLY,
             locations="ALL",
             location_type="ALL",
             verbose=verbose,
         )
-
-        return data.sort_values(["Interval Start", "Location"]).reset_index(drop=True)
+        return self._from_ercot_pandas(pdf).sort(["Interval Start", "Location"])
 
     @support_date_range(frequency=None)
     def get_60_day_dam_disclosure(
@@ -1649,7 +1691,7 @@ class ErcotAPI:
         end: str | pd.Timestamp = None,
         verbose: bool = False,
         output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
-    ) -> Dict[str, pd.DataFrame]:
+    ) -> Dict[str, pl.DataFrame]:
         """
         Get the 60-day DAM disclosure reports from ERCOT.
 
@@ -1719,7 +1761,13 @@ class ErcotAPI:
             df_list.append(processed_files)
 
         # Take the list of dictionaries and concat the dataframes for each key
-        return {key: pd.concat([d[key] for d in df_list]) for key in df_list[0].keys()}
+        return {
+            key: pl.concat(
+                [d[key] for d in df_list],
+                how="diagonal_relaxed",
+            )
+            for key in df_list[0].keys()
+        }
 
     @support_date_range(frequency=None)
     def get_60_day_sced_disclosure(
@@ -1729,7 +1777,7 @@ class ErcotAPI:
         verbose: bool = False,
         process: bool = True,
         output_format: CurveOutputFormat | str = CurveOutputFormat.LIST,
-    ) -> Dict[str, pd.DataFrame]:
+    ) -> Dict[str, pl.DataFrame]:
         """
         Get the 60-day SCED disclosure reports from ERCOT.
 
@@ -1787,7 +1835,13 @@ class ErcotAPI:
             df_list.append(processed_files)
 
         # Take the list of dictionaries and concat the dataframes for each key
-        return {key: pd.concat([d[key] for d in df_list]) for key in df_list[0].keys()}
+        return {
+            key: pl.concat(
+                [d[key] for d in df_list],
+                how="diagonal_relaxed",
+            )
+            for key in df_list[0].keys()
+        }
 
     @support_date_range(frequency=None)
     def get_cop_adjustment_period_snapshot_60_day(
@@ -1795,7 +1849,7 @@ class ErcotAPI:
         date: str | pd.Timestamp,
         end: str | pd.Timestamp = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         # Reports are delayed by 60 days
         date = date + pd.DateOffset(days=60)
 
@@ -1814,9 +1868,10 @@ class ErcotAPI:
             add_post_datetime=False,
         )
 
-        data = Ercot().parse_doc(raw_data)
-
-        return Ercot()._process_cop_adjustment_period_snapshot_60_day_data(data)
+        pdf = self.ercot.parse_doc(self._to_ercot_pandas(raw_data)).to_pandas()
+        return self._from_ercot_pandas(
+            Ercot()._process_cop_adjustment_period_snapshot_60_day_data(pdf),
+        )
 
     @support_date_range(frequency=None)
     def get_system_load_charging_4_seconds(
@@ -1824,7 +1879,7 @@ class ErcotAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             return self.get_system_load_charging_4_seconds(
                 "today",
@@ -1853,30 +1908,30 @@ class ErcotAPI:
             pd.to_datetime(data["AGCExecTime"].min()).tz
             != pd.to_datetime(data["AGCExecTime"].max()).tz
         ):
-            data = data.drop_duplicates(
+            data = data.unique(
                 subset=["AGCExecTime", "DSTFlag", "SystemDemand"],
+                keep="first",
             )
 
-        data["AGCExecTime"] = pd.to_datetime(data["AGCExecTime"]).dt.tz_localize(
-            self.default_timezone,
-            ambiguous=Ercot().ambiguous_based_on_dstflag(data),
+        data = data.with_columns(
+            pl.col("AGCExecTime")
+            .str.to_datetime(format="%Y-%m-%dT%H:%M:%S", strict=False)
+            .dt.replace_time_zone(
+                self.default_timezone,
+                ambiguous=self._ambiguous_based_on_dstflag_expr(),
+            )
+            .alias("AGCExecTime"),
         )
 
         data = data.rename(
-            columns={
+            {
                 "AGCExecTime": "Time",
                 "SystemDemand": "System Demand",
                 "ESRChargingMW": "ESR Charging MW",
             },
         )
 
-        data = (
-            data.drop(columns=["DSTFlag", "AGCExecTimeUTC"])
-            .sort_values("Time")
-            .reset_index(drop=True)
-        )
-
-        return data
+        return data.drop(["DSTFlag", "AGCExecTimeUTC"], strict=False).sort("Time")
 
     def get_historical_data(
         self,
@@ -1889,7 +1944,7 @@ class ErcotAPI:
         bulk_download: bool = True,
         include_source_filename: bool = False,
         api: APITypeEnum = APITypeEnum.PUBLIC_API,
-    ) -> pd.DataFrame | bytes:
+    ) -> pl.DataFrame | bytes:
         """Retrieves historical data from the given emil_id from start to end date.
         The historical data endpoint only allows filtering by the postDatetimeTo and
         postDatetimeFrom parameters. The retrieval process has two steps:
@@ -1919,7 +1974,7 @@ class ErcotAPI:
                 False.
 
         Returns:
-            [pandas.DataFrame]: a dataframe of historical data when read_as_csv is
+            [pl.DataFrame]: a dataframe of historical data when read_as_csv is
                 True. Otherwise, returns the bytes.
         """
         emil_id = endpoint.split("/")[1]
@@ -1967,15 +2022,15 @@ class ErcotAPI:
                 bytes_data = file_data
                 filename = None
 
-            df = pd.read_csv(bytes_data, compression="zip")
+            pdf = pd.read_csv(bytes_data, compression="zip")
             if add_post_datetime:
-                df["postDatetime"] = posted_datetime
+                pdf["postDatetime"] = posted_datetime
             if include_source_filename:
                 # Store filename for xhr detection (prefer filename from zip, fallback to link)
-                df["_source_filename"] = filename if filename else link
-            dfs.append(df)
+                pdf["_source_filename"] = filename if filename else link
+            dfs.append(pl.from_pandas(pdf, include_index=False))
 
-        return pd.concat(dfs)
+        return pl.concat(dfs)
 
     def _individually_download_documents(
         self,
@@ -2142,7 +2197,7 @@ class ErcotAPI:
         verbose: bool = False,
         api: APITypeEnum = APITypeEnum.PUBLIC_API,
         **api_params,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Retrieves data from the given endpoint of the ERCOT API
 
         Arguments:
@@ -2241,8 +2296,12 @@ class ErcotAPI:
         columns = [col[:1].upper() + col[1:] for col in columns]
 
         # Strip the extra whitespace from the data
-        data = pd.DataFrame(data=data_results, columns=columns)
-        data = data.apply(lambda x: x.str.strip() if x.dtype == "object" else x)
+        data = pl.DataFrame(data_results, schema=columns, orient="row")
+        string_cols = [c for c, dtype in data.schema.items() if dtype == pl.Utf8]
+        if string_cols:
+            data = data.with_columns(
+                [pl.col(c).str.strip_chars() for c in string_cols],
+            )
 
         return data
 

--- a/gridstatus/ieso.py
+++ b/gridstatus/ieso.py
@@ -8,13 +8,14 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from enum import Enum
 from io import StringIO
-from typing import Literal, Optional
+from typing import Literal
 from urllib.error import HTTPError
 from warnings import warn
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
 
 import pandas as pd
+import polars as pl
 import requests
 import tqdm
 import xmltodict
@@ -74,11 +75,11 @@ class SurplusState(str, Enum):
 
 
 def _safe_find_text(
-    element: Optional[Element],
+    element: Element | None,
     tag: str,
-    namespaces: Optional[dict[str, str]] = None,
-    default: Optional[str] = None,
-) -> Optional[str]:
+    namespaces: dict[str, str] | None = None,
+    default: str | None = None,
+) -> str | None:
     """Safely find and extract text from an XML element.
 
     Args:
@@ -101,11 +102,11 @@ def _safe_find_text(
 
 
 def _safe_find_int(
-    element: Optional[Element],
+    element: Element | None,
     tag: str,
-    namespaces: Optional[dict[str, str]] = None,
-    default: Optional[int] = None,
-) -> Optional[int]:
+    namespaces: dict[str, str] | None = None,
+    default: int | None = None,
+) -> int | None:
     """Safely find and extract integer from an XML element.
 
     Args:
@@ -128,11 +129,11 @@ def _safe_find_int(
 
 
 def _safe_find_float(
-    element: Optional[Element],
+    element: Element | None,
     tag: str,
-    namespaces: Optional[dict[str, str]] = None,
-    default: Optional[float] = None,
-) -> Optional[float]:
+    namespaces: dict[str, str] | None = None,
+    default: float | None = None,
+) -> float | None:
     """Safely find and extract float from an XML element.
 
     Args:
@@ -190,7 +191,7 @@ class IESO(ISOBase):
             frequency (str, optional): Frequency of data. Defaults to "5min".
 
         Returns:
-            pd.DataFrame: zonal load as a wide table with columns for each zone
+            pl.DataFrame: zonal load as a wide table with columns for each zone
         """
         raise NotSupported(
             f"With the IESO Market Renewal on {RETIRED_DATE}, this method is no longer supported. To get load data, use the `get_real_time_totals` method instead.",
@@ -206,7 +207,7 @@ class IESO(ISOBase):
             verbose (bool, optional): Print verbose output. Defaults to False.
 
         Returns:
-            pd.DataFrame: Ontario load forecast
+            pl.DataFrame: Ontario load forecast
         """
         raise NotSupported(
             f"With the IESO Market Renewal on {RETIRED_DATE}, this method is no longer supported. To get load forecast data, use the `get_resource_adequacy_report` method instead.",
@@ -237,7 +238,7 @@ class IESO(ISOBase):
 
 
         Returns:
-            pd.DataFrame: forecasted load as a wide table with columns for each zone
+            pl.DataFrame: forecasted load as a wide table with columns for each zone
         """
         raise NotSupported(
             f"With the IESO Market Renewal on {RETIRED_DATE}, this method is no longer supported. To get zonal load forecast data, use the `get_resource_adequacy_report` method instead.",
@@ -265,7 +266,7 @@ class IESO(ISOBase):
             verbose (bool, optional): Print verbose output. Defaults to False.
 
         Returns:
-            pd.DataFrame: fuel mix
+            pl.DataFrame: fuel mix
         """
         # Required because this method is not decorated with support_date_range
         if isinstance(date, tuple):
@@ -290,25 +291,26 @@ class IESO(ISOBase):
         else:
             data = (
                 self._retrieve_fuel_mix(date, end, verbose)
-                .groupby(["Fuel Type", "Interval Start", "Interval End"])
-                .sum(numeric_only=True)
-                .reset_index()
+                .group_by(["Fuel Type", "Interval Start", "Interval End"])
+                .agg(pl.col("Output MW").sum())
             )
 
-            pivoted = data.pivot_table(
+            pivoted = data.pivot(
                 index=["Interval Start", "Interval End"],
-                columns="Fuel Type",
+                on="Fuel Type",
                 values="Output MW",
-            ).reset_index()
+                aggregate_function="sum",
+            )
 
-            pivoted.columns = [c.title() for c in pivoted.columns]
-            pivoted.index.name = None
+            rename_map = {
+                c: c.title()
+                for c in pivoted.columns
+                if c not in ["Interval Start", "Interval End"]
+            }
+            data = pivoted.rename(rename_map)
 
-            data = pivoted.copy()
-
-        # Older data does not have the other fuel type
         if "Other" not in data.columns:
-            data["Other"] = pd.NA
+            data = data.with_columns(pl.lit(None).cast(pl.Float64).alias("Other"))
 
         data = utils.move_cols_to_front(
             data,
@@ -327,14 +329,14 @@ class IESO(ISOBase):
         if end:
             end = utils._handle_date(end, tz=self.default_timezone)
 
-            return data[
-                (data["Interval Start"] >= date) & (data["Interval Start"] <= end)
-            ].reset_index(drop=True)
+            return data.filter(
+                (pl.col("Interval Start") >= date) & (pl.col("Interval Start") <= end),
+            ).sort("Interval Start")
 
         elif date == "latest":
-            return data
+            return data.sort("Interval Start")
 
-        return data[data["Interval Start"] >= date].reset_index(drop=True)
+        return data.filter(pl.col("Interval Start") >= date).sort("Interval Start")
 
     def get_generator_report_hourly(
         self,
@@ -358,7 +360,7 @@ class IESO(ISOBase):
             verbose (bool, optional): Print verbose output. Defaults to False.
 
         Returns:
-            pd.DataFrame: generator output and capability/available capacity
+            pl.DataFrame: generator output and capability/available capacity
         """
         # Required because this method is not decorated with support_date_range
         if isinstance(date, tuple):
@@ -396,19 +398,19 @@ class IESO(ISOBase):
                 "Available Capacity MW",
                 "Forecast MW",
             ],
-        ).sort_values(["Interval Start", "Fuel Type", "Generator Name"])
+        ).sort(["Interval Start", "Fuel Type", "Generator Name"])
 
         if end:
             end = utils._handle_date(end, tz=self.default_timezone)
 
-            return data[
-                (data["Interval Start"] >= date) & (data["Interval Start"] <= end)
-            ].reset_index(drop=True)
+            return data.filter(
+                (pl.col("Interval Start") >= date) & (pl.col("Interval Start") <= end),
+            )
 
         if date == "latest":
-            return data.reset_index(drop=True)
+            return data
 
-        return data[data["Interval Start"] >= date].reset_index(drop=True)
+        return data.filter(pl.col("Interval Start") >= date)
 
     @support_date_range(frequency="DAY_START")
     def _retrieve_fuel_mix(
@@ -431,7 +433,7 @@ class IESO(ISOBase):
             verbose (bool, optional): Whether to print verbose output. Defaults to False.
 
         Returns:
-            pd.DataFrame: Fuel mix data
+            pl.DataFrame: Fuel mix data
         """
         url = FUEL_MIX_TEMPLATE_URL.replace(
             "_YYYYMMDD",
@@ -528,17 +530,16 @@ class IESO(ISOBase):
         ]
 
         # Creating the DataFrame with the correct date
-        df = pd.DataFrame(data, columns=columns)
-        df["Interval Start"] = (
-            pd.to_datetime(df["Date"])
+        pdf = pd.DataFrame(data, columns=columns)
+        pdf["Interval Start"] = (
+            pd.to_datetime(pdf["Date"])
             + pd.to_timedelta(
-                # Subtract 1 from the hour because hour 1 is from 00:00 - 01:00
-                df["Hour"].astype(int) - 1,
+                pdf["Hour"].astype(int) - 1,
                 unit="h",
             )
         ).dt.tz_localize(self.default_timezone)
 
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(hours=1)
+        pdf["Interval End"] = pdf["Interval Start"] + pd.Timedelta(hours=1)
 
         float_cols = [
             "Output MW",
@@ -547,9 +548,9 @@ class IESO(ISOBase):
             "Forecast MW",
         ]
 
-        df[float_cols] = df[float_cols].astype(float)
+        pdf[float_cols] = pdf[float_cols].astype(float)
 
-        return df.drop(columns=["Date", "Hour"])
+        return pl.from_pandas(pdf.drop(columns=["Date", "Hour"]), include_index=False)
 
     @support_date_range(frequency="YEAR_START")
     def _retrieve_historical_fuel_mix(
@@ -626,17 +627,17 @@ class IESO(ISOBase):
         columns = [c.title() for c in columns]
 
         # Creating the DataFrame with the adjusted parsing logic
-        df = pd.DataFrame(data, columns=columns)
-        df["Interval Start"] = (
-            pd.to_datetime(df["Date"])
-            + pd.to_timedelta(
-                # Subtract 1 from the hour because hour 1 is from 00:00 - 01:00
-                df["Hour"].astype(int) - 1,
-                unit="h",
+        df = pl.DataFrame(data, schema=columns, orient="row")
+        df = df.with_columns(
+            (
+                pl.col("Date").str.to_datetime()
+                + pl.duration(hours=pl.col("Hour").cast(pl.Int64) - 1)
             )
-        ).dt.tz_localize(self.default_timezone)
-
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(hours=1)
+            .dt.replace_time_zone(self.default_timezone)
+            .alias("Interval Start"),
+        ).with_columns(
+            (pl.col("Interval Start") + pl.duration(hours=1)).alias("Interval End"),
+        )
 
         return utils.move_cols_to_front(
             df,
@@ -650,7 +651,7 @@ class IESO(ISOBase):
                 "Solar",
                 "Biofuel",
             ],
-        ).drop(columns=["Date", "Hour"])
+        ).drop(["Date", "Hour"])
 
     # Function to extract data for a specific Market Quantity considering namespace
     def _extract_load_in_market_quantity(
@@ -728,17 +729,15 @@ class IESO(ISOBase):
 
         return self._handle_mcp_data(data)
 
-    def _handle_mcp_data(self, data: pd.DataFrame) -> pd.DataFrame:
+    def _handle_mcp_data(self, data: pd.DataFrame) -> pl.DataFrame:
         data["Interval End"] = (
             pd.to_datetime(data["Delivery Date"])
             + pd.to_timedelta(data["Hour Ending"] - 1, unit="h")
-            # Each interval is 5 minutes
             + (5 * pd.to_timedelta(data["Interval"], unit="m"))
         ).dt.tz_localize(self.default_timezone)
 
         data["Interval Start"] = data["Interval End"] - pd.Timedelta(minutes=5)
 
-        # Pivot so each component is a column
         data = data.pivot_table(
             index=["Interval Start", "Interval End", "Location"],
             columns="Component",
@@ -766,7 +765,10 @@ class IESO(ISOBase):
             ]
         ]
 
-        return data.sort_values(["Interval Start", "Location"])
+        return pl.from_pandas(
+            data.sort_values(["Interval Start", "Location"]),
+            include_index=False,
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_hoep_real_time_hourly(
@@ -774,7 +776,7 @@ class IESO(ISOBase):
         date: str | datetime.date | datetime.datetime,
         end: datetime.date | datetime.datetime | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         retired_data_warning()
 
         if date == "latest":
@@ -811,7 +813,7 @@ class IESO(ISOBase):
 
         data = data[["Interval Start", "Interval End", "HOEP"]]
 
-        return data.sort_values("Interval Start")
+        return pl.from_pandas(data.sort_values("Interval Start"), include_index=False)
 
     @support_date_range(frequency="YEAR_START")
     def get_hoep_historical_hourly(
@@ -846,7 +848,7 @@ class IESO(ISOBase):
             ]
         ]
 
-        return data.sort_values("Interval Start")
+        return pl.from_pandas(data.sort_values("Interval Start"), include_index=False)
 
     def _request(self, url: str, verbose: bool = False):
         logger.info(f"Fetching URL: {url}")
@@ -896,7 +898,7 @@ class IESO(ISOBase):
         end: datetime.date | datetime.datetime | None = None,
         vintage: Literal["all", "latest"] = "latest",
         last_modified: str | datetime.date | datetime.datetime | None = None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Retrieve and parse the Resource Adequacy Report for a given date.
 
         Args:
@@ -906,7 +908,7 @@ class IESO(ISOBase):
             last_modified (str | datetime.date | datetime.datetime | None): The last modified time after which to get report(s)
 
         Returns:
-            pd.DataFrame: The Resource Adequacy Report df for the given date
+            pl.DataFrame: The Resource Adequacy Report df for the given date
         """
         if last_modified:
             last_modified = utils._handle_date(last_modified, tz=self.default_timezone)
@@ -917,7 +919,7 @@ class IESO(ISOBase):
                 last_modified,
             )
             df = self._parse_resource_adequacy_report(json_data)
-            df["Last Modified"] = file_last_modified
+            df = df.with_columns(pl.lit(file_last_modified).alias("Last Modified"))
 
         elif vintage == "all":
             json_data_with_times = self._get_all_resource_adequacy_jsons(
@@ -926,10 +928,12 @@ class IESO(ISOBase):
             )
             dfs = []
             for json_data, file_last_modified in json_data_with_times:
-                df = self._parse_resource_adequacy_report(json_data)
-                df["Last Modified"] = file_last_modified
-                dfs.append(df)
-            df = pd.concat(dfs)
+                report_df = self._parse_resource_adequacy_report(json_data)
+                report_df = report_df.with_columns(
+                    pl.lit(file_last_modified).alias("Last Modified"),
+                )
+                dfs.append(report_df)
+            df = pl.concat(dfs, how="diagonal_relaxed")
 
         df = utils.move_cols_to_front(
             df,
@@ -941,12 +945,12 @@ class IESO(ISOBase):
             ],
         )
         logger.debug(f"DataFrame Shape: {df.shape}")
-        return df.sort_values(["Interval Start", "Publish Time", "Last Modified"])
+        return df.sort(["Interval Start", "Publish Time", "Last Modified"])
 
     def get_resource_adequacy_report_by_last_modified(
         self,
         last_modified: str | datetime.date | datetime.datetime,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Retrieve and parse Resource Adequacy Reports modified after last_modified time.
         This method bypasses date iteration and gets all files across all dates.
         This is useful for ETL systems that want to get all new files at once.
@@ -956,7 +960,7 @@ class IESO(ISOBase):
             vintage: The version of the report to get
 
         Returns:
-            pd.DataFrame: The Resource Adequacy Report df with all files modified after last_modified
+            pl.DataFrame: The Resource Adequacy Report df with all files modified after last_modified
         """
         if last_modified:
             last_modified = utils._handle_date(last_modified, tz=self.default_timezone)
@@ -967,9 +971,11 @@ class IESO(ISOBase):
         dfs = []
         for json_data, file_last_modified in json_data_with_times:
             try:
-                df = self._parse_resource_adequacy_report(json_data)
-                df["Last Modified"] = file_last_modified
-                dfs.append(df)
+                report_df = self._parse_resource_adequacy_report(json_data)
+                report_df = report_df.with_columns(
+                    pl.lit(file_last_modified).alias("Last Modified"),
+                )
+                dfs.append(report_df)
             except Exception as e:
                 logger.warning(
                     f"Failed to parse resource adequacy report: {str(e)}",
@@ -977,9 +983,9 @@ class IESO(ISOBase):
                 continue
 
         if not dfs:
-            return pd.DataFrame()
+            return pl.DataFrame()
 
-        df = pd.concat(dfs, ignore_index=True) if len(dfs) > 1 else dfs[0]
+        df = pl.concat(dfs, how="diagonal_relaxed") if len(dfs) > 1 else dfs[0]
         df = utils.move_cols_to_front(
             df,
             [
@@ -990,7 +996,7 @@ class IESO(ISOBase):
             ],
         )
         logger.debug(f"DataFrame Shape: {df.shape}")
-        return df.sort_values(["Interval Start", "Publish Time", "Last Modified"])
+        return df.sort(["Interval Start", "Publish Time", "Last Modified"])
 
     # Note(Kladar): This might be fairly generalizable to other XML reports from IESO
     def _get_latest_resource_adequacy_json(
@@ -1275,7 +1281,7 @@ class IESO(ISOBase):
 
         return json_data_with_times
 
-    def _parse_resource_adequacy_report(self, json_data: dict) -> pd.DataFrame:
+    def _parse_resource_adequacy_report(self, json_data: dict) -> pl.DataFrame:
         """Parse the Resource Adequacy Report JSON into DataFrames."""
         document_body = json_data["Document"]["DocBody"]
         report_data = []
@@ -1438,7 +1444,7 @@ class IESO(ISOBase):
 
         # NOTE(kladar): This is the first place where pandas is truly invoked, leaving it open for more modern
         # dataframe libraries to be swapped in in the future
-        df = pd.DataFrame(report_data)
+        df = pl.DataFrame(report_data, infer_schema_length=None)
 
         publish_time = pd.Timestamp(
             json_data["Document"]["DocHeader"]["CreatedAt"],
@@ -1450,15 +1456,17 @@ class IESO(ISOBase):
         )
         logger.debug(f"Publish Time: {publish_time}")
         logger.debug(f"Delivery Date: {delivery_date}")
-        df["Interval Start"] = delivery_date + pd.to_timedelta(
-            df["DeliveryHour"] - 1,
-            unit="h",
+        df = df.with_columns(
+            (
+                pl.lit(delivery_date)
+                + pl.duration(hours=pl.col("DeliveryHour").cast(pl.Int64) - 1)
+            ).alias("Interval Start"),
+        ).with_columns(
+            (pl.col("Interval Start") + pl.duration(hours=1)).alias("Interval End"),
+            pl.lit(publish_time).alias("Publish Time"),
         )
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(hours=1)
-        df["Publish Time"] = publish_time
 
-        df = df.drop(columns=["DeliveryHour"])
-        return df
+        return df.drop("DeliveryHour")
 
     def _extract_hourly_values(
         self,
@@ -1531,7 +1539,7 @@ class IESO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get forecast surplus baseload generation.
 
         Args:
@@ -1617,11 +1625,13 @@ class IESO(ISOBase):
                     },
                 )
 
-        df = pd.DataFrame(data)
-        df.sort_values("Interval Start", inplace=True)
-        df.reset_index(drop=True, inplace=True)
+        df = (
+            pl.DataFrame(data, infer_schema_length=None)
+            .with_columns(pl.col("Action").cast(pl.Utf8))
+            .sort("Interval Start")
+        )
 
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -1631,8 +1641,8 @@ class IESO(ISOBase):
                 "Action",
                 "Export Forecast MW",
                 "Minimum Generation Status",
-            ]
-        ]
+            ],
+        )
 
     @support_date_range(frequency="YEAR_START")
     def get_yearly_intertie_actual_schedule_flow_hourly(
@@ -1642,7 +1652,7 @@ class IESO(ISOBase):
         verbose: bool = False,
         vintage: Literal["all", "latest"] = "latest",
         last_modified: str | datetime.date | datetime.datetime | None = None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get yearly intertie actual schedule flow hourly. Since this is a yearly file
         it is updated less frequency than the daily files. These can be retrieved via
         the get_intertie_schedule_flow_hourly method.
@@ -1690,16 +1700,16 @@ class IESO(ISOBase):
                 all_data.append(df)
 
             if not all_data:
-                return pd.DataFrame()
+                return pl.DataFrame()
 
-            result_df = pd.concat(all_data)
+            result_df = pl.concat(all_data, how="diagonal_relaxed")
 
-            result_df = result_df[
-                (result_df["Interval Start"] >= pd.Timestamp(start_date))
-                & (result_df["Interval Start"] <= pd.Timestamp(end_date))
-            ]
+            result_df = result_df.filter(
+                (pl.col("Interval Start") >= pd.Timestamp(start_date))
+                & (pl.col("Interval Start") <= pd.Timestamp(end_date)),
+            )
 
-            return result_df.sort_values(["Interval Start", "Publish Time"])
+            return result_df.sort(["Interval Start", "Publish Time"])
 
         year = pd.Timestamp(date).year
         df = self._get_intertie_schedule_flow_data(
@@ -1711,15 +1721,15 @@ class IESO(ISOBase):
 
         if end:
             end_date = utils._handle_date(end, tz=self.default_timezone)
-            df = df[
-                (df["Interval Start"] >= pd.Timestamp(date))
-                & (df["Interval Start"] <= end_date)
-            ]
+            df = df.filter(
+                (pl.col("Interval Start") >= pd.Timestamp(date))
+                & (pl.col("Interval Start") <= end_date),
+            )
         else:
             target_date = pd.Timestamp(date).date()
-            df = df[df["Interval Start"].dt.date == target_date]
+            df = df.filter(pl.col("Interval Start").dt.date() == target_date)
 
-        return df[INTERTIE_ACTUAL_SCHEDULE_FLOW_HOURLY_COLUMNS].reset_index(drop=True)
+        return df.select(INTERTIE_ACTUAL_SCHEDULE_FLOW_HOURLY_COLUMNS)
 
     def _get_intertie_schedule_flow_data(
         self,
@@ -1727,7 +1737,7 @@ class IESO(ISOBase):
         vintage: Literal["all", "latest"] = "latest",
         last_modified: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Fetch and parse intertie schedule flow data for a specific year.
         Args:
             year: The year to fetch data for
@@ -1774,7 +1784,7 @@ class IESO(ISOBase):
 
             if last_modified and last_modified_time < last_modified:
                 logger.info(f"No files for year {year} modified after {last_modified}")
-                return pd.DataFrame()
+                return pl.DataFrame()
 
             logger.info(f"Fetching intertie schedule flow data from {url}")
             return self._parse_intertie_schedule_flow_file(
@@ -1812,21 +1822,20 @@ class IESO(ISOBase):
                     verbose,
                 )
                 all_data.append(df)
-            df_final = pd.concat(all_data)
+            df_final = pl.concat(all_data, how="diagonal_relaxed")
             logger.info(
                 f"Dropping duplicates from vintage {vintage} concatenation of files",
             )
-            df_final.drop_duplicates(inplace=True)
-            return df_final.sort_values(["Interval Start", "Publish Time"]).reset_index(
-                drop=True,
-            )
+            return df_final.unique(
+                maintain_order=True,
+            ).sort(["Interval Start", "Publish Time"])
 
     def _parse_intertie_schedule_flow_file(
         self,
         url: str,
         last_modified_time: pd.Timestamp,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Parse a single intertie schedule flow CSV file.
         Args:
             url: URL of the CSV file to parse
@@ -1887,8 +1896,8 @@ class IESO(ISOBase):
         total_columns = sorted([column for column in df.columns if "Total" in column])
         df = utils.move_cols_to_front(df, key_columns + total_columns)
 
-        df.drop(columns=["Date", "Hour"], inplace=True)
-        return df
+        df = df.drop(columns=["Date", "Hour"])
+        return pl.from_pandas(df, include_index=False)
 
     @support_date_range(frequency="DAY_START")
     def get_intertie_actual_schedule_flow_hourly(
@@ -1896,7 +1905,7 @@ class IESO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_and_parse_intertie_schedule_flow(
             date,
             return_five_minute_data=False,
@@ -1909,7 +1918,7 @@ class IESO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_and_parse_intertie_schedule_flow(
             date,
             return_five_minute_data=True,
@@ -1921,7 +1930,7 @@ class IESO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         return_five_minute_data: bool = False,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         directory_path = "IntertieScheduleFlow"
         file_directory = f"{PUBLIC_REPORTS_URL_PREFIX}/{directory_path}"
 
@@ -1990,9 +1999,9 @@ class IESO(ISOBase):
                 )
 
         zone_five_minute_data = pd.DataFrame(zone_interval_records)
-        zone_five_minute_data = zone_five_minute_data.pivot(
-            columns="Zone",
+        zone_five_minute_data = zone_five_minute_data.pivot_table(
             index=["Hour", "Interval"],
+            columns="Zone",
             values=["Import", "Export", "Flow"],
         )
 
@@ -2020,7 +2029,6 @@ class IESO(ISOBase):
             imports = _safe_find_float(schedule, ".//Import", ns)
             exports = _safe_find_float(schedule, ".//Export", ns)
 
-            # Skip if any required values are missing
             if any(val is None for val in [hour, imports, exports]):
                 continue
             total_hourly_schedule_records.append(
@@ -2041,7 +2049,6 @@ class IESO(ISOBase):
             interval = _safe_find_int(actual, ".//Interval", ns)
             flow = _safe_find_float(actual, ".//Flow", ns)
 
-            # Skip if any required values are missing
             if any(val is None for val in [hour, interval, flow]):
                 continue
             total_five_minute_actuals_records.append(
@@ -2082,18 +2089,19 @@ class IESO(ISOBase):
 
             five_minute_data["Publish Time"] = created_at
 
-            five_minute_data = (
-                five_minute_data[INTERTIE_FLOW_5_MIN_COLUMNS]
-                .sort_values(["Interval Start"])
-                .reset_index(drop=True)
+            result = pl.from_pandas(
+                five_minute_data[INTERTIE_FLOW_5_MIN_COLUMNS].sort_values(
+                    ["Interval Start"],
+                ),
+                include_index=False,
             )
 
-            return five_minute_data
+            return result
 
         hourly_data = (
             five_minute_data.drop(columns=["Interval"])
             .groupby(["Hour"])
-            .mean()
+            .mean(numeric_only=True)
             .reset_index()
         )
         hourly_data["Interval Start"] = base_datetime + pd.to_timedelta(
@@ -2106,13 +2114,12 @@ class IESO(ISOBase):
 
         hourly_data["Publish Time"] = created_at
 
-        hourly_data = (
-            hourly_data[INTERTIE_ACTUAL_SCHEDULE_FLOW_HOURLY_COLUMNS]
-            .sort_values(["Interval Start"])
-            .reset_index(drop=True)
+        return pl.from_pandas(
+            hourly_data[INTERTIE_ACTUAL_SCHEDULE_FLOW_HOURLY_COLUMNS].sort_values(
+                ["Interval Start"],
+            ),
+            include_index=False,
         )
-
-        return hourly_data
 
     def _parse_intertie_limits(
         self,
@@ -2120,7 +2127,7 @@ class IESO(ISOBase):
         interval_element_name: str,
         interval_minutes: int,
         include_publish_time: bool = False,
-    ) -> tuple[pd.DataFrame, pd.Timestamp | None]:
+    ) -> tuple[pl.DataFrame, pd.Timestamp | None]:
         """Shared parser for intertie limit XML data.
 
         Args:
@@ -2223,21 +2230,27 @@ class IESO(ISOBase):
                 zone_data[interval_num][column_name] = energy
 
         # Convert to DataFrame with interval numbers as index
-        df = pd.DataFrame.from_dict(zone_data, orient="index").sort_index()
+        rows = [
+            {"_interval": interval_num, **values}
+            for interval_num, values in zone_data.items()
+        ]
+        df = pl.DataFrame(rows).sort("_interval")
 
-        # Add time columns based on interval numbers
-        df["Interval Start"] = base_datetime + pd.to_timedelta(
-            (df.index - 1) * interval_minutes,
-            unit="m",
-        )
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(
-            minutes=interval_minutes,
+        df = df.with_columns(
+            (
+                pl.lit(base_datetime)
+                + pl.duration(minutes=(pl.col("_interval") - 1) * interval_minutes)
+            ).alias("Interval Start"),
+        ).with_columns(
+            (pl.col("Interval Start") + pl.duration(minutes=interval_minutes)).alias(
+                "Interval End",
+            ),
         )
 
         if include_publish_time:
-            df["Publish Time"] = publish_time
+            df = df.with_columns(pl.lit(publish_time).alias("Publish Time"))
 
-        return df, publish_time
+        return df.drop("_interval"), publish_time
 
     @support_date_range(frequency="HOUR_START")
     def get_intertie_limits_real_time_5_min(
@@ -2245,7 +2258,7 @@ class IESO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get real-time intertie scheduling limits.
 
         This returns 5-minute interval data showing import and export limits
@@ -2280,7 +2293,7 @@ class IESO(ISOBase):
             include_publish_time=False,
         )
 
-        return df[INTERTIE_LIMITS_COLUMNS].reset_index(drop=True)
+        return df.select(INTERTIE_LIMITS_COLUMNS)
 
     @support_date_range(frequency="DAY_START")
     def get_intertie_limits_day_ahead_hourly(
@@ -2288,7 +2301,7 @@ class IESO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get day-ahead intertie scheduling limits.
 
         This returns hourly data showing import and export limits for each
@@ -2320,7 +2333,7 @@ class IESO(ISOBase):
             include_publish_time=False,
         )
 
-        return df[INTERTIE_LIMITS_COLUMNS].reset_index(drop=True)
+        return df.select(INTERTIE_LIMITS_COLUMNS)
 
     @support_date_range(frequency="HOUR_START")
     def get_lmp_real_time_5_min(
@@ -2354,7 +2367,7 @@ class IESO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get day-ahead LMP data.
         Args:
             date: The date to get the data for.
@@ -2384,7 +2397,7 @@ class IESO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         directory_path = "PredispHourlyEnergyLMP"
         file_directory = f"{PUBLIC_REPORTS_URL_PREFIX}/{directory_path}"
 
@@ -2410,7 +2423,7 @@ class IESO(ISOBase):
                 f"No Predispatch Hourly LMP data found for {date} to {end}",
             )
 
-        def process_url(url: str, verbose: bool = False) -> pd.DataFrame:
+        def process_url(url: str, verbose: bool = False) -> pl.DataFrame:
             # We need to get the file created date from the first line of the csv
             # Example: CREATED AT 2025/05/01 23:14:53 FOR 2025/05/02
             text = self._request(url, verbose=False).text
@@ -2439,8 +2452,7 @@ class IESO(ISOBase):
                 verbose=verbose,
             )
 
-            file_data["Publish Time"] = publish_time
-            return file_data
+            return file_data.with_columns(pl.lit(publish_time).alias("Publish Time"))
 
         data = self._process_urls_with_threadpool(
             urls,
@@ -2449,9 +2461,9 @@ class IESO(ISOBase):
             verbose=verbose,
         )
 
-        data["Location"] = data["Location"].str.replace(":LMP", "")
-
-        return data
+        return data.with_columns(
+            pl.col("Location").str.replace(":LMP", ""),
+        )
 
     def _get_lmp_csv_data(
         self,
@@ -2521,15 +2533,14 @@ class IESO(ISOBase):
             "Loss",
         ]
 
-        data = (
-            data[columns]
-            .sort_values(["Interval Start", "Location"])
-            .reset_index(drop=True)
+        data = pl.from_pandas(
+            data[columns].sort_values(["Interval Start", "Location"]),
+            include_index=False,
         )
 
-        data["Location"] = data["Location"].str.replace(":LMP", "")
-
-        return data
+        return data.with_columns(
+            pl.col("Location").str.replace(":LMP", ""),
+        )
 
     @support_date_range(frequency="HOUR_START")
     def get_lmp_real_time_5_min_virtual_zonal(
@@ -2606,16 +2617,12 @@ class IESO(ISOBase):
                     },
                 )
 
-        df = (
-            pd.DataFrame(data_rows)
-            .sort_values(["Interval Start", "Location"])
-            .reset_index(drop=True)
+        df = pl.DataFrame(data_rows, infer_schema_length=None).sort(
+            ["Interval Start", "Location"],
         )
 
         # Strip out the :HUB from the location
-        df["Location"] = df["Location"].str.replace(":HUB", "")
-
-        return df
+        return df.with_columns(pl.col("Location").str.replace(":HUB", ""))
 
     @support_date_range(frequency="DAY_START")
     def get_lmp_day_ahead_hourly_virtual_zonal(
@@ -2623,7 +2630,7 @@ class IESO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get day-ahead zonal virtual LMP data.
         Args:
             date: The date to get the data for.
@@ -2676,7 +2683,7 @@ class IESO(ISOBase):
                 f"No Predispatch Hourly Virtual Zonal LMP data found for {date} to {end}",
             )
 
-        def process_url(url: str, verbose: bool = False) -> pd.DataFrame:
+        def process_url(url: str, verbose: bool = False) -> pl.DataFrame:
             return self._parse_lmp_hourly_virtual_zonal(
                 url,
                 verbose=verbose,
@@ -2695,7 +2702,7 @@ class IESO(ISOBase):
         url: str,
         verbose: bool = False,
         predispatch: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         xml_content = self._request(url, verbose).text
         soup = BeautifulSoup(xml_content, "xml")
 
@@ -2765,14 +2772,12 @@ class IESO(ISOBase):
                         },
                     )
 
-        df = (
-            pd.DataFrame(data_rows)
-            .sort_values(["Interval Start", "Location"])
-            .reset_index(drop=True)
+        df = pl.DataFrame(data_rows, infer_schema_length=None).sort(
+            ["Interval Start", "Location"],
         )
 
         if predispatch:
-            df["Publish Time"] = created_at
+            df = df.with_columns(pl.lit(created_at).alias("Publish Time"))
 
             df = utils.move_cols_to_front(
                 df,
@@ -2785,9 +2790,7 @@ class IESO(ISOBase):
             )
 
         # Strip out the :HUB from the location
-        df["Location"] = df["Location"].str.replace(":HUB", "")
-
-        return df
+        return df.with_columns(pl.col("Location").str.replace(":HUB", ""))
 
     @support_date_range(frequency="HOUR_START")
     def get_lmp_real_time_5_min_intertie(
@@ -2903,16 +2906,12 @@ class IESO(ISOBase):
 
                     data_rows.append(row)
 
-        df = (
-            pd.DataFrame(data_rows)
-            .sort_values(["Interval Start", "Location"])
-            .reset_index(drop=True)
+        df = pl.DataFrame(data_rows, infer_schema_length=None).sort(
+            ["Interval Start", "Location"],
         )
 
         # Strip out the :LMP from the location
-        df["Location"] = df["Location"].str.replace(":LMP", "")
-
-        return df
+        return df.with_columns(pl.col("Location").str.replace(":LMP", ""))
 
     @support_date_range(frequency="DAY_START")
     def get_lmp_day_ahead_hourly_intertie(
@@ -2920,7 +2919,7 @@ class IESO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         directory_path = "DAHourlyIntertieLMP"
         file_directory = f"{PUBLIC_REPORTS_URL_PREFIX}/{directory_path}"
 
@@ -2937,7 +2936,7 @@ class IESO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         directory_path = "PredispHourlyIntertieLMP"
         file_directory = f"{PUBLIC_REPORTS_URL_PREFIX}/{directory_path}"
 
@@ -2963,7 +2962,7 @@ class IESO(ISOBase):
                 f"No Predispatch Hourly Intertie LMP data found for {date} to {end}",
             )
 
-        def process_url(url: str, verbose: bool = False) -> pd.DataFrame:
+        def process_url(url: str, verbose: bool = False) -> pl.DataFrame:
             return self._parse_lmp_hourly_intertie(
                 url,
                 verbose=verbose,
@@ -2982,7 +2981,7 @@ class IESO(ISOBase):
         url: str,
         verbose: bool = False,
         predispatch: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         xml_content = self._request(url, verbose).text
         root = ElementTree.fromstring(xml_content)
 
@@ -3071,24 +3070,19 @@ class IESO(ISOBase):
                         },
                     )
 
-        df = (
-            pd.DataFrame(data_rows)
-            .sort_values(["Interval Start", "Location"])
-            .reset_index(drop=True)
+        df = pl.DataFrame(data_rows, infer_schema_length=None).sort(
+            ["Interval Start", "Location"],
         )
 
         if predispatch:
-            # For pre-dispatch, we need to add the publish time
-            df["Publish Time"] = created_at
+            df = df.with_columns(pl.lit(created_at).alias("Publish Time"))
             df = utils.move_cols_to_front(
                 df,
                 ["Interval Start", "Interval End", "Publish Time", "Location"],
             )
 
         # Strip out the :LMP from the location
-        df["Location"] = df["Location"].str.replace(":LMP", "")
-
-        return df
+        return df.with_columns(pl.col("Location").str.replace(":LMP", ""))
 
     @support_date_range(frequency="HOUR_START")
     def get_lmp_real_time_5_min_ontario_zonal(
@@ -3223,11 +3217,7 @@ class IESO(ISOBase):
                         },
                     )
 
-        df = (
-            pd.DataFrame(data_rows)
-            .sort_values(["Interval Start"])
-            .reset_index(drop=True)
-        )
+        df = pl.DataFrame(data_rows, infer_schema_length=None).sort(["Interval Start"])
 
         return df
 
@@ -3280,7 +3270,7 @@ class IESO(ISOBase):
                 f"No Predispatch Hourly Ontario Zonal LMP data found for {date} to {end}",
             )
 
-        def process_url(url: str, verbose: bool = False) -> pd.DataFrame:
+        def process_url(url: str, verbose: bool = False) -> pl.DataFrame:
             return self._process_lmp_hourly_ontario_zonal(
                 url,
                 verbose,
@@ -3299,7 +3289,7 @@ class IESO(ISOBase):
         url: str,
         verbose: bool = False,
         predispatch: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         xml_content = self._request(url, verbose).text
 
         root = ElementTree.fromstring(xml_content)
@@ -3347,14 +3337,10 @@ class IESO(ISOBase):
                 },
             )
 
-        df = (
-            pd.DataFrame(data_rows)
-            .sort_values(["Interval Start"])
-            .reset_index(drop=True)
-        )
+        df = pl.DataFrame(data_rows, infer_schema_length=None).sort(["Interval Start"])
 
         if predispatch:
-            df["Publish Time"] = created_at
+            df = df.with_columns(pl.lit(created_at).alias("Publish Time"))
             df = utils.move_cols_to_front(
                 df,
                 ["Interval Start", "Interval End", "Publish Time", "Location"],
@@ -3368,7 +3354,7 @@ class IESO(ISOBase):
         process_func: callable,
         error_message: str,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Generic helper to process multiple URLs using ThreadPoolExecutor.
 
         Args:
@@ -3401,31 +3387,24 @@ class IESO(ISOBase):
         if not data_list:
             raise NoDataFoundException(error_message)
 
-        data = pd.concat(data_list)
+        data = pl.concat(data_list, how="diagonal_relaxed")
 
         # It's possible we may have duplicates since some of the files are the same.
         # We remove these by dropping duplicate rows based on a subset
-        data = data.drop_duplicates(
+        data = data.unique(
             subset=["Interval Start", "Location", "Publish Time"],
+            maintain_order=True,
         )
 
-        data = (
-            utils.move_cols_to_front(
-                data,
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Publish Time",
-                    "Location",
-                ],
-            )
-            .sort_values(
-                ["Interval Start", "Location", "Publish Time"],
-            )
-            .reset_index(drop=True)
-        )
-
-        return data
+        return utils.move_cols_to_front(
+            data,
+            [
+                "Interval Start",
+                "Interval End",
+                "Publish Time",
+                "Location",
+            ],
+        ).sort(["Interval Start", "Location", "Publish Time"])
 
     def _get_directory_files_and_timestamps(
         self,
@@ -3543,18 +3522,13 @@ class IESO(ISOBase):
                         },
                     )
 
-        data = pd.DataFrame(outage_data)
+        data = pl.DataFrame(outage_data)
 
-        # There will be overlap between the reports so we need to drop duplicates,
-        # keeping the latest publish time
-        data = data.sort_values(["Interval Start", "Outage ID", "Publish Time"])
-
-        data = data.drop_duplicates(
+        return data.sort(["Interval Start", "Outage ID", "Publish Time"]).unique(
             subset=[c for c in data.columns if c != "Publish Time"],
             keep="last",
-        ).reset_index(drop=True)
-
-        return data
+            maintain_order=True,
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_in_service_transmission_limits(
@@ -3598,17 +3572,15 @@ class IESO(ISOBase):
             xml_content = self._request(url, verbose).text
             data_list.append(self._process_transmission_limits(xml_content))
 
-        data = pd.concat(data_list)
+        data = pl.concat(data_list, how="diagonal_relaxed")
 
-        # Drop rows duplicated on every column except Publish Time
-        data = data.drop_duplicates(
+        return data.unique(
             subset=[c for c in data.columns if c != "Publish Time"],
             keep="last",
-        ).reset_index(drop=True)
+            maintain_order=True,
+        )
 
-        return data
-
-    def _process_transmission_limits(self, xml_content: str) -> pd.DataFrame:
+    def _process_transmission_limits(self, xml_content: str) -> pl.DataFrame:
         parser = lxml_etree.XMLParser(remove_blank_text=True)
         tree = lxml_etree.fromstring(xml_content.encode(), parser)
 
@@ -3679,10 +3651,8 @@ class IESO(ISOBase):
                         },
                     )
 
-        df = (
-            pd.DataFrame(data)
-            .sort_values(["Interval Start", "Publish Time", "Facility"])
-            .reset_index(drop=True)
+        df = pl.DataFrame(data, infer_schema_length=None).sort(
+            ["Interval Start", "Publish Time", "Facility"],
         )
 
         return df
@@ -3693,7 +3663,7 @@ class IESO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             url = f"{PUBLIC_REPORTS_URL_PREFIX}/RealtimeDemandZonal/PUB_RealtimeDemandZonal.csv"
         else:
@@ -3707,7 +3677,7 @@ class IESO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             url = f"{PUBLIC_REPORTS_URL_PREFIX}/DemandZonal/PUB_DemandZonal.csv"
         else:
@@ -3720,7 +3690,7 @@ class IESO(ISOBase):
         url: str,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         df = pd.read_csv(url, skiprows=3, parse_dates=["Date"])
 
         if "Interval" in df.columns:
@@ -3761,10 +3731,9 @@ class IESO(ISOBase):
             else:
                 mask = (df["Interval Start"] >= date) & (df["Interval Start"] < end)
                 df = df[mask]
-        return (
-            df[ZONAL_LOAD_COLUMNS]
-            .sort_values(["Interval Start"])
-            .reset_index(drop=True)
+        return pl.from_pandas(
+            df[ZONAL_LOAD_COLUMNS].sort_values(["Interval Start"]),
+            include_index=False,
         )
 
     @support_date_range(frequency="HOUR_START")
@@ -3773,7 +3742,7 @@ class IESO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             url = f"{PUBLIC_REPORTS_URL_PREFIX}/RealtimeTotals/PUB_RealtimeTotals.xml"
         else:
@@ -3850,9 +3819,9 @@ class IESO(ISOBase):
 
         # Create DataFrame
         data = (
-            pd.DataFrame(data)[columns]
-            .sort_values(["Interval Start"])
-            .reset_index(drop=True)
+            pl.DataFrame(data, infer_schema_length=None)
+            .select(columns)
+            .sort(["Interval Start"])
         )
 
         return data
@@ -3864,7 +3833,7 @@ class IESO(ISOBase):
         end: pd.Timestamp | None = None,
         vintage: Literal["latest", "all"] = "latest",
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         json_data_with_times = self._get_variable_generation_forecast_json(
             date,
             end,
@@ -3875,12 +3844,15 @@ class IESO(ISOBase):
             self._parse_variable_generation_forecast(json_data, last_modified_time)
             for json_data, last_modified_time in json_data_with_times
         ]
-        df = pd.concat(dfs).reset_index(drop=True)
-        df.drop_duplicates(inplace=True)
-        df = df[
-            (df["Organization Type"] == "Embedded") & (df["Type"] == "Solar")
-        ].reset_index(drop=True)
-        df.drop(columns=["Organization Type", "Type"], inplace=True)
+        df = (
+            pl.concat(dfs, how="diagonal_relaxed")
+            .unique(maintain_order=True)
+            .filter(
+                (pl.col("Organization Type") == "Embedded")
+                & (pl.col("Type") == "Solar"),
+            )
+            .drop(["Organization Type", "Type"])
+        )
         return df
 
     @support_date_range(frequency="DAY_START")
@@ -3890,7 +3862,7 @@ class IESO(ISOBase):
         end: pd.Timestamp | None = None,
         vintage: Literal["latest", "all"] = "latest",
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         json_data_with_times = self._get_variable_generation_forecast_json(
             date,
             end,
@@ -3901,12 +3873,15 @@ class IESO(ISOBase):
             self._parse_variable_generation_forecast(json_data, last_modified_time)
             for json_data, last_modified_time in json_data_with_times
         ]
-        df = pd.concat(dfs).reset_index(drop=True)
-        df.drop_duplicates(inplace=True)
-        df = df[
-            (df["Organization Type"] == "Embedded") & (df["Type"] == "Wind")
-        ].reset_index(drop=True)
-        df.drop(columns=["Organization Type", "Type"], inplace=True)
+        df = (
+            pl.concat(dfs, how="diagonal_relaxed")
+            .unique(maintain_order=True)
+            .filter(
+                (pl.col("Organization Type") == "Embedded")
+                & (pl.col("Type") == "Wind"),
+            )
+            .drop(["Organization Type", "Type"])
+        )
         return df
 
     @support_date_range(frequency="DAY_START")
@@ -3916,7 +3891,7 @@ class IESO(ISOBase):
         end: pd.Timestamp | None = None,
         vintage: Literal["latest", "all"] = "latest",
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         json_data_with_times = self._get_variable_generation_forecast_json(
             date,
             end,
@@ -3927,12 +3902,15 @@ class IESO(ISOBase):
             self._parse_variable_generation_forecast(json_data, last_modified_time)
             for json_data, last_modified_time in json_data_with_times
         ]
-        df = pd.concat(dfs).reset_index(drop=True)
-        df.drop_duplicates(inplace=True)
-        df = df[
-            (df["Organization Type"] == "Market Participant") & (df["Type"] == "Solar")
-        ].reset_index(drop=True)
-        df.drop(columns=["Organization Type", "Type"], inplace=True)
+        df = (
+            pl.concat(dfs, how="diagonal_relaxed")
+            .unique(maintain_order=True)
+            .filter(
+                (pl.col("Organization Type") == "Market Participant")
+                & (pl.col("Type") == "Solar"),
+            )
+            .drop(["Organization Type", "Type"])
+        )
         return df
 
     @support_date_range(frequency="DAY_START")
@@ -3942,7 +3920,7 @@ class IESO(ISOBase):
         end: pd.Timestamp | None = None,
         vintage: Literal["latest", "all"] = "latest",
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         json_data_with_times = self._get_variable_generation_forecast_json(
             date,
             end,
@@ -3953,11 +3931,14 @@ class IESO(ISOBase):
             self._parse_variable_generation_forecast(json_data, last_modified_time)
             for json_data, last_modified_time in json_data_with_times
         ]
-        df = pd.concat(dfs).reset_index(drop=True)
-        df = df[
-            (df["Organization Type"] == "Market Participant") & (df["Type"] == "Wind")
-        ].reset_index(drop=True)
-        df.drop(columns=["Organization Type", "Type"], inplace=True)
+        df = (
+            pl.concat(dfs, how="diagonal_relaxed")
+            .filter(
+                (pl.col("Organization Type") == "Market Participant")
+                & (pl.col("Type") == "Wind"),
+            )
+            .drop(["Organization Type", "Type"])
+        )
         return df
 
     def _get_variable_generation_forecast_json(
@@ -4055,7 +4036,7 @@ class IESO(ISOBase):
         self,
         json_data: dict,
         last_modified_time: pd.Timestamp,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         document_body = json_data["Document"]["DocBody"]
         publish_time = pd.Timestamp(document_body["ForecastTimeStamp"]).tz_localize(
             self.default_timezone,
@@ -4120,10 +4101,10 @@ class IESO(ISOBase):
                                 },
                             )
 
-        df = pd.DataFrame(data)
-        return df.sort_values(
+        df = pl.DataFrame(data, infer_schema_length=None)
+        return df.sort(
             ["Interval Start", "Publish Time", "Last Modified", "Zone"],
-        ).reset_index(drop=True)
+        )
 
     @support_date_range(frequency="HOUR_START")
     def get_lmp_real_time_operating_reserves(
@@ -4174,18 +4155,15 @@ class IESO(ISOBase):
             ],
         )
 
-        data = (
-            utils.move_cols_to_front(
-                data,
-                ["Interval Start", "Interval End", "Location"],
-            )
-            .sort_values(
-                ["Interval Start", "Location"],
-            )
-            .reset_index(drop=True)
+        data = utils.move_cols_to_front(
+            data,
+            ["Interval Start", "Interval End", "Location"],
         )
 
-        return data
+        return pl.from_pandas(
+            data.sort_values(["Interval Start", "Location"]),
+            include_index=False,
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_lmp_day_ahead_operating_reserves(
@@ -4193,7 +4171,7 @@ class IESO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get day-ahead operating reserves LMP data.
 
         Args:
@@ -4252,18 +4230,15 @@ class IESO(ISOBase):
             ],
         )
 
-        data = (
-            utils.move_cols_to_front(
-                data,
-                ["Interval Start", "Interval End", "Location"],
-            )
-            .sort_values(
-                ["Interval Start", "Location"],
-            )
-            .reset_index(drop=True)
+        data = utils.move_cols_to_front(
+            data,
+            ["Interval Start", "Interval End", "Location"],
         )
 
-        return data
+        return pl.from_pandas(
+            data.sort_values(["Interval Start", "Location"]),
+            include_index=False,
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_shadow_prices_real_time_5_min(
@@ -4272,7 +4247,7 @@ class IESO(ISOBase):
         end: pd.Timestamp | None = None,
         verbose: bool = False,
         last_modified: str | pd.Timestamp | None = None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if last_modified:
             last_modified = utils._handle_date(last_modified, tz=self.default_timezone)
         if date == "latest":
@@ -4284,20 +4259,19 @@ class IESO(ISOBase):
             )
             json_data = self._fetch_and_parse_shadow_prices_file(base_url, file)
             df = self._parse_real_time_shadow_prices_report(json_data)
-            df["Publish Time"] = file_last_modified
-            df.sort_values(
-                ["Interval Start", "Publish Time", "Constraint"],
-                inplace=True,
+            return (
+                df.with_columns(pl.lit(file_last_modified).alias("Publish Time"))
+                .sort(["Interval Start", "Publish Time", "Constraint"])
+                .select(
+                    [
+                        "Interval Start",
+                        "Interval End",
+                        "Publish Time",
+                        "Constraint",
+                        "Shadow Price",
+                    ],
+                )
             )
-            return df[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Publish Time",
-                    "Constraint",
-                    "Shadow Price",
-                ]
-            ].reset_index(drop=True)
 
         json_data_with_times = self._get_all_shadow_prices_jsons(
             date,
@@ -4306,32 +4280,34 @@ class IESO(ISOBase):
         )
         dfs = []
         for json_data, file_last_modified in json_data_with_times:
-            df = self._parse_real_time_shadow_prices_report(json_data)
-            df["Publish Time"] = file_last_modified
-            dfs.append(df)
-        df = pd.concat(dfs)
+            report_df = self._parse_real_time_shadow_prices_report(json_data)
+            dfs.append(
+                report_df.with_columns(
+                    pl.lit(file_last_modified).alias("Publish Time"),
+                ),
+            )
+        df = pl.concat(dfs, how="diagonal_relaxed")
         df = utils.move_cols_to_front(
             df,
             ["Interval Start", "Interval End", "Publish Time"],
         )
-        df.sort_values(
-            ["Interval Start", "Publish Time", "Constraint"],
-            inplace=True,
+        return (
+            df.sort(["Interval Start", "Publish Time", "Constraint"])
+            .unique(
+                subset=["Interval Start", "Publish Time", "Constraint"],
+                keep="last",
+                maintain_order=True,
+            )
+            .select(
+                [
+                    "Interval Start",
+                    "Interval End",
+                    "Publish Time",
+                    "Constraint",
+                    "Shadow Price",
+                ],
+            )
         )
-        df.drop_duplicates(
-            subset=["Interval Start", "Publish Time", "Constraint"],
-            inplace=True,
-            keep="last",
-        )
-        return df[
-            [
-                "Interval Start",
-                "Interval End",
-                "Publish Time",
-                "Constraint",
-                "Shadow Price",
-            ]
-        ].reset_index(drop=True)
 
     @support_date_range(frequency="DAY_START")
     def get_shadow_prices_day_ahead_hourly(
@@ -4340,7 +4316,7 @@ class IESO(ISOBase):
         end: pd.Timestamp | None = None,
         verbose: bool = False,
         last_modified: str | pd.Timestamp | None = None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if last_modified:
             last_modified = utils._handle_date(last_modified, tz=self.default_timezone)
         if date == "latest":
@@ -4352,20 +4328,19 @@ class IESO(ISOBase):
             )
             json_data = self._fetch_and_parse_shadow_prices_file(base_url, file)
             df = self._parse_day_ahead_shadow_prices_report(json_data)
-            df["Publish Time"] = file_last_modified
-            df.sort_values(
-                ["Interval Start", "Publish Time", "Constraint"],
-                inplace=True,
+            return (
+                df.with_columns(pl.lit(file_last_modified).alias("Publish Time"))
+                .sort(["Interval Start", "Publish Time", "Constraint"])
+                .select(
+                    [
+                        "Interval Start",
+                        "Interval End",
+                        "Publish Time",
+                        "Constraint",
+                        "Shadow Price",
+                    ],
+                )
             )
-            return df[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Publish Time",
-                    "Constraint",
-                    "Shadow Price",
-                ]
-            ].reset_index(drop=True)
 
         json_data_with_times = self._get_all_shadow_prices_jsons(
             date,
@@ -4374,32 +4349,34 @@ class IESO(ISOBase):
         )
         dfs = []
         for json_data, file_last_modified in json_data_with_times:
-            df = self._parse_day_ahead_shadow_prices_report(json_data)
-            df["Publish Time"] = file_last_modified
-            dfs.append(df)
-        df = pd.concat(dfs)
+            report_df = self._parse_day_ahead_shadow_prices_report(json_data)
+            dfs.append(
+                report_df.with_columns(
+                    pl.lit(file_last_modified).alias("Publish Time"),
+                ),
+            )
+        df = pl.concat(dfs, how="diagonal_relaxed")
         df = utils.move_cols_to_front(
             df,
             ["Interval Start", "Interval End", "Publish Time"],
         )
-        df.sort_values(
-            ["Interval Start", "Publish Time", "Constraint"],
-            inplace=True,
+        return (
+            df.sort(["Interval Start", "Publish Time", "Constraint"])
+            .unique(
+                subset=["Interval Start", "Publish Time", "Constraint"],
+                keep="last",
+                maintain_order=True,
+            )
+            .select(
+                [
+                    "Interval Start",
+                    "Interval End",
+                    "Publish Time",
+                    "Constraint",
+                    "Shadow Price",
+                ],
+            )
         )
-        df.drop_duplicates(
-            subset=["Interval Start", "Publish Time", "Constraint"],
-            inplace=True,
-            keep="last",
-        )
-        return df[
-            [
-                "Interval Start",
-                "Interval End",
-                "Publish Time",
-                "Constraint",
-                "Shadow Price",
-            ]
-        ].reset_index(drop=True)
 
     def _fetch_and_parse_shadow_prices_file(self, base_url: str, file: str) -> dict:
         url = f"{base_url}/{file}"
@@ -4528,7 +4505,7 @@ class IESO(ISOBase):
 
         return json_data_with_times
 
-    def _parse_day_ahead_shadow_prices_report(self, json_data: dict) -> pd.DataFrame:
+    def _parse_day_ahead_shadow_prices_report(self, json_data: dict) -> pl.DataFrame:
         doc_header = json_data["Document"]["DocHeader"]
         doc_body = json_data["Document"]["DocBody"]
         shadow_prices = doc_body["HourlyPrice"]
@@ -4556,9 +4533,9 @@ class IESO(ISOBase):
                         "Shadow Price": float(price),
                     },
                 )
-        return pd.DataFrame(rows)
+        return pl.DataFrame(rows)
 
-    def _parse_real_time_shadow_prices_report(self, json_data: dict) -> pd.DataFrame:
+    def _parse_real_time_shadow_prices_report(self, json_data: dict) -> pl.DataFrame:
         doc_header = json_data["Document"]["DocHeader"]
         doc_body = json_data["Document"]["DocBody"]
         publish_time = pd.Timestamp(doc_header["CreatedAt"], tz=self.default_timezone)
@@ -4568,13 +4545,13 @@ class IESO(ISOBase):
         # NB: Handle the case where there is no hourly price data in the report
         if "HourlyPrice" not in doc_body or not doc_body["HourlyPrice"]:
             logger.debug(f"No hourly price data in report for {delivery_date}")
-            return pd.DataFrame(
-                {
-                    "Interval Start": pd.Series(dtype="datetime64[ns, EST]"),
-                    "Interval End": pd.Series(dtype="datetime64[ns, EST]"),
-                    "Publish Time": pd.Series(dtype="datetime64[ns, EST]"),
-                    "Constraint": pd.Series(dtype="string"),
-                    "Shadow Price": pd.Series(dtype="float64"),
+            return pl.DataFrame(
+                schema={
+                    "Interval Start": pl.Datetime(time_zone=self.default_timezone),
+                    "Interval End": pl.Datetime(time_zone=self.default_timezone),
+                    "Publish Time": pl.Datetime(time_zone=self.default_timezone),
+                    "Constraint": pl.Utf8,
+                    "Shadow Price": pl.Float64,
                 },
             )
 
@@ -4605,5 +4582,5 @@ class IESO(ISOBase):
                         "Shadow Price": float(price),
                     },
                 )
-        df = pd.DataFrame(rows)
+        df = pl.DataFrame(rows)
         return df

--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -129,7 +129,9 @@ class ISONE(ISOBase):
             {
                 "Date": naive.to_numpy(),
                 "Fuel Category": df["Fuel Category"].astype(str).to_numpy(),
-                "Gen Mw": pd.to_numeric(df["Gen Mw"], errors="coerce").to_numpy(),
+                "Gen Mw": pd.to_numeric(df["Gen Mw"], errors="coerce")
+                .astype(float)
+                .to_numpy(),
             },
         )
 
@@ -274,6 +276,9 @@ class ISONE(ISOBase):
 
         df.columns = df.iloc[0]
         df = df.drop(columns=["D", "Date"], index=[0]).reset_index(drop=True)
+        # Trailing empty CSV columns produce NaN column names, which pandas
+        # tolerates but polars rejects
+        df = df.loc[:, df.columns.notna()]
 
         pl_df = pl.from_pandas(df)
         value_cols = [c for c in pl_df.columns if c != "Hour Ending"]

--- a/gridstatus/isone_api/isone_api.py
+++ b/gridstatus/isone_api/isone_api.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Literal
 
 import pandas as pd
+import polars as pl
 import pytz
 import requests
 
@@ -34,6 +35,8 @@ from gridstatus.isone_api.isone_api_constants import (
 
 # Default page size for API requests
 DEFAULT_PAGE_SIZE = 1000
+
+ISO_OFFSET_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S%.f%z"
 
 
 # See more info here: https://www.iso-ne.com/participate/support/web-services-data#loadzone
@@ -143,6 +146,49 @@ class ISONEAPI:
             return [records]
         return records
 
+    def _records_to_polars(self, records: dict | list[dict]) -> pl.DataFrame:
+        prepared = self._prepare_records(records)
+        if not prepared:
+            return pl.DataFrame()
+        return pl.DataFrame(prepared)
+
+    def _parse_offset_datetime_expr(self, col: str) -> pl.Expr:
+        return (
+            pl.col(col)
+            .str.to_datetime(format=ISO_OFFSET_DATETIME_FORMAT)
+            .dt.convert_time_zone(self.default_timezone)
+        )
+
+    def _parse_begin_date_interval_start(self, df: pl.DataFrame) -> pl.DataFrame:
+        try:
+            return df.with_columns(
+                self._parse_offset_datetime_expr("BeginDate").alias("Interval Start"),
+            )
+        except Exception:
+            log.warning("Standard datetime conversion failed. Using custom parsing.")
+            return df.with_columns(
+                pl.col("BeginDate")
+                .map_elements(
+                    self.parse_problematic_datetime,
+                    return_dtype=pl.Datetime("us", self.default_timezone),
+                )
+                .alias("Interval Start"),
+            )
+
+    def _extract_location_columns(self, df: pl.DataFrame) -> pl.DataFrame:
+        if isinstance(df.schema["Location"], pl.Struct):
+            return df.with_columns(
+                pl.col("Location").struct.field("$").alias("Location"),
+                pl.col("Location").struct.field("@LocId").alias("Location Id"),
+            )
+        location_df = pl.from_pandas(
+            pd.json_normalize(df.get_column("Location").to_list()),
+        )
+        return df.with_columns(
+            location_df["$"].alias("Location"),
+            location_df["@LocId"].alias("Location Id"),
+        )
+
     def make_api_call(
         self,
         url: str,
@@ -193,12 +239,12 @@ class ISONEAPI:
         else:
             return response.content
 
-    def get_locations(self) -> pd.DataFrame:
+    def get_locations(self) -> pl.DataFrame:
         """
         Get a list of core hub and zone locations.
 
         Returns:
-            pandas.DataFrame: A DataFrame containing location information.
+            polars.DataFrame: A DataFrame containing location information.
         """
         url = f"{self.base_url}/locations"
         response = self.make_api_call(url)
@@ -206,11 +252,9 @@ class ISONEAPI:
             raise NoDataFoundException("No location data found.")
 
         locations = response["Locations"]["Location"]
-        df = pd.DataFrame(locations)
+        return pl.DataFrame(locations)
 
-        return df
-
-    def get_location_by_id(self, location_id: int) -> pd.DataFrame:
+    def get_location_by_id(self, location_id: int) -> pl.DataFrame:
         """
         Get information for a specific location by its ID.
 
@@ -218,7 +262,7 @@ class ISONEAPI:
             location_id (int): The ID of the location to retrieve.
 
         Returns:
-            pandas.DataFrame: A DataFrame containing the location information.
+            polars.DataFrame: A DataFrame containing the location information.
         """
         url = f"{self.base_url}/locations/{location_id}"
         response = self.make_api_call(url)
@@ -227,15 +271,14 @@ class ISONEAPI:
             raise NoDataFoundException(f"No data found for location ID: {location_id}")
 
         location = response["Location"]
-        df = pd.DataFrame([location])
-        return df
+        return pl.DataFrame([location])
 
-    def get_locations_all(self) -> pd.DataFrame:
+    def get_locations_all(self) -> pl.DataFrame:
         """
         Get detailed information for all locations.
 
         Returns:
-            pandas.DataFrame: A DataFrame containing detailed information for all locations.
+            polars.DataFrame: A DataFrame containing detailed information for all locations.
         """
         url = f"{self.base_url}/locations/all"
         response = self.make_api_call(url)
@@ -244,8 +287,7 @@ class ISONEAPI:
             raise NoDataFoundException("No location data found.")
 
         locations = response["Locations"]["Location"]
-        df = pd.DataFrame(locations)
-        return df
+        return pl.DataFrame(locations)
 
     @support_date_range("DAY_START")
     def get_fuel_mix(
@@ -253,7 +295,7 @@ class ISONEAPI:
         date: str | pd.Timestamp = "latest",
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Return fuel mix data for the specified date range
 
         Args:
@@ -262,7 +304,7 @@ class ISONEAPI:
             verbose (bool): Whether to print verbose logging information.
 
         Returns:
-            pd.DataFrame: DataFrame containing fuel mix data with timestamps and generation by fuel type
+            pl.DataFrame: DataFrame containing fuel mix data with timestamps and generation by fuel type
         """
         if date == "latest":
             url = f"{self.base_url}/genfuelmix/current"
@@ -270,22 +312,24 @@ class ISONEAPI:
             url = f"{self.base_url}/genfuelmix/day/{date.strftime('%Y%m%d')}"
 
         response = self.make_api_call(url)
-        df = pd.DataFrame(response["GenFuelMixes"]["GenFuelMix"])
+        df = pl.DataFrame(response["GenFuelMixes"]["GenFuelMix"])
 
-        mix_df = df.pivot_table(
+        mix_df = df.pivot(
+            on="FuelCategory",
             index="BeginDate",
-            columns="FuelCategory",
             values="GenMw",
-            aggfunc="first",
-        ).reset_index()
-        mix_df.columns.name = None
+            aggregate_function="first",
+        ).rename({"BeginDate": "Time"})
 
-        mix_df = mix_df.rename(columns={"BeginDate": "Time"})
-        mix_df["Time"] = mix_df["Time"].apply(self.parse_problematic_datetime)
-        mix_df = mix_df.fillna(0)
-        mix_df = utils.move_cols_to_front(mix_df, ["Time"])
+        mix_df = mix_df.with_columns(
+            self._parse_offset_datetime_expr("Time"),
+        )
+        fuel_cols = sorted(c for c in mix_df.columns if c != "Time")
+        mix_df = mix_df.with_columns(
+            [pl.col(col).fill_null(0).cast(pl.Float64) for col in fuel_cols],
+        )
 
-        return mix_df
+        return utils.move_cols_to_front(mix_df, ["Time"])
 
     @support_date_range("DAY_START")
     def get_marginal_fuel_type(
@@ -293,7 +337,7 @@ class ISONEAPI:
         date: str | pd.Timestamp = "latest",
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Return marginal-fuel flags per timestamp, one boolean column per fuel type.
 
         Args:
@@ -302,7 +346,7 @@ class ISONEAPI:
             verbose (bool): Whether to print verbose logging information.
 
         Returns:
-            pd.DataFrame: One row per timestamp. Column "Time" plus one boolean
+            pl.DataFrame: One row per timestamp. Column "Time" plus one boolean
                 column per fuel category (e.g. "Natural Gas", "Solar"). True
                 means the fuel was marginal at that timestamp; missing
                 (timestamp, fuel) pairs and timestamps with no marginal fuel
@@ -314,22 +358,24 @@ class ISONEAPI:
             url = f"{self.base_url}/genfuelmix/day/{date.strftime('%Y%m%d')}"
 
         response = self.make_api_call(url)
-        df = pd.DataFrame(response["GenFuelMixes"]["GenFuelMix"])
-        df["IsMarginal"] = (df["MarginalFlag"] == "Y").astype(int)
+        df = pl.DataFrame(response["GenFuelMixes"]["GenFuelMix"])
+        df = df.with_columns((pl.col("MarginalFlag") == "Y").alias("IsMarginal"))
 
-        pivoted = df.pivot_table(
+        pivoted = df.pivot(
+            on="FuelCategory",
             index="BeginDate",
-            columns="FuelCategory",
             values="IsMarginal",
-            aggfunc="first",
-        ).reset_index()
-        pivoted.columns.name = None
+            aggregate_function="first",
+        ).rename({"BeginDate": "Time"})
 
-        pivoted = pivoted.rename(columns={"BeginDate": "Time"})
-        pivoted["Time"] = pivoted["Time"].apply(self.parse_problematic_datetime)
+        pivoted = pivoted.with_columns(
+            self._parse_offset_datetime_expr("Time"),
+        )
 
         fuel_cols = sorted(c for c in pivoted.columns if c != "Time")
-        pivoted[fuel_cols] = pivoted[fuel_cols].fillna(0).astype(bool)
+        pivoted = pivoted.with_columns(
+            [pl.col(col).fill_null(False).cast(pl.Boolean) for col in fuel_cols],
+        )
 
         return utils.move_cols_to_front(pivoted, ["Time"] + fuel_cols)
 
@@ -339,7 +385,7 @@ class ISONEAPI:
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get ISO-NE's daily morning report for the operating day."""
         url = f"{self.base_url}/morningreport/day/{date.strftime('%Y%m%d')}/all"
         response = self.make_api_call(url, verbose=verbose)
@@ -358,8 +404,8 @@ class ISONEAPI:
             ),
             reports[0],
         )
-        df = pd.DataFrame([self._parse_morning_report(report)])
-        return df[ISONE_MORNING_REPORT_COLUMNS]
+        df = pl.DataFrame([self._parse_morning_report(report)])
+        return df.select(ISONE_MORNING_REPORT_COLUMNS)
 
     def _parse_morning_report(self, report: dict) -> dict[str, object]:
         """Flatten one MorningReport JSON object into the daily wide-row output schema."""
@@ -403,18 +449,22 @@ class ISONEAPI:
             ),
         )
 
-        cities = pd.json_normalize(
-            self._prepare_records(report.get("CityForecastDetail") or []),
+        cities = pl.from_pandas(
+            pd.json_normalize(
+                self._prepare_records(report.get("CityForecastDetail") or []),
+            ),
         )
         for city_key, prefix in [("boston", "Boston"), ("hartford", "Hartford")]:
             for api_field, suffix in ISONE_MORNING_REPORT_CITY_FIELDS.items():
                 row[f"{prefix} {suffix}"] = None
-            if cities.empty or "CityName" not in cities.columns:
+            if cities.is_empty() or "CityName" not in cities.columns:
                 continue
-            match = cities.loc[cities["CityName"].str.casefold() == city_key]
-            if match.empty:
+            match = cities.filter(
+                pl.col("CityName").str.to_lowercase() == city_key,
+            )
+            if match.is_empty():
                 continue
-            city_row = match.iloc[0]
+            city_row = match.row(0, named=True)
             for api_field, suffix in ISONE_MORNING_REPORT_CITY_FIELDS.items():
                 row[f"{prefix} {suffix}"] = city_row.get(api_field)
 
@@ -434,21 +484,31 @@ class ISONEAPI:
         if not records:
             return columns
 
-        ties = pd.json_normalize(self._prepare_records(records))
-        ties["TieName"] = ties["TieName"].map(
-            lambda name: ISONE_MORNING_REPORT_TIE_ALIASES.get(
-                str(name).strip().casefold(),
-                str(name).strip(),
-            ),
+        ties = pl.from_pandas(
+            pd.json_normalize(self._prepare_records(records)),
+        )
+        ties = ties.with_columns(
+            pl.col("TieName")
+            .map_elements(
+                lambda name: ISONE_MORNING_REPORT_TIE_ALIASES.get(
+                    str(name).strip().casefold(),
+                    str(name).strip(),
+                ),
+                return_dtype=pl.Utf8,
+            )
+            .alias("TieName"),
         )
         for api_field, suffix in api_field_suffix_pairs.items():
             if api_field not in ties.columns:
                 continue
-            values = ties.set_index("TieName")[api_field]
+            tie_values = {
+                row["TieName"]: row[api_field]
+                for row in ties.select(["TieName", api_field]).iter_rows(named=True)
+            }
             for tie in ISONE_MORNING_REPORT_TIE_NAMES:
                 column = f"{tie} {suffix}"
-                if tie in values.index:
-                    columns[column] = values.loc[tie]
+                if tie in tie_values:
+                    columns[column] = tie_values[tie]
         return columns
 
     @support_date_range("DAY_START")
@@ -458,7 +518,7 @@ class ISONEAPI:
         end: str | pd.Timestamp | None = None,
         locations: list[str] = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get the real-time hourly demand data for specified locations and date range.
 
@@ -469,7 +529,7 @@ class ISONEAPI:
                                              If None, data for all locations will be retrieved.
 
         Returns:
-            pandas.DataFrame: A DataFrame containing the real-time hourly demand data for all requested locations.
+            polars.DataFrame: A DataFrame containing the real-time hourly demand data for all requested locations.
         """
         all_data = []
 
@@ -477,9 +537,11 @@ class ISONEAPI:
             case ("latest", None):
                 url = f"{self.base_url}/realtimehourlydemand/current"
                 response = self.make_api_call(url)
-                df = pd.DataFrame(response["HourlyRtDemands"]["HourlyRtDemand"])
-                df["LocId"] = df["Location"].apply(lambda x: x["@LocId"])
-                df["Location"] = df["Location"].apply(lambda x: x["$"])
+                df = pl.DataFrame(response["HourlyRtDemands"]["HourlyRtDemand"])
+                df = df.with_columns(
+                    pl.col("Location").struct.field("@LocId").alias("LocId"),
+                    pl.col("Location").struct.field("$").alias("Location"),
+                )
                 return self._handle_demand(df, interval_minutes=60)
 
             case ("latest", _):
@@ -535,7 +597,7 @@ class ISONEAPI:
                 "No real-time hourly demand data found for the specified parameters.",
             )
 
-        df = pd.DataFrame(all_data)
+        df = pl.DataFrame(all_data)
         return self._handle_demand(df, interval_minutes=60)
 
     @support_date_range("DAY_START")
@@ -544,7 +606,7 @@ class ISONEAPI:
         date: str | pd.Timestamp,
         end: str | pd.Timestamp = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Return hourly load data for a given date or date range
 
         Args:
@@ -556,7 +618,7 @@ class ISONEAPI:
 
 
         Returns:
-            pd.DataFrame: DataFrame containing load data with timestamps and load
+            pl.DataFrame: DataFrame containing load data with timestamps and load
         """
 
         if date == "latest":
@@ -568,16 +630,21 @@ class ISONEAPI:
             response = self.make_api_call(url)
             raw_data = response["HourlySystemLoads"]["HourlySystemLoad"]
 
-        df = pd.json_normalize(
-            raw_data,
-            meta=["BeginDate", "Load", "NativeLoad", "ArdDemand"],
+        df = pl.from_pandas(
+            pd.json_normalize(
+                raw_data,
+                meta=["BeginDate", "Load", "NativeLoad", "ArdDemand"],
+            ),
         )
-        df["Location"] = df["Location.$"]
-        df["LocId"] = df["Location.@LocId"]
-        df = df.drop(columns=["Location.$", "Location.@LocId"])
-        df.rename(
-            columns={"NativeLoad": "Native Load", "ArdDemand": "ARD Demand"},
-            inplace=True,
+        df = df.with_columns(
+            pl.col("Location.$").alias("Location"),
+            pl.col("Location.@LocId").alias("LocId"),
+        ).drop(["Location.$", "Location.@LocId"])
+        df = df.rename(
+            {
+                "NativeLoad": "Native Load",
+                "ArdDemand": "ARD Demand",
+            },
         )
 
         return self._handle_demand(
@@ -601,7 +668,7 @@ class ISONEAPI:
         end: str | pd.Timestamp | None = None,
         locations: list[str] = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get the day-ahead hourly demand data for specified locations and date range.
 
@@ -612,7 +679,7 @@ class ISONEAPI:
                                              If None, data for all locations will be retrieved.
 
         Returns:
-            pandas.DataFrame: A DataFrame containing the day-ahead hourly demand data for all requested locations.
+            polars.DataFrame: A DataFrame containing the day-ahead hourly demand data for all requested locations.
         """
         all_data = []
 
@@ -620,9 +687,11 @@ class ISONEAPI:
             case ("latest", None):
                 url = f"{self.base_url}/dayaheadhourlydemand/current"
                 response = self.make_api_call(url)
-                df = pd.DataFrame(response["HourlyDaDemands"]["HourlyDaDemand"])
-                df["LocId"] = df["Location"].apply(lambda x: x["@LocId"])
-                df["Location"] = df["Location"].apply(lambda x: x["$"])
+                df = pl.DataFrame(response["HourlyDaDemands"]["HourlyDaDemand"])
+                df = df.with_columns(
+                    pl.col("Location").struct.field("@LocId").alias("LocId"),
+                    pl.col("Location").struct.field("$").alias("Location"),
+                )
                 return self._handle_demand(df, interval_minutes=60)
 
             case ("latest", _):
@@ -667,28 +736,32 @@ class ISONEAPI:
                 "No day-ahead hourly demand data found for the specified parameters.",
             )
 
-        df = pd.DataFrame(all_data)
+        df = pl.DataFrame(all_data)
         # NOTE(kladar): 2017-07-01 to 2018-06-01 causes an issue
         # as there are duplicates of the .H.INTERNALHUB location. Deduping them here
-        df = df.drop_duplicates(subset=["BeginDate", "Location"], keep="first")
+        df = df.unique(
+            subset=["BeginDate", "Location"],
+            keep="first",
+            maintain_order=True,
+        )
 
         return self._handle_demand(df, interval_minutes=60)
 
     def _handle_demand(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         interval_minutes: int = 60,
         columns: list[str] | None = None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Process demand DataFrame: convert types, rename columns, and add Interval End.
 
         Args:
-            df (pd.DataFrame): Input DataFrame with demand data.
+            df (pl.DataFrame): Input DataFrame with demand data.
             interval_minutes (int): Duration of each interval in minutes. Default is 60.
 
         Returns:
-            pd.DataFrame: Processed DataFrame.
+            pl.DataFrame: Processed DataFrame.
         """
         if columns is None:
             columns = [
@@ -699,33 +772,20 @@ class ISONEAPI:
                 "Load",
             ]
 
-        try:
-            # Try the standard pandas datetime conversion first
-            df["Interval Start"] = pd.to_datetime(df["BeginDate"])
-            df["Interval Start"] = df["Interval Start"].dt.tz_convert(
-                self.default_timezone,
-            )
-        except AttributeError:
-            # NOTE(kladar) consistently the above logic fails for DST conversion days.
-            # This catches those and fixes it.
-            # Data coming out looks good, no missed intervals and no duplicates.
-            log.warning("Standard datetime conversion failed. Using custom parsing.")
-            df["Interval Start"] = df["BeginDate"].apply(
-                self.parse_problematic_datetime,
-            )
-
-        df = df.sort_values(["Interval Start", "Location"])
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(
-            minutes=interval_minutes,
+        df = self._parse_begin_date_interval_start(df)
+        df = df.sort(["Interval Start", "Location"])
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(minutes=interval_minutes)).alias(
+                "Interval End",
+            ),
+            pl.col("Load").cast(pl.Float64, strict=False),
+            pl.col("LocId").cast(pl.Float64, strict=False).alias("Location Id"),
         )
-
-        df["Load"] = pd.to_numeric(df["Load"], errors="coerce")
-        df["Location Id"] = pd.to_numeric(df["LocId"], errors="coerce")
 
         log.info(
-            f"Processed demand data: {len(df)} entries from {df['Interval Start'].min()} to {df['Interval Start'].max()}",
+            f"Processed demand data: {df.height} entries from {df['Interval Start'].min()} to {df['Interval Start'].max()}",
         )
-        return df[columns]
+        return df.select(columns)
 
     @support_date_range("DAY_START")
     def get_load_forecast_hourly(
@@ -734,7 +794,7 @@ class ISONEAPI:
         end: str | pd.Timestamp | None = None,
         vintage: Literal["latest", "all"] = "all",
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get the hourly load forecast data for specified locations and date range.
 
@@ -755,13 +815,13 @@ class ISONEAPI:
             vintage (Literal["latest", "all"]): The vintage for the data request. Options are "latest" or "all", defaults to "all".
 
         Returns:
-            pandas.DataFrame: A DataFrame containing the hourly load forecast data for the system.
+            polars.DataFrame: A DataFrame containing the hourly load forecast data for the system.
         """
 
         if date == "latest":
             url = f"{self.base_url}/hourlyloadforecast/current"
             response = self.make_api_call(url)
-            df = pd.DataFrame(response["HourlyLoadForecast"])
+            df = pl.DataFrame(response["HourlyLoadForecast"])
             return self._handle_load_forecast(df, interval_minutes=60)
 
         elif vintage == "all":
@@ -772,7 +832,7 @@ class ISONEAPI:
             url = f"{self.base_url}/hourlyloadforecast/day/{date.strftime('%Y%m%d')}"
 
         response = self.make_api_call(url)
-        df = pd.DataFrame(response["HourlyLoadForecasts"]["HourlyLoadForecast"])
+        df = pl.DataFrame(response["HourlyLoadForecasts"]["HourlyLoadForecast"])
         return self._handle_load_forecast(df, interval_minutes=60)
 
     @support_date_range("DAY_START")
@@ -782,7 +842,7 @@ class ISONEAPI:
         end: str | pd.Timestamp | None = None,
         vintage: Literal["latest", "all"] = "all",
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get the regional load forecast data for specified date range and vintages.
 
@@ -792,7 +852,7 @@ class ISONEAPI:
             vintages (Literal["latest", "all"]): The vintage for the data request. Options are "latest" or "all".
 
         Returns:
-            pandas.DataFrame: A DataFrame containing the regional load forecast data for all requested locations.
+            polars.DataFrame: A DataFrame containing the regional load forecast data for all requested locations.
         """
 
         if date == "latest":
@@ -803,47 +863,55 @@ class ISONEAPI:
             url = f"{self.base_url}/reliabilityregionloadforecast/day/{date.strftime('%Y%m%d')}"
 
         response = self.make_api_call(url)
-        df = pd.DataFrame(
+        df = pl.DataFrame(
             response["ReliabilityRegionLoadForecasts"]["ReliabilityRegionLoadForecast"],
         )
         return self._handle_load_forecast(df, interval_minutes=60)
 
     def _handle_load_forecast(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         interval_minutes: int = 60,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Process load forecast DataFrame: convert types, rename columns, and add Interval End.
 
         Args:
-            df (pd.DataFrame): Input DataFrame with load forecast data.
+            df (pl.DataFrame): Input DataFrame with load forecast data.
             interval_minutes (int): Duration of each interval in minutes. Default is 60.
 
         Returns:
-            pd.DataFrame: Processed DataFrame.
+            pl.DataFrame: Processed DataFrame.
         """
         try:
-            # Try the standard pandas datetime conversion first
-
-            date_columns = ["BeginDate", "CreationDate"]
-            df[date_columns] = df[date_columns].apply(pd.to_datetime)
-            df[date_columns] = df[date_columns].apply(
-                lambda x: x.dt.tz_convert(self.default_timezone),
+            df = df.with_columns(
+                self._parse_offset_datetime_expr("BeginDate"),
+                self._parse_offset_datetime_expr("CreationDate"),
             )
-
-        except AttributeError:
+        except Exception:
             # NOTE(kladar) consistently the above logic fails for DST conversion days.
             # This catches those and fixes it.
             # Data coming out looks good, no missed intervals and no duplicates.
             log.warning("Standard datetime conversion failed. Using custom parsing.")
-            df["BeginDate"] = df["BeginDate"].apply(self.parse_problematic_datetime)
-            df["CreationDate"] = df["CreationDate"].apply(
-                self.parse_problematic_datetime,
+            df = df.with_columns(
+                pl.col("BeginDate")
+                .map_elements(
+                    self.parse_problematic_datetime,
+                    return_dtype=pl.Datetime("us", self.default_timezone),
+                )
+                .alias("BeginDate"),
+                pl.col("CreationDate")
+                .map_elements(
+                    self.parse_problematic_datetime,
+                    return_dtype=pl.Datetime("us", self.default_timezone),
+                )
+                .alias("CreationDate"),
             )
 
-        df["Interval End"] = df["BeginDate"] + pd.Timedelta(
-            minutes=interval_minutes,
+        df = df.with_columns(
+            (pl.col("BeginDate") + pl.duration(minutes=interval_minutes)).alias(
+                "Interval End",
+            ),
         )
         regional_cols = {
             "BeginDate": "Interval Start",
@@ -861,33 +929,25 @@ class ISONEAPI:
             "NetLoadMw": "Net Load Forecast",
         }
         if "ReliabilityRegion" in df.columns:
-            df = df.rename(columns=regional_cols)
-            df["Regional Percentage"] = pd.to_numeric(
-                df["Regional Percentage"],
-                errors="coerce",
+            df = df.rename(regional_cols)
+            df = df.with_columns(
+                pl.col("Regional Percentage").cast(pl.Float64, strict=False),
             )
+            output_cols = list(regional_cols.values())
         else:
-            df = df.rename(columns=system_cols)
-            df["Net Load Forecast"] = pd.to_numeric(
-                df["Net Load Forecast"],
-                errors="coerce",
+            df = df.rename(system_cols)
+            df = df.with_columns(
+                pl.col("Net Load Forecast").cast(pl.Float64, strict=False),
             )
+            output_cols = list(system_cols.values())
 
-        df = df.sort_values(["Interval Start", "Publish Time"])
-        df["Load Forecast"] = pd.to_numeric(df["Load Forecast"], errors="coerce")
+        df = df.sort(["Interval Start", "Publish Time"])
+        df = df.with_columns(pl.col("Load Forecast").cast(pl.Float64, strict=False))
 
         log.info(
-            f"Processed load forecast data: {len(df)} entries from {df['Interval Start'].min()} to {df['Interval Start'].max()}",
+            f"Processed load forecast data: {df.height} entries from {df['Interval Start'].min()} to {df['Interval Start'].max()}",
         )
-        return df[
-            list(
-                (
-                    regional_cols.values()
-                    if "Location" in df.columns
-                    else system_cols.values()
-                ),
-            )
-        ]
+        return df.select(output_cols)
 
     @support_date_range("DAY_START")
     def get_interchange_hourly(
@@ -895,7 +955,7 @@ class ISONEAPI:
         date: str | pd.Timestamp = "latest",
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get the hourly interchange data for specified date range. Hourly data includes
         multiple locations.
@@ -907,7 +967,7 @@ class ISONEAPI:
             is not "latest".
 
         Returns:
-            pandas.DataFrame: A DataFrame containing the interchange fifteen minute
+            polars.DataFrame: A DataFrame containing the interchange fifteen minute
             data for all requested locations.
         """
         if date == "latest":
@@ -920,7 +980,7 @@ class ISONEAPI:
         response = self.make_api_call(url)
 
         if data := response.get("ActualInterchanges"):
-            df = pd.DataFrame(
+            df = pl.DataFrame(
                 data["ActualInterchange"],
             )
         else:
@@ -934,7 +994,7 @@ class ISONEAPI:
         date: str | pd.Timestamp = "latest",
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get the fifteen minute interchange data for specified date range.
 
@@ -945,7 +1005,7 @@ class ISONEAPI:
             is not "latest".
 
         Returns:
-            pandas.DataFrame: A DataFrame containing the interchange fifteen minute
+            polars.DataFrame: A DataFrame containing the interchange fifteen minute
             data for all requested locations.
         """
         if date == "latest":
@@ -958,7 +1018,7 @@ class ISONEAPI:
         response = self.make_api_call(url)
 
         if data := response.get("ActualFifteenMinInterchanges"):
-            df = pd.DataFrame(data["ActualFifteenMinInterchange"])
+            df = pl.DataFrame(data["ActualFifteenMinInterchange"])
         else:
             raise NoDataFoundException(
                 f"No fifteen minute interchange data found for {date}",
@@ -966,21 +1026,23 @@ class ISONEAPI:
 
         return self._handle_interchange_dataframe(df, interval_minutes=15)
 
-    def _handle_interchange_dataframe(self, df: pd.DataFrame, interval_minutes: int):
-        df["Interval Start"] = pd.to_datetime(df["BeginDate"], utc=True).dt.tz_convert(
-            self.default_timezone,
+    def _handle_interchange_dataframe(
+        self,
+        df: pl.DataFrame,
+        interval_minutes: int,
+    ) -> pl.DataFrame:
+        df = df.with_columns(
+            self._parse_offset_datetime_expr("BeginDate").alias("Interval Start"),
         )
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(
-            minutes=interval_minutes,
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(minutes=interval_minutes)).alias(
+                "Interval End",
+            ),
         )
+        df = self._extract_location_columns(df)
+        df = df.rename({"ActInterchange": "Actual Interchange"})
 
-        # Split location column from {'$': '.I.ROSETON 345 1', '@LocId': '4011'} to
-        # Location and Location Id
-        df[["Location", "Location Id"]] = pd.json_normalize(df["Location"])
-
-        df = df.rename(columns={"ActInterchange": "Actual Interchange"})
-
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -989,8 +1051,8 @@ class ISONEAPI:
                 "Actual Interchange",
                 "Purchase",
                 "Sale",
-            ]
-        ].sort_values(["Interval Start", "Location"])
+            ],
+        ).sort(["Interval Start", "Location"])
 
     @support_date_range("DAY_START")
     def get_external_flows_5_min(
@@ -998,7 +1060,7 @@ class ISONEAPI:
         date: str | pd.Timestamp = "latest",
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get the five minute external flow data for specified date range.
 
@@ -1009,7 +1071,7 @@ class ISONEAPI:
             is not "latest".
 
         Returns:
-            pandas.DataFrame: A DataFrame containing the external flow five minute
+            polars.DataFrame: A DataFrame containing the external flow five minute
             data for all requested locations.
         """
         if date == "latest":
@@ -1024,7 +1086,7 @@ class ISONEAPI:
         response = self.make_api_call(url)
 
         if data := response.get("ExternalFlows"):
-            df = pd.DataFrame(data["ExternalFlow"])
+            df = pl.DataFrame(data["ExternalFlow"])
         else:
             raise NoDataFoundException(
                 f"No five minute external flow data found for {date}",
@@ -1032,20 +1094,26 @@ class ISONEAPI:
 
         return self._handle_external_flows_dataframe(df, interval_minutes=5)
 
-    def _handle_external_flows_dataframe(self, df: pd.DataFrame, interval_minutes: int):
-        df["Interval Start"] = pd.to_datetime(df["BeginDate"], utc=True).dt.tz_convert(
-            self.default_timezone,
+    def _handle_external_flows_dataframe(
+        self,
+        df: pl.DataFrame,
+        interval_minutes: int,
+    ) -> pl.DataFrame:
+        df = df.with_columns(
+            self._parse_offset_datetime_expr("BeginDate").alias("Interval Start"),
         )
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(
-            minutes=interval_minutes,
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(minutes=interval_minutes)).alias(
+                "Interval End",
+            ),
         )
 
         # Split location column from {'$': '.I.ROSETON 345 1', '@LocId': '4011'} to
         # Location and Location Id
-        df[["Location", "Location Id"]] = pd.json_normalize(df["Location"])
+        df = self._extract_location_columns(df)
 
         df = df.rename(
-            columns={
+            {
                 "ActualFlow": "Actual Flow",
                 "ImportLimit": "Import Limit",
                 "ExportLimit": "Export Limit",
@@ -1055,7 +1123,7 @@ class ISONEAPI:
             },
         )
 
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -1069,8 +1137,8 @@ class ISONEAPI:
                 "Sale",
                 "Total Exports",
                 "Total Imports",
-            ]
-        ].sort_values(["Interval Start", "Location"])
+            ],
+        ).sort(["Interval Start", "Location"])
 
     @support_date_range("DAY_START")
     def get_zonal_load_estimated_5_min(
@@ -1078,7 +1146,7 @@ class ISONEAPI:
         date: str | pd.Timestamp | Literal["latest"],
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get five-minute estimated zonal load data for all load zones.
 
@@ -1090,7 +1158,7 @@ class ISONEAPI:
             verbose (bool): Whether to print verbose logging information.
 
         Returns:
-            pd.DataFrame: A DataFrame containing five-minute estimated zonal load data.
+            pl.DataFrame: A DataFrame containing five-minute estimated zonal load data.
         """
         url = self._build_url("fiveminuteestimatedzonalload", date)
         response = self.make_api_call(url, verbose=verbose)
@@ -1109,16 +1177,20 @@ class ISONEAPI:
                 f"No five-minute estimated zonal load data found for {date}",
             )
 
-        df = pd.DataFrame(records)
+        df = pl.DataFrame(records)
 
-        df["Interval Start"] = pd.to_datetime(
-            df["interval_begin_date"],
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(minutes=5)
+        df = df.with_columns(
+            pl.col("interval_begin_date")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Interval Start"),
+        )
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(minutes=5)).alias("Interval End"),
+        )
 
         df = df.rename(
-            columns={
+            {
                 "load_zone_id": "Load Zone ID",
                 "load_zone_name": "Load Zone Name",
                 "estimated_load_mw": "Estimated Load",
@@ -1126,17 +1198,13 @@ class ISONEAPI:
             },
         )
 
-        df["Load Zone ID"] = pd.to_numeric(df["Load Zone ID"], errors="coerce")
-        df["Estimated Load"] = pd.to_numeric(
-            df["Estimated Load"],
-            errors="coerce",
-        )
-        df["Estimated BTM Solar"] = pd.to_numeric(
-            df["Estimated BTM Solar"],
-            errors="coerce",
+        df = df.with_columns(
+            pl.col("Load Zone ID").cast(pl.Float64, strict=False),
+            pl.col("Estimated Load").cast(pl.Float64, strict=False),
+            pl.col("Estimated BTM Solar").cast(pl.Float64, strict=False),
         )
 
-        return df[ISONE_FIVE_MIN_ESTIMATED_ZONAL_LOAD_COLUMNS].sort_values(
+        return df.select(ISONE_FIVE_MIN_ESTIMATED_ZONAL_LOAD_COLUMNS).sort(
             ["Interval Start", "Load Zone ID"],
         )
 
@@ -1145,7 +1213,7 @@ class ISONEAPI:
         date: str | pd.Timestamp | Literal["latest"] = "latest",
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get five-minute zonal load forecast data for all load zones.
 
@@ -1156,7 +1224,7 @@ class ISONEAPI:
             verbose (bool): Whether to print verbose logging information.
 
         Returns:
-            pd.DataFrame: A DataFrame containing five-minute zonal load forecast data.
+            pl.DataFrame: A DataFrame containing five-minute zonal load forecast data.
                 Publish Time comes from the /info endpoint CreationDate field.
         """
         if end is not None:
@@ -1190,16 +1258,20 @@ class ISONEAPI:
                 "No five-minute zonal load forecast data found",
             )
 
-        df = pd.DataFrame(records)
+        df = pl.DataFrame(records)
 
-        df["Interval Start"] = pd.to_datetime(
-            df["interval_begin_date"],
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(minutes=5)
+        df = df.with_columns(
+            pl.col("interval_begin_date")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Interval Start"),
+        )
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(minutes=5)).alias("Interval End"),
+        )
 
         df = df.rename(
-            columns={
+            {
                 "load_zone_id": "Load Zone ID",
                 "load_zone_name": "Load Zone Name",
                 "load_mw": "Load Forecast",
@@ -1207,19 +1279,15 @@ class ISONEAPI:
             },
         )
 
-        df["Publish Time"] = publish_time
-
-        df["Load Zone ID"] = pd.to_numeric(df["Load Zone ID"], errors="coerce")
-        df["Load Forecast"] = pd.to_numeric(df["Load Forecast"], errors="coerce")
-        df["BTM Solar Forecast"] = pd.to_numeric(
-            df["BTM Solar Forecast"],
-            errors="coerce",
+        df = df.with_columns(
+            pl.lit(publish_time).alias("Publish Time"),
+            pl.col("Load Zone ID").cast(pl.Float64, strict=False),
+            pl.col("Load Forecast").cast(pl.Float64, strict=False),
+            pl.col("BTM Solar Forecast").cast(pl.Float64, strict=False),
         )
 
-        return (
-            df[ISONE_FIVE_MIN_ZONAL_LOAD_FORECAST_COLUMNS]
-            .sort_values(["Interval Start", "Load Zone Name"])
-            .reset_index(drop=True)
+        return df.select(ISONE_FIVE_MIN_ZONAL_LOAD_FORECAST_COLUMNS).sort(
+            ["Interval Start", "Load Zone Name"],
         )
 
     @support_date_range("DAY_START")
@@ -1228,7 +1296,7 @@ class ISONEAPI:
         date: str | pd.Timestamp | Literal["latest"],
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get five-minute system load ("total demand") data.
 
@@ -1244,7 +1312,7 @@ class ISONEAPI:
             verbose (bool): Whether to print verbose logging information.
 
         Returns:
-            pd.DataFrame: A DataFrame containing five-minute total demand data.
+            pl.DataFrame: A DataFrame containing five-minute total demand data.
         """
         url = self._build_url("fiveminutesystemload", date)
         response = self.make_api_call(url, verbose=verbose)
@@ -1259,16 +1327,17 @@ class ISONEAPI:
                 f"No five-minute system load data found for {date}",
             )
 
-        df = pd.DataFrame(records)
+        df = pl.DataFrame(records)
 
-        df["Interval Start"] = pd.to_datetime(
-            df["BeginDate"],
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(minutes=5)
+        df = df.with_columns(
+            self._parse_offset_datetime_expr("BeginDate").alias("Interval Start"),
+        )
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(minutes=5)).alias("Interval End"),
+        )
 
         df = df.rename(
-            columns={
+            {
                 "LoadMw": "Total Load",
                 "NativeLoad": "Native Load",
                 "ArdDemand": "Storage Load",
@@ -1277,10 +1346,14 @@ class ISONEAPI:
             },
         )
 
-        for col in ISONE_TOTAL_DEMAND_COLUMNS[2:]:
-            df[col] = pd.to_numeric(df[col], errors="coerce")
+        df = df.with_columns(
+            [
+                pl.col(col).cast(pl.Float64, strict=False)
+                for col in ISONE_TOTAL_DEMAND_COLUMNS[2:]
+            ],
+        )
 
-        return df[ISONE_TOTAL_DEMAND_COLUMNS].sort_values("Interval Start")
+        return df.select(ISONE_TOTAL_DEMAND_COLUMNS).sort("Interval Start")
 
     @support_date_range("HOUR_START")
     def get_lmp_real_time_5_min_prelim(
@@ -1288,7 +1361,7 @@ class ISONEAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get the real-time 5 minute LMP preliminary data for specified date range.
 
@@ -1298,7 +1371,7 @@ class ISONEAPI:
             verbose (bool): Whether to print verbose logging information.
 
         Returns:
-            pd.DataFrame: A DataFrame containing the real-time 5 minute LMP preliminary data.
+            pl.DataFrame: A DataFrame containing the real-time 5 minute LMP preliminary data.
         """
 
         if date == "latest":
@@ -1314,7 +1387,7 @@ class ISONEAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get the real-time 5 minute LMP final data for specified date range.
 
@@ -1324,7 +1397,7 @@ class ISONEAPI:
             verbose (bool): Whether to print verbose logging information.
 
         Returns:
-            pd.DataFrame: A DataFrame containing the real-time 5 minute LMP final data.
+            pl.DataFrame: A DataFrame containing the real-time 5 minute LMP final data.
         """
 
         if date == "latest":
@@ -1351,7 +1424,7 @@ class ISONEAPI:
         date: str | pd.Timestamp = "latest",
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get the real-time hourly LMP data for specified date range.
 
@@ -1377,7 +1450,7 @@ class ISONEAPI:
         date: str | pd.Timestamp = "latest",
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get the real-time hourly LMP data for specified date range.
 
@@ -1401,25 +1474,26 @@ class ISONEAPI:
         url: str,
         verbose: bool = False,
         interval_minutes: int = 60,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         response = self.make_api_call(url)
 
         if interval_minutes == 60:
-            df = pd.DataFrame(response["HourlyLmps"]["HourlyLmp"])
+            df = pl.DataFrame(response["HourlyLmps"]["HourlyLmp"])
         else:
-            df = pd.DataFrame(response["FiveMinLmps"]["FiveMinLmp"])
+            df = pl.DataFrame(response["FiveMinLmps"]["FiveMinLmp"])
 
-        df["Interval Start"] = pd.to_datetime(df["BeginDate"], utc=True).dt.tz_convert(
-            self.default_timezone,
+        df = df.with_columns(
+            self._parse_offset_datetime_expr("BeginDate").alias("Interval Start"),
         )
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(
-            minutes=interval_minutes,
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(minutes=interval_minutes)).alias(
+                "Interval End",
+            ),
+            pl.col("Location").struct.field("@LocType").alias("Location Type"),
+            pl.col("Location").struct.field("$").alias("Location"),
         )
-
-        df["Location Type"] = df["Location"].apply(lambda x: x["@LocType"])
-        df["Location"] = df["Location"].apply(lambda x: x["$"])
         df = df.rename(
-            columns={
+            {
                 "LmpTotal": "LMP",
                 "EnergyComponent": "Energy",
                 "CongestionComponent": "Congestion",
@@ -1427,7 +1501,7 @@ class ISONEAPI:
             },
         )
 
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -1437,8 +1511,8 @@ class ISONEAPI:
                 "Energy",
                 "Congestion",
                 "Loss",
-            ]
-        ].sort_values(["Interval Start", "Location"])
+            ],
+        ).sort(["Interval Start", "Location"])
 
     @support_date_range("DAY_START")
     def get_capacity_forecast_7_day(
@@ -1446,7 +1520,7 @@ class ISONEAPI:
         date: str | pd.Timestamp = "latest",
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get the capacity forecast for the next 7 days.
         """
@@ -1461,24 +1535,32 @@ class ISONEAPI:
         self,
         url: str,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         response = self.make_api_call(url)
-        df = pd.json_normalize(
-            response["SevenDayForecasts"]["SevenDayForecast"],
-            record_path=["MarketDay"],
-            meta=["CreationDate"],
+        df = pl.from_pandas(
+            pd.json_normalize(
+                response["SevenDayForecasts"]["SevenDayForecast"],
+                record_path=["MarketDay"],
+                meta=["CreationDate"],
+            ),
         )
 
-        df["Publish Time"] = pd.to_datetime(df["CreationDate"], utc=True).dt.tz_convert(
-            self.default_timezone,
+        df = df.with_columns(
+            pl.col("CreationDate")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Publish Time"),
+            pl.col("MarketDate")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Interval Start"),
         )
-        df["Interval Start"] = pd.to_datetime(df["MarketDate"], utc=True).dt.tz_convert(
-            self.default_timezone,
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(days=1)).alias("Interval End"),
         )
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(days=1)
 
         df = df.rename(
-            columns={
+            {
                 "TotAvailGenMw": "Total Generation Available",
                 "CsoMw": "Total Capacity Supply Obligation",
                 "ColdWeatherOutagesMw": "Anticipated Cold Weather Outages",
@@ -1507,34 +1589,48 @@ class ISONEAPI:
             "Load Relief Actions Anticipated",
             "Generating Capacity Position",
         ]:
-            df[col] = None
+            df = df.with_columns(pl.lit(None).alias(col))
 
-        df["High Temperature Boston"] = df["Weather.CityWeather"].apply(
-            lambda x: next(
-                (city["HighTempF"] for city in x if city["CityName"] == "Boston"),
-                None,
-            ),
-        )
-        df["High Temperature Hartford"] = df["Weather.CityWeather"].apply(
-            lambda x: next(
-                (city["HighTempF"] for city in x if city["CityName"] == "Hartford"),
-                None,
-            ),
-        )
-        df["Dew Point Boston"] = df["Weather.CityWeather"].apply(
-            lambda x: next(
-                (city["DewPointF"] for city in x if city["CityName"] == "Boston"),
-                None,
-            ),
-        )
-        df["Dew Point Hartford"] = df["Weather.CityWeather"].apply(
-            lambda x: next(
-                (city["DewPointF"] for city in x if city["CityName"] == "Hartford"),
-                None,
-            ),
+        def _city_weather_value(
+            cities: list[dict] | None,
+            city_name: str,
+            field: str,
+        ) -> object:
+            if not cities:
+                return None
+            for city in cities:
+                if city.get("CityName") == city_name:
+                    return city.get(field)
+            return None
+
+        df = df.with_columns(
+            pl.col("Weather.CityWeather")
+            .map_elements(
+                lambda cities: _city_weather_value(cities, "Boston", "HighTempF"),
+                return_dtype=pl.Float64,
+            )
+            .alias("High Temperature Boston"),
+            pl.col("Weather.CityWeather")
+            .map_elements(
+                lambda cities: _city_weather_value(cities, "Hartford", "HighTempF"),
+                return_dtype=pl.Float64,
+            )
+            .alias("High Temperature Hartford"),
+            pl.col("Weather.CityWeather")
+            .map_elements(
+                lambda cities: _city_weather_value(cities, "Boston", "DewPointF"),
+                return_dtype=pl.Float64,
+            )
+            .alias("Dew Point Boston"),
+            pl.col("Weather.CityWeather")
+            .map_elements(
+                lambda cities: _city_weather_value(cities, "Hartford", "DewPointF"),
+                return_dtype=pl.Float64,
+            )
+            .alias("Dew Point Hartford"),
         )
 
-        return df[ISONE_CAPACITY_FORECAST_7_DAY_COLUMNS]
+        return df.select(ISONE_CAPACITY_FORECAST_7_DAY_COLUMNS)
 
     @support_date_range("DAY_START")
     def get_regulation_clearing_prices_real_time_5_min(
@@ -1542,7 +1638,7 @@ class ISONEAPI:
         date: str | pd.Timestamp | Literal["latest"],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get five-minute clearing prices for both regulation capacity and service in real-time.
 
@@ -1552,52 +1648,50 @@ class ISONEAPI:
             verbose (bool): Whether to print verbose logging information.
 
         Returns:
-            pd.DataFrame: A DataFrame containing five-minute regulation clearing prices.
+            pl.DataFrame: A DataFrame containing five-minute regulation clearing prices.
         """
         url = self._build_url("fiveminutercp", date)
         response = self.make_api_call(url, verbose=verbose)
-        df = pd.DataFrame(self._safe_get(response, "FiveMinRcps", "FiveMinRcp"))
+        df = pl.DataFrame(self._safe_get(response, "FiveMinRcps", "FiveMinRcp"))
 
-        if df.empty:
+        if df.is_empty():
             raise NoDataFoundException(
                 f"No five-minute regulation clearing price data found for {date}",
             )
 
         # Timestamps already have an offset, so we parse as UTC then convert to local
-        df["Interval Start"] = pd.to_datetime(df["BeginDate"], utc=True)
         # Floor to 5-minute intervals to handle API data inconsistencies (sometimes returns :01, :02, etc instead of :00). Round in UTC to avoid DST issues
-        df["Interval Start"] = (
-            df["Interval Start"]
-            .dt.floor("5min")
-            .dt.tz_convert(
-                self.default_timezone,
-            )
+        df = df.with_columns(
+            pl.col("BeginDate")
+            .str.to_datetime(time_zone="UTC")
+            .dt.truncate("5m")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Interval Start"),
         )
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(minutes=5)
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(minutes=5)).alias("Interval End"),
+        )
 
         df = df.rename(
-            columns={
+            {
                 "RegServiceClearingPrice": "Reg Service Clearing Price",
                 "RegCapacityClearingPrice": "Reg Capacity Clearing Price",
             },
         )
 
-        df["Reg Service Clearing Price"] = df["Reg Service Clearing Price"].astype(
-            float,
+        df = df.with_columns(
+            pl.col("Reg Service Clearing Price").cast(pl.Float64),
+            pl.col("Reg Capacity Clearing Price").cast(pl.Float64),
         )
 
-        df["Reg Capacity Clearing Price"] = df["Reg Capacity Clearing Price"].astype(
-            float,
-        )
-
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
                 "Reg Service Clearing Price",
                 "Reg Capacity Clearing Price",
-            ]
-        ].sort_values("Interval Start")
+            ],
+        ).sort("Interval Start")
 
     @support_date_range("DAY_START")
     def get_reserve_requirements_prices_forecast_day_ahead(
@@ -1605,7 +1699,7 @@ class ISONEAPI:
         date: str | pd.Timestamp | Literal["latest"],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get day-ahead reserve prices, requirements, and forecast for reserve zone 7000 (system-wide).
 
@@ -1615,34 +1709,38 @@ class ISONEAPI:
             verbose (bool): Whether to print verbose logging information.
 
         Returns:
-            pd.DataFrame: A DataFrame containing day-ahead reserve requirements, prices, and forecast.
+            pl.DataFrame: A DataFrame containing day-ahead reserve requirements, prices, and forecast.
         """
         url = self._build_url("daasreservedata", date)
         response = self.make_api_call(url, verbose=verbose)
 
-        df = pd.json_normalize(
-            self._safe_get(
-                response,
-                "isone_web_services",
-                "day_ahead_reserves",
-                "day_ahead_reserve",
+        df = pl.from_pandas(
+            pd.json_normalize(
+                self._safe_get(
+                    response,
+                    "isone_web_services",
+                    "day_ahead_reserves",
+                    "day_ahead_reserve",
+                ),
             ),
         )
 
-        if df.empty:
+        if df.is_empty():
             raise NoDataFoundException(f"No day-ahead reserve data found for {date}")
 
         # Parse market hour information - API returns timezone-aware datetimes
-        df["Interval Start"] = pd.to_datetime(
-            df["market_hour.local_day"],
-            utc=True,
-        ).dt.tz_convert(
-            self.default_timezone,
+        df = df.with_columns(
+            pl.col("market_hour.local_day")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Interval Start"),
         )
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(hours=1)
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(hours=1)).alias("Interval End"),
+        )
 
         df = df.rename(
-            columns={
+            {
                 "eir_designation_mw": "EIR Designation MW",
                 "fer_clearing_price": "FER Clearing Price",
                 "forecasted_energy_req_mw": "Forecasted Energy Req MW",
@@ -1673,10 +1771,11 @@ class ISONEAPI:
             "Total Thirty Min Req MW",
         ]
 
-        for col in numeric_columns:
-            df[col] = pd.to_numeric(df[col], errors="coerce")
+        df = df.with_columns(
+            [pl.col(col).cast(pl.Float64, strict=False) for col in numeric_columns],
+        )
 
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -1692,8 +1791,38 @@ class ISONEAPI:
                 "TMSR Designation MW",
                 "Total Ten Min Req MW",
                 "Total Thirty Min Req MW",
-            ]
-        ].sort_values("Interval Start")
+            ],
+        ).sort("Interval Start")
+
+    def _handle_reserve_zone_dataframe(
+        self,
+        df: pl.DataFrame,
+        interval_minutes: int,
+        floor_to_five_minutes: bool = False,
+    ) -> pl.DataFrame:
+        if floor_to_five_minutes:
+            interval_start = (
+                pl.col("BeginDate")
+                .str.to_datetime(time_zone="UTC")
+                .dt.truncate("5m")
+                .dt.convert_time_zone(self.default_timezone)
+            )
+        else:
+            interval_start = self._parse_offset_datetime_expr("BeginDate")
+
+        df = df.with_columns(interval_start.alias("Interval Start"))
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(minutes=interval_minutes)).alias(
+                "Interval End",
+            ),
+        )
+        df = df.rename(ISONE_RESERVE_ZONE_COLUMN_MAP)
+        df = df.with_columns(
+            [pl.col(col).cast(pl.Float64) for col in ISONE_RESERVE_ZONE_FLOAT_COLUMNS],
+        )
+        return df.select(ISONE_RESERVE_ZONE_ALL_COLUMNS).sort(
+            ["Interval Start", "Reserve Zone Id"],
+        )
 
     @support_date_range("DAY_START")
     def get_reserve_zone_prices_designations_real_time_5_min(
@@ -1701,7 +1830,7 @@ class ISONEAPI:
         date: str | pd.Timestamp | Literal["latest"],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get five-minute real-time reserve prices, requirements, and designations by zone.
 
@@ -1711,38 +1840,25 @@ class ISONEAPI:
             verbose (bool): Whether to print verbose logging information.
 
         Returns:
-            pd.DataFrame: A DataFrame containing five-minute reserve zone prices and designations.
+            pl.DataFrame: A DataFrame containing five-minute reserve zone prices and designations.
         """
         url = self._build_url("fiveminutereserveprice", date)
         response = self.make_api_call(url, verbose=verbose)
 
-        df = pd.DataFrame(
+        df = pl.DataFrame(
             self._safe_get(response, "FiveMinReservePrices", "FiveMinReservePrice"),
         )
 
-        if df.empty:
+        if df.is_empty():
             raise NoDataFoundException(
                 f"No five-minute reserve zone price data found for {date}",
             )
 
         # Floor to 5-minute intervals to handle API data inconsistencies (sometimes returns :01, :02, etc instead of :00). Do rounding in UTC.
-        df["Interval Start"] = (
-            pd.to_datetime(df["BeginDate"], utc=True)
-            .dt.floor("5min")
-            .dt.tz_convert(
-                self.default_timezone,
-            )
-        )
-
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(minutes=5)
-
-        df = df.rename(columns=ISONE_RESERVE_ZONE_COLUMN_MAP)
-
-        for col in ISONE_RESERVE_ZONE_FLOAT_COLUMNS:
-            df[col] = df[col].astype(float)
-
-        return df[ISONE_RESERVE_ZONE_ALL_COLUMNS].sort_values(
-            ["Interval Start", "Reserve Zone Id"],
+        return self._handle_reserve_zone_dataframe(
+            df,
+            interval_minutes=5,
+            floor_to_five_minutes=True,
         )
 
     @support_date_range("DAY_START")
@@ -1751,7 +1867,7 @@ class ISONEAPI:
         date: str | pd.Timestamp | Literal["latest"],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get preliminary hourly reserve prices, requirements, and designations by zone.
 
@@ -1761,12 +1877,12 @@ class ISONEAPI:
             verbose (bool): Whether to print verbose logging information.
 
         Returns:
-            pd.DataFrame: A DataFrame containing preliminary hourly reserve zone prices and designations.
+            pl.DataFrame: A DataFrame containing preliminary hourly reserve zone prices and designations.
         """
         url = self._build_url("hourlyprelimreserveprice", date)
         response = self.make_api_call(url, verbose=verbose)
 
-        df = pd.DataFrame(
+        df = pl.DataFrame(
             self._safe_get(
                 response,
                 "PrelimHourlyReservePrices",
@@ -1774,24 +1890,12 @@ class ISONEAPI:
             ),
         )
 
-        if df.empty:
+        if df.is_empty():
             raise NoDataFoundException(
                 f"No preliminary hourly reserve zone price data found for {date}",
             )
 
-        df["Interval Start"] = pd.to_datetime(df["BeginDate"], utc=True).dt.tz_convert(
-            self.default_timezone,
-        )
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(hours=1)
-
-        df = df.rename(columns=ISONE_RESERVE_ZONE_COLUMN_MAP)
-
-        for col in ISONE_RESERVE_ZONE_FLOAT_COLUMNS:
-            df[col] = df[col].astype(float)
-
-        return df[ISONE_RESERVE_ZONE_ALL_COLUMNS].sort_values(
-            ["Interval Start", "Reserve Zone Id"],
-        )
+        return self._handle_reserve_zone_dataframe(df, interval_minutes=60)
 
     @support_date_range("DAY_START")
     def get_reserve_zone_prices_designations_real_time_hourly_final(
@@ -1799,7 +1903,7 @@ class ISONEAPI:
         date: str | pd.Timestamp | Literal["latest"],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get final hourly reserve prices, requirements, and designations by zone.
 
@@ -1809,12 +1913,12 @@ class ISONEAPI:
             verbose (bool): Whether to print verbose logging information.
 
         Returns:
-            pd.DataFrame: A DataFrame containing final hourly reserve zone prices and designations.
+            pl.DataFrame: A DataFrame containing final hourly reserve zone prices and designations.
         """
         url = self._build_url("hourlyfinalreserveprice", date)
         response = self.make_api_call(url, verbose=verbose)
 
-        df = pd.DataFrame(
+        df = pl.DataFrame(
             self._safe_get(
                 response,
                 "FinalHourlyReservePrices",
@@ -1822,24 +1926,12 @@ class ISONEAPI:
             ),
         )
 
-        if df.empty:
+        if df.is_empty():
             raise NoDataFoundException(
                 f"No final hourly reserve zone price data found for {date}",
             )
 
-        df["Interval Start"] = pd.to_datetime(df["BeginDate"], utc=True).dt.tz_convert(
-            self.default_timezone,
-        )
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(hours=1)
-
-        df = df.rename(columns=ISONE_RESERVE_ZONE_COLUMN_MAP)
-
-        for col in ISONE_RESERVE_ZONE_FLOAT_COLUMNS:
-            df[col] = df[col].astype(float)
-
-        return df[ISONE_RESERVE_ZONE_ALL_COLUMNS].sort_values(
-            ["Interval Start", "Reserve Zone Id"],
-        )
+        return self._handle_reserve_zone_dataframe(df, interval_minutes=60)
 
     @support_date_range("DAY_START")
     def get_ancillary_services_strike_prices_day_ahead(
@@ -1847,7 +1939,7 @@ class ISONEAPI:
         date: str | pd.Timestamp | Literal["latest"],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get day-ahead strike prices and close-out components for ISO-NE.
 
@@ -1857,44 +1949,44 @@ class ISONEAPI:
             verbose (bool): Whether to print verbose logging information.
 
         Returns:
-            pd.DataFrame: A DataFrame containing day-ahead strike prices and related data.
+            pl.DataFrame: A DataFrame containing day-ahead strike prices and related data.
         """
         url = self._build_url("daasstrikeprices", date)
         response = self.make_api_call(url, verbose=verbose)
 
-        df = pd.json_normalize(
-            self._safe_get(
-                response,
-                "isone_web_services",
-                "day_ahead_strike_prices",
-                "day_ahead_strike_price",
+        df = pl.from_pandas(
+            pd.json_normalize(
+                self._safe_get(
+                    response,
+                    "isone_web_services",
+                    "day_ahead_strike_prices",
+                    "day_ahead_strike_price",
+                ),
             ),
         )
 
-        if df.empty:
+        if df.is_empty():
             raise NoDataFoundException(
                 f"No day-ahead strike price data found for {date}",
             )
 
         # Parse market hour information - API returns timezone-aware datetimes
-        df["Interval Start"] = pd.to_datetime(
-            df["market_hour.local_day"],
-            utc=True,
-        ).dt.tz_convert(
-            self.default_timezone,
+        df = df.with_columns(
+            pl.col("market_hour.local_day")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Interval Start"),
+            pl.col("strike_price_timestamp")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Publish Time"),
         )
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(hours=1)
-
-        # Parse publish time
-        df["Publish Time"] = pd.to_datetime(
-            df["strike_price_timestamp"],
-            utc=True,
-        ).dt.tz_convert(
-            self.default_timezone,
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(hours=1)).alias("Interval End"),
         )
 
         df = df.rename(
-            columns={
+            {
                 "expected_closeout_charge": "Expected Closeout Charge",
                 "expected_closeout_charge_override": "Expected Closeout Charge Override",
                 "expected_rt_hub_lmp": "Expected RT Hub LMP",
@@ -1919,10 +2011,11 @@ class ISONEAPI:
             "Strike Price",
         ]
 
-        for col in numeric_columns:
-            df[col] = pd.to_numeric(df[col], errors="coerce")
+        df = df.with_columns(
+            [pl.col(col).cast(pl.Float64, strict=False) for col in numeric_columns],
+        )
 
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -1936,8 +2029,8 @@ class ISONEAPI:
                 "Percentile 90 RT Hub LMP",
                 "SPC Load Forecast MW",
                 "Strike Price",
-            ]
-        ].sort_values(["Interval Start", "Publish Time"])
+            ],
+        ).sort(["Interval Start", "Publish Time"])
 
     @support_date_range("DAY_START")
     def get_binding_constraints_day_ahead_hourly(
@@ -1945,7 +2038,7 @@ class ISONEAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         url = self._build_url("dayaheadconstraints", date)
         response = self.make_api_call(url, verbose=verbose)
         records = self._prepare_records(
@@ -1957,7 +2050,7 @@ class ISONEAPI:
                 f"No day-ahead constraint data found for {date}.",
             )
 
-        df = pd.DataFrame(records)
+        df = pl.DataFrame(records)
 
         return self._parse_constraint_dataframe(
             df,
@@ -1978,7 +2071,7 @@ class ISONEAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_constraints_fifteen_min(
             date,
             constraint_type="prelim",
@@ -1991,7 +2084,7 @@ class ISONEAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_constraints_fifteen_min(
             date,
             constraint_type="final",
@@ -2003,7 +2096,7 @@ class ISONEAPI:
         date: str | pd.Timestamp,
         constraint_type: Literal["prelim", "final"],
         verbose: bool,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         dataset = f"fifteenminuteconstraints/{constraint_type}"
         url = self._build_url(dataset, date)
         response = self.make_api_call(url, verbose=verbose)
@@ -2016,7 +2109,7 @@ class ISONEAPI:
                 f"No fifteen-minute {constraint_type} constraint data found for {date}.",
             )
 
-        df = pd.DataFrame(records)
+        df = pl.DataFrame(records)
 
         return self._parse_constraint_dataframe(
             df,
@@ -2036,7 +2129,7 @@ class ISONEAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_constraints_five_min(
             date,
             constraint_type="prelim",
@@ -2049,7 +2142,7 @@ class ISONEAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_constraints_five_min(
             date,
             constraint_type="final",
@@ -2061,7 +2154,7 @@ class ISONEAPI:
         date: str | pd.Timestamp,
         constraint_type: Literal["prelim", "final"],
         verbose: bool,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         dataset = f"fiveminuteconstraints/{constraint_type}"
         url = self._build_url(dataset, date)
         response = self.make_api_call(url, verbose=verbose)
@@ -2074,7 +2167,7 @@ class ISONEAPI:
                 f"No five-minute {constraint_type} constraint data found for {date}.",
             )
 
-        df = pd.DataFrame(records)
+        df = pl.DataFrame(records)
 
         rename_map = {
             "ConstraintName": "Constraint Name",
@@ -2093,42 +2186,58 @@ class ISONEAPI:
 
     def _parse_constraint_dataframe(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         interval_field: str,
         interval_minutes: int,
         rename_map: dict[str, str],
         columns: list[str],
-    ) -> pd.DataFrame:
-        if df.empty:
+    ) -> pl.DataFrame:
+        if df.is_empty():
             raise NoDataFoundException(
                 "No constraint data found for the requested parameters.",
             )
 
-        df = df.copy()
-
-        df["Interval Start"] = pd.to_datetime(
-            df[interval_field],
-            errors="coerce",
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(
-            minutes=interval_minutes,
+        df = df.with_columns(
+            pl.col(interval_field)
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Interval Start"),
         )
-        df = df.rename(columns=rename_map)
-        df["Marginal Value"] = pd.to_numeric(df["Marginal Value"], errors="coerce")
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(minutes=interval_minutes)).alias(
+                "Interval End",
+            ),
+        )
+        df = df.rename(rename_map)
+        df = df.with_columns(
+            pl.col("Marginal Value").cast(pl.Float64, strict=False),
+        )
 
         if "Contingency Name" in df.columns:
-            df["Contingency Name"] = (
-                df["Contingency Name"]
-                .astype("string")
-                .str.strip()
-                .mask(lambda s: s.isna() | (s == "") | (s.str.upper() == "NULL"))
-                .map(lambda value: None if pd.isna(value) else value)
+            df = df.with_columns(
+                pl.when(
+                    pl.col("Contingency Name").is_null()
+                    | (pl.col("Contingency Name").cast(pl.Utf8).str.strip_chars() == "")
+                    | (
+                        pl.col("Contingency Name")
+                        .cast(pl.Utf8)
+                        .str.strip_chars()
+                        .str.to_uppercase()
+                        == "NULL"
+                    ),
+                )
+                .then(None)
+                .otherwise(
+                    pl.col("Contingency Name").cast(pl.Utf8).str.strip_chars(),
+                )
+                .alias("Contingency Name"),
             )
 
-        df = df.reindex(columns=columns)
-        df = df.sort_values("Interval Start").reset_index(drop=True)
-        return df
+        for col in columns:
+            if col not in df.columns:
+                df = df.with_columns(pl.lit(None).alias(col))
+
+        return df.select(columns).sort("Interval Start")
 
     @support_date_range(frequency="MONTH_START")
     def get_fcm_reconfiguration_monthly(
@@ -2136,7 +2245,7 @@ class ISONEAPI:
         date: str | pd.Timestamp = "latest",
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get FCM Monthly Reconfiguration Auction data.
 
@@ -2146,7 +2255,7 @@ class ISONEAPI:
             verbose (bool): Whether to print verbose logging information.
 
         Returns:
-            pd.DataFrame: A DataFrame containing monthly reconfiguration auction data.
+            pl.DataFrame: A DataFrame containing monthly reconfiguration auction data.
         """
         if date == "latest":
             endpoint = f"{self.base_url}/fcmmra/current"
@@ -2187,7 +2296,7 @@ class ISONEAPI:
         date: str | pd.Timestamp = "latest",
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get FCM Annual Reconfiguration Auction data for all three auctions (ARA1, ARA2, ARA3).
 
@@ -2200,7 +2309,7 @@ class ISONEAPI:
             verbose (bool): Whether to print verbose logging information.
 
         Returns:
-            pd.DataFrame: A DataFrame containing annual reconfiguration auction data with an "ARA"
+            pl.DataFrame: A DataFrame containing annual reconfiguration auction data with an "ARA"
                           column with values 1, 2, or 3 distinguishing between ARA1, ARA2, and ARA3.
                           Note that not all three auctions may exist for all commitment periods
                           (e.g., ARA3 may not exist yet for recent periods).
@@ -2326,8 +2435,8 @@ class ISONEAPI:
         self,
         auction_records: list[tuple[dict, pd.Timestamp, pd.Timestamp]],
         auction_type: str = "monthly",
-    ) -> pd.DataFrame:
-        frames: list[pd.DataFrame] = []
+    ) -> pl.DataFrame:
+        frames: list[pl.DataFrame] = []
 
         zone_column_map = {
             "CapacityZoneID": "Location ID",
@@ -2353,18 +2462,20 @@ class ISONEAPI:
         }
 
         for auction, interval_start, interval_end in auction_records:
-            zone_frame = pd.json_normalize(
-                auction,
-                record_path=["ClearedCapacityZones", "ClearedCapacityZone"],
-                errors="ignore",
+            zone_frame = pl.from_pandas(
+                pd.json_normalize(
+                    auction,
+                    record_path=["ClearedCapacityZones", "ClearedCapacityZone"],
+                    errors="ignore",
+                ),
             )
 
-            zone_frame = zone_frame.rename(columns=zone_column_map)
-            zone_assign_dict = {
-                "Interval Start": interval_start,
-                "Interval End": interval_end,
-                "Location Type": "Capacity Zone",
-            }
+            zone_frame = zone_frame.rename(zone_column_map)
+            zone_frame = zone_frame.with_columns(
+                pl.lit(interval_start).alias("Interval Start"),
+                pl.lit(interval_end).alias("Interval End"),
+                pl.lit("Capacity Zone").alias("Location Type"),
+            )
             if auction_type == "annual":
                 auction_type_str = auction.get("Type", "")
                 ara_value = None
@@ -2373,28 +2484,29 @@ class ISONEAPI:
                         ara_value = int(auction_type_str.replace("ARA", ""))
                     except ValueError:
                         pass
-                zone_assign_dict["ARA"] = ara_value
-            zone_frame = zone_frame.assign(**zone_assign_dict)
+                zone_frame = zone_frame.with_columns(pl.lit(ara_value).alias("ARA"))
             frames.append(zone_frame)
 
-            interface_frame = pd.json_normalize(
-                auction,
-                record_path=[
-                    "ClearedCapacityZones",
-                    "ClearedCapacityZone",
-                    "ClearedExternalInterfaces",
-                    "ClearedExternalInterface",
-                ],
-                errors="ignore",
+            interface_frame = pl.from_pandas(
+                pd.json_normalize(
+                    auction,
+                    record_path=[
+                        "ClearedCapacityZones",
+                        "ClearedCapacityZone",
+                        "ClearedExternalInterfaces",
+                        "ClearedExternalInterface",
+                    ],
+                    errors="ignore",
+                ),
             )
 
-            interface_frame = interface_frame.rename(columns=interface_column_map)
-            interface_assign_dict = {
-                "Interval Start": interval_start,
-                "Interval End": interval_end,
-                "Location Type": "External Interface",
-                "Capacity Zone Type": None,
-            }
+            interface_frame = interface_frame.rename(interface_column_map)
+            interface_frame = interface_frame.with_columns(
+                pl.lit(interval_start).alias("Interval Start"),
+                pl.lit(interval_end).alias("Interval End"),
+                pl.lit("External Interface").alias("Location Type"),
+                pl.lit(None).alias("Capacity Zone Type"),
+            )
             if auction_type == "annual":
                 auction_type_str = auction.get("Type", "")
                 ara_value = None
@@ -2403,11 +2515,12 @@ class ISONEAPI:
                         ara_value = int(auction_type_str.replace("ARA", ""))
                     except ValueError:
                         pass
-                interface_assign_dict["ARA"] = ara_value
-            interface_frame = interface_frame.assign(**interface_assign_dict)
+                interface_frame = interface_frame.with_columns(
+                    pl.lit(ara_value).alias("ARA"),
+                )
             frames.append(interface_frame)
 
-        df = pd.concat(frames, ignore_index=True)
+        df = pl.concat(frames, how="diagonal")
 
         numeric_columns = [
             "Total Supply Offers Submitted",
@@ -2418,28 +2531,35 @@ class ISONEAPI:
             "Clearing Price",
         ]
 
-        for column in numeric_columns:
-            if column in df.columns:
-                df[column] = pd.to_numeric(df[column], errors="coerce")
+        cast_exprs = [
+            pl.col(column).cast(pl.Float64, strict=False)
+            for column in numeric_columns
+            if column in df.columns
+        ]
+        if cast_exprs:
+            df = df.with_columns(cast_exprs)
 
         if auction_type == "annual":
-            df["ARA"] = df["ARA"].astype("Int64")
+            df = df.with_columns(pl.col("ARA").cast(pl.Int64))
 
         columns_to_use = (
             ISONE_FCM_RECONFIGURATION_COLUMNS
             if auction_type == "annual"
             else [col for col in ISONE_FCM_RECONFIGURATION_COLUMNS if col != "ARA"]
         )
-        df = df.reindex(columns=columns_to_use)
+        for col in columns_to_use:
+            if col not in df.columns:
+                df = df.with_columns(pl.lit(None).alias(col))
+        df = df.select(columns_to_use)
 
         sort_columns = ["Interval Start", "Location ID"]
         if auction_type == "annual":
             sort_columns.insert(1, "ARA")
-        df = df.sort_values(sort_columns).reset_index(drop=True)
+        df = df.sort(sort_columns)
 
         log.debug(
             f"Processed FCM reconfiguration auction data. "
-            f"{len(df)} entries from {df['Interval Start'].min()} to {df['Interval Start'].max()}",
+            f"{df.height} entries from {df['Interval Start'].min()} to {df['Interval Start'].max()}",
         )
 
         return df

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -7,6 +7,7 @@ import zipfile
 from typing import BinaryIO, Dict
 
 import pandas as pd
+import polars as pl
 import requests
 
 from gridstatus import utils
@@ -16,22 +17,30 @@ from gridstatus.gs_logging import logger
 from gridstatus.lmp_config import lmp_config
 
 
-def add_interval_end(df: pd.DataFrame, duration_min: int) -> pd.DataFrame:
+def add_interval_end(df: pl.DataFrame, duration_min: int) -> pl.DataFrame:
     """Add an interval end column to a dataframe
 
     Args:
-        df (pandas.DataFrame): Dataframe with a time column
+        df (polars.DataFrame): Dataframe with a time column
         duration_min (int): Interval duration in minutes
 
     Returns:
-        pandas.DataFrame: Dataframe with an interval end column
+        polars.DataFrame: Dataframe with an interval end column
     """
-    df["Interval End"] = df["Interval Start"] + pd.Timedelta(minutes=duration_min)
-    df["Time"] = df["Interval Start"]
-    df = utils.move_cols_to_front(
-        df,
+    return utils.move_cols_to_front(
+        df.with_columns(
+            (pl.col("Interval Start") + pl.duration(minutes=duration_min)).alias(
+                "Interval End",
+            ),
+            pl.col("Interval Start").alias("Time"),
+        ),
         ["Time", "Interval Start", "Interval End"],
     )
+
+
+def _cast_constraint_description_utf8(df: pl.DataFrame) -> pl.DataFrame:
+    if "Constraint Description" in df.columns:
+        return df.with_columns(pl.col("Constraint Description").cast(pl.Utf8))
     return df
 
 
@@ -87,7 +96,7 @@ class MISO(ISOBase):
         self,
         date: str | pd.Timestamp,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get the fuel mix for a given day for a provided MISO.
 
         Arguments:
@@ -111,23 +120,28 @@ class MISO(ISOBase):
             )
 
         response_json = self._get_json(url, verbose=verbose)
-        return self._parse_fuel_mix(response_json)
+        df = self._parse_fuel_mix(response_json)
+        if date == "latest" and df.height > 1:
+            df = df.filter(pl.col("Interval Start") == pl.col("Interval Start").max())
+        return df
 
-    def _parse_fuel_mix(self, raw_json: Dict[str, dict]) -> pd.DataFrame:
-        df = pd.json_normalize(raw_json["Fuel"]["Type"])
-        df["INTERVALEST"] = pd.to_datetime(
-            df["INTERVALEST"],
-            format="%Y-%m-%d %I:%M:%S %p",
-        ).dt.tz_localize(
-            self.default_timezone,
+    def _parse_fuel_mix(self, raw_json: Dict[str, dict]) -> pl.DataFrame:
+        df = pl.from_pandas(pd.json_normalize(raw_json["Fuel"]["Type"]))
+        df = df.with_columns(
+            pl.col("INTERVALEST")
+            .str.to_datetime(format="%Y-%m-%d %I:%M:%S %p")
+            .dt.replace_time_zone(self.default_timezone)
+            .alias("INTERVALEST"),
         )
-
-        df_pivoted = df.pivot(index="INTERVALEST", columns="CATEGORY", values="ACT")
-        df_pivoted = df_pivoted.reset_index().rename(
-            columns={"INTERVALEST": "Interval Start"},
+        df_pivoted = df.pivot(
+            "CATEGORY",
+            index="INTERVALEST",
+            values="ACT",
+            aggregate_function="first",
+        ).rename(
+            {"INTERVALEST": "Interval Start"},
         )
         df_pivoted = add_interval_end(df_pivoted, 5)
-        df_pivoted.columns.name = None
         for col in [
             "Battery Storage",
             "Coal",
@@ -138,10 +152,24 @@ class MISO(ISOBase):
             "Solar",
             "Wind",
         ]:
-            df_pivoted[col] = df_pivoted[col].astype("Int64")
-        return df_pivoted
+            if col in df_pivoted.columns:
+                df_pivoted = df_pivoted.with_columns(pl.col(col).cast(pl.Int64))
+        output_cols = [
+            "Time",
+            "Interval Start",
+            "Interval End",
+            "Battery Storage",
+            "Coal",
+            "Imports",
+            "Natural Gas",
+            "Nuclear",
+            "Other",
+            "Solar",
+            "Wind",
+        ]
+        return df_pivoted.select([c for c in output_cols if c in df_pivoted.columns])
 
-    def get_load(self, date: str | pd.Timestamp, verbose: bool = False) -> pd.DataFrame:
+    def get_load(self, date: str | pd.Timestamp, verbose: bool = False) -> pl.DataFrame:
         if date == "latest":
             return self.get_load(date="today", verbose=verbose)
 
@@ -150,26 +178,24 @@ class MISO(ISOBase):
 
             date = pd.to_datetime(r["LoadInfo"]["RefId"].split(" ")[0])
 
-            df = pd.DataFrame([x["Load"] for x in r["LoadInfo"]["FiveMinTotalLoad"]])
+            df = pl.DataFrame([x["Load"] for x in r["LoadInfo"]["FiveMinTotalLoad"]])
 
-            df["Interval Start"] = df["Time"].apply(
-                lambda x, date=date: (
-                    date
-                    + pd.Timedelta(
-                        hours=int(
-                            x.split(":")[0],
-                        ),
-                        minutes=int(x.split(":")[1]),
-                    )
-                ),
+            def _time_to_interval_start(time_str: str) -> pd.Timestamp:
+                hours, minutes = map(int, time_str.split(":"))
+                return (date + pd.Timedelta(hours=hours, minutes=minutes)).tz_localize(
+                    self.default_timezone,
+                )
+
+            df = df.with_columns(
+                pl.col("Time")
+                .map_elements(
+                    _time_to_interval_start,
+                    return_dtype=pl.Datetime(time_zone=self.default_timezone),
+                )
+                .alias("Interval Start"),
+                pl.col("Value").cast(pl.Float64).alias("Load"),
             )
-            df["Interval Start"] = df["Interval Start"].dt.tz_localize(
-                self.default_timezone,
-            )
-            df = df.rename(columns={"Value": "Load"})
-            df["Load"] = pd.to_numeric(df["Load"])
-            df = add_interval_end(df, 5)
-            return df
+            return add_interval_end(df.select(["Interval Start", "Load"]), 5)
 
         else:
             raise NotSupported
@@ -180,7 +206,7 @@ class MISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         https://docs.misoenergy.org/marketreports/YYYYMMDD_df_al.xls
         """
@@ -188,15 +214,15 @@ class MISO(ISOBase):
             return self.get_load_forecast(date="today", verbose=verbose)
 
         df = self._get_load_forecast_file(date)
-        df = df.loc[
-            df["Interval Start"] >= date,
-            [col for col in df if "ActualLoad" not in col],
-        ]
-        df = utils.move_cols_to_front(
-            df,
-            ["Interval Start", "Interval End", "Publish Time"],
-        ).drop(columns=["Market Day", "HourEnding"])
-        return df.sort_values("Interval Start").reset_index(drop=True)
+        cols = [col for col in df.columns if "ActualLoad" not in col]
+        return (
+            utils.move_cols_to_front(
+                df.filter(pl.col("Interval Start") >= date).select(cols),
+                ["Interval Start", "Interval End", "Publish Time"],
+            )
+            .drop(["Market Day", "HourEnding"])
+            .sort("Interval Start")
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_zonal_load_hourly(
@@ -204,7 +230,7 @@ class MISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         https://docs.misoenergy.org/marketreports/YYYYMMDD_df_al.xls
         """
@@ -218,17 +244,20 @@ class MISO(ISOBase):
             )
             df = self.get_historical_zonal_load_hourly(date.year)
             if end is None:
-                df = df[df["Interval Start"].dt.date == date.date()]
+                df = df.filter(pl.col("Interval Start").dt.date() == date.date())
             else:
-                df = df[(df["Interval Start"] >= date) & (df["Interval Start"] <= end)]
-            return df.reset_index(drop=True)
+                df = df.filter(
+                    (pl.col("Interval Start") >= date)
+                    & (pl.col("Interval Start") <= end),
+                )
+            return df
 
         # NB: Report available is based on publish time, which is 12am the next day
         date = date + pd.Timedelta(days=1)
         df = self._get_load_forecast_file(date)
 
         df = df.rename(
-            columns={
+            {
                 "LRZ1 ActualLoad": "LRZ1",
                 "LRZ2_7 ActualLoad": "LRZ2 7",
                 "LRZ3_5 ActualLoad": "LRZ3 5",
@@ -239,39 +268,38 @@ class MISO(ISOBase):
             },
         )
 
-        df = utils.move_cols_to_front(
-            df,
-            ["Interval Start", "Interval End"],
-        ).drop(columns=["Market Day", "HourEnding"])
-
-        df = df.sort_values("Interval Start").reset_index(drop=True)
-        df = df.dropna()
-        df = df.astype(
-            {
-                "LRZ1": float,
-                "LRZ2 7": float,
-                "LRZ3 5": float,
-                "LRZ4": float,
-                "LRZ6": float,
-                "LRZ8 9 10": float,
-                "MISO": float,
-            },
-        )
-        return df[
-            [
-                "Interval Start",
-                "Interval End",
-                "LRZ1",
-                "LRZ2 7",
-                "LRZ3 5",
-                "LRZ4",
-                "LRZ6",
-                "LRZ8 9 10",
-                "MISO",
-            ]
+        zonal_cols = [
+            "Interval Start",
+            "Interval End",
+            "LRZ1",
+            "LRZ2 7",
+            "LRZ3 5",
+            "LRZ4",
+            "LRZ6",
+            "LRZ8 9 10",
+            "MISO",
         ]
+        return (
+            utils.move_cols_to_front(
+                df,
+                ["Interval Start", "Interval End"],
+            )
+            .drop(["Market Day", "HourEnding"])
+            .sort("Interval Start")
+            .drop_nulls()
+            .with_columns(
+                pl.col("LRZ1").cast(pl.Float64),
+                pl.col("LRZ2 7").cast(pl.Float64),
+                pl.col("LRZ3 5").cast(pl.Float64),
+                pl.col("LRZ4").cast(pl.Float64),
+                pl.col("LRZ6").cast(pl.Float64),
+                pl.col("LRZ8 9 10").cast(pl.Float64),
+                pl.col("MISO").cast(pl.Float64),
+            )
+            .select(zonal_cols)
+        )
 
-    def _get_load_forecast_file(self, date: str | pd.Timestamp) -> pd.DataFrame:
+    def _get_load_forecast_file(self, date: str | pd.Timestamp) -> pl.DataFrame:
         url = f"https://docs.misoenergy.org/marketreports/{date.strftime('%Y%m%d')}_df_al.xls"  # noqa
         logger.info(f"Downloading hourly load and load forecast data from {url}")
         # Locate the header row dynamically: MISO changed the file layout on
@@ -301,14 +329,14 @@ class MISO(ISOBase):
         df["Publish Time"] = date.normalize()
 
         df.columns = df.columns.map(lambda x: x.replace("(MWh)", "").strip())
-        return df
+        return pl.from_pandas(df)
 
     def _get_load_data(self, verbose: bool = False) -> dict:
         url = "https://public-api.misoenergy.org/api/RealTimeTotalLoad"
         r = self._get_json(url, verbose=verbose)
         return r
 
-    def get_historical_zonal_load_hourly(self, year: int) -> pd.DataFrame:
+    def get_historical_zonal_load_hourly(self, year: int) -> pl.DataFrame:
         url = f"https://docs.misoenergy.org/marketreports/{year}12_dfal_HIST_xls.zip"
         logger.info(f"Downloading historical zonal load data from {url}")
 
@@ -376,22 +404,30 @@ class MISO(ISOBase):
                 "MISO": float,
             },
         )
+        zonal_cols = [
+            "Interval Start",
+            "Interval End",
+            "LRZ1",
+            "LRZ2 7",
+            "LRZ3 5",
+            "LRZ4",
+            "LRZ6",
+            "LRZ8 9 10",
+            "MISO",
+        ]
         return (
-            df_pivoted[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "LRZ1",
-                    "LRZ2 7",
-                    "LRZ3 5",
-                    "LRZ4",
-                    "LRZ6",
-                    "LRZ8 9 10",
-                    "MISO",
-                ]
-            ]
-            .sort_values("Interval Start")
-            .reset_index(drop=True)
+            pl.from_pandas(df_pivoted)
+            .with_columns(
+                pl.col("LRZ1").cast(pl.Float64),
+                pl.col("LRZ2 7").cast(pl.Float64),
+                pl.col("LRZ3 5").cast(pl.Float64),
+                pl.col("LRZ4").cast(pl.Float64),
+                pl.col("LRZ6").cast(pl.Float64),
+                pl.col("LRZ8 9 10").cast(pl.Float64),
+                pl.col("MISO").cast(pl.Float64),
+            )
+            .select(zonal_cols)
+            .sort("Interval Start")
         )
 
     # Older datasets do not have every region. In that case, we insert the column
@@ -415,7 +451,7 @@ class MISO(ISOBase):
         self,
         date: str | pd.Timestamp,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             return self.get_solar_forecast(date="today", verbose=verbose)
 
@@ -430,7 +466,7 @@ class MISO(ISOBase):
         self,
         date: str | pd.Timestamp,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             return self.get_wind_forecast(date="today", verbose=verbose)
 
@@ -467,54 +503,54 @@ class MISO(ISOBase):
         date: str | pd.Timestamp,
         fuel: str,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         excel_file = self._get_mom_forecast_report(date, verbose)
         publish_time = pd.to_datetime(excel_file.book.properties.modified, utc=True)
 
-        # The data schema changes on 2022-06-13
         skiprows = (
             4 if date > pd.Timestamp("2022-06-12", tz=self.default_timezone) else 3
         )
 
-        df = (
-            pd.read_excel(
-                excel_file,
-                sheet_name=f"{fuel.upper()} HOURLY",
-                skiprows=skiprows,
-                skipfooter=1,
-            )
-            .dropna(how="all")
-            .assign(**{"Publish Time": publish_time})
+        def _process_forecast(df: pd.DataFrame) -> pd.DataFrame:
+            return df.dropna(how="all")
+
+        df = utils.read_excel_via_pandas(
+            excel_file,
+            sheet_name=f"{fuel.upper()} HOURLY",
+            skiprows=skiprows,
+            skipfooter=1,
+            process=_process_forecast,
         )
 
-        # Handle older datasets
-        df = df.rename(columns={"Day HE": "DAY HE"})
+        df = df.with_columns(pl.lit(publish_time).alias("Publish Time"))
 
-        # Convert column that looks like this **03/27/2024 1 **03/27/2024 24 or to
-        # a valid datetime. Assume Hour Ending is in local time
+        if "Day HE" in df.columns:
+            df = df.rename({"Day HE": "DAY HE"})
 
-        df["hour"] = df["DAY HE"].str.extract(r"(\d+)$").astype(int)
-        df["date"] = pd.to_datetime(
-            df["DAY HE"].str.replace("**", "").str.split(" ").str[0],
-            format="%m/%d/%Y",
+        df = df.with_columns(
+            pl.col("DAY HE").str.extract(r"(\d+)$", 1).cast(pl.Int64).alias("hour"),
+            pl.col("DAY HE")
+            .str.replace_all(r"\*\*", "")
+            .str.split(" ")
+            .list.first()
+            .str.to_datetime(format="%m/%d/%Y")
+            .alias("date"),
         )
 
-        df["Interval Start"] = (
-            pd.to_datetime(df["date"])
-            + pd.to_timedelta(
-                df["hour"] - 1,
-                "h",
-            )
-            # This forecast does not handle DST changes
-        ).dt.tz_localize(self.default_timezone)
-
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(hours=1)
+        df = df.with_columns(
+            (pl.col("date") + pl.duration(hours=pl.col("hour") - 1))
+            .dt.replace_time_zone(self.default_timezone)
+            .alias("Interval Start"),
+        )
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(hours=1)).alias("Interval End"),
+        )
 
         for col in self.solar_and_wind_forecast_region_cols:
             if col not in df.columns:
-                df[col] = pd.NA
+                df = df.with_columns(pl.lit(None).cast(pl.Float64).alias(col))
 
-        return df[self.solar_and_wind_forecast_cols]
+        return df.select(self.solar_and_wind_forecast_cols)
 
     @support_date_range(frequency="W-MON")
     def get_lmp_real_time_5_min_final(
@@ -522,7 +558,7 @@ class MISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Retrieves real time final lmp data that includes price corrections to the
         preliminary real time data.
 
@@ -544,7 +580,7 @@ class MISO(ISOBase):
         download_url = f"https://docs.misoenergy.org/marketreports/{date.strftime('%Y%m%d')}_5MIN_LMP.zip"
 
         try:
-            df = pd.read_csv(
+            df = utils.read_csv_exotic_via_pandas(
                 download_url,
                 compression="zip",
                 skiprows=4,
@@ -559,16 +595,20 @@ class MISO(ISOBase):
 
     def _handle_lmp_real_time_5_min_final(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         verbose: bool = False,
-    ) -> pd.DataFrame:
-        df["Interval Start"] = pd.to_datetime(df["MKTHOUR_EST"]).dt.tz_localize(
-            self.default_timezone,
+    ) -> pl.DataFrame:
+        df = df.with_columns(
+            pl.from_pandas(
+                pd.to_datetime(df["MKTHOUR_EST"].to_pandas()).dt.tz_localize(
+                    self.default_timezone,
+                ),
+            ).alias("Interval Start"),
         )
-        df = add_interval_end(df, 5).drop(columns=["Time"])
+        df = add_interval_end(df, 5).drop("Time")
 
         df = df.rename(
-            columns={
+            {
                 "CON_LMP": "Congestion",
                 "LOSS_LMP": "Loss",
                 "PNODENAME": "Location",
@@ -576,32 +616,36 @@ class MISO(ISOBase):
         )
         node_to_type = self._get_node_to_type_mapping(verbose)
 
-        df = df.merge(
+        df = df.join(
             node_to_type,
             left_on="Location",
             right_on="Node",
             how="left",
         )
 
-        df["Energy"] = df["LMP"] - df["Loss"] - df["Congestion"]
-        df["Market"] = Markets.REAL_TIME_5_MIN_FINAL.value
+        df = df.with_columns(
+            (pl.col("LMP") - pl.col("Loss") - pl.col("Congestion")).alias("Energy"),
+            pl.lit(Markets.REAL_TIME_5_MIN_FINAL.value).alias("Market"),
+        )
 
-        df = utils.move_cols_to_front(
-            df,
-            [
-                "Interval Start",
-                "Interval End",
-                "Market",
-                "Location",
-                "Location Type",
-                "LMP",
-                "Energy",
-                "Congestion",
-                "Loss",
-            ],
-        ).drop(columns=["MKTHOUR_EST", "Node"])
-
-        return df.sort_values("Interval Start").reset_index(drop=True)
+        return (
+            utils.move_cols_to_front(
+                df,
+                [
+                    "Interval Start",
+                    "Interval End",
+                    "Market",
+                    "Location",
+                    "Location Type",
+                    "LMP",
+                    "Energy",
+                    "Congestion",
+                    "Loss",
+                ],
+            )
+            .drop([c for c in ["MKTHOUR_EST", "Time", "Node"] if c in df.columns])
+            .sort("Interval Start")
+        )
 
     @lmp_config(
         supports={
@@ -619,7 +663,7 @@ class MISO(ISOBase):
         market: str = Markets.REAL_TIME_5_MIN,
         locations: list = "ALL",
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Supported Markets:
             - ``REAL_TIME_5_MIN`` - (Prelim ExPost 5 Minute)
@@ -647,21 +691,24 @@ class MISO(ISOBase):
             logger.info(f"Downloading LMP data from {url}")
             response_json = self._get_json(url, verbose=verbose)
 
-            # Convert JSON format to DataFrame
-            data = pd.DataFrame(response_json["data"], columns=response_json["headers"])
-
-            data["Interval Start"] = pd.to_datetime(data["INTERVAL"]).dt.tz_localize(
-                self.default_timezone,
+            data = pl.from_pandas(
+                pd.DataFrame(response_json["data"], columns=response_json["headers"]),
             )
 
-            node_to_type_mapping = (
-                MISO()
-                ._get_node_to_type_mapping()
-                .set_index("Node")["Location Type"]
-                .to_dict()
+            data = data.with_columns(
+                pl.col("INTERVAL")
+                .str.to_datetime()
+                .dt.replace_time_zone(self.default_timezone)
+                .alias("Interval Start"),
             )
-            data["Location Type"] = data["CPNODE"].map(node_to_type_mapping)
-            data.rename(columns={"CPNODE": "Node"}, inplace=True)
+
+            node_to_type_mapping = self._get_node_to_type_mapping()
+            data = data.join(
+                node_to_type_mapping,
+                left_on="CPNODE",
+                right_on="Node",
+                how="left",
+            ).rename({"CPNODE": "Node"})
 
             interval_duration = 5
 
@@ -680,32 +727,35 @@ class MISO(ISOBase):
                 url = f"https://docs.misoenergy.org/marketreports/{date_str}_rt_lmp_prelim.csv"
 
             logger.info(f"Downloading LMP data from {url}")
-            raw_data = pd.read_csv(url, skiprows=4)
+            raw_data = pl.read_csv(url, skip_rows=4)
             data = self._handle_hourly_lmp(date, raw_data)
             interval_duration = 60
 
-        data = data.sort_values(["Interval Start", "Node"])
+        data = data.sort(["Interval Start", "Node"])
         data = add_interval_end(data, interval_duration)
 
-        data = data.rename(
-            columns={
-                "Node": "Location",
-                "Type": "Location Type",
-                "LMP": "LMP",
-                "MLC": "Loss",
-                "MCC": "Congestion",
-            },
+        rename_map = {
+            "Node": "Location",
+            "LMP": "LMP",
+            "MLC": "Loss",
+            "MCC": "Congestion",
+        }
+        if "Type" in data.columns:
+            rename_map["Type"] = "Location Type"
+        data = data.rename(rename_map)
+
+        data = data.with_columns(
+            pl.col("LMP").cast(pl.Float64, strict=False),
+            pl.col("Loss").cast(pl.Float64, strict=False),
+            pl.col("Congestion").cast(pl.Float64, strict=False),
         )
 
-        data[["LMP", "Loss", "Congestion"]] = data[["LMP", "Loss", "Congestion"]].apply(
-            pd.to_numeric,
-            errors="coerce",
+        data = data.with_columns(
+            (pl.col("LMP") - pl.col("Loss") - pl.col("Congestion")).alias("Energy"),
+            pl.lit(market.value).alias("Market"),
         )
 
-        data["Energy"] = data["LMP"] - data["Loss"] - data["Congestion"]
-        data["Market"] = market.value
-
-        data = data[
+        data = data.select(
             [
                 "Time",
                 "Interval Start",
@@ -717,12 +767,10 @@ class MISO(ISOBase):
                 "Energy",
                 "Congestion",
                 "Loss",
-            ]
-        ]
+            ],
+        )
 
-        data = utils.filter_lmp_locations(data, locations)
-
-        return data
+        return utils.filter_lmp_locations(data, locations)
 
     @lmp_config(
         supports={
@@ -739,7 +787,7 @@ class MISO(ISOBase):
         market: str = Markets.REAL_TIME_5_MIN,
         locations: list = "ALL",
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Deprecated. Use the per-dataset methods instead:
         :meth:`get_lmp_real_time_5_min`, :meth:`get_lmp_day_ahead_hourly`,
         :meth:`get_lmp_real_time_hourly_prelim`,
@@ -766,7 +814,7 @@ class MISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get prelim ExPost real-time 5-minute LMPs for all nodes.
 
         Only today, yesterday, and "latest" are supported.
@@ -784,7 +832,7 @@ class MISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get ExPost day-ahead hourly LMPs for all nodes."""
         return self._get_lmp(
             date,
@@ -799,7 +847,7 @@ class MISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get prelim ExPost real-time hourly LMPs for all nodes.
 
         Only 4 days of data available, with the most recent being yesterday.
@@ -817,7 +865,7 @@ class MISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get final ExPost real-time hourly LMPs for all nodes."""
         return self._get_lmp(
             date,
@@ -830,45 +878,54 @@ class MISO(ISOBase):
     def _handle_hourly_lmp(
         self,
         date: str | pd.Timestamp,
-        raw_data: pd.DataFrame,
-    ) -> pd.DataFrame:
-        data_melted = raw_data.melt(
-            id_vars=["Node", "Type", "Value"],
-            value_vars=[col for col in raw_data.columns if col.startswith("HE")],
-            var_name="HE",
+        raw_data: pl.DataFrame,
+    ) -> pl.DataFrame:
+        he_cols = [col for col in raw_data.columns if col.startswith("HE")]
+        data_melted = raw_data.unpivot(
+            index=["Node", "Type", "Value"],
+            on=he_cols,
+            variable_name="HE",
             value_name="value",
         )
 
-        data = data_melted.pivot_table(
+        data = data_melted.pivot(
+            "Value",
             index=["Node", "Type", "HE"],
-            columns="Value",
             values="value",
-            aggfunc="first",
-        ).reset_index()
+            aggregate_function="first",
+        )
 
-        data["Interval Start"] = (
-            data["HE"]
-            .apply(
-                lambda x: date.replace(tzinfo=None, hour=int(x.split(" ")[1]) - 1),
+        base = pl.lit(
+            date.replace(tzinfo=None).replace(
+                hour=0,
+                minute=0,
+                second=0,
+                microsecond=0,
+            ),
+        )
+        data = data.with_columns(
+            (
+                base
+                + pl.duration(
+                    hours=pl.col("HE").str.split(" ").list.get(1).cast(pl.Int64) - 1,
+                )
             )
-            .dt.tz_localize(self.default_timezone)
+            .dt.replace_time_zone(self.default_timezone)
+            .alias("Interval Start"),
         )
 
         return data
 
-    def _get_node_to_type_mapping(self, verbose: bool = False) -> pd.DataFrame:
-        # use dam to get location types
+    def _get_node_to_type_mapping(self, verbose: bool = False) -> pl.DataFrame:
         today = utils._handle_date("today", self.default_timezone)
         url = f"https://docs.misoenergy.org/marketreports/{today.strftime('%Y%m%d')}_da_expost_lmp.csv"  # noqa
         logger.info(f"Downloading LMP data from {url}")
-        today_dam_data = pd.read_csv(url, skiprows=4)
-        node_to_type = (
-            today_dam_data[["Node", "Type"]]
-            .drop_duplicates()
-            .rename(columns={"Type": "Location Type"})
+        today_dam_data = pl.read_csv(url, skip_rows=4)
+        return (
+            today_dam_data.select(["Node", "Type"])
+            .unique()
+            .rename({"Type": "Location Type"})
         )
-
-        return node_to_type
 
     def get_raw_interconnection_queue(self, verbose: bool = False) -> BinaryIO:
         url = "https://www.misoenergy.org/api/giqueue/getprojects"
@@ -879,31 +936,26 @@ class MISO(ISOBase):
         response = requests.get(url, headers="")
         return utils.get_response_blob(response)
 
-    def get_interconnection_queue(self, verbose: bool = False) -> pd.DataFrame:
+    def get_interconnection_queue(self, verbose: bool = False) -> pl.DataFrame:
         """Get the interconnection queue
 
         Returns:
-            pandas.DataFrame: Interconnection queue
+            polars.DataFrame: Interconnection queue
         """
         raw_data = self.get_raw_interconnection_queue(verbose)
         data = json.loads(raw_data.read().decode("utf-8"))
-        # todo there are also study documents available:  https://www.misoenergy.org/planning/generator-interconnection/GI_Queue/gi-interactive-queue/
-        # there is also a map that plots the locations of these projects:
-        queue = pd.DataFrame(data)
+        queue = pl.from_pandas(pd.DataFrame(data))
 
         queue = queue.rename(
-            columns={
+            {
                 "postGIAStatus": "Post Generator Interconnection Agreement Status",
                 "doneDate": "Interconnection Approval Date",
             },
         )
 
-        queue["Capacity (MW)"] = queue[
-            [
-                "summerNetMW",
-                "winterNetMW",
-            ]
-        ].max(axis=1)
+        queue = queue.with_columns(
+            pl.max_horizontal("summerNetMW", "winterNetMW").alias("Capacity (MW)"),
+        )
 
         rename = {
             "projectNumber": "Queue ID",
@@ -962,7 +1014,7 @@ class MISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get the forecasted generation outages published on the date for the next
         seven days."""
         return self._get_generation_outages_data(date, type="forecast", verbose=verbose)
@@ -973,7 +1025,7 @@ class MISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get the estimated generation outages published on the date for the past 30
         days. NOTE: since these are estimates, they change with each file published.
         """
@@ -984,9 +1036,8 @@ class MISO(ISOBase):
         date: str | pd.Timestamp,
         type: str = "forecast",
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
-            # Latest available file is for yesterday
             date = pd.Timestamp.now(
                 tz=self.default_timezone,
             ).normalize() - pd.DateOffset(days=1)
@@ -1001,41 +1052,33 @@ class MISO(ISOBase):
         if type == "actual":
             skiprows = 26
 
-        # There's an unavoidable warning from openpyxl about styles so we suppress it
+        def _process_outages(df: pd.DataFrame) -> pd.DataFrame:
+            df.columns = [col.replace(" **", "").strip() for col in df.columns]
+            df.columns = ["Region", "Type"] + list(df.columns[2:])
+            return df.drop(columns=[col for col in df.columns if "Unnamed" in col])
+
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",
                 category=UserWarning,
                 module=re.escape("openpyxl.styles.stylesheet"),
             )
-            data = pd.read_excel(
+            data = utils.read_excel_via_pandas(
                 url,
                 sheet_name="OUTAGE",
                 skiprows=skiprows,
                 nrows=nrows,
+                process=_process_outages,
             )
 
-        data.columns = [col.replace(" **", "").strip() for col in data.columns]
-        data.columns = ["Region", "Type"] + list(data.columns[2:])
-
-        # Some of the files have empty columns called "Unnamed x" that we need to drop
-        data = data.drop(columns=[col for col in data.columns if "Unnamed" in col])
-
-        data = data.melt(id_vars=["Region", "Type"], value_name="MW", var_name="Date")
-        data = data.pivot(index=["Region", "Date"], columns=["Type"])
-
-        data.columns = data.columns.droplevel(0)
-        data.columns.name = None
-
-        data = data.reset_index()
-
-        data["Interval Start"] = pd.to_datetime(
-            data["Date"],
-            format="mixed",
-        ).dt.tz_localize(self.default_timezone)
-
-        data["Interval End"] = data["Interval Start"] + pd.DateOffset(days=1)
-        data["Publish Time"] = date.tz_convert(self.default_timezone)
+        date_cols = [c for c in data.columns if c not in ["Region", "Type"]]
+        data = data.unpivot(
+            index=["Region", "Type"],
+            on=date_cols,
+            variable_name="Date",
+            value_name="MW",
+        )
+        data = data.pivot("Type", index=["Region", "Date"], values="MW")
 
         rename_dict = {
             "Derated": "Derated Outages MW",
@@ -1044,14 +1087,164 @@ class MISO(ISOBase):
             "Unplanned": "Unplanned Outages MW",
         }
 
+        output_cols = [
+            "Interval Start",
+            "Interval End",
+            "Publish Time",
+            "Region",
+            *rename_dict.values(),
+        ]
+
         return (
-            data.rename(columns=rename_dict)[
-                ["Interval Start", "Interval End", "Publish Time", "Region"]
-                + list(rename_dict.values())
-            ]
-            .sort_values(["Interval Start", "Region"])
-            .reset_index(drop=True)
+            data.with_columns(
+                pl.col("Date")
+                .str.to_datetime(format="%m/%d/%y")
+                .dt.replace_time_zone(self.default_timezone)
+                .alias("Interval Start"),
+            )
+            .with_columns(
+                (pl.col("Interval Start") + pl.duration(days=1)).alias("Interval End"),
+                pl.lit(date.tz_convert(self.default_timezone)).alias("Publish Time"),
+            )
+            .rename(rename_dict)
+            .select(output_cols)
+            .sort(["Interval Start", "Region"])
         )
+
+    _SUBREGIONAL_PBC_COLS = [
+        "Interval Start",
+        "Interval End",
+        "CONSTRAINT_NAME",
+        "PRELIMINARY_SHADOW_PRICE",
+        "CURVETYPE",
+        "BP1",
+        "PC1",
+        "BP2",
+        "PC2",
+        "BP3",
+        "PC3",
+        "BP4",
+        "PC4",
+        "OVERRIDE",
+        "REASON",
+    ]
+
+    _RESERVE_PRODUCT_COLS = [
+        "Interval Start",
+        "Interval End",
+        "Constraint Name",
+        "Shadow Price",
+        "Constraint Description",
+    ]
+
+    def _subregional_pbc_empty_df(self) -> pl.DataFrame:
+        tz = self.default_timezone
+        return pl.DataFrame(
+            schema={
+                "Interval Start": pl.Datetime("ns", tz),
+                "Interval End": pl.Datetime("ns", tz),
+                "CONSTRAINT_NAME": pl.Utf8,
+                "PRELIMINARY_SHADOW_PRICE": pl.Float64,
+                "CURVETYPE": pl.Utf8,
+                "BP1": pl.Float64,
+                "PC1": pl.Float64,
+                "BP2": pl.Float64,
+                "PC2": pl.Float64,
+                "BP3": pl.Float64,
+                "PC3": pl.Float64,
+                "BP4": pl.Float64,
+                "PC4": pl.Float64,
+                "OVERRIDE": pl.Int64,
+                "REASON": pl.Utf8,
+            },
+        )
+
+    def _reserve_product_empty_df(self) -> pl.DataFrame:
+        tz = self.default_timezone
+        return pl.DataFrame(
+            schema={
+                "Interval Start": pl.Datetime("ns", tz),
+                "Interval End": pl.Datetime("ns", tz),
+                "Constraint Name": pl.Utf8,
+                "Shadow Price": pl.Float64,
+                "Constraint Description": pl.Utf8,
+            },
+        )
+
+    def _finalize_reserve_product(self, data: pl.DataFrame) -> pl.DataFrame:
+        tz = self.default_timezone
+        return data.select(self._RESERVE_PRODUCT_COLS).with_columns(
+            pl.col("Interval Start").cast(pl.Datetime("ns", tz)),
+            pl.col("Interval End").cast(pl.Datetime("ns", tz)),
+            pl.col("Constraint Name").cast(pl.Utf8),
+            pl.col("Constraint Description").cast(pl.Utf8),
+            pl.col("Shadow Price").cast(pl.Float64, strict=False),
+        )
+
+    def _read_subregional_pbc_csv(
+        self,
+        url: str,
+        interval_minutes: int,
+    ) -> pl.DataFrame:
+        def _process_pbc(df: pd.DataFrame) -> pd.DataFrame:
+            return df.iloc[:-1]
+
+        data = utils.read_csv_exotic_via_pandas(
+            url,
+            skiprows=3,
+            index_col=False,
+            process=_process_pbc,
+        )
+        data = data.rename({c: c.strip() for c in data.columns})
+        data = data.with_columns(
+            pl.col("PRELIMINARY_SHADOW_PRICE").cast(pl.Float64, strict=False),
+            pl.col("BP1").cast(pl.Float64, strict=False),
+            pl.col("PC1").cast(pl.Float64, strict=False),
+            pl.col("BP2").cast(pl.Float64, strict=False),
+            pl.col("PC2").cast(pl.Float64, strict=False),
+            pl.col("BP3").cast(pl.Float64, strict=False),
+            pl.col("PC3").cast(pl.Float64, strict=False),
+            pl.col("BP4").cast(pl.Float64, strict=False),
+            pl.col("PC4").cast(pl.Float64, strict=False),
+            pl.col("OVERRIDE").cast(pl.Int64, strict=False),
+            pl.col("REASON").cast(pl.Utf8),
+        )
+
+        if data.is_empty():
+            return self._subregional_pbc_empty_df()
+
+        interval_end = pd.to_datetime(
+            data["MARKET_HOUR_EST"].to_pandas(),
+        ).dt.tz_localize(
+            self.default_timezone,
+        )
+        data = data.with_columns(
+            pl.from_pandas(interval_end).alias("Interval End"),
+        )
+        data = data.with_columns(
+            (pl.col("Interval End") - pl.duration(minutes=interval_minutes)).alias(
+                "Interval Start",
+            ),
+        )
+        data = data.with_columns(
+            pl.col("Interval End").cast(pl.Datetime("ns", self.default_timezone)),
+            pl.col("Interval Start").cast(pl.Datetime("ns", self.default_timezone)),
+        )
+        return data.select(self._SUBREGIONAL_PBC_COLS)
+
+    def _get_constraint_header_dates_from_url(
+        self,
+        url: str,
+    ) -> tuple[pd.Timestamp, pd.Timestamp]:
+        header = utils.read_excel_via_pandas(url, nrows=2, usecols=[0])
+        col = header.columns[0]
+        market_date = pd.to_datetime(header[col][0].split(": ")[1]).tz_localize(
+            self.default_timezone,
+        )
+        publish_date = pd.to_datetime(header[col][1].split(": ")[1]).tz_localize(
+            self.default_timezone,
+        )
+        return market_date, publish_date
 
     @support_date_range(frequency="DAY_START")
     def get_binding_constraints_supplemental(
@@ -1059,7 +1252,7 @@ class MISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get the supplemental binding constraints data from MISO.
 
         Source URL: https://www.misoenergy.org/markets-and-operations/real-time--market-data/market-reports/#nt=%2FMarketReportType%3ADay-Ahead%2FMarketReportName%3ABinding Constraints Supplemental (xls)&t=10&p=0&s=MarketReportPublished&sd=desc
@@ -1070,20 +1263,17 @@ class MISO(ISOBase):
             verbose (bool, optional): Verbosity. Defaults to False.
 
         Returns:
-            pandas.DataFrame: Supplemental binding constraints data
+            polars.DataFrame: Supplemental binding constraints data
         """
         query_date = date - pd.Timedelta("1D")
         url = f"https://docs.misoenergy.org/marketreports/{query_date.strftime('%Y%m%d')}_da_bcsf.xls"
         logger.info(f"Downloading supplemental binding constraints data from {url}")
 
-        excel_file = pd.ExcelFile(url)
-        market_date, publish_date = self._get_constraint_header_dates_from_excel(
-            excel_file,
-        )
-        data = pd.read_excel(excel_file, skiprows=3)
-        data["Date"] = market_date
+        market_date, publish_date = self._get_constraint_header_dates_from_url(url)
+        data = utils.read_excel_via_pandas(url, skiprows=3)
+        data = data.with_columns(pl.lit(market_date).alias("Date"))
 
-        return data[
+        return data.select(
             [
                 "Date",
                 "Constraint ID",
@@ -1102,8 +1292,8 @@ class MISO(ISOBase):
                 "To Station",
                 "From KV",
                 "To KV",
-            ]
-        ]
+            ],
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_binding_constraints_day_ahead_hourly(
@@ -1111,17 +1301,14 @@ class MISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         query_date = date - pd.Timedelta("1D")
         url = f"https://docs.misoenergy.org/marketreports/{query_date.strftime('%Y%m%d')}_da_bc.xls"
         logger.info(f"Downloading day-ahead binding constraints data from {url}")
 
-        excel_file = pd.ExcelFile(url)
-        market_date, publish_date = self._get_constraint_header_dates_from_excel(
-            excel_file,
-        )
-        data = pd.read_excel(
-            excel_file,
+        market_date, publish_date = self._get_constraint_header_dates_from_url(url)
+        data = utils.read_excel_via_pandas(
+            url,
             skiprows=3,
             dtype={
                 "Constraint Description": object,
@@ -1133,20 +1320,26 @@ class MISO(ISOBase):
                 "PC2": float,
             },
         )
+        data = _cast_constraint_description_utf8(data)
 
-        data["Interval End"] = market_date + pd.to_timedelta(
-            data["Hour of Occurrence"],
-            unit="h",
+        data = data.with_columns(
+            (
+                pl.lit(market_date) + pl.duration(hours=pl.col("Hour of Occurrence"))
+            ).alias(
+                "Interval End",
+            ),
         )
-        data["Interval Start"] = data["Interval End"] - pd.Timedelta(hours=1)
+        data = data.with_columns(
+            (pl.col("Interval End") - pl.duration(hours=1)).alias("Interval Start"),
+        )
         data = data.rename(
-            columns={
+            {
                 "Branch Name ( Branch Type / From CA / To CA )": "Branch Name",
                 "Constraint_ID": "Constraint ID",
             },
         )
 
-        return data[
+        return data.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -1164,15 +1357,14 @@ class MISO(ISOBase):
                 "BP2",
                 "PC2",
                 "Reason",
-            ]
-        ]
+            ],
+        )
 
-    # NOTE(kladar): Mostly this method is used for efficient backfilling
     def get_binding_constraints_day_ahead_yearly_historical(
         self,
         year: int,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get the day-ahead binding constraints data from MISO for a given year.
 
         Args:
@@ -1180,29 +1372,33 @@ class MISO(ISOBase):
             verbose (bool, optional): Verbosity. Defaults to False.
 
         Returns:
-            pandas.DataFrame: Historical day-ahead binding constraints data
+            polars.DataFrame: Historical day-ahead binding constraints data
         """
         url = f"https://docs.misoenergy.org/marketreports/{year}_da_bc_HIST.csv"
         logger.info(f"Downloading day-ahead binding constraints data from {url}")
 
-        data = pd.read_csv(url)
-        data["Interval End"] = pd.to_datetime(data["Market Date"]).dt.tz_localize(
-            self.default_timezone,
-        ) + pd.to_timedelta(data["Hour of Occurrence"], unit="h")
-        data["Interval Start"] = data["Interval End"] - pd.Timedelta(hours=1)
-
-        data = data.rename(
-            columns={
-                "Branch Name ( Branch Type / From CA / To CA )": "Branch Name",
-            },
+        data = pl.read_csv(url)
+        data = data.with_columns(
+            (
+                pl.col("Market Date")
+                .str.to_datetime()
+                .dt.replace_time_zone(
+                    self.default_timezone,
+                )
+                + pl.duration(hours=pl.col("Hour of Occurrence"))
+            ).alias("Interval End"),
+        )
+        data = data.with_columns(
+            (pl.col("Interval End") - pl.duration(hours=1)).alias("Interval Start"),
         )
         data = data.rename(
-            columns={
+            {
+                "Branch Name ( Branch Type / From CA / To CA )": "Branch Name",
                 "Constraint_ID": "Constraint ID",
             },
         )
 
-        return data[
+        return data.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -1220,8 +1416,8 @@ class MISO(ISOBase):
                 "BP2",
                 "PC2",
                 "Reason",
-            ]
-        ]
+            ],
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_subregional_power_balance_constraints_day_ahead_hourly(
@@ -1229,80 +1425,14 @@ class MISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         query_date = date - pd.Timedelta("1D")
         url = f"https://docs.misoenergy.org/marketreports/{query_date.strftime('%Y%m%d')}_da_pbc.csv"
         logger.info(
             f"Downloading day-ahead subregional power balance constraints data from {url}",
         )
 
-        data = pd.read_csv(
-            url,
-            skiprows=3,
-            index_col=False,
-            dtype={
-                "PRELIMINARY_SHADOW_PRICE": float,
-                "BP1": float,
-                "PC1": float,
-                "BP2": float,
-                "PC2": float,
-                "BP3": float,
-                "PC3": float,
-                "BP4": float,
-                "PC4": float,
-                "REASON": object,
-            },
-        )
-
-        # NOTE(kladar): The last row is a text disclaimer, and there is a leading space
-        # in the column names, so we clean it all up.
-        data = data.iloc[:-1]
-        data.columns = data.columns.str.strip()
-        if data.empty:
-            return data[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "CONSTRAINT_NAME",
-                    "PRELIMINARY_SHADOW_PRICE",
-                    "CURVETYPE",
-                    "BP1",
-                    "PC1",
-                    "BP2",
-                    "PC2",
-                    "BP3",
-                    "PC3",
-                    "BP4",
-                    "PC4",
-                    "OVERRIDE",
-                    "REASON",
-                ]
-            ]
-
-        data["Interval End"] = pd.to_datetime(data["MARKET_HOUR_EST"]).dt.tz_localize(
-            self.default_timezone,
-        )
-        data["Interval Start"] = data["Interval End"] - pd.Timedelta(hours=1)
-
-        return data[
-            [
-                "Interval Start",
-                "Interval End",
-                "CONSTRAINT_NAME",
-                "PRELIMINARY_SHADOW_PRICE",
-                "CURVETYPE",
-                "BP1",
-                "PC1",
-                "BP2",
-                "PC2",
-                "BP3",
-                "PC3",
-                "BP4",
-                "PC4",
-                "OVERRIDE",
-                "REASON",
-            ]
-        ]
+        return self._read_subregional_pbc_csv(url, interval_minutes=60)
 
     @support_date_range(frequency="DAY_START")
     def get_reserve_product_binding_constraints_day_ahead_hourly(
@@ -1310,50 +1440,36 @@ class MISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         query_date = date - pd.Timedelta("1D")
         url = f"https://docs.misoenergy.org/marketreports/{query_date.strftime('%Y%m%d')}_da_rpe.xls"
         logger.info(
             f"Downloading day-ahead reserve product binding constraints data from {url}",
         )
 
-        excel_file = pd.ExcelFile(url)
-        market_date, publish_date = self._get_constraint_header_dates_from_excel(
-            excel_file,
-        )
-        data = pd.read_excel(excel_file, skiprows=3)
-        data = data.iloc[:-1]
-        print(data)
-        print(market_date)
-        data["Interval End"] = market_date + pd.to_timedelta(
-            data[
-                "Hour of Occurence"
-            ],  # NOTE(kladar): sic, this is a persistent typo in the header from MISO
-            unit="h",
-        )
+        market_date, publish_date = self._get_constraint_header_dates_from_url(url)
 
-        if data.empty:
-            return data[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Constraint Name",
-                    "Shadow Price",
-                    "Constraint Description",
-                ]
-            ]
+        def _process_rpe(df: pd.DataFrame) -> pd.DataFrame:
+            return df.iloc[:-1]
 
-        data["Interval Start"] = data["Interval End"] - pd.Timedelta(hours=1)
+        data = utils.read_excel_via_pandas(url, skiprows=3, process=_process_rpe)
+        data = _cast_constraint_description_utf8(data)
 
-        return data[
-            [
-                "Interval Start",
+        if data.is_empty():
+            return self._reserve_product_empty_df()
+
+        data = data.with_columns(
+            (
+                pl.lit(market_date) + pl.duration(hours=pl.col("Hour of Occurence"))
+            ).alias(
                 "Interval End",
-                "Constraint Name",
-                "Shadow Price",
-                "Constraint Description",
-            ]
-        ]
+            ),
+        )
+        data = data.with_columns(
+            (pl.col("Interval End") - pl.duration(hours=1)).alias("Interval Start"),
+        )
+
+        return self._finalize_reserve_product(data)
 
     @support_date_range(frequency="DAY_START")
     def get_binding_constraints_real_time_5_min(
@@ -1361,17 +1477,22 @@ class MISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         query_date = date + pd.Timedelta("1D")
         url = f"https://docs.misoenergy.org/marketreports/{query_date.strftime('%Y%m%d')}_rt_bc.xls"
         logger.info(f"Downloading real-time binding constraints data from {url}")
 
-        excel_file = pd.ExcelFile(url)
-        market_date, publish_date = self._get_constraint_header_dates_from_excel(
-            excel_file,
-        )
-        data = pd.read_excel(
-            excel_file,
+        market_date, publish_date = self._get_constraint_header_dates_from_url(url)
+
+        def _process_rt_bc(df: pd.DataFrame) -> pd.DataFrame:
+            df["Interval End"] = pd.to_datetime(
+                market_date.strftime("%Y-%m-%d") + " " + df["Hour of  Occurrence"],
+            ).dt.tz_localize(self.default_timezone)
+            df["Interval Start"] = df["Interval End"] - pd.Timedelta(minutes=5)
+            return df
+
+        data = utils.read_excel_via_pandas(
+            url,
             skiprows=3,
             dtype={
                 "Constraint Description": object,
@@ -1381,26 +1502,16 @@ class MISO(ISOBase):
                 "BP2": float,
                 "PC2": float,
             },
+            process=_process_rt_bc,
         )
-
-        data["Interval End"] = pd.to_datetime(
-            market_date.strftime("%Y-%m-%d")
-            + " "
-            + data[
-                "Hour of  Occurrence"
-            ],  # NOTE(kladar): sic, there are two spaces between "Hour of" and "Occurrence"
-        ).dt.tz_localize(
-            self.default_timezone,
-        )
-
-        data["Interval Start"] = data["Interval End"] - pd.Timedelta(minutes=5)
+        data = _cast_constraint_description_utf8(data)
         data = data.rename(
-            columns={
+            {
                 "Branch Name ( Branch Type / From CA / To CA )": "Branch Name",
             },
         )
 
-        return data[
+        return data.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -1417,15 +1528,14 @@ class MISO(ISOBase):
                 "PC1",
                 "BP2",
                 "PC2",
-            ]
-        ]
+            ],
+        )
 
-    # NOTE(kladar): Mostly this method is used for efficient backfilling
     def get_binding_constraints_real_time_yearly_historical(
         self,
         year: int,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get the real-time binding constraints data from MISO for a given year.
 
         Args:
@@ -1433,41 +1543,56 @@ class MISO(ISOBase):
             verbose (bool, optional): Verbosity. Defaults to False.
 
         Returns:
-            pandas.DataFrame: Historical real-time binding constraints data
+            polars.DataFrame: Historical real-time binding constraints data
         """
         url = f"https://docs.misoenergy.org/marketreports/{year}_rt_bc_HIST.csv"
         logger.info(f"Downloading real-time binding constraints data from {url}")
 
-        data = pd.read_csv(
+        def _process_rt_hist(df: pd.DataFrame) -> pd.DataFrame:
+            df = df.iloc[:-2].copy()
+            df["Interval End"] = pd.to_datetime(
+                df["Market Date"] + " " + df["Hour of Occurrence"],
+            ).dt.tz_localize(self.default_timezone)
+            df["Interval Start"] = df["Interval End"] - pd.Timedelta(hours=1)
+            for col in [
+                "Preliminary Shadow Price",
+                "BP1",
+                "PC1",
+                "BP2",
+                "PC2",
+                "Override",
+                "Constraint ID",
+                "Flowgate NERC ID",
+            ]:
+                if col in df.columns:
+                    df[col] = pd.to_numeric(df[col], errors="coerce")
+            for col in [
+                "Constraint Description",
+                "Constraint Name",
+                "Branch Name",
+                "Contingency Description",
+                "Curve Type",
+            ]:
+                if col in df.columns:
+                    df[col] = df[col].astype("object")
+            return df
+
+        data = utils.read_csv_exotic_via_pandas(
             url,
             skiprows=2,
-            dtype={
-                "Constraint Description": object,
-            },
+            dtype=str,
+            process=_process_rt_hist,
         )
-        data = data.iloc[
-            :-2
-        ]  # NOTE(kladar): The last two rows are report descriptions and disclaimers
-        data["Interval End"] = pd.to_datetime(
-            data["Market Date"] + " " + data["Hour of Occurrence"],
-        ).dt.tz_localize(
-            self.default_timezone,
-        )
-        data["Interval Start"] = data["Interval End"] - pd.Timedelta(hours=1)
-
+        data = _cast_constraint_description_utf8(data)
         data = data.rename(
-            columns={
+            {
                 "Branch Name ( Branch Type / From CA / To CA )": "Branch Name",
-            },
-        )
-        data = data.rename(
-            columns={
                 "Flowgate NERCID": "Flowgate NERC ID",
                 "Constraint_ID": "Constraint ID",
             },
         )
 
-        return data[
+        return data.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -1484,8 +1609,8 @@ class MISO(ISOBase):
                 "PC1",
                 "BP2",
                 "PC2",
-            ]
-        ]
+            ],
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_binding_constraint_overrides_real_time_5_min(
@@ -1493,19 +1618,24 @@ class MISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         query_date = date + pd.Timedelta("1D")
         url = f"https://docs.misoenergy.org/marketreports/{query_date.strftime('%Y%m%d')}_rt_or.xls"
         logger.info(
             f"Downloading real-time binding constraint overrides data from {url}",
         )
 
-        excel_file = pd.ExcelFile(url)
-        market_date, publish_date = self._get_constraint_header_dates_from_excel(
-            excel_file,
-        )
-        data = pd.read_excel(
-            excel_file,
+        market_date, publish_date = self._get_constraint_header_dates_from_url(url)
+
+        def _process_rt_or(df: pd.DataFrame) -> pd.DataFrame:
+            df["Interval End"] = pd.to_datetime(
+                market_date.strftime("%Y-%m-%d") + " " + df["Hour of  Occurrence"],
+            ).dt.tz_localize(self.default_timezone)
+            df["Interval Start"] = df["Interval End"] - pd.Timedelta(minutes=5)
+            return df
+
+        data = utils.read_excel_via_pandas(
+            url,
             skiprows=3,
             dtype={
                 "Constraint Description": object,
@@ -1515,24 +1645,15 @@ class MISO(ISOBase):
                 "PC2": float,
                 "Reason": object,
             },
+            process=_process_rt_or,
         )
-
-        data["Interval End"] = pd.to_datetime(
-            market_date.strftime("%Y-%m-%d")
-            + " "
-            + data[
-                "Hour of  Occurrence"
-            ],  # NOTE(kladar): sic, there are two spaces between "Hour of" and "Occurrence"
-        ).dt.tz_localize(self.default_timezone)
-
-        data["Interval Start"] = data["Interval End"] - pd.Timedelta(minutes=5)
-
+        data = _cast_constraint_description_utf8(data)
         data = data.rename(
-            columns={
+            {
                 "Branch Name ( Branch Type / From CA / To CA )": "Branch Name",
             },
         )
-        return data[
+        return data.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -1549,8 +1670,8 @@ class MISO(ISOBase):
                 "BP2",
                 "PC2",
                 "Reason",
-            ]
-        ]
+            ],
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_subregional_power_balance_constraints_real_time_5_min(
@@ -1558,80 +1679,14 @@ class MISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         query_date = date + pd.Timedelta("1D")
         url = f"https://docs.misoenergy.org/marketreports/{query_date.strftime('%Y%m%d')}_rt_pbc.csv"
         logger.info(
             f"Downloading real-time subregional power balance constraints data from {url}",
         )
 
-        data = pd.read_csv(
-            url,
-            skiprows=3,
-            index_col=False,
-            dtype={
-                "PRELIMINARY_SHADOW_PRICE": float,
-                "BP1": float,
-                "PC1": float,
-                "BP2": float,
-                "PC2": float,
-                "BP3": float,
-                "PC3": float,
-                "BP4": float,
-                "PC4": float,
-                "REASON": object,
-            },
-        )
-
-        # NOTE(kladar): The last row is a text disclaimer, and there is a leading space
-        # in the column names, so we clean it all up.
-        data = data.iloc[:-1]
-        data.columns = data.columns.str.strip()
-        if data.empty:
-            return data[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "CONSTRAINT_NAME",
-                    "PRELIMINARY_SHADOW_PRICE",
-                    "CURVETYPE",
-                    "BP1",
-                    "PC1",
-                    "BP2",
-                    "PC2",
-                    "BP3",
-                    "PC3",
-                    "BP4",
-                    "PC4",
-                    "OVERRIDE",
-                    "REASON",
-                ]
-            ]
-
-        data["Interval End"] = pd.to_datetime(data["MARKET_HOUR_EST"]).dt.tz_localize(
-            self.default_timezone,
-        )
-        data["Interval Start"] = data["Interval End"] - pd.Timedelta(minutes=5)
-
-        return data[
-            [
-                "Interval Start",
-                "Interval End",
-                "CONSTRAINT_NAME",
-                "PRELIMINARY_SHADOW_PRICE",
-                "CURVETYPE",
-                "BP1",
-                "PC1",
-                "BP2",
-                "PC2",
-                "BP3",
-                "PC3",
-                "BP4",
-                "PC4",
-                "OVERRIDE",
-                "REASON",
-            ]
-        ]
+        return self._read_subregional_pbc_csv(url, interval_minutes=5)
 
     @support_date_range(frequency="DAY_START")
     def get_reserve_product_binding_constraints_real_time_5_min(
@@ -1639,43 +1694,29 @@ class MISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         query_date = date + pd.Timedelta("1D")
         url = f"https://docs.misoenergy.org/marketreports/{query_date.strftime('%Y%m%d')}_rt_rpe.xls"
         logger.info(
             f"Downloading real-time reserve product binding constraints data from {url}",
         )
 
-        data = pd.read_excel(url, skiprows=3)
+        def _process_rt_rpe(df: pd.DataFrame) -> pd.DataFrame:
+            df = df.iloc[:-1].copy()
+            if not df.empty:
+                df["Interval End"] = pd.to_datetime(
+                    df["Time of Occurence"],
+                ).dt.tz_localize(self.default_timezone)
+                df["Interval Start"] = df["Interval End"] - pd.Timedelta(minutes=5)
+            return df
 
-        # NOTE(kladar): The last row is a text disclaimer, and there is a leading space
-        # in the column names, so we clean it all up.
-        data = data.iloc[:-1]
-        if data.empty:
-            return data[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Constraint Name",
-                    "Shadow Price",
-                    "Constraint Description",
-                ]
-            ]
+        data = utils.read_excel_via_pandas(url, skiprows=3, process=_process_rt_rpe)
+        data = _cast_constraint_description_utf8(data)
 
-        data["Interval End"] = pd.to_datetime(data["Time of Occurence"]).dt.tz_localize(
-            self.default_timezone,
-        )  # NOTE(kladar) sic, this is a persistent typo from MISO
-        data["Interval Start"] = data["Interval End"] - pd.Timedelta(minutes=5)
+        if data.is_empty():
+            return self._reserve_product_empty_df()
 
-        return data[
-            [
-                "Interval Start",
-                "Interval End",
-                "Constraint Name",
-                "Shadow Price",
-                "Constraint Description",
-            ]
-        ]
+        return self._finalize_reserve_product(data)
 
     @support_date_range(frequency=None)
     def get_binding_constraints_real_time_intraday(
@@ -1683,7 +1724,7 @@ class MISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get real-time binding constraints data from MISO's intraday API.
 
         This provides active real-time constraint data updated every 5 minutes.
@@ -1712,70 +1753,77 @@ class MISO(ISOBase):
     def _parse_binding_constraints_real_time_intraday(
         self,
         response_json: dict,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         constraints = response_json.get("Constraint", [])
 
         if not constraints:
             raise NoDataFoundException("No real-time binding constraints data found")
 
-        df = pd.DataFrame(constraints)
+        df = pl.from_pandas(pd.DataFrame(constraints))
 
-        # MISO publishes empty binding constraints when there are no active constraints
         if (df["Name"] == "None").all():
             raise NoDataFoundException("No real-time binding constraints data found")
 
-        # Period is Interval End
-        df["Interval End"] = pd.to_datetime(df["Period"]).dt.tz_localize(
-            self.default_timezone,
+        df = df.with_columns(
+            pl.col("Period")
+            .str.to_datetime()
+            .dt.replace_time_zone(self.default_timezone)
+            .alias("Interval End"),
         )
-
         df = df.rename(
-            columns={
+            {
                 "Name": "Constraint Name",
                 "Price": "Shadow Price",
                 "OVERRIDE": "Override",
                 "CURVETYPE": "Curve Type",
             },
         )
-
-        # Shadow price is a float, all others are integers
-        df["Shadow Price"] = pd.to_numeric(df["Shadow Price"], errors="coerce")
-        for col in ["Override", "BP1", "PC1", "BP2", "PC2"]:
-            df[col] = df[col].replace({"": None}).astype("Int64")
-
-        df["Interval Start"] = df["Interval End"] - pd.Timedelta(minutes=5)
-
-        return (
-            df[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Constraint Name",
-                    "Shadow Price",
-                    "Override",
-                    "Curve Type",
-                    "BP1",
-                    "PC1",
-                    "BP2",
-                    "PC2",
-                ]
-            ]
-            .sort_values("Interval Start")
-            .reset_index(drop=True)
+        df = df.with_columns(
+            pl.col("Shadow Price").cast(pl.Float64, strict=False),
+            pl.when(pl.col("Override") == "")
+            .then(None)
+            .otherwise(pl.col("Override"))
+            .cast(pl.Int64)
+            .alias("Override"),
+            pl.when(pl.col("BP1") == "")
+            .then(None)
+            .otherwise(pl.col("BP1"))
+            .cast(pl.Int64)
+            .alias("BP1"),
+            pl.when(pl.col("PC1") == "")
+            .then(None)
+            .otherwise(pl.col("PC1"))
+            .cast(pl.Int64)
+            .alias("PC1"),
+            pl.when(pl.col("BP2") == "")
+            .then(None)
+            .otherwise(pl.col("BP2"))
+            .cast(pl.Int64)
+            .alias("BP2"),
+            pl.when(pl.col("PC2") == "")
+            .then(None)
+            .otherwise(pl.col("PC2"))
+            .cast(pl.Int64)
+            .alias("PC2"),
+        )
+        df = df.with_columns(
+            (pl.col("Interval End") - pl.duration(minutes=5)).alias("Interval Start"),
         )
 
-    def _get_constraint_header_dates_from_excel(
-        self,
-        file: pd.ExcelFile,
-    ) -> tuple[pd.Timestamp, pd.Timestamp]:
-        header = pd.read_excel(file, nrows=2, usecols=[0])
-        market_date = pd.to_datetime(header.iloc[0, 0].split(": ")[1]).tz_localize(
-            self.default_timezone,
-        )
-        publish_date = pd.to_datetime(header.iloc[1, 0].split(": ")[1]).tz_localize(
-            self.default_timezone,
-        )
-        return market_date, publish_date
+        return df.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "Constraint Name",
+                "Shadow Price",
+                "Override",
+                "Curve Type",
+                "BP1",
+                "PC1",
+                "BP2",
+                "PC2",
+            ],
+        ).sort("Interval Start")
 
     @support_date_range(frequency="DAY_START")
     def get_look_ahead_hourly(
@@ -1783,7 +1831,7 @@ class MISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             return self.get_look_ahead_hourly(date="today", verbose=verbose)
 
@@ -1792,67 +1840,76 @@ class MISO(ISOBase):
 
         publish_time = date.normalize()
 
-        df = pd.read_csv(url, skiprows=3, skipfooter=15, engine="python")
+        df = utils.read_csv_exotic_via_pandas(
+            url,
+            skiprows=3,
+            skipfooter=15,
+            engine="python",
+        )
         id_cols = ["Hourend_EST", "Region"]
         value_cols = [col for col in df.columns if col not in id_cols]
 
-        df_melted = df.melt(
-            id_vars=id_cols,
-            value_vars=value_cols,
-            var_name="date_col",
+        df_melted = df.unpivot(
+            index=id_cols,
+            on=value_cols,
+            variable_name="date_col",
             value_name="value",
         )
 
-        df_melted["date"] = df_melted["date_col"].str.extract(r"(\d{2}/\d{2}/\d{4})")
-        df_melted["type"] = (
-            df_melted["date_col"]
-            .str.contains("Outage")
-            .map({True: "Outage", False: "MTLF"})
+        df_melted = df_melted.with_columns(
+            pl.col("date_col").str.extract(r"(\d{2}/\d{2}/\d{4})", 1).alias("date"),
+            pl.when(pl.col("date_col").str.contains("Outage"))
+            .then(pl.lit("Outage"))
+            .otherwise(pl.lit("MTLF"))
+            .alias("type"),
         )
 
         df_wide = df_melted.pivot(
+            "type",
             index=["Hourend_EST", "Region", "date"],
-            columns="type",
             values="value",
-        ).reset_index()
+        )
 
-        df_wide["Hour Ending"] = (
-            df_wide["Hourend_EST"]
-            .str.extract(r"Hour   (\d+)")[0]
-            .astype(int)
-            .sub(1)  # Subtract 1 to convert from 1-24 to 0-23
-            .astype(str)
+        df_wide = df_wide.with_columns(
+            pl.col("Hourend_EST")
+            .str.extract(r"Hour   (\d+)", 1)
+            .cast(pl.Int64)
+            .sub(1)
+            .cast(pl.Utf8)
             .str.zfill(2)
+            .alias("Hour Ending"),
         )
 
-        df_wide["Interval End"] = pd.to_datetime(
-            df_wide["date"] + " " + df_wide["Hour Ending"],
-            format="mixed",
-        ).dt.tz_localize(self.default_timezone, nonexistent="shift_forward")
-        df_wide["Interval End"] = df_wide["Interval End"] + pd.Timedelta(
-            hours=1,
-        )  # Add back hour from 1-24 to 0-23 conversion
-        df_wide["Interval Start"] = df_wide["Interval End"] - pd.Timedelta(hours=1)
-        df_wide["Publish Time"] = publish_time
-        df_wide["MTLF"] = df_wide["MTLF"] * 1000  # GW to MW
-        df_wide["Outage"] = df_wide["Outage"] * 1000  # GW to MW
-
-        final_df = (
-            df_wide[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Publish Time",
-                    "Region",
-                    "MTLF",
-                    "Outage",
-                ]
-            ]
-            .sort_values(["Interval Start", "Region"])
-            .reset_index(drop=True)
+        df_wide = df_wide.with_columns(
+            (pl.col("date") + " " + pl.col("Hour Ending") + ":00")
+            .str.to_datetime(format="%m/%d/%Y %H:%M")
+            .alias("Interval End Naive"),
+        )
+        df_wide = utils.localize_shift_forward_polars(
+            df_wide,
+            "Interval End Naive",
+            self.default_timezone,
+        )
+        df_wide = df_wide.with_columns(
+            (pl.col("Interval End Naive") + pl.duration(hours=1)).alias("Interval End"),
+        ).drop("Interval End Naive")
+        df_wide = df_wide.with_columns(
+            (pl.col("Interval End") - pl.duration(hours=1)).alias("Interval Start"),
+            pl.lit(publish_time).alias("Publish Time"),
+            (pl.col("MTLF") * 1000).alias("MTLF"),
+            (pl.col("Outage") * 1000).alias("Outage"),
         )
 
-        return final_df
+        return df_wide.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "Publish Time",
+                "Region",
+                "MTLF",
+                "Outage",
+            ],
+        ).sort(["Interval Start", "Region"])
 
     @support_date_range(frequency=None)
     def get_interchange_5_min(
@@ -1860,18 +1917,13 @@ class MISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date != "latest":
             raise NotSupported(
                 "Only latest MISO interchange data is available. Use 'latest' as date.",
             )
 
-        # The actuals are available with historical data in the Imports endpoint. Data
-        # in this file is in UTC, confirmed using https://publiccharts.misoenergy.org/charts/interchange
         actual_url = "https://public-api.misoenergy.org/api/Interchange/GetNai/Imports"
-
-        # Scheduled data with historical 5-minute data including all components. Data
-        # in this file is in EST, confirmed using https://publiccharts.misoenergy.org/charts/interchange
         scheduled_url = (
             "https://public-api.misoenergy.org/api/Interchange/GetNsi/FiveMinute"
         )
@@ -1880,76 +1932,71 @@ class MISO(ISOBase):
             f"Downloading interchange data from {scheduled_url} and {actual_url}",
         )
 
-        # Get actual data - new API returns array of historical values
         actual_response = self._get_json(actual_url, verbose=verbose)
-        actual_data = pd.DataFrame(actual_response)
+        actual_data = pl.from_pandas(pd.DataFrame(actual_response))
+        actual_data = actual_data.with_columns(
+            pl.col("Time")
+            .str.to_datetime(format="%Y-%m-%d %I:%M:%S %p", time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Time"),
+            pl.col("Value").cast(pl.Float64, strict=False).cast(pl.Int64),
+        )
 
-        # Parse actual data timestamp (format: "2025-12-10 2:15:00 AM")
-        actual_data["Time"] = pd.to_datetime(
-            actual_data["Time"],
-            format="%Y-%m-%d %I:%M:%S %p",
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
-
-        # Convert Value to numeric
-        actual_data["Value"] = pd.to_numeric(actual_data["Value"])
-
-        # Get scheduled data - new API returns array in "instance" key
         scheduled_response = self._get_json(scheduled_url, verbose=verbose)
-        scheduled_data = pd.DataFrame(scheduled_response["instance"])
+        scheduled_data = pl.from_pandas(pd.DataFrame(scheduled_response["instance"]))
+        scheduled_data = scheduled_data.with_columns(
+            pl.col("timestamp")
+            .str.to_datetime()
+            .dt.replace_time_zone(self.default_timezone)
+            .alias("timestamp"),
+            pl.col("MISO").cast(pl.Float64, strict=False).cast(pl.Int64),
+        )
+        for col in ["AECI", "LGEE", "MHEB", "ONT", "PJM", "SOCO", "SPA", "SWPP", "TVA"]:
+            if col in scheduled_data.columns:
+                scheduled_data = scheduled_data.with_columns(
+                    pl.col(col).cast(pl.Float64, strict=False).cast(pl.Int64),
+                )
 
-        scheduled_data["timestamp"] = pd.to_datetime(
-            scheduled_data["timestamp"],
-        ).dt.tz_localize(self.default_timezone)
-
-        # Merge actual and scheduled data
-        data = scheduled_data.merge(
+        data = scheduled_data.join(
             actual_data,
             left_on="timestamp",
             right_on="Time",
-            how="outer",
-        ).rename(
-            columns={
-                "timestamp": "Interval End",
+            how="full",
+            suffix="_actual",
+        )
+        data = data.with_columns(
+            pl.coalesce(pl.col("timestamp"), pl.col("Time")).alias("Interval End"),
+        ).drop(["timestamp", "Time"])
+        data = data.rename(
+            {
                 "Value": "Net Actual Interchange",
                 "MISO": "Net Scheduled Interchange",
             },
         )
-
-        data["Interval End"] = data["Interval End"].fillna(data["Time"])
-        data = data.drop(columns=["Time"])
-
-        data["Interval Start"] = data["Interval End"] - pd.Timedelta(minutes=5)
-
-        # The actual data does not go as far back as the scheduled data so it has NAs.
-        # The scheduled data lags the actual by 1 interval so it has NAs as well.
-        # We must use Pandas nullable integer type to avoid issues with NAs.
-        # https://pandas.pydata.org/docs/user_guide/integer_na.html
-        for col in data:
-            if col not in ["Interval Start", "Interval End"]:
-                data[col] = data[col].astype("Int64")
-
-        return (
-            data[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Net Scheduled Interchange",
-                    "Net Actual Interchange",
-                    "AECI",
-                    "LGEE",
-                    "MHEB",
-                    "ONT",
-                    "PJM",
-                    "SOCO",
-                    "SPA",
-                    "SWPP",
-                    "TVA",
-                ]
-            ]
-            .sort_values("Interval Start")
-            .reset_index(drop=True)
+        data = data.with_columns(
+            (pl.col("Interval End") - pl.duration(minutes=5)).alias("Interval Start"),
         )
+
+        output_cols = [
+            "Interval Start",
+            "Interval End",
+            "Net Scheduled Interchange",
+            "Net Actual Interchange",
+            "AECI",
+            "LGEE",
+            "MHEB",
+            "ONT",
+            "PJM",
+            "SOCO",
+            "SPA",
+            "SWPP",
+            "TVA",
+        ]
+        for col in output_cols:
+            if col not in ["Interval Start", "Interval End"] and col in data.columns:
+                data = data.with_columns(pl.col(col).cast(pl.Int64, strict=False))
+
+        return data.select(output_cols).sort("Interval Start")
 
     @support_date_range(frequency="DAY_START")
     def get_multiday_operating_margin(
@@ -1957,7 +2004,7 @@ class MISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get the multiday operating margin forecast.
 
         This data comes from the Multiday Operating Margin Forecast (MOMF) report
@@ -2006,7 +2053,7 @@ class MISO(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get the multiday operating margin forecast for all regions.
 
         This data comes from the Multiday Operating Margin Forecast (MOMF) report
@@ -2053,7 +2100,7 @@ class MISO(ISOBase):
                 sheet_data=all_sheets[region],
                 verbose=verbose,
             )
-            if len(df) > 0:
+            if df.height > 0:
                 dfs.append(df)
 
         if not dfs:
@@ -2061,15 +2108,15 @@ class MISO(ISOBase):
                 f"No data found for any region on {date}",
             )
 
-        return pd.concat(dfs, ignore_index=True)
+        return pl.concat(dfs, how="diagonal")
 
     def _get_multiday_operating_margin_data(
         self,
         date: str | pd.Timestamp,
         region: str = "MISO",
-        sheet_data: pd.DataFrame = None,
+        sheet_data: pd.DataFrame | pl.DataFrame | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Internal helper to process multiday operating margin sheet data.
 
         Args:
@@ -2081,7 +2128,10 @@ class MISO(ISOBase):
         Returns:
             DataFrame with operating margin forecast data.
         """
-        data = sheet_data
+        if isinstance(sheet_data, pl.DataFrame):
+            data = sheet_data.to_pandas()
+        else:
+            data = sheet_data
 
         # Map sheet names to display names
         region_display_names = {
@@ -2315,4 +2365,4 @@ class MISO(ISOBase):
                 [col for col in desired_order if col in result_df.columns]
             ]
 
-        return result_df.sort_values(["Peak Hour"]).reset_index(drop=True)
+        return pl.from_pandas(result_df).sort("Peak Hour")

--- a/gridstatus/miso_api.py
+++ b/gridstatus/miso_api.py
@@ -5,6 +5,7 @@ from itertools import chain
 from typing import Any, Callable, Dict, List, Literal
 
 import pandas as pd
+import polars as pl
 import requests
 
 from gridstatus import utils
@@ -94,7 +95,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         **kwargs,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_pricing_data(
             date,
             end,
@@ -111,7 +112,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         **kwargs,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_pricing_data(
             date,
             end,
@@ -128,7 +129,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         **kwargs,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_pricing_data(
             date,
             end,
@@ -145,7 +146,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         **kwargs,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_pricing_data(
             date,
             end,
@@ -162,7 +163,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         **kwargs,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_pricing_data(
             date,
             end,
@@ -178,7 +179,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         **kwargs,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_pricing_data(
             date,
             end,
@@ -195,7 +196,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         **kwargs,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_pricing_data(
             date,
             end,
@@ -217,7 +218,7 @@ class MISOAPI:
         market: Markets,
         verbose: bool = False,
         **kwargs: Any,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         data_lists = retrieval_func(date, end, verbose=verbose, **kwargs)
 
         data_list = self._flatten(data_lists)
@@ -306,33 +307,28 @@ class MISOAPI:
         self,
         start: pd.Timestamp,
         end: pd.Timestamp,
-    ) -> pd.DataFrame:
-        # use miso pricing api (Aggregated Pnode) to get location types
+    ) -> pl.DataFrame:
         df = self.get_pricing_nodes(start, end)
 
-        return df[["Node", "Location Type"]]
+        return df.select(["Node", "Location Type"])
 
     def _process_pricing_data(
         self,
         data_list: List[Dict[str, Any]],
         market: Markets,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         df = self._data_list_to_df(data_list)
 
         start = df["Interval Start"].min()
         end = df["Interval End"].max()
 
-        node_to_type_mapping = (
-            self._get_node_to_type_mapping(start, end)
-            .set_index("Node")["Location Type"]
-            .to_dict()
-        )
+        mapping_df = self._get_node_to_type_mapping(start, end).rename({"Node": "node"})
 
-        df["Location Type"] = df["node"].map(node_to_type_mapping)
-        df["Market"] = market.value
+        df = df.join(mapping_df, on="node", how="left")
+        df = df.with_columns(pl.lit(market.value).alias("Market"))
 
         df = df.rename(
-            columns={
+            {
                 "node": "Location",
                 "lmp": "LMP",
                 "mcc": "Congestion",
@@ -341,8 +337,7 @@ class MISOAPI:
             },
         )
 
-        # Column ordering
-        df = df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -353,10 +348,8 @@ class MISOAPI:
                 "Energy",
                 "Congestion",
                 "Loss",
-            ]
-        ]
-
-        return df
+            ],
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_interchange_hourly(
@@ -364,7 +357,7 @@ class MISOAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             date = pd.Timestamp.now(tz=self.default_timezone).floor("h")
 
@@ -389,14 +382,17 @@ class MISOAPI:
         historical_scheduled_df = self._data_list_to_df(
             historical_scheduled_data_list,
         ).pivot(
-            columns="adjacentBa",
+            on="adjacentBa",
             index=["Interval Start", "Interval End"],
             values="nsi",
         )
 
-        historical_scheduled_df.columns = historical_scheduled_df.columns + " Scheduled"
-
-        historical_scheduled_df = historical_scheduled_df.reset_index()
+        scheduled_rename = {
+            col: f"{col} Scheduled"
+            for col in historical_scheduled_df.columns
+            if col not in ["Interval Start", "Interval End"]
+        }
+        historical_scheduled_df = historical_scheduled_df.rename(scheduled_rename)
 
         real_time_actual_url = f"{BASE_LOAD_GENERATION_AND_INTERCHANGE_URL}/real-time/{date_str}/interchange/net-actual"  # noqa
 
@@ -409,18 +405,24 @@ class MISOAPI:
         real_time_actual_df = self._data_list_to_df(real_time_actual_data_list)
 
         # Historical data has this as ONT, so convert for consistency
-        real_time_actual_df["adjacentBa"] = real_time_actual_df["adjacentBa"].replace(
-            "IESO",
-            "ONT",
+        real_time_actual_df = real_time_actual_df.with_columns(
+            pl.when(pl.col("adjacentBa") == "IESO")
+            .then(pl.lit("ONT"))
+            .otherwise(pl.col("adjacentBa"))
+            .alias("adjacentBa"),
         )
 
         real_time_actual_df = real_time_actual_df.pivot(
-            columns="adjacentBa",
+            on="adjacentBa",
             index=["Interval Start", "Interval End"],
             values="nai",
         )
-        real_time_actual_df.columns = real_time_actual_df.columns + " Actual"
-        real_time_actual_df = real_time_actual_df.reset_index()
+        actual_rename = {
+            col: f"{col} Actual"
+            for col in real_time_actual_df.columns
+            if col not in ["Interval Start", "Interval End"]
+        }
+        real_time_actual_df = real_time_actual_df.rename(actual_rename)
 
         real_time_scheduled_url = f"{BASE_LOAD_GENERATION_AND_INTERCHANGE_URL}/real-time/{date_str}/interchange/net-scheduled"  # noqa
 
@@ -433,37 +435,38 @@ class MISOAPI:
         real_time_scheduled_df = self._data_list_to_df(real_time_scheduled_data_list)
 
         real_time_scheduled_df = real_time_scheduled_df.rename(
-            columns={
+            {
                 "nsiForward": "Net Scheduled Interchange Forward",
                 "nsiRealTime": "Net Scheduled Interchange Real Time",
                 "nsiDelta": "Net Scheduled Interchange Delta",
             },
         )
 
-        data = pd.merge(
-            historical_scheduled_df,
+        data = historical_scheduled_df.join(
             real_time_actual_df,
             on=["Interval Start", "Interval End"],
-            how="outer",
+            how="full",
+            coalesce=True,
         )
 
-        data = pd.merge(
-            data,
+        data = data.join(
             real_time_scheduled_df,
             on=["Interval Start", "Interval End"],
-            how="outer",
+            how="full",
+            coalesce=True,
         )
 
-        data = data[data["Interval Start"] >= date]
+        data = data.filter(pl.col("Interval Start") >= pl.lit(date))
 
         if end is not None:
-            data = data[data["Interval End"] <= end]
+            data = data.filter(pl.col("Interval End") <= pl.lit(end))
 
-        for col in data.columns:
-            if col not in ["Interval Start", "Interval End"]:
-                data[col] = data[col].astype(float)
+        float_cols = [
+            col for col in data.columns if col not in ["Interval Start", "Interval End"]
+        ]
+        data = data.with_columns([pl.col(col).cast(pl.Float64) for col in float_cols])
 
-        return data[
+        return data.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -488,8 +491,8 @@ class MISOAPI:
                 "PJM Actual",
                 "OTHER Scheduled",
                 "SPA Actual",
-            ]
-        ].reset_index(drop=True)
+            ],
+        )
 
     def _get_day_ahead_cleared_demand(
         self,
@@ -497,7 +500,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         time_resolution: str = DAILY_RESOLUTION,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         date_str = date.strftime("%Y-%m-%d")
 
         url = f"{BASE_LOAD_GENERATION_AND_INTERCHANGE_URL}/day-ahead/{date_str}/demand?timeResolution={time_resolution}"
@@ -513,7 +516,7 @@ class MISOAPI:
         )
 
         df = df.rename(
-            columns={
+            {
                 "region": "Region",
                 "fixed": "Fixed Bids Cleared",
                 "priceSens": "Price Sensitive Bids Cleared",
@@ -521,18 +524,19 @@ class MISOAPI:
             },
         )
 
-        data = df.reset_index()
-
-        data = data[data["Interval Start"] >= date]
+        data = df.filter(pl.col("Interval Start") >= pl.lit(date))
 
         if end is not None:
-            data = data[data["Interval End"] <= end]
+            data = data.filter(pl.col("Interval End") <= pl.lit(end))
 
-        for col in data.columns:
-            if col not in ["Interval Start", "Interval End", "Region"]:
-                data[col] = data[col].astype(float)
+        float_cols = [
+            col
+            for col in data.columns
+            if col not in ["Interval Start", "Interval End", "Region"]
+        ]
+        data = data.with_columns([pl.col(col).cast(pl.Float64) for col in float_cols])
 
-        return data[
+        return data.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -540,8 +544,8 @@ class MISOAPI:
                 "Fixed Bids Cleared",
                 "Price Sensitive Bids Cleared",
                 "Virtual Bids Cleared",
-            ]
-        ].reset_index(drop=True)
+            ],
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_day_ahead_cleared_demand_daily(
@@ -549,7 +553,7 @@ class MISOAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
@@ -566,7 +570,7 @@ class MISOAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
@@ -583,7 +587,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         generation_type: str = "physical",
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get day-ahead cleared generation (physical or virtual) hourly.
 
         Args:
@@ -607,23 +611,24 @@ class MISOAPI:
         )
 
         df = df.rename(
-            columns={"region": "Region", "supply": "Supply Cleared"},
+            {"region": "Region", "supply": "Supply Cleared"},
         )
 
-        data = df.reset_index()
-
-        data = data[data["Interval Start"] >= date]
+        data = df.filter(pl.col("Interval Start") >= pl.lit(date))
 
         if end is not None:
-            data = data[data["Interval End"] <= end]
+            data = data.filter(pl.col("Interval End") <= pl.lit(end))
 
-        for col in data.columns:
-            if col not in ["Interval Start", "Interval End", "Region"]:
-                data[col] = data[col].astype(float)
+        float_cols = [
+            col
+            for col in data.columns
+            if col not in ["Interval Start", "Interval End", "Region"]
+        ]
+        data = data.with_columns([pl.col(col).cast(pl.Float64) for col in float_cols])
 
-        return data[
-            ["Interval Start", "Interval End", "Region", "Supply Cleared"]
-        ].reset_index(drop=True)
+        return data.select(
+            ["Interval Start", "Interval End", "Region", "Supply Cleared"],
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_day_ahead_cleared_generation_physical_hourly(
@@ -631,7 +636,7 @@ class MISOAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
@@ -648,7 +653,7 @@ class MISOAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
@@ -665,7 +670,7 @@ class MISOAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
@@ -684,26 +689,27 @@ class MISOAPI:
         )
 
         df = df.rename(
-            columns={
+            {
                 "region": "Region",
                 "nsi": "Net Scheduled Interchange",
             },
         )
 
-        data = df.reset_index()
-
-        data = data[data["Interval Start"] >= date]
+        data = df.filter(pl.col("Interval Start") >= pl.lit(date))
 
         if end is not None:
-            data = data[data["Interval End"] <= end]
+            data = data.filter(pl.col("Interval End") <= pl.lit(end))
 
-        for col in data.columns:
-            if col not in ["Interval Start", "Interval End", "Region"]:
-                data[col] = data[col].astype(float)
+        float_cols = [
+            col
+            for col in data.columns
+            if col not in ["Interval Start", "Interval End", "Region"]
+        ]
+        data = data.with_columns([pl.col(col).cast(pl.Float64) for col in float_cols])
 
-        return data[
-            ["Interval Start", "Interval End", "Region", "Net Scheduled Interchange"]
-        ].reset_index(drop=True)
+        return data.select(
+            ["Interval Start", "Interval End", "Region", "Net Scheduled Interchange"],
+        )
 
     def _get_day_ahead_offered_generation_hourly(
         self,
@@ -711,7 +717,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         ecotype: str = "ecomax",
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get day-ahead offered generation ecomax/ecomin hourly.
 
         Args:
@@ -734,7 +740,7 @@ class MISOAPI:
         )
 
         df = df.rename(
-            columns={
+            {
                 "region": "Region",
                 "mustRun": "Must Run",
                 "economic": "Economic",
@@ -742,18 +748,19 @@ class MISOAPI:
             },
         )
 
-        data = df.reset_index()
-
-        data = data[data["Interval Start"] >= date]
+        data = df.filter(pl.col("Interval Start") >= pl.lit(date))
 
         if end is not None:
-            data = data[data["Interval End"] <= end]
+            data = data.filter(pl.col("Interval End") <= pl.lit(end))
 
-        for col in data.columns:
-            if col not in ["Interval Start", "Interval End", "Region"]:
-                data[col] = data[col].astype(float)
+        float_cols = [
+            col
+            for col in data.columns
+            if col not in ["Interval Start", "Interval End", "Region"]
+        ]
+        data = data.with_columns([pl.col(col).cast(pl.Float64) for col in float_cols])
 
-        return data[
+        return data.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -761,8 +768,8 @@ class MISOAPI:
                 "Must Run",
                 "Economic",
                 "Emergency",
-            ]
-        ].reset_index(drop=True)
+            ],
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_day_ahead_offered_generation_ecomax_hourly(
@@ -770,7 +777,7 @@ class MISOAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
@@ -787,7 +794,7 @@ class MISOAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
@@ -804,7 +811,7 @@ class MISOAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         date_str = date.strftime("%Y-%m-%d")
 
         url = f"{BASE_LOAD_GENERATION_AND_INTERCHANGE_URL}/day-ahead/{date_str}/generation/fuel-type"
@@ -820,14 +827,13 @@ class MISOAPI:
         )
 
         if "interval" in df.columns:
-            df = df.drop(columns=["interval"])
+            df = df.drop("interval")
 
         # Expand the 'fuelTypes' dictionary column into separate columns
-        fuel_types_df = df["fuelTypes"].apply(pd.Series)
-        df = pd.concat([df.drop(columns=["fuelTypes"]), fuel_types_df], axis=1)
+        df = df.unnest("fuelTypes")
 
         df = df.rename(
-            columns={
+            {
                 "region": "Region",
                 "totalMw": "Total",
                 "coal": "Coal",
@@ -841,19 +847,20 @@ class MISOAPI:
             },
         )
 
-        data = df.reset_index()
-
-        data = data[data["Interval Start"] >= date]
+        data = df.filter(pl.col("Interval Start") >= pl.lit(date))
 
         if end is not None:
-            data = data[data["Interval End"] <= end]
+            data = data.filter(pl.col("Interval End") <= pl.lit(end))
 
-        for col in data.columns:
-            if col not in ["Interval Start", "Interval End", "Region"]:
-                data[col] = data[col].astype(float)
+        float_cols = [
+            col
+            for col in data.columns
+            if col not in ["Interval Start", "Interval End", "Region"]
+        ]
+        data = data.with_columns([pl.col(col).cast(pl.Float64) for col in float_cols])
 
         data = self._append_miso_generation_fuel_type_aggregate(
-            data[
+            data.select(
                 [
                     "Interval Start",
                     "Interval End",
@@ -867,8 +874,8 @@ class MISOAPI:
                     "Solar",
                     "Other",
                     "Storage",
-                ]
-            ],
+                ],
+            ),
         )
 
         return data
@@ -879,7 +886,7 @@ class MISOAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         date_str = date.strftime("%Y-%m-%d")
 
         url = f"{BASE_LOAD_GENERATION_AND_INTERCHANGE_URL}/real-time/{date_str}/generation/fuel-type"
@@ -895,13 +902,12 @@ class MISOAPI:
         )
 
         if "interval" in df.columns:
-            df = df.drop(columns=["interval"])
+            df = df.drop("interval")
 
-        fuel_types_df = df["fuelTypes"].apply(pd.Series)
-        df = pd.concat([df.drop(columns=["fuelTypes"]), fuel_types_df], axis=1)
+        df = df.unnest("fuelTypes")
 
         df = df.rename(
-            columns={
+            {
                 "region": "Region",
                 "totalMw": "Total",
                 "coal": "Coal",
@@ -915,19 +921,20 @@ class MISOAPI:
             },
         )
 
-        data = df.reset_index()
-
-        data = data[data["Interval Start"] >= date]
+        data = df.filter(pl.col("Interval Start") >= pl.lit(date))
 
         if end is not None:
-            data = data[data["Interval End"] <= end]
+            data = data.filter(pl.col("Interval End") <= pl.lit(end))
 
-        for col in data.columns:
-            if col not in ["Interval Start", "Interval End", "Region"]:
-                data[col] = data[col].astype(float)
+        float_cols = [
+            col
+            for col in data.columns
+            if col not in ["Interval Start", "Interval End", "Region"]
+        ]
+        data = data.with_columns([pl.col(col).cast(pl.Float64) for col in float_cols])
 
         data = self._append_miso_generation_fuel_type_aggregate(
-            data[
+            data.select(
                 [
                     "Interval Start",
                     "Interval End",
@@ -941,8 +948,8 @@ class MISOAPI:
                     "Solar",
                     "Other",
                     "Storage",
-                ]
-            ],
+                ],
+            ),
         )
 
         return data
@@ -953,7 +960,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         time_resolution: str = DAILY_RESOLUTION,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         date_str = date.strftime("%Y-%m-%d")
 
         url = f"{BASE_LOAD_GENERATION_AND_INTERCHANGE_URL}/real-time/{date_str}/demand/forecast?timeResolution={time_resolution}"
@@ -968,28 +975,27 @@ class MISOAPI:
             data_list,
         )
 
-        df = df.rename(
-            columns={"demand": "Cleared Demand"},
-        )
+        df = df.rename({"demand": "Cleared Demand"})
 
-        data = df.reset_index()
-
-        data = data[data["Interval Start"] >= date]
+        data = df.filter(pl.col("Interval Start") >= pl.lit(date))
 
         if end is not None:
-            data = data[data["Interval End"] <= end]
+            data = data.filter(pl.col("Interval End") <= pl.lit(end))
 
-        for col in data.columns:
-            if col not in ["Interval Start", "Interval End", "Region"]:
-                data[col] = data[col].astype(float)
+        float_cols = [
+            col
+            for col in data.columns
+            if col not in ["Interval Start", "Interval End", "Region"]
+        ]
+        data = data.with_columns([pl.col(col).cast(pl.Float64) for col in float_cols])
 
-        return data[
+        return data.select(
             [
                 "Interval Start",
                 "Interval End",
                 "Cleared Demand",
-            ]
-        ].reset_index(drop=True)
+            ],
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_real_time_cleared_demand_daily(
@@ -997,7 +1003,7 @@ class MISOAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
@@ -1014,7 +1020,7 @@ class MISOAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             date = pd.Timestamp.today(tz=self.default_timezone).floor(
                 "d",
@@ -1033,7 +1039,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         time_resolution: str = HOURLY_RESOLUTION,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         date_str = date.strftime("%Y-%m-%d")
         url = f"{BASE_LOAD_GENERATION_AND_INTERCHANGE_URL}/real-time/{date_str}/generation/cleared/supply?timeResolution={time_resolution}"
 
@@ -1047,26 +1053,21 @@ class MISOAPI:
             data_list,
         )
 
-        df = df.rename(
-            columns={"generation": "Generation Cleared"},
-        )
+        df = df.rename({"generation": "Generation Cleared"})
 
-        data = df.reset_index()
-
-        data = data[data["Interval Start"] >= date]
+        data = df.filter(pl.col("Interval Start") >= pl.lit(date))
 
         if end is not None:
-            data = data[data["Interval End"] <= end]
+            data = data.filter(pl.col("Interval End") <= pl.lit(end))
 
-        for col in data.columns:
-            if col not in ["Interval Start", "Interval End"]:
-                data[col] = data[col].astype(float)
+        float_cols = [
+            col for col in data.columns if col not in ["Interval Start", "Interval End"]
+        ]
+        data = data.with_columns([pl.col(col).cast(pl.Float64) for col in float_cols])
 
-        data = data.sort_values(["Interval Start", "Interval End"])
-
-        return data[
-            ["Interval Start", "Interval End", "Generation Cleared"]
-        ].reset_index(drop=True)
+        return data.select(
+            ["Interval Start", "Interval End", "Generation Cleared"],
+        ).sort(["Interval Start", "Interval End"])
 
     @support_date_range(frequency="DAY_START")
     def get_real_time_cleared_generation_hourly(
@@ -1074,7 +1075,7 @@ class MISOAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         NOTE: This function is not ready for use yet. MISO Real-Time Cleared Generation API returns wrong timestamp.
         The timestamps are off by 5 hours, seems to be a timezone issue, UTC instead of EST.
@@ -1100,7 +1101,7 @@ class MISOAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
@@ -1119,35 +1120,32 @@ class MISOAPI:
         )
 
         df = df.rename(
-            columns={
+            {
                 "offerForwardEcoMax": "Offered FRAC Economic Max",
                 "offerRealTimeEcoMax": "Offered Real Time Economic Max",
                 "offerEcoMaxDelta": "Offered Economic Max Delta",
             },
         )
 
-        data = df.reset_index()
-
-        data = data[data["Interval Start"] >= date]
+        data = df.filter(pl.col("Interval Start") >= pl.lit(date))
 
         if end is not None:
-            data = data[data["Interval End"] <= end]
+            data = data.filter(pl.col("Interval End") <= pl.lit(end))
 
-        for col in data.columns:
-            if col not in ["Interval Start", "Interval End"]:
-                data[col] = data[col].astype(float)
+        float_cols = [
+            col for col in data.columns if col not in ["Interval Start", "Interval End"]
+        ]
+        data = data.with_columns([pl.col(col).cast(pl.Float64) for col in float_cols])
 
-        data = data.sort_values(["Interval Start", "Interval End"])
-
-        return data[
+        return data.select(
             [
                 "Interval Start",
                 "Interval End",
                 "Offered FRAC Economic Max",
                 "Offered Real Time Economic Max",
                 "Offered Economic Max Delta",
-            ]
-        ].reset_index(drop=True)
+            ],
+        ).sort(["Interval Start", "Interval End"])
 
     @support_date_range(frequency="DAY_START")
     def get_real_time_committed_generation_ecomax_hourly(
@@ -1155,7 +1153,7 @@ class MISOAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
@@ -1174,35 +1172,32 @@ class MISOAPI:
         )
 
         df = df.rename(
-            columns={
+            {
                 "committedForwardEcoMax": "Committed FRAC Economic Max",
                 "committedRealTimeEcoMax": "Committed Real Time Economic Max",
                 "committedEcoMaxDelta": "Committed Economic Max Delta",
             },
         )
 
-        data = df.reset_index()
-
-        data = data[data["Interval Start"] >= date]
+        data = df.filter(pl.col("Interval Start") >= pl.lit(date))
 
         if end is not None:
-            data = data[data["Interval End"] <= end]
+            data = data.filter(pl.col("Interval End") <= pl.lit(end))
 
-        for col in data.columns:
-            if col not in ["Interval Start", "Interval End"]:
-                data[col] = data[col].astype(float)
+        float_cols = [
+            col for col in data.columns if col not in ["Interval Start", "Interval End"]
+        ]
+        data = data.with_columns([pl.col(col).cast(pl.Float64) for col in float_cols])
 
-        data = data.sort_values(["Interval Start", "Interval End"])
-
-        return data[
+        return data.select(
             [
                 "Interval Start",
                 "Interval End",
                 "Committed FRAC Economic Max",
                 "Committed Real Time Economic Max",
                 "Committed Economic Max Delta",
-            ]
-        ].reset_index(drop=True)
+            ],
+        ).sort(["Interval Start", "Interval End"])
 
     @support_date_range(frequency="DAY_START")
     def get_real_time_generation_fuel_type_hourly(
@@ -1210,7 +1205,7 @@ class MISOAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             date = pd.Timestamp.now(tz=self.default_timezone).floor("d")
 
@@ -1229,14 +1224,13 @@ class MISOAPI:
         )
 
         if "interval" in df.columns:
-            df = df.drop(columns=["interval"])
+            df = df.drop("interval")
 
         # Expand the 'fuelTypes' dictionary column into separate columns
-        fuel_types_df = df["fuelTypes"].apply(pd.Series)
-        df = pd.concat([df.drop(columns=["fuelTypes"]), fuel_types_df], axis=1)
+        df = df.unnest("fuelTypes")
 
         df = df.rename(
-            columns={
+            {
                 "region": "Region",
                 "totalMw": "Total",
                 "coal": "Coal",
@@ -1250,19 +1244,20 @@ class MISOAPI:
             },
         )
 
-        data = df.reset_index()
-
-        data = data[data["Interval Start"] >= date]
+        data = df.filter(pl.col("Interval Start") >= pl.lit(date))
 
         if end is not None:
-            data = data[data["Interval End"] <= end]
+            data = data.filter(pl.col("Interval End") <= pl.lit(end))
 
-        for col in data.columns:
-            if col not in ["Interval Start", "Interval End", "Region"]:
-                data[col] = data[col].astype(float)
+        float_cols = [
+            col
+            for col in data.columns
+            if col not in ["Interval Start", "Interval End", "Region"]
+        ]
+        data = data.with_columns([pl.col(col).cast(pl.Float64) for col in float_cols])
 
         data = self._append_miso_generation_fuel_type_aggregate(
-            data[
+            data.select(
                 [
                     "Interval Start",
                     "Interval End",
@@ -1276,16 +1271,16 @@ class MISOAPI:
                     "Solar",
                     "Other",
                     "Storage",
-                ]
-            ],
+                ],
+            ),
         )
 
         return data
 
     def _append_miso_generation_fuel_type_aggregate(
         self,
-        data: pd.DataFrame,
-    ) -> pd.DataFrame:
+        data: pl.DataFrame,
+    ) -> pl.DataFrame:
         """Append a MISO system total region by summing the CENTRAL, NORTH, and SOUTH
         regions for each interval. The API only returns the three sub-regions, so the
         system-wide total is derived to match the retired Market Reports Generation
@@ -1302,16 +1297,14 @@ class MISOAPI:
             "Storage",
         ]
 
-        miso = data.groupby(["Interval Start", "Interval End"], as_index=False)[
-            value_columns
-        ].sum()
-        miso["Region"] = "MISO"
-
-        combined = pd.concat([data, miso], ignore_index=True)
-
-        return combined.sort_values(["Interval Start", "Region"]).reset_index(
-            drop=True,
+        miso = data.group_by(["Interval Start", "Interval End"]).agg(
+            [pl.col(col).sum() for col in value_columns],
         )
+        miso = miso.with_columns(pl.lit("MISO").alias("Region"))
+
+        combined = pl.concat([data, miso], how="vertical_relaxed")
+
+        return combined.sort(["Interval Start", "Region"])
 
     def _get_actual_load(
         self,
@@ -1320,7 +1313,7 @@ class MISOAPI:
         verbose: bool = False,
         time_resolution: str = HOURLY_RESOLUTION,
         geo_resolution: Literal["region", "localResourceZone"] = "region",
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             date = pd.Timestamp.now(tz=self.default_timezone).floor("d") - pd.Timedelta(
                 days=1,
@@ -1341,33 +1334,34 @@ class MISOAPI:
         )
 
         if "interval" in df.columns:
-            df = df.drop(columns=["interval"])
+            df = df.drop("interval")
 
         if geo_resolution == "region":
-            df["region"] = df["region"].str.upper()
             subseries_index = "Region"
-            df = df.rename(columns={"region": subseries_index, "load": "Load"})
+            df = df.with_columns(pl.col("region").str.to_uppercase()).rename(
+                {"region": subseries_index, "load": "Load"},
+            )
         elif geo_resolution == "localResourceZone":
             subseries_index = "Local Resource Zone"
             df = df.rename(
-                columns={"localResourceZone": subseries_index, "load": "Load"},
+                {"localResourceZone": subseries_index, "load": "Load"},
             )
 
-        data = df.reset_index()
-
-        data = data[data["Interval Start"] >= date]
+        data = df.filter(pl.col("Interval Start") >= pl.lit(date))
 
         if end is not None:
-            data = data[data["Interval End"] <= end]
+            data = data.filter(pl.col("Interval End") <= pl.lit(end))
 
-        for col in data.columns:
-            if col not in ["Interval Start", "Interval End", subseries_index]:
-                data[col] = data[col].astype(float)
+        float_cols = [
+            col
+            for col in data.columns
+            if col not in ["Interval Start", "Interval End", subseries_index]
+        ]
+        data = data.with_columns([pl.col(col).cast(pl.Float64) for col in float_cols])
 
-        data = data.sort_values(["Interval Start", subseries_index])
-        return data[
-            ["Interval Start", "Interval End", subseries_index, "Load"]
-        ].reset_index(drop=True)
+        return data.select(
+            ["Interval Start", "Interval End", subseries_index, "Load"],
+        ).sort(["Interval Start", subseries_index])
 
     @support_date_range(frequency="DAY_START")
     def get_actual_load_hourly(
@@ -1376,7 +1370,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         geo_resolution: Literal["region", "localResourceZone"] = "region",
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_actual_load(
             date,
             end=end,
@@ -1391,7 +1385,7 @@ class MISOAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get actual load by local resource zone in hourly intervals,
         pivoted with zones as columns.
@@ -1407,21 +1401,40 @@ class MISOAPI:
         )
 
         # Replace underscores with spaces in zone names
-        df["Local Resource Zone"] = df["Local Resource Zone"].str.replace("_", " ")
-
-        # Pivot to get zones as columns
-        df = df.pivot_table(
-            index=["Interval Start", "Interval End"],
-            columns="Local Resource Zone",
-            values="Load",
-        ).reset_index()
-
-        # Add MISO total
-        df["MISO"] = df[["LRZ1", "LRZ2 7", "LRZ3 5", "LRZ4", "LRZ6", "LRZ8 9 10"]].sum(
-            axis=1,
+        df = df.with_columns(
+            pl.col("Local Resource Zone").str.replace("_", " "),
         )
 
-        return df
+        # Pivot to get zones as columns
+        df = df.pivot(
+            on="Local Resource Zone",
+            index=["Interval Start", "Interval End"],
+            values="Load",
+        )
+
+        if "LRZ8 9_10" in df.columns:
+            df = df.rename({"LRZ8 9_10": "LRZ8 9 10"})
+
+        # Add MISO total
+        df = df.with_columns(
+            pl.sum_horizontal(
+                ["LRZ1", "LRZ2 7", "LRZ3 5", "LRZ4", "LRZ6", "LRZ8 9 10"],
+            ).alias("MISO"),
+        )
+
+        return df.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "LRZ1",
+                "LRZ2 7",
+                "LRZ3 5",
+                "LRZ4",
+                "LRZ6",
+                "LRZ8 9 10",
+                "MISO",
+            ],
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_actual_load_daily(
@@ -1430,7 +1443,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         geo_resolution: Literal["region", "localResourceZone"] = "region",
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_actual_load(
             date,
             end=end,
@@ -1446,7 +1459,7 @@ class MISOAPI:
         verbose: bool = False,
         publish_time: str | pd.Timestamp | None = None,
         time_resolution: str = HOURLY_RESOLUTION,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get load forecast data.
 
         Args:
@@ -1489,10 +1502,10 @@ class MISOAPI:
         )
 
         if "interval" in df.columns:
-            df = df.drop(columns=["interval"])
+            df = df.drop("interval")
 
         df = df.rename(
-            columns={
+            {
                 "region": "Region",
                 "localResourceZone": "Local Resource Zone",
                 "loadForecast": "Load Forecast",
@@ -1504,34 +1517,41 @@ class MISOAPI:
             pd.Timestamp.now(tz=self.default_timezone).normalize()
             - pd.DateOffset(days=1),
         )
-        df["Publish Time"] = (
+        publish_time_value = (
             publish_time.normalize() if publish_time is not None else miso_publish_time
         )
+        df = df.with_columns(pl.lit(publish_time_value).alias("Publish Time"))
 
-        data = df.reset_index()
-
-        data = data[data["Interval Start"] >= date]
+        data = df.filter(pl.col("Interval Start") >= pl.lit(date))
 
         if end is not None:
-            data = data[data["Interval End"] <= end]
+            data = data.filter(pl.col("Interval End") <= pl.lit(end))
 
-        for col in data.columns:
-            if col not in [
+        int_cols = [
+            col
+            for col in data.columns
+            if col
+            not in [
                 "Interval Start",
                 "Interval End",
                 "Publish Time",
                 "Region",
                 "Local Resource Zone",
                 "init",
-            ]:
-                data[col] = (
-                    pd.to_numeric(data[col], errors="coerce").round().astype("Int64")
-                )
-
-        data = data.sort_values(
-            ["Interval Start", "Publish Time", "Region", "Local Resource Zone"],
+            ]
+        ]
+        data = data.with_columns(
+            [
+                pl.col(col)
+                .cast(pl.Float64, strict=False)
+                .round(0)
+                .cast(pl.Int64)
+                .alias(col)
+                for col in int_cols
+            ],
         )
-        return data[
+
+        return data.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -1539,8 +1559,8 @@ class MISOAPI:
                 "Region",
                 "Local Resource Zone",
                 "Load Forecast",
-            ]
-        ].reset_index(drop=True)
+            ],
+        ).sort(["Interval Start", "Publish Time", "Region", "Local Resource Zone"])
 
     @support_date_range(frequency="DAY_START")
     def get_load_forecast_mid_term_by_region(
@@ -1549,7 +1569,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         max_offset: int = 7,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get hourly mid-term load forecast by region and LRZ for a publish date.
 
         The ``date`` parameter is the forecast run publish date (``init`` date), not
@@ -1562,7 +1582,7 @@ class MISOAPI:
                 first forecast day.
         """
         publish_time = utils._handle_date(date, self.default_timezone).normalize()
-        all_dfs: list[pd.DataFrame] = []
+        all_dfs: list[pl.DataFrame] = []
 
         for offset in range(1, max_offset + 1):
             forecast_date = publish_time + pd.DateOffset(days=offset)
@@ -1572,25 +1592,25 @@ class MISOAPI:
                 publish_time=publish_time,
                 time_resolution=HOURLY_RESOLUTION,
             )
-            if not df.empty:
+            if not df.is_empty():
                 all_dfs.append(df)
 
         if not all_dfs:
-            return pd.DataFrame(
-                columns=[
-                    "Interval Start",
-                    "Interval End",
-                    "Publish Time",
-                    "Region",
-                    "LRZ",
-                    "Load Forecast",
-                ],
+            return pl.DataFrame(
+                schema={
+                    "Interval Start": pl.Datetime(time_unit="ns", time_zone="EST"),
+                    "Interval End": pl.Datetime(time_unit="ns", time_zone="EST"),
+                    "Publish Time": pl.Datetime(time_unit="ns", time_zone="EST"),
+                    "Region": pl.Utf8,
+                    "LRZ": pl.Utf8,
+                    "Load Forecast": pl.Int64,
+                },
             )
 
-        data = pd.concat(all_dfs, ignore_index=True)
-        data = data.rename(columns={"Local Resource Zone": "LRZ"})
+        data = pl.concat(all_dfs)
+        data = data.rename({"Local Resource Zone": "LRZ"})
 
-        return data[
+        return data.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -1598,8 +1618,8 @@ class MISOAPI:
                 "Region",
                 "LRZ",
                 "Load Forecast",
-            ]
-        ].reset_index(drop=True)
+            ],
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_medium_term_load_forecast_hourly_aggregated(
@@ -1608,7 +1628,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         publish_time: str | pd.Timestamp | None = None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get medium term load forecast aggregated from individual zones (Z1-Z10)
         to LRZ aggregates and pivoted with zones as columns.
@@ -1638,33 +1658,33 @@ class MISOAPI:
             "Z9": "LRZ8_9_10 MTLF",
             "Z10": "LRZ8_9_10 MTLF",
         }
-        df["LRZ"] = df["Local Resource Zone"].map(zone_map)
+        df = df.with_columns(
+            pl.col("Local Resource Zone").replace(zone_map).alias("LRZ"),
+        )
 
         # Aggregate and pivot to match expected format
-        df_agg = (
-            df.groupby(["Interval Start", "Interval End", "Publish Time", "LRZ"])[
-                "Load Forecast"
-            ]
-            .sum()
-            .reset_index()
-        )
-        df = df_agg.pivot_table(
+        df_agg = df.group_by(
+            ["Interval Start", "Interval End", "Publish Time", "LRZ"],
+        ).agg(pl.col("Load Forecast").sum())
+        df = df_agg.pivot(
+            on="LRZ",
             index=["Interval Start", "Interval End", "Publish Time"],
-            columns="LRZ",
             values="Load Forecast",
-        ).reset_index()
+        )
 
         # Add MISO total
-        df["MISO MTLF"] = df[
-            [
-                "LRZ1 MTLF",
-                "LRZ2_7 MTLF",
-                "LRZ3_5 MTLF",
-                "LRZ4 MTLF",
-                "LRZ6 MTLF",
-                "LRZ8_9_10 MTLF",
-            ]
-        ].sum(axis=1)
+        df = df.with_columns(
+            pl.sum_horizontal(
+                [
+                    "LRZ1 MTLF",
+                    "LRZ2_7 MTLF",
+                    "LRZ3_5 MTLF",
+                    "LRZ4 MTLF",
+                    "LRZ6 MTLF",
+                    "LRZ8_9_10 MTLF",
+                ],
+            ).alias("MISO MTLF"),
+        )
 
         mtlf_cols = [
             "LRZ1 MTLF",
@@ -1675,10 +1695,25 @@ class MISOAPI:
             "LRZ8_9_10 MTLF",
             "MISO MTLF",
         ]
-        for col in mtlf_cols:
-            df[col] = pd.to_numeric(df[col], errors="coerce").round().astype("Int64")
+        df = df.with_columns(
+            [
+                pl.col(col)
+                .cast(pl.Float64, strict=False)
+                .round(0)
+                .cast(pl.Int64)
+                .alias(col)
+                for col in mtlf_cols
+            ],
+        )
 
-        return df
+        return df.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "Publish Time",
+                *mtlf_cols,
+            ],
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_medium_term_load_forecast_daily(
@@ -1687,7 +1722,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         publish_time: str | pd.Timestamp | None = None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_medium_term_load_forecast(
             date,
             end=end,
@@ -1702,7 +1737,7 @@ class MISOAPI:
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get hourly outage forecast. The API only returns hourly data for today and
         future days. Historical outage forecast data is not supported.
@@ -1734,31 +1769,27 @@ class MISOAPI:
         df = self._data_list_to_df(data_list)
 
         df = df.rename(
-            columns={
+            {
                 "region": "Region",
                 "onOutage": "Outage Forecast",
             },
         )
 
-        df = df[df["Interval Start"] >= date]
+        df = df.filter(pl.col("Interval Start") >= pl.lit(date))
 
         if end is not None:
-            df = df[df["Interval End"] <= end]
+            df = df.filter(pl.col("Interval End") <= pl.lit(end))
 
-        df["Outage Forecast"] = df["Outage Forecast"].astype(float)
+        df = df.with_columns(pl.col("Outage Forecast").cast(pl.Float64))
 
-        return (
-            df[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Region",
-                    "Outage Forecast",
-                ]
-            ]
-            .sort_values(by=["Interval Start", "Region"])
-            .reset_index(drop=True)
-        )
+        return df.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "Region",
+                "Outage Forecast",
+            ],
+        ).sort(["Interval Start", "Region"])
 
     @support_date_range(frequency="DAY_START")
     def get_look_ahead_hourly(
@@ -1767,7 +1798,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         publish_time: str | pd.Timestamp | None = None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Get look-ahead hourly data combining medium-term load forecast and outage forecast.
         Look-ahead data is only available for future dates (today and beyond).
@@ -1806,45 +1837,37 @@ class MISOAPI:
         )
 
         # Aggregate load forecast by Region (sum across Local Resource Zones)
-        load_agg = (
-            load_forecast.groupby(
-                ["Interval Start", "Interval End", "Publish Time", "Region"],
-            )["Load Forecast"]
-            .sum()
-            .reset_index()
-        )
+        load_agg = load_forecast.group_by(
+            ["Interval Start", "Interval End", "Publish Time", "Region"],
+        ).agg(pl.col("Load Forecast").sum())
 
         # Merge the two datasets
-        merged = pd.merge(
-            load_agg,
+        merged = load_agg.join(
             outage_forecast,
             on=["Interval Start", "Interval End", "Region"],
-            how="outer",
+            how="full",
+            coalesce=True,
         )
 
         # Rename columns to match MISO().get_look_ahead_hourly() output
         merged = merged.rename(
-            columns={
+            {
                 "Load Forecast": "MTLF",
                 "Outage Forecast": "Outage",
             },
         )
 
         # Sort and return
-        return (
-            merged[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Publish Time",
-                    "Region",
-                    "MTLF",
-                    "Outage",
-                ]
-            ]
-            .sort_values(["Interval Start", "Region"])
-            .reset_index(drop=True)
-        )
+        return merged.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "Publish Time",
+                "Region",
+                "MTLF",
+                "Outage",
+            ],
+        ).sort(["Interval Start", "Region"])
 
     def _get_url(
         self,
@@ -1961,30 +1984,30 @@ class MISOAPI:
         # If we've exhausted all retries, raise the last exception
         raise last_exception  # type: ignore[misc]
 
-    def _data_list_to_df(self, data_list: List[Dict[str, Any]]) -> pd.DataFrame:
-        df = pd.DataFrame(data_list)
+    def _data_list_to_df(self, data_list: List[Dict[str, Any]]) -> pl.DataFrame:
+        df = pl.DataFrame(data_list)
 
         if "timeInterval" not in df.columns and "interval" in df.columns:
-            df["timeInterval"] = df["interval"]
-            df = df.drop(columns=["interval"])
+            df = df.with_columns(pl.col("interval").alias("timeInterval")).drop(
+                "interval",
+            )
 
         # Split timeInterval dict into separate columns for 'start' and 'end'
-        df = pd.concat(
-            [
-                df["timeInterval"].apply(pd.Series)[["start", "end"]],
-                df.drop(columns=["timeInterval"]),
-            ],
-            axis=1,
+        df = df.with_columns(
+            pl.col("timeInterval").struct.field("start").alias("start"),
+            pl.col("timeInterval").struct.field("end").alias("end"),
+        ).drop("timeInterval")
+
+        df = df.with_columns(
+            pl.col("start")
+            .str.to_datetime(time_zone=self.default_timezone)
+            .alias("Interval Start"),
+            pl.col("end")
+            .str.to_datetime(time_zone=self.default_timezone)
+            .alias("Interval End"),
         )
 
-        df["Interval Start"] = pd.to_datetime(df["start"]).dt.tz_localize(
-            self.default_timezone,
-        )
-        df["Interval End"] = pd.to_datetime(df["end"]).dt.tz_localize(
-            self.default_timezone,
-        )
-
-        return df.drop(columns=["start", "end"]).reset_index(drop=True)
+        return df.drop("start", "end")
 
     def _get_next_key(self, product: str) -> str:
         """Get the next API key in the rotation."""
@@ -2028,7 +2051,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         use_daily_requests: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_mcp_data(
             date,
             end,
@@ -2045,7 +2068,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         use_daily_requests: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_mcp_data(
             date,
             end,
@@ -2062,7 +2085,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         use_daily_requests: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_mcp_data(
             date,
             end,
@@ -2078,7 +2101,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         use_daily_requests: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_mcp_data(
             date,
             end,
@@ -2095,7 +2118,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         use_daily_requests: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_mcp_data(
             date,
             end,
@@ -2112,7 +2135,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         use_daily_requests: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_mcp_data(
             date,
             end,
@@ -2129,7 +2152,7 @@ class MISOAPI:
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         use_daily_requests: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         return self._get_mcp_data(
             date,
             end,
@@ -2149,7 +2172,7 @@ class MISOAPI:
         use_daily_requests: bool = False,
         verbose: bool = False,
         **kwargs: Any,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if use_daily_requests:
             if daily_retrieval_func is None:
                 raise ValueError(
@@ -2310,28 +2333,22 @@ class MISOAPI:
     def _process_as_mcp_data(
         self,
         data_list: List[Dict[str, Any]],
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         df = self._data_list_to_df(data_list)
 
         df = df.rename(
-            columns={
+            {
                 "zone": "Zone",
                 "product": "Product",
                 "mcp": "MCP",
             },
         )
 
-        df_pivot = (
-            df.pivot(
-                index=["Interval Start", "Interval End", "Zone"],
-                columns="Product",
-                values="MCP",
-            )
-            .reset_index()
-            .rename(columns={"Ramp-up": "Ramp Up", "Ramp-down": "Ramp Down"})
-        )
-
-        df_pivot.columns.name = None
+        df_pivot = df.pivot(
+            on="Product",
+            index=["Interval Start", "Interval End", "Zone"],
+            values="MCP",
+        ).rename({"Ramp-up": "Ramp Up", "Ramp-down": "Ramp Down"})
 
         return df_pivot
 
@@ -2368,7 +2385,7 @@ class MISOAPI:
         date: str | pd.Timestamp | None = "latest",
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Retrieve MISO pricing nodes for a specific date or date range.
 
         MISO pricing nodes change quarterly on March 1st, June 1st, September 1st,
@@ -2401,9 +2418,9 @@ class MISOAPI:
                 verbose=verbose,
             )
 
-            df = pd.DataFrame(data_list)
+            df = pl.DataFrame(data_list)
 
-            df = df.rename(columns={"node": "Node", "nodeType": "Location Type"})
+            df = df.rename({"node": "Node", "nodeType": "Location Type"})
 
             return df
 
@@ -2427,16 +2444,10 @@ class MISOAPI:
                     verbose=verbose,
                 )
 
-                df = pd.DataFrame(data_list)
+                df = pl.DataFrame(data_list)
 
-                df = df.rename(columns={"node": "Node", "nodeType": "Location Type"})
+                df = df.rename({"node": "Node", "nodeType": "Location Type"})
 
                 dfs.append(df)
 
-            df = (
-                pd.concat(dfs, ignore_index=True)
-                .drop_duplicates()
-                .reset_index(drop=True)
-            )
-
-            return df
+            return pl.concat(dfs).unique()

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -4,6 +4,7 @@ from io import BytesIO
 from typing import BinaryIO, Dict, Literal, NamedTuple
 
 import pandas as pd
+import polars as pl
 import requests
 
 import gridstatus
@@ -96,12 +97,35 @@ class NYISO(ISOBase):
     status_homepage = "https://www.nyiso.com/system-conditions"
     interconnection_homepage = "https://www.nyiso.com/interconnections"
 
+    def _parse_time_stamp_column(
+        self,
+        df: pl.DataFrame,
+        time_stamp_col: str,
+    ) -> pl.DataFrame:
+        if df.schema[time_stamp_col] == pl.Utf8:
+            stripped = pl.col(time_stamp_col).str.replace(r"\s+(EDT|EST)$", "")
+            return df.with_columns(
+                pl.coalesce(
+                    stripped.str.to_datetime(
+                        format="%m/%d/%Y %H:%M:%S",
+                        strict=False,
+                    ),
+                    stripped.str.to_datetime(
+                        format="%m/%d/%Y %H:%M",
+                        strict=False,
+                    ),
+                ).alias(time_stamp_col),
+            )
+        return df.with_columns(
+            pl.col(time_stamp_col).cast(pl.Datetime("us")).alias(time_stamp_col),
+        )
+
     def _handle_time(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         dataset_name: str,
         groupby: str | None = None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         time_type, interval_duration_minutes = DATASET_INTERVAL_MAP[dataset_name]
 
         if "Time Stamp" in df.columns:
@@ -109,47 +133,54 @@ class NYISO(ISOBase):
         elif "Timestamp" in df.columns:
             time_stamp_col = "Timestamp"
 
-        def time_to_datetime(s: pd.Series, dst: str = "infer") -> pd.Series:
-            return pd.to_datetime(s).dt.tz_localize(
-                self.default_timezone,
-                ambiguous=dst,
-            )
+        df = self._parse_time_stamp_column(df, time_stamp_col)
 
         if "Time Zone" in df.columns:
-            dst = df["Time Zone"] == "EDT"
-            df[time_stamp_col] = time_to_datetime(
-                df[time_stamp_col],
-                dst,
+            df = df.with_columns(
+                pl.when(pl.col("Time Zone") == "EDT")
+                .then(pl.lit("earliest"))
+                .otherwise(pl.lit("latest"))
+                .alias("_ambiguous"),
             )
-
+            df = df.with_columns(
+                pl.col(time_stamp_col).dt.replace_time_zone(
+                    self.default_timezone,
+                    ambiguous=pl.col("_ambiguous"),
+                ),
+            ).drop("_ambiguous")
         elif "Name" in df.columns or groupby:
-            groupby = groupby or "Name"
-            # once we group by name, the time series for each group is no longer ambiguous
-            df[time_stamp_col] = df.groupby(groupby, group_keys=False)[
-                time_stamp_col
-            ].apply(
-                time_to_datetime,
-                "infer",
+            groupby_col = groupby or "Name"
+            df = utils.localize_ambiguous_infer_polars(
+                df,
+                time_stamp_col,
+                self.default_timezone,
+                group_cols=[groupby_col],
             )
         else:
-            df[time_stamp_col] = time_to_datetime(
-                df[time_stamp_col],
-                "infer",
+            df = utils.localize_ambiguous_infer_polars(
+                df,
+                time_stamp_col,
+                self.default_timezone,
             )
 
-        df = df.rename(columns={time_stamp_col: "Time"})
+        df = df.rename({time_stamp_col: "Time"})
 
         if time_type != "instantaneous":
-            interval_duration = pd.Timedelta(minutes=interval_duration_minutes)
+            interval_duration = pl.duration(minutes=interval_duration_minutes)
             if time_type == "start":
-                df["Interval Start"] = df["Time"]
-                df["Interval End"] = df["Interval Start"] + interval_duration
+                df = df.with_columns(
+                    pl.col("Time").alias("Interval Start"),
+                    (pl.col("Time") + interval_duration).alias("Interval End"),
+                )
             elif time_type == "end":
-                df["Interval Start"] = df["Time"] - interval_duration
-                df["Interval End"] = df["Time"]
-                df["Time"] = df["Interval Start"]
+                df = df.with_columns(
+                    (pl.col("Time") - interval_duration).alias("Interval Start"),
+                    pl.col("Time").alias("Interval End"),
+                ).with_columns(
+                    pl.col("Interval Start").alias("Time"),
+                )
 
-            utils.move_cols_to_front(
+            df = utils.move_cols_to_front(
                 df,
                 ["Time", "Interval Start", "Interval End"],
             )
@@ -162,7 +193,7 @@ class NYISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         status_df = self._download_nyiso_archive(
             date=date,
             end=end,
@@ -170,31 +201,42 @@ class NYISO(ISOBase):
             verbose=verbose,
         )
 
-        status_df = status_df.rename(
-            columns={"Message": "Status"},
+        status_df = status_df.rename({"Message": "Status"})
+
+        state_change = "**State Change. System now operating in "
+
+        def _parse_status_fields(status: str) -> dict[str, str | list[str] | None]:
+            notes: list[str] | None = None
+            if status == "Start of day system state is NORMAL":
+                return {"Status": "Normal", "Notes": [status]}
+            if state_change in status:
+                notes = [status]
+                parsed_status = status[
+                    status.index(state_change) + len(state_change) : -len(" state.**")
+                ].capitalize()
+                return {"Status": parsed_status, "Notes": notes}
+            return {"Status": status, "Notes": None}
+
+        status_df = status_df.rename({"Status": "_orig_status"})
+        status_df = (
+            status_df.with_columns(
+                pl.col("_orig_status")
+                .map_elements(
+                    _parse_status_fields,
+                    return_dtype=pl.Struct(
+                        {
+                            "Status": pl.Utf8,
+                            "Notes": pl.List(pl.Utf8),
+                        },
+                    ),
+                )
+                .alias("_parsed"),
+            )
+            .unnest("_parsed")
+            .drop("_orig_status")
         )
 
-        def _parse_status(row: pd.Series) -> pd.Series:
-            STATE_CHANGE = "**State Change. System now operating in "
-
-            row["Notes"] = None
-            if row["Status"] == "Start of day system state is NORMAL":
-                row["Notes"] = [row["Status"]]
-                row["Status"] = "Normal"
-            elif STATE_CHANGE in row["Status"]:
-                row["Notes"] = [row["Status"]]
-
-                row["Status"] = row["Status"][
-                    row["Status"].index(STATE_CHANGE) + len(STATE_CHANGE) : -len(
-                        " state.**",
-                    )
-                ].capitalize()
-
-            return row
-
-        status_df = status_df.apply(_parse_status, axis=1)
-        status_df = status_df[["Time", "Status", "Notes"]]
-        return status_df
+        return status_df.select(["Time", "Status", "Notes"])
 
     @support_date_range(frequency="MONTH_START")
     def get_fuel_mix(
@@ -202,7 +244,7 @@ class NYISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         # note: this is simlar datastructure to pjm
         mix_df = self._download_nyiso_archive(
             date=date,
@@ -211,16 +253,15 @@ class NYISO(ISOBase):
             verbose=verbose,
         )
 
-        mix_df = mix_df.pivot_table(
-            index=["Time"],
-            columns="Fuel Category",
+        mix_df = mix_df.pivot(
+            index="Time",
+            on="Fuel Category",
             values="Gen MW",
-            aggfunc="first",
-        ).reset_index()
+            aggregate_function="first",
+        )
 
-        mix_df.columns.name = None
-
-        return mix_df
+        fuel_cols = sorted(c for c in mix_df.columns if c != "Time")
+        return mix_df.select(["Time", *fuel_cols])
 
     @support_date_range(frequency="MONTH_START")
     def get_load(
@@ -228,7 +269,7 @@ class NYISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Returns load at a previous date in 5 minute intervals for
           each zone and total load
 
@@ -239,7 +280,7 @@ class NYISO(ISOBase):
             verbose (bool): Whether to print verbose output. Optional.
 
         Returns:
-            pandas.DataFrame: Load data for NYISO and each zone
+            polars.DataFrame: Load data for NYISO and each zone
 
         """
         data = self._download_nyiso_archive(
@@ -249,21 +290,16 @@ class NYISO(ISOBase):
             verbose=verbose,
         )
 
-        # pivot table
-        df = data.pivot_table(
-            index=["Time"],
-            columns="Name",
+        df = data.pivot(
+            index="Time",
+            on="Name",
             values="Load",
-            aggfunc="first",
+            aggregate_function="first",
         )
 
-        df.insert(0, "Load", df.sum(axis=1))
-
-        df.reset_index(inplace=True)
-        # drop NA loads
-        # data = data.dropna(subset=["Load"])
-
-        return df
+        value_cols = [c for c in df.columns if c != "Time"]
+        df = df.with_columns(pl.sum_horizontal(value_cols).alias("Load"))
+        return df.select(["Time", "Load", *value_cols])
 
     @support_date_range(frequency="MONTH_START")
     def get_btm_solar(
@@ -271,7 +307,7 @@ class NYISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Returns estimated BTM solar generation at a previous date in hourly
             intervals for system and each zone.
 
@@ -285,7 +321,7 @@ class NYISO(ISOBase):
             verbose (bool): Whether to print verbose output. Optional.
 
         Returns:
-            pandas.DataFrame: BTM solar data for NYISO system and each zone
+            polars.DataFrame: BTM solar data for NYISO system and each zone
 
         """
         data = self._download_nyiso_archive(
@@ -296,21 +332,20 @@ class NYISO(ISOBase):
             verbose=verbose,
         )
 
-        df = data.pivot_table(
+        df = data.pivot(
             index=["Time", "Interval Start", "Interval End"],
-            columns="Zone Name",
+            on="Zone Name",
             values="MW Value",
-            aggfunc="first",
+            aggregate_function="first",
         )
 
-        # move system to first column
-        df.insert(0, "SYSTEM", df.pop("SYSTEM"))
-
-        df = df.reset_index()
-
-        df.columns.name = None
-
-        return df
+        zone_cols = [
+            c for c in df.columns if c not in ["Time", "Interval Start", "Interval End"]
+        ]
+        other_cols = [c for c in zone_cols if c != "SYSTEM"]
+        return df.select(
+            ["Time", "Interval Start", "Interval End", "SYSTEM", *other_cols],
+        )
 
     @support_date_range(frequency="MONTH_START")
     def get_btm_solar_forecast(
@@ -318,7 +353,7 @@ class NYISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         data = self._download_nyiso_archive(
             date=date,
             end=end,
@@ -326,29 +361,40 @@ class NYISO(ISOBase):
             verbose=verbose,
         )
 
-        df = data.pivot_table(
+        df = data.pivot(
             index=["Time", "Interval Start", "Interval End"],
-            columns="Zone Name",
+            on="Zone Name",
             values="MW Value",
-            aggfunc="first",
+            aggregate_function="first",
         )
 
-        # move system to first column
-        df.insert(0, "SYSTEM", df.pop("SYSTEM"))
-
-        df = df.reset_index()
+        zone_cols = [
+            c for c in df.columns if c not in ["Time", "Interval Start", "Interval End"]
+        ]
+        other_cols = [c for c in zone_cols if c != "SYSTEM"]
+        df = df.select(
+            ["Time", "Interval Start", "Interval End", "SYSTEM", *other_cols],
+        )
 
         # Report is published day before the forecast at 7:55 AM in NYISO time
-        df.insert(
-            3,
-            "Publish Time",
-            df["Interval Start"].dt.floor("D")
-            - pd.Timedelta(days=1, hours=-7, minutes=-55),
+        df = df.with_columns(
+            (
+                pl.col("Interval Start").dt.truncate("1d")
+                - pl.duration(days=1)
+                + pl.duration(hours=7, minutes=55)
+            ).alias("Publish Time"),
         )
 
-        df.columns.name = None
-
-        return df
+        return df.select(
+            [
+                "Time",
+                "Interval Start",
+                "Interval End",
+                "Publish Time",
+                "SYSTEM",
+                *other_cols,
+            ],
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_btm_installed_capacity(
@@ -356,7 +402,7 @@ class NYISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Returns NYISO's daily estimate of installed behind-the-meter solar capacity
         by zone.
 
@@ -373,15 +419,15 @@ class NYISO(ISOBase):
             verbose=verbose,
         )
 
-        return data[
+        return data.select(
             [
                 "Interval Start",
                 "Interval End",
                 "Zone Name",
                 "MW Value",
-            ]
-        ].rename(
-            columns={
+            ],
+        ).rename(
+            {
                 "Zone Name": "Zone",
                 "MW Value": "MW",
             },
@@ -393,7 +439,7 @@ class NYISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get load forecast for a date in 1 hour intervals"""
         # todo optimize this to accept a date range
         data = self._download_nyiso_archive(
@@ -403,13 +449,12 @@ class NYISO(ISOBase):
             verbose=verbose,
         )
 
-        data = data[
-            ["Time", "Interval Start", "Interval End", "File Date", "NYISO"]
-        ].rename(
-            columns={
+        data = data.select(
+            ["Time", "Interval Start", "Interval End", "File Date", "NYISO"],
+        ).rename(
+            {
                 "File Date": "Forecast Time",
                 "NYISO": "Load Forecast",
-                "Time": "Time",
             },
         )
 
@@ -421,7 +466,7 @@ class NYISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get zonal load forecast for a date in 1 hour intervals"""
         data = self._download_nyiso_archive(
             date,
@@ -430,7 +475,7 @@ class NYISO(ISOBase):
             verbose=verbose,
         )
 
-        data = data[
+        data = data.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -447,9 +492,9 @@ class NYISO(ISOBase):
                 "N.Y.C.",
                 "North",
                 "West",
-            ]
-        ].rename(
-            columns={
+            ],
+        ).rename(
+            {
                 "File Date": "Publish Time",
             },
         )
@@ -461,7 +506,7 @@ class NYISO(ISOBase):
         date: str | pd.Timestamp | Literal["latest"] = "latest",
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get forecasted generation outage capacity for the next 30 days."""
         if end is not None:
             raise ValueError(
@@ -480,36 +525,33 @@ class NYISO(ISOBase):
             utc=True,
         ).tz_convert(self.default_timezone)
 
-        df = pd.read_csv(BytesIO(response.content))
+        df = pl.read_csv(BytesIO(response.content), infer_schema_length=None)
         df = df.rename(
-            columns={
+            {
                 "Date": "Interval Start",
                 "Forecasted Generation Outage (MW)": "Generation Outage",
             },
         )
-        df["Interval Start"] = pd.to_datetime(df["Interval Start"]).dt.tz_localize(
-            self.default_timezone,
+        df = df.with_columns(
+            pl.col("Interval Start")
+            .str.to_datetime(strict=False)
+            .dt.replace_time_zone(self.default_timezone)
+            .alias("Interval Start"),
         )
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(days=1)
-        df["Publish Time"] = publish_time
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(days=1)).alias("Interval End"),
+            pl.lit(publish_time).alias("Publish Time"),
+            pl.col("Generation Outage").cast(pl.Float64, strict=False),
+        )
 
-        df["Generation Outage"] = pd.to_numeric(
-            df["Generation Outage"],
-            errors="coerce",
-        )
-
-        return (
-            df[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Publish Time",
-                    "Generation Outage",
-                ]
-            ]
-            .sort_values(["Interval Start"])
-            .reset_index(drop=True)
-        )
+        return df.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "Publish Time",
+                "Generation Outage",
+            ],
+        ).sort(["Interval Start"])
 
     @support_date_range(frequency="MONTH_START")
     def get_zonal_load_hourly(
@@ -517,7 +559,7 @@ class NYISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get hourly integrated real-time load by zone."""
         data = self._download_nyiso_archive(
             date=date,
@@ -529,28 +571,26 @@ class NYISO(ISOBase):
         )
 
         df = data.rename(
-            columns={
+            {
                 "Name": "Zone",
                 "Integrated Load": "Load",
             },
         )
 
-        df["PTID"] = pd.to_numeric(df["PTID"], errors="coerce")
-        df["Load"] = pd.to_numeric(df["Load"], errors="coerce")
-
-        return (
-            df[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Zone",
-                    "PTID",
-                    "Load",
-                ]
-            ]
-            .sort_values(["Interval Start", "Zone"])
-            .reset_index(drop=True)
+        df = df.with_columns(
+            pl.col("PTID").cast(pl.Float64, strict=False),
+            pl.col("Load").cast(pl.Float64, strict=False),
         )
+
+        return df.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "Zone",
+                "PTID",
+                "Load",
+            ],
+        ).sort(["Interval Start", "Zone"])
 
     @support_date_range(frequency="MONTH_START")
     def get_interface_limits_and_flows_5_min(
@@ -558,11 +598,12 @@ class NYISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get interface limits and flows for a date"""
         if date == "latest":
-            data = pd.read_csv(
-                "https://mis.nyiso.com/public/csv/ExternalLimitsFlows/currentExternalLimitsFlows.csv",  # noqa
+            data = pl.read_csv(
+                "https://mis.nyiso.com/public/csv/ExternalLimitsFlows/currentExternalLimitsFlows.csv",
+                infer_schema_length=None,
             )
             data = self._handle_time(
                 data,
@@ -580,14 +621,14 @@ class NYISO(ISOBase):
 
         # The source has these values as MWH but they are actually MW
         data = data.rename(
-            columns={
+            {
                 "Flow (MWH)": "Flow MW",
                 "Positive Limit (MWH)": "Positive Limit MW",
                 "Negative Limit (MWH)": "Negative Limit MW",
             },
         )
 
-        data = data[
+        return data.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -596,10 +637,8 @@ class NYISO(ISOBase):
                 "Flow MW",
                 "Positive Limit MW",
                 "Negative Limit MW",
-            ]
-        ].sort_values(["Interval Start", "Interface Name"])
-
-        return data
+            ],
+        ).sort(["Interval Start", "Interface Name"])
 
     @support_date_range(frequency="MONTH_START")
     def get_lake_erie_circulation_real_time(
@@ -607,7 +646,7 @@ class NYISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         data = self._download_nyiso_archive(
             date,
             end=end,
@@ -617,11 +656,9 @@ class NYISO(ISOBase):
         )
 
         # The source has MWH in the column name but it's actually MW
-        data = data.rename(columns={"Lake Erie Circulation (MWH)": "MW"})
+        data = data.rename({"Lake Erie Circulation (MWH)": "MW"})
 
-        data = data[["Time", "MW"]].sort_values("Time")
-
-        return data
+        return data.select(["Time", "MW"]).sort("Time")
 
     @support_date_range(frequency="MONTH_START")
     def get_lake_erie_circulation_day_ahead(
@@ -629,7 +666,7 @@ class NYISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         data = self._download_nyiso_archive(
             date,
             end=end,
@@ -638,11 +675,9 @@ class NYISO(ISOBase):
             verbose=verbose,
         )
 
-        data = data.rename(columns={"Lake Erie Circulation (MWH)": "MW"})
+        data = data.rename({"Lake Erie Circulation (MWH)": "MW"})
 
-        data = data[["Time", "MW"]].sort_values("Time")
-
-        return data
+        return data.select(["Time", "MW"]).sort("Time")
 
     @lmp_config(
         supports={
@@ -663,7 +698,7 @@ class NYISO(ISOBase):
         locations: list | None = None,
         location_type: NYISOLocationType | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Supported Markets:
             - ``REAL_TIME_5_MIN`` (RTC)
@@ -703,9 +738,9 @@ class NYISO(ISOBase):
                 )
             else:
                 url = f"https://mis.nyiso.com/public/realtime/realtime_{file_location_type}_lbmp.csv"
-                df = pd.read_csv(url)
+                df = pl.read_csv(url, infer_schema_length=None)
                 df = self._handle_time(df, dataset_name=marketname)
-                df["Market"] = market.value
+                df = df.with_columns(pl.lit(market.value).alias("Market"))
         else:
             filename = marketname + f"_{file_location_type}"
 
@@ -721,38 +756,61 @@ class NYISO(ISOBase):
 
     def _process_lmp_data(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None,
         market: Markets,
         location_type: NYISOLocationType,
         locations: list | str,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         columns = {
             "Name": "Location",
             "LBMP ($/MWHr)": "LMP",
             "Marginal Cost Losses ($/MWHr)": "Loss",
             "Marginal Cost Congestion ($/MWHr)": "Congestion",
-            "Marginal Cost Congestion ($/MWH": "Congestion",  # Deal with older data
+            "Marginal Cost Congestion ($/MWH": "Congestion",
         }
 
-        df = df.rename(columns=columns)
+        df = df.rename(
+            {k: v for k, v in columns.items() if k in df.columns},
+        )
+
+        df = df.with_columns(
+            pl.col("LMP").cast(pl.Float64, strict=False),
+            pl.col("Loss").cast(pl.Float64, strict=False),
+            pl.col("Congestion").cast(pl.Float64, strict=False),
+        )
 
         # In NYISO raw data, a negative congestion number means a higher LMP. We
         # flip the sign to make it consistent with other ISOs where a negative
         # congestion number means a lower LMP. Thus, LMP = Energy + Loss + Congestion
         # for NYISO, as in other ISOs.
-        df["Congestion"] *= -1
-        df["Energy"] = (df["LMP"] - df["Loss"] - df["Congestion"]).round(2)
-        df["Market"] = market.value
-        df["Location Type"] = NYISOLocationType(location_type).value.capitalize()
+        df = df.with_columns(
+            (-pl.col("Congestion")).alias("Congestion"),
+        )
+        df = df.with_columns(
+            (pl.col("LMP") - pl.col("Loss") - pl.col("Congestion"))
+            .round(2)
+            .alias(
+                "Energy",
+            ),
+            pl.lit(market.value).alias("Market"),
+            pl.lit(NYISOLocationType(location_type).value.capitalize()).alias(
+                "Location Type",
+            ),
+        )
 
         # We manually update the location type for the reference bus location because
         # it's included in the generator data.
-        if REFERENCE_BUS_LOCATION in df["Location"].unique():
-            df.loc[
-                df["Location"] == REFERENCE_BUS_LOCATION,
-                "Location Type",
-            ] = "Reference Bus"
+        if (
+            REFERENCE_BUS_LOCATION
+            in df["Location"].unique(maintain_order=True).to_list()
+        ):
+            df = df.with_columns(
+                pl.when(pl.col("Location") == REFERENCE_BUS_LOCATION)
+                .then(pl.lit("Reference Bus"))
+                .otherwise(pl.col("Location Type"))
+                .alias("Location Type"),
+            )
 
         # NYISO includes both 5 min (RTD - Real Time Dispatch) and
         # 15 min (RTC - Real Time Commitment) data in the daily file
@@ -775,37 +833,44 @@ class NYISO(ISOBase):
 
             most_recent_5_min_timestamp = most_recent_5_min_data["Interval Start"].max()
 
-            daily_subset = (
-                df[df["Interval Start"] == most_recent_5_min_timestamp]
-                .sort_values(["Interval Start", "Location"])
-                .reset_index(drop=True)
-            )
+            daily_subset = df.filter(
+                pl.col("Interval Start") == most_recent_5_min_timestamp,
+            ).sort(["Interval Start", "Location"])
 
-            if daily_subset[["LMP", "Loss", "Congestion"]].equals(
-                most_recent_5_min_data[["LMP", "Loss", "Congestion"]],
+            most_recent_subset = most_recent_5_min_data.filter(
+                pl.col("Interval Start") == most_recent_5_min_timestamp,
+            ).sort(["Interval Start", "Location"])
+
+            compare_cols = ["LMP", "Loss", "Congestion"]
+            if daily_subset.select(compare_cols).equals(
+                most_recent_subset.select(compare_cols),
             ):
-                # When equal, the daily data has the most recent 5 min data
-                mask_15_min = df["Interval Start"] > most_recent_5_min_timestamp
+                mask_15_min = pl.col("Interval Start") > most_recent_5_min_timestamp
             else:
-                # When not equal, the data at this timestamp is 15 min data
-                mask_15_min = df["Interval Start"] >= most_recent_5_min_timestamp
+                mask_15_min = pl.col("Interval Start") >= most_recent_5_min_timestamp
 
-            df.loc[~mask_15_min, "Market"] = Markets.REAL_TIME_5_MIN.value
-            df.loc[mask_15_min, "Market"] = Markets.REAL_TIME_15_MIN.value
+            df = df.with_columns(
+                pl.when(~mask_15_min)
+                .then(pl.lit(Markets.REAL_TIME_5_MIN.value))
+                .when(mask_15_min)
+                .then(pl.lit(Markets.REAL_TIME_15_MIN.value))
+                .otherwise(pl.col("Market"))
+                .alias("Market"),
+            )
 
             # For 15-min data, the original "Interval End" column contains the correct
             # end time (since the raw data has timestamps as interval END). However,
             # "Interval Start" was calculated assuming a 5-minute interval, so we need
             # to recalculate it for 15-minute intervals.
             # Interval Start = Interval End - 15 minutes
-            df.loc[mask_15_min, "Interval Start"] = df.loc[
-                mask_15_min,
-                "Interval End",
-            ] - pd.Timedelta(
-                minutes=15,
+            df = df.with_columns(
+                pl.when(mask_15_min)
+                .then(pl.col("Interval End") - pl.duration(minutes=15))
+                .otherwise(pl.col("Interval Start"))
+                .alias("Interval Start"),
             )
 
-        df = df[
+        df = df.select(
             [
                 "Time",
                 "Interval Start",
@@ -817,15 +882,13 @@ class NYISO(ISOBase):
                 "Energy",
                 "Congestion",
                 "Loss",
-            ]
-        ]
+            ],
+        )
 
         df = utils.filter_lmp_locations(df, locations)
 
-        return (
-            df[df["Market"] == market.value]
-            .sort_values(["Interval Start", "Location"])
-            .reset_index(drop=True)
+        return df.filter(pl.col("Market") == market.value).sort(
+            ["Interval Start", "Location"],
         )
 
     @lmp_config(
@@ -844,7 +907,7 @@ class NYISO(ISOBase):
         locations: list | None = None,
         location_type: NYISOLocationType | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Deprecated. Use the per-dataset methods instead:
         :meth:`get_lmp_real_time_5_min`, :meth:`get_lmp_real_time_15_min`,
         :meth:`get_lmp_real_time_hourly`, :meth:`get_lmp_day_ahead_hourly`.
@@ -871,7 +934,7 @@ class NYISO(ISOBase):
         market: Markets,
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+    ) -> tuple[pl.DataFrame, pl.DataFrame]:
         """Fetch both zone and generator LMPs for a market.
 
         The generator data also contains the single Reference Bus location.
@@ -899,7 +962,7 @@ class NYISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get real-time 5-minute (RTD) LMPs for all zone and generator locations."""
         zone, generator = self._get_lmp_zone_and_generator(
             date,
@@ -908,7 +971,7 @@ class NYISO(ISOBase):
             verbose=verbose,
         )
 
-        df = pd.concat([zone, generator], axis=0)
+        df = pl.concat([zone, generator], how="diagonal")
 
         # Only keep intervals where both zone and generator data are present so the
         # combined dataset is internally consistent.
@@ -916,16 +979,16 @@ class NYISO(ISOBase):
             zone["Interval Start"].max(),
             generator["Interval Start"].max(),
         )
-        df = df[df["Interval Start"] <= maximum_timestamp]
+        df = df.filter(pl.col("Interval Start") <= maximum_timestamp)
 
-        return df.sort_values(["Interval Start", "Location"]).reset_index(drop=True)
+        return df.sort(["Interval Start", "Location"])
 
     def get_lmp_real_time_15_min(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get real-time 15-minute (RTC) LMPs for all zone and generator locations."""
         zone, generator = self._get_lmp_zone_and_generator(
             date,
@@ -934,16 +997,16 @@ class NYISO(ISOBase):
             verbose=verbose,
         )
 
-        df = pd.concat([zone, generator], axis=0)
+        df = pl.concat([zone, generator], how="diagonal")
 
-        return df.sort_values(["Interval Start", "Location"]).reset_index(drop=True)
+        return df.sort(["Interval Start", "Location"])
 
     def get_lmp_real_time_hourly(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get real-time hourly LMPs for all zone and generator locations."""
         zone, generator = self._get_lmp_zone_and_generator(
             date,
@@ -952,16 +1015,16 @@ class NYISO(ISOBase):
             verbose=verbose,
         )
 
-        df = pd.concat([zone, generator], axis=0)
+        df = pl.concat([zone, generator], how="diagonal")
 
-        return df.sort_values(["Interval Start", "Location"]).reset_index(drop=True)
+        return df.sort(["Interval Start", "Location"])
 
     def get_lmp_day_ahead_hourly(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get day-ahead hourly LMPs for all zone and generator locations."""
         zone, generator = self._get_lmp_zone_and_generator(
             date,
@@ -970,9 +1033,9 @@ class NYISO(ISOBase):
             verbose=verbose,
         )
 
-        df = pd.concat([zone, generator], axis=0)
+        df = pl.concat([zone, generator], how="diagonal")
 
-        return df.sort_values(["Interval Start", "Location"]).reset_index(drop=True)
+        return df.sort(["Interval Start", "Location"])
 
     def get_raw_interconnection_queue(self) -> BinaryIO:
         url = "https://www.nyiso.com/documents/20142/1407078/NYISO-Interconnection-Queue.xlsx"  # noqa
@@ -981,13 +1044,13 @@ class NYISO(ISOBase):
         response = requests.get(url)
         return utils.get_response_blob(response)
 
-    def get_interconnection_queue(self) -> pd.DataFrame:
+    def get_interconnection_queue(self) -> pl.DataFrame:
         """Return NYISO interconnection queue
 
         Additional Non-NYISO queue info: https://www3.dps.ny.gov/W/PSCWeb.nsf/All/286D2C179E9A5A8385257FBF003F1F7E?OpenDocument
 
         Returns:
-            pandas.DataFrame: Interconnection queue containing, active, withdrawn, \
+            polars.DataFrame: Interconnection queue containing, active, withdrawn, \
                 and completed project
 
         """  # noqa
@@ -996,60 +1059,42 @@ class NYISO(ISOBase):
         # harded coded for now. perhaps this url can be parsed from the html here:
         raw_data = self.get_raw_interconnection_queue()
 
-        # Create ExcelFile so we only need to download file once
-        excel_file = pd.ExcelFile(raw_data)
-
-        # Drop extra rows at bottom
-        active = (
-            pd.read_excel(excel_file, sheet_name="Interconnection Queue")
-            .dropna(
-                subset=["Queue Pos.", "Project Name"],
+        def _process_active_sheet(df: pd.DataFrame) -> pd.DataFrame:
+            return (
+                df.dropna(
+                    subset=["Queue Pos.", "Project Name"],
+                )
+                .copy()
+                .rename(columns={"Points of Interconnection": "Interconnection Point"})
             )
-            .copy()
-            # Active projects can have multiple values for "Points of Interconnection"
-        ).rename(columns={"Points of Interconnection": "Interconnection Point"})
 
-        cluster_active = (
-            pd.read_excel(excel_file, sheet_name=" Cluster Projects")
-            .dropna(
-                subset=["Queue Pos.", "Project Name"],
-            )
-            .copy()
-            # Active projects can have multiple values for "Points of Interconnection"
-        ).rename(columns={"Points of Interconnection": "Interconnection Point"})
+        active = utils.read_excel_via_pandas(
+            raw_data,
+            sheet_name="Interconnection Queue",
+            process=_process_active_sheet,
+        )
+        cluster_active = utils.read_excel_via_pandas(
+            raw_data,
+            sheet_name=" Cluster Projects",
+            process=_process_active_sheet,
+        )
+        active = pl.concat([active, cluster_active], how="diagonal")
+        active = active.with_columns(
+            pl.lit(InterconnectionQueueStatus.ACTIVE.value).alias("Status"),
+        )
 
-        active = pd.concat([active, cluster_active])
-
-        active["Status"] = InterconnectionQueueStatus.ACTIVE.value
-
-        withdrawn = pd.read_excel(excel_file, sheet_name="Withdrawn")
-        cluster_withdrawn = pd.read_excel(
-            excel_file,
+        withdrawn = utils.read_excel_via_pandas(raw_data, sheet_name="Withdrawn")
+        cluster_withdrawn = utils.read_excel_via_pandas(
+            raw_data,
             sheet_name="Cluster Projects-Withdrawn",
         )
-        withdrawn = pd.concat([withdrawn, cluster_withdrawn])
+        withdrawn = pl.concat([withdrawn, cluster_withdrawn], how="diagonal")
+        withdrawn = withdrawn.with_columns(
+            pl.lit(InterconnectionQueueStatus.WITHDRAWN.value).alias("Status"),
+            pl.col("Last Update").alias("Withdrawn Date"),
+            pl.lit(None).alias("Withdrawal Comment"),
+        ).rename({"Utility ": "Utility", "Owner/Developer": "Developer Name"})
 
-        withdrawn["Status"] = InterconnectionQueueStatus.WITHDRAWN.value
-        # assume it was withdrawn when last updated
-        withdrawn["Withdrawn Date"] = withdrawn["Last Update"]
-        withdrawn["Withdrawal Comment"] = None
-        withdrawn = withdrawn.rename(columns={"Utility ": "Utility"})
-
-        withdrawn = withdrawn.rename(columns={"Owner/Developer": "Developer Name"})
-
-        # make completed look like the other two sheets
-        completed = pd.read_excel(excel_file, sheet_name="In Service", header=[0, 1])
-        completed.insert(15, "SGIA Tender Date", None)
-        completed.insert(16, "CY Complete Date", None)
-        completed.insert(17, "Proposed Initial-Sync Date", None)
-
-        completed["Status"] = InterconnectionQueueStatus.COMPLETED.value
-
-        if (
-            "SGIA Tender Date" in active.columns
-            and "SGIA Tender Date" not in completed.columns
-        ):
-            active = active.drop(columns=["SGIA Tender Date"])
         completed_colnames_map = {
             ("Queue", "Pos."): "Queue Pos.",
             ("Queue", "Owner/Developer"): "Developer Name",
@@ -1076,81 +1121,88 @@ class NYISO(ISOBase):
             ("Proposed", "COD.3"): "Proposed COD.3",
             ("Status", ""): "Status",
         }
-        completed.columns = completed.columns.to_flat_index().map(
-            lambda c: completed_colnames_map[c],
+
+        def _process_completed_sheet(df: pd.DataFrame) -> pd.DataFrame:
+            completed = df.copy()
+            completed.insert(15, "SGIA Tender Date", None)
+            completed.insert(16, "CY Complete Date", None)
+            completed.insert(17, "Proposed Initial-Sync Date", None)
+            completed["Status"] = InterconnectionQueueStatus.COMPLETED.value
+            completed.columns = completed.columns.to_flat_index().map(
+                lambda c: completed_colnames_map[c],
+            )
+            completed["Actual Completion Date"] = completed["Last Updated Date"]
+            return completed
+
+        completed = utils.read_excel_via_pandas(
+            raw_data,
+            sheet_name="In Service",
+            header=[0, 1],
+            process=_process_completed_sheet,
         )
 
-        # assume it was finished when last updated
-        completed["Actual Completion Date"] = completed["Last Updated Date"]
+        if (
+            "SGIA Tender Date" in active.columns
+            and "SGIA Tender Date" not in completed.columns
+        ):
+            active = active.drop("SGIA Tender Date")
 
         dfs = [
             df
             for df in [active, withdrawn, completed]
-            if not df.empty and not df.isna().all().all()
+            if df.height > 0 and not df.select(pl.all().is_null().all()).row(0)[0]
         ]
-        queue = pd.concat(dfs)
+        queue = pl.concat(dfs, how="diagonal")
 
         # fix extra space in column name
 
-        queue["Type/ Fuel"] = queue["Type/ Fuel"].map(
-            {
-                "S": "Solar",
-                "ES": "Energy Storage",
-                "W": "Wind",
-                "AC": "AC Transmission",
-                "DC": "DC Transmission",
-                "CT": "Combustion Turbine",
-                "CC": "Combined Cycle",
-                "M": "Methane",
-                #    "CR": "",
-                "H": "Hydro",
-                "L": "Load",
-                "ST": "Steam Turbine",
-                "CC-NG": "Natural Gas",
-                "FC": "Fuel Cell",
-                "PS": "Pumped Storage",
-                "NU": "Nuclear",
-                "D": "Dual Fuel",
-                #    "C": "",
-                "NG": "Natural Gas",
-                "Wo": "Wood",
-                "F": "Flywheel",
-                #    "CW": "",
-                "CC-D": "Combined Cycle - Dual Fuel",
-                "SW": "=Solid Waste",
-                #    "CR=CSR - ES + Solar": "",
-                "CT-NG": "Combustion Turbine - Natural Gas",
-                "DC/AC": "DC/AC Transmission",
-                "CT-D": "Combustion Turbine - Dual Fuel",
-                "CS-NG": "Steam Turbine & Combustion Turbine-  Natural Gas",
-                "ST-NG": "Steam Turbine - Natural Gas",
-            },
-        )
-
-        queue["Capacity (MW)"] = (
-            queue[["SP (MW)", "WP (MW)"]]
-            .replace(
-                "TBD",
-                0,
-            )
-            .replace(" ", 0)
-            .fillna(0)
-            .astype(float)
-            .max(axis=1)
-        )
-
-        queue["Date of IR"] = pd.to_datetime(queue["Date of IR"])
-        queue["Proposed COD"] = pd.to_datetime(
-            queue["Proposed COD"],
-            errors="coerce",
-        )
-        queue["Proposed In-Service Date"] = pd.to_datetime(
-            queue["Proposed In-Service Date"],
-            errors="coerce",
-        )
-        queue["Proposed Initial-Sync Date"] = pd.to_datetime(
-            queue["Proposed Initial-Sync Date"],
-            errors="coerce",
+        queue = queue.with_columns(
+            pl.col("Type/ Fuel").replace(
+                {
+                    "S": "Solar",
+                    "ES": "Energy Storage",
+                    "W": "Wind",
+                    "AC": "AC Transmission",
+                    "DC": "DC Transmission",
+                    "CT": "Combustion Turbine",
+                    "CC": "Combined Cycle",
+                    "M": "Methane",
+                    "H": "Hydro",
+                    "L": "Load",
+                    "ST": "Steam Turbine",
+                    "CC-NG": "Natural Gas",
+                    "FC": "Fuel Cell",
+                    "PS": "Pumped Storage",
+                    "NU": "Nuclear",
+                    "D": "Dual Fuel",
+                    "NG": "Natural Gas",
+                    "Wo": "Wood",
+                    "F": "Flywheel",
+                    "CC-D": "Combined Cycle - Dual Fuel",
+                    "SW": "=Solid Waste",
+                    "CT-NG": "Combustion Turbine - Natural Gas",
+                    "DC/AC": "DC/AC Transmission",
+                    "CT-D": "Combustion Turbine - Dual Fuel",
+                    "CS-NG": "Steam Turbine & Combustion Turbine-  Natural Gas",
+                    "ST-NG": "Steam Turbine - Natural Gas",
+                },
+            ),
+            pl.max_horizontal(
+                pl.col("SP (MW)")
+                .replace("TBD", 0)
+                .replace(" ", 0)
+                .fill_null(0)
+                .cast(pl.Float64, strict=False),
+                pl.col("WP (MW)")
+                .replace("TBD", 0)
+                .replace(" ", 0)
+                .fill_null(0)
+                .cast(pl.Float64, strict=False),
+            ).alias("Capacity (MW)"),
+            pl.col("Date of IR").str.to_datetime(strict=False),
+            pl.col("Proposed COD").str.to_datetime(strict=False),
+            pl.col("Proposed In-Service Date").str.to_datetime(strict=False),
+            pl.col("Proposed Initial-Sync Date").str.to_datetime(strict=False),
         )
 
         # TODO handle other 2 sheets
@@ -1188,11 +1240,11 @@ class NYISO(ISOBase):
 
         return queue
 
-    def get_generators(self, verbose: bool = False) -> pd.DataFrame:
+    def get_generators(self, verbose: bool = False) -> pl.DataFrame:
         """Get a list of generators in NYISO. When possible return capacity and fuel type information
 
         Returns:
-            pandas.DataFrame: a DataFrame of generators and locations
+            polars.DataFrame: a DataFrame of generators and locations
 
             **Possible Columns**
 
@@ -1225,7 +1277,7 @@ class NYISO(ISOBase):
 
         logger.info(f"Requesting {generator_url}")
 
-        df = pd.read_csv(generator_url)
+        df = pl.read_csv(generator_url, infer_schema_length=None)
 
         # need to be updated once a year. approximately around end of april
         # find it here: https://www.nyiso.com/gold-book-resources
@@ -1233,20 +1285,6 @@ class NYISO(ISOBase):
 
         logger.info(f"Requesting {capacity_url_2024}")
 
-        generators = pd.read_excel(
-            capacity_url_2024,
-            sheet_name=[
-                "Table III-2a",
-                "Table III-2b",
-            ],
-            skiprows=3,
-            header=[0, 1, 2, 3, 4],
-        )
-
-        generators["Table III-2a"]["Generator Type"] = "Market Generator"
-        generators["Table III-2b"]["Generator Type"] = "Non-Market Generator"
-
-        # manually transcribed column names (inspect spreadsheet for confirmation)
         mapped_columns = [
             "LINE REF. NO.",
             "Owner, Operator, and / or Billing Organization",
@@ -1271,23 +1309,40 @@ class NYISO(ISOBase):
             "Generator Type",
         ]
 
-        # Rename the columns separately, so they match on the concat
-        generators["Table III-2a"].columns = mapped_columns
-        generators["Table III-2b"].columns = mapped_columns
+        def _process_table_2a(sheet_df: pd.DataFrame) -> pd.DataFrame:
+            sheet_df = sheet_df.copy()
+            sheet_df.columns = mapped_columns
+            sheet_df["Generator Type"] = "Market Generator"
+            return sheet_df
 
-        # combine both sheets
-        generators = pd.concat(generators.values())
+        def _process_table_2b(sheet_df: pd.DataFrame) -> pd.DataFrame:
+            sheet_df = sheet_df.copy()
+            sheet_df.columns = mapped_columns
+            sheet_df["Generator Type"] = "Non-Market Generator"
+            return sheet_df
 
-        generators = generators.dropna(subset=["PTID"])
+        gen_2a = utils.read_excel_via_pandas(
+            capacity_url_2024,
+            sheet_name="Table III-2a",
+            skiprows=3,
+            header=[0, 1, 2, 3, 4],
+            process=_process_table_2a,
+        )
+        gen_2b = utils.read_excel_via_pandas(
+            capacity_url_2024,
+            sheet_name="Table III-2b",
+            skiprows=3,
+            header=[0, 1, 2, 3, 4],
+            process=_process_table_2b,
+        )
 
-        generators["PTID"] = generators["PTID"].astype(int)
-
-        # in other data
-        generators = generators.drop(columns=["Zone", "LINE REF. NO."])
+        generators = pl.concat([gen_2a, gen_2b], how="diagonal")
+        generators = generators.drop_nulls(subset=["PTID"])
+        generators = generators.with_columns(pl.col("PTID").cast(pl.Int64))
+        generators = generators.drop(["Zone", "LINE REF. NO."])
 
         # TODO: df has both Generator PTID and Aggregation PTID
-        combined = pd.merge(
-            df,
+        combined = df.join(
             generators,
             left_on="Generator PTID",
             right_on="PTID",
@@ -1312,8 +1367,6 @@ class NYISO(ISOBase):
             "ST": "Steam Turbine (Fossil)",
             "WT": "Wind Turbine",
         }
-        combined["Unit Type"] = combined["Unit Type"].map(unit_type_map)
-
         fuel_type_map = {
             "BAT": "Battery",
             "BUT": "Butane",
@@ -1333,41 +1386,37 @@ class NYISO(ISOBase):
             "WD": "Wood and/or Wood Waste",
             "WND": "Wind",
         }
-        combined["Fuel Type 1"] = combined["Fuel Type 1"].map(
-            fuel_type_map,
-        )
-        combined["Fuel Type 2"] = combined["Fuel Type 2"].map(
-            fuel_type_map,
-        )
-
-        combined["Is Dual Fuel"] = combined["Is Dual Fuel"] == "YES"
-
         state_code_map = {
             36: "New York",
             42: "Pennsylvania",
             25: "Massachusetts",
             34: "New Jersey",
         }
-        combined["State"] = combined["State"].map(state_code_map)
+
+        combined = combined.with_columns(
+            pl.col("Unit Type").replace(unit_type_map),
+            pl.col("Fuel Type 1").replace(fuel_type_map),
+            pl.col("Fuel Type 2").replace(fuel_type_map),
+            (pl.col("Is Dual Fuel") == "YES").alias("Is Dual Fuel"),
+            pl.col("State").replace(state_code_map),
+        )
 
         # todo map county codes to names. info on first sheet of excel
 
         return combined
 
-    def get_loads(self) -> pd.DataFrame:
+    def get_loads(self) -> pl.DataFrame:
         """Get a list of loads in NYISO
 
         Returns:
-            pandas.DataFrame: a DataFrame of loads and locations
+            polars.DataFrame: a DataFrame of loads and locations
         """
 
         url = "http://mis.nyiso.com/public/csv/load/load.csv"
 
         logger.info(f"Requesting {url}")
 
-        df = pd.read_csv(url)
-
-        return df
+        return pl.read_csv(url, infer_schema_length=None)
 
     def _set_marketname(self, market: Markets) -> str:
         if market in [Markets.REAL_TIME_5_MIN, Markets.REAL_TIME_15_MIN]:
@@ -1399,7 +1448,7 @@ class NYISO(ISOBase):
         filename: str | None = None,
         groupby: str | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Download a dataset from NYISO's archive
 
         Arguments:
@@ -1416,7 +1465,7 @@ class NYISO(ISOBase):
             verbose (bool): print out requested url
 
         Returns:
-            pandas.DataFrame: the downloaded data
+            polars.DataFrame: the downloaded data
 
         """
         if filename is None:
@@ -1445,10 +1494,14 @@ class NYISO(ISOBase):
             csv_url = f"http://mis.nyiso.com/public/csv/{dataset_name}/{csv_filename}"
             logger.info(f"Requesting {csv_url}")
 
-            df = pd.read_csv(csv_url)
+            df = pl.read_csv(csv_url, infer_schema_length=None)
             df = self._handle_time(df, dataset_name, groupby=groupby)
             if add_file_date:
-                df["File Date"] = self._get_load_forecast_file_date(date, verbose)
+                df = df.with_columns(
+                    pl.lit(self._get_load_forecast_file_date(date, verbose)).alias(
+                        "File Date",
+                    ),
+                )
         else:
             zip_url = f"http://mis.nyiso.com/public/csv/{dataset_name}/{month}{filename}_csv.zip"  # noqa: E501
             z = utils.get_zip_folder(zip_url, verbose=verbose)
@@ -1479,20 +1532,22 @@ class NYISO(ISOBase):
                 if csv_filename not in z.namelist():
                     logger.info(f"{csv_filename} not found in {zip_url}")
                     continue
-                df = pd.read_csv(z.open(csv_filename))
+                content = z.open(csv_filename).read()
+                df = pl.read_csv(BytesIO(content), infer_schema_length=None)
 
                 if add_file_date:
                     # NB: The File Date is the last modified time of the individual csv file
-                    df["File Date"] = pd.Timestamp(
+                    file_date = pd.Timestamp(
                         *z.getinfo(csv_filename).date_time,
                         tz=self.default_timezone,
                     )
+                    df = df.with_columns(pl.lit(file_date).alias("File Date"))
                 df = self._handle_time(df, dataset_name, groupby=groupby)
                 all_dfs.append(df)
 
-            df = pd.concat(all_dfs)
+            df = pl.concat(all_dfs, how="diagonal")
 
-        return df.sort_values("Time").reset_index(drop=True)
+        return df.sort("Time")
 
     def _get_load_forecast_file_date(
         self,
@@ -1500,24 +1555,24 @@ class NYISO(ISOBase):
         verbose: bool = False,
     ) -> pd.Timestamp:
         """Retrieves the last updated time for load forecast file from the archive"""
-        data = pd.read_html(
+        data = utils.read_html_via_pandas(
             "http://mis.nyiso.com/public/P-7list.htm",
             skiprows=2,
             header=0,
         )[0]
 
-        last_updated_date = data.loc[
-            data["CSV Files"] == date.strftime("%m-%d-%Y"),
-            "Last Updated",
-        ].iloc[0]
+        last_updated_date = data.filter(
+            pl.col("CSV Files") == date.strftime("%m-%d-%Y"),
+        )["Last Updated"][0]
 
-        return pd.Timestamp(last_updated_date, tz=self.default_timezone)
+        clean = str(last_updated_date).replace(" EDT", "").replace(" EST", "")
+        return pd.Timestamp(clean, tz=self.default_timezone)
 
     def get_capacity_prices(
         self,
         date: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Pull the most recent capacity market report's market clearing prices
 
         Arguments:
@@ -1577,11 +1632,19 @@ class NYISO(ISOBase):
 
         logger.info(f"Requesting {url}")
 
-        df = pd.read_excel(url, sheet_name="MCP Table", header=[0, 1])
+        def _process_mcp_table(sheet_df: pd.DataFrame) -> pd.DataFrame:
+            sheet_df = sheet_df.rename(
+                columns={"Unnamed: 0_level_0": "", "Date": ""},
+            )
+            sheet_df = sheet_df.set_index("")
+            return sheet_df.dropna(how="any", axis="columns").reset_index()
 
-        df.rename(columns={"Unnamed: 0_level_0": "", "Date": ""}, inplace=True)
-        df.set_index("", inplace=True)
-        return df.dropna(how="any", axis="columns")
+        return utils.read_excel_via_pandas(
+            url,
+            sheet_name="MCP Table",
+            header=[0, 1],
+            process=_process_mcp_table,
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_as_prices_day_ahead_hourly(
@@ -1589,7 +1652,7 @@ class NYISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Pull the most recent ancillary service market report's market clearing prices
 
         Arguments:
@@ -1610,7 +1673,7 @@ class NYISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Pull the most recent ancillary service market report's market clearing prices
 
         Arguments:
@@ -1627,11 +1690,11 @@ class NYISO(ISOBase):
 
     def _handle_as_prices(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         rt_or_dam: Literal["rt", "dam"],
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         df = df.rename(
-            columns={
+            {
                 "Name": "Zone",
                 "10 Min Spinning Reserve ($/MWHr)": "10 Min Spin Reserves",
                 "10 Min Non-Synchronous Reserve ($/MWHr)": "10 Min Non-Spin Reserves",
@@ -1640,14 +1703,20 @@ class NYISO(ISOBase):
             },
         )
         if rt_or_dam == "rt":
-            df["Interval End"] = df["Interval Start"]
-            df["Interval Start"] = df["Interval Start"] - pd.Timedelta(minutes=5)
+            df = df.with_columns(
+                pl.col("Interval Start").alias("Interval End"),
+                (pl.col("Interval Start") - pl.duration(minutes=5)).alias(
+                    "Interval Start",
+                ),
+            )
         else:
-            df["Interval End"] = df["Interval Start"] + pd.Timedelta(
-                minutes=60,
+            df = df.with_columns(
+                (pl.col("Interval Start") + pl.duration(minutes=60)).alias(
+                    "Interval End",
+                ),
             )
 
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -1656,8 +1725,8 @@ class NYISO(ISOBase):
                 "10 Min Non-Spin Reserves",
                 "30 Min Reserves",
                 "Regulation Capacity",
-            ]
-        ]
+            ],
+        )
 
     @support_date_range(frequency="DAY_START")
     def get_limiting_constraints_real_time(
@@ -1665,10 +1734,11 @@ class NYISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
-            data = pd.read_csv(
+            data = pl.read_csv(
                 "https://mis.nyiso.com/public/csv/LimitingConstraints/currentLimitingConstraints.csv",
+                infer_schema_length=None,
             )
             data = self._handle_time(
                 data,
@@ -1684,26 +1754,18 @@ class NYISO(ISOBase):
                 verbose=verbose,
             )
 
-        data = data.rename(columns={"Constraint Cost($)": "Constraint Cost"})
+        data = data.rename({"Constraint Cost($)": "Constraint Cost"})
 
-        data = (
-            data[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Limiting Facility",
-                    "Facility PTID",
-                    "Contingency",
-                    "Constraint Cost",
-                ]
-            ]
-            .sort_values(["Interval Start", "Limiting Facility", "Contingency"])
-            .reset_index(
-                drop=True,
-            )
-        )
-
-        return data
+        return data.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "Limiting Facility",
+                "Facility PTID",
+                "Contingency",
+                "Constraint Cost",
+            ],
+        ).sort(["Interval Start", "Limiting Facility", "Contingency"])
 
     @support_date_range(frequency="DAY_START")
     def get_limiting_constraints_day_ahead(
@@ -1711,7 +1773,7 @@ class NYISO(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         df = self._download_nyiso_archive(
             date,
             end=end,
@@ -1720,23 +1782,15 @@ class NYISO(ISOBase):
             verbose=verbose,
         )
 
-        df = df.rename(columns={"Constraint Cost($)": "Constraint Cost"})
+        df = df.rename({"Constraint Cost($)": "Constraint Cost"})
 
-        df = (
-            df[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Limiting Facility",
-                    "Facility PTID",
-                    "Contingency",
-                    "Constraint Cost",
-                ]
-            ]
-            .sort_values(["Interval Start", "Limiting Facility", "Contingency"])
-            .reset_index(
-                drop=True,
-            )
-        )
-
-        return df
+        return df.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "Limiting Facility",
+                "Facility PTID",
+                "Contingency",
+                "Constraint Cost",
+            ],
+        ).sort(["Interval Start", "Limiting Facility", "Contingency"])

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -8,6 +8,7 @@ import xml.etree.ElementTree as ET
 from typing import BinaryIO
 
 import pandas as pd
+import polars as pl
 import requests
 import tqdm
 from bs4 import BeautifulSoup
@@ -98,7 +99,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get fuel mix for a date or date range  in hourly intervals"""
         # earliest date available appears to be 1/1/2016
         data = {
@@ -115,16 +116,18 @@ class PJM(ISOBase):
             interval_duration_min=60,
         )
 
-        mix_df = mix_df.pivot_table(
+        mix_df = mix_df.pivot(
             index=["Time", "Interval Start", "Interval End"],
-            columns="fuel_type",
+            on="fuel_type",
             values="mw",
-            aggfunc="first",
-        ).reset_index()
-
-        mix_df.columns.name = None
-
-        return mix_df
+            aggregate_function="first",
+        )
+        fuel_cols = sorted(
+            c
+            for c in mix_df.columns
+            if c not in ["Time", "Interval Start", "Interval End"]
+        )
+        return mix_df.select(["Time", "Interval Start", "Interval End", *fuel_cols])
 
     @support_date_range(frequency="30D")
     def get_load(
@@ -132,7 +135,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Returns load at a previous date at 5 minute intervals.
 
         Args:
@@ -165,30 +168,25 @@ class PJM(ISOBase):
             verbose=verbose,
         )
 
-        # round to nearest minute before the pivot
-        # need to round in utc time
-        load["Interval Start"] = (
-            load["Interval Start"]
-            .dt.tz_convert("UTC")
-            .dt.round("1min")
-            .dt.tz_convert(self.default_timezone)
+        load = load.with_columns(
+            pl.col("Interval Start")
+            .dt.convert_time_zone("UTC")
+            .dt.round("1m")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Interval Start"),
         )
-        load["Time"] = load["Interval Start"]
+        load = load.with_columns(pl.col("Interval Start").alias("Time"))
 
-        # pivot on area
-        load = load.pivot_table(
+        load = load.pivot(
             index=["Time", "Interval Start"],
-            columns="area",
+            on="area",
             values="instantaneous_load",
-            aggfunc="first",
-        ).reset_index()
-
-        load["Interval End"] = load["Interval Start"] + pd.Timedelta(minutes=5)
-
-        load.columns.name = None
-
-        # set Load column name to match return column of other ISOs
-        load["Load"] = load["PJM RTO"]
+            aggregate_function="first",
+        )
+        load = load.with_columns(
+            (pl.col("Interval Start") + pl.duration(minutes=5)).alias("Interval End"),
+            pl.col("PJM RTO").alias("Load"),
+        )
 
         load = utils.move_cols_to_front(
             load,
@@ -203,7 +201,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Load forecast made today extending for six days in hourly intervals.
 
@@ -241,7 +239,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Historical load forecast in hourly intervals. Historical forecasts include all
         vintages of the forecast but has fewer regions than the current forecast.
@@ -279,7 +277,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Load forecast made today extending for 2 hours in 5 minute intervals.
         """
@@ -303,9 +301,9 @@ class PJM(ISOBase):
 
         return self._handle_load_forecast(data)
 
-    def _handle_load_forecast(self, data: pd.DataFrame) -> pd.DataFrame:
+    def _handle_load_forecast(self, data: pl.DataFrame) -> pl.DataFrame:
         data = data.rename(
-            columns={
+            {
                 "evaluated_at_utc": "Publish Time",
                 "evaluated_at_datetime_utc": "Publish Time",
                 "forecast_load_mw": "Load Forecast",
@@ -317,54 +315,49 @@ class PJM(ISOBase):
         )
 
         data = data.pivot(
-            columns="Forecast Area",
-            values="Load Forecast",
             index=["Publish Time", "Interval Start"],
-        ).reset_index()
+            on="Forecast Area",
+            values="Load Forecast",
+            aggregate_function="first",
+        )
+        rename_cols = {c: c.replace("&", "").replace("/", "_") for c in data.columns}
+        data = data.rename(rename_cols)
 
-        # Replace & with "" and / with _ in column names
-        data.columns = data.columns.str.replace("&", "").str.replace("/", "_")
-
-        data["Publish Time"] = pd.to_datetime(
-            data["Publish Time"],
-            utc=True,
-        ).dt.tz_convert(
-            self.default_timezone,
+        data = data.with_columns(
+            pl.col("Publish Time")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone),
+            pl.col("Interval Start")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone),
         )
 
-        data["Interval Start"] = pd.to_datetime(
-            data["Interval Start"],
-            utc=True,
-        ).dt.tz_convert(
-            self.default_timezone,
-        )
-
-        # Only real-time data has Interval End
         if "Interval End" in data.columns:
-            data["Interval End"] = pd.to_datetime(
-                data["Interval End"],
-                utc=True,
-            ).dt.tz_convert(
-                self.default_timezone,
+            data = data.with_columns(
+                pl.col("Interval End")
+                .str.to_datetime(time_zone="UTC")
+                .dt.convert_time_zone(self.default_timezone),
             )
         else:
-            data["Interval End"] = data["Interval Start"] + pd.Timedelta(hours=1)
+            data = data.with_columns(
+                (pl.col("Interval Start") + pl.duration(hours=1)).alias("Interval End"),
+            )
 
         if "RTO" in data.columns:
-            data["Load Forecast"] = data["RTO"]
+            data = data.with_columns(pl.col("RTO").alias("Load Forecast"))
         elif "RTO_COMBINED" in data.columns:
-            data["Load Forecast"] = data["RTO_COMBINED"]
+            data = data.with_columns(pl.col("RTO_COMBINED").alias("Load Forecast"))
 
         data = utils.move_cols_to_front(
             data,
             ["Interval Start", "Interval End", "Publish Time", "Load Forecast"],
         )
 
-        return data.sort_values(["Interval Start", "Publish Time"]).reset_index(
+        return data.sort(["Interval Start", "Publish Time"]).reset_index(
             drop=True,
         )
 
-    def get_pnode_ids(self) -> pd.DataFrame:
+    def get_pnode_ids(self) -> pl.DataFrame:
         data = {
             "fields": "effective_date,pnode_id,pnode_name,pnode_subtype,pnode_type\
                 ,termination_date,voltage_level,zone",
@@ -375,32 +368,27 @@ class PJM(ISOBase):
         # only keep most recent effective date for each id
         # return sorted by pnode_id
         nodes = (
-            nodes.sort_values("effective_date", ascending=False)
-            .drop_duplicates(
-                "pnode_id",
-            )
-            .sort_values("pnode_id")
-            .reset_index(drop=True)
+            nodes.sort("effective_date", descending=True)
+            .unique(subset=["pnode_id"], keep="first")
+            .sort("pnode_id")
         )
 
-        # NB: this is needed because rt_unverified_fivemin_lmps
-        # doesn't have short name
-        # so we need to extract it from full name
-        # other LMP datasets have but do it this way
-        # for consistent logic
-        def extract_short_name(row: pd.Series) -> str:
-            if row["voltage_level"] is None or pd.isna(row["voltage_level"]):
-                return row["pnode_name"]
-            else:
-                # Find the index where voltage_level starts
-                # and extract everything before it
-                index = row["pnode_name"].find(row["voltage_level"])
-                # if not found, return full name
-                if index == -1:
-                    return row["pnode_name"]
-                return row["pnode_name"][:index].strip()
+        def extract_short_name(voltage_level: str | None, pnode_name: str) -> str:
+            if voltage_level is None:
+                return pnode_name
+            index = pnode_name.find(voltage_level)
+            if index == -1:
+                return pnode_name
+            return pnode_name[:index].strip()
 
-        nodes["pnode_short_name"] = nodes.apply(extract_short_name, axis=1)
+        nodes = nodes.with_columns(
+            pl.struct(["voltage_level", "pnode_name"])
+            .map_elements(
+                lambda row: extract_short_name(row["voltage_level"], row["pnode_name"]),
+                return_dtype=pl.Utf8,
+            )
+            .alias("pnode_short_name"),
+        )
 
         return nodes
 
@@ -420,7 +408,7 @@ class PJM(ISOBase):
         locations: str = "hubs",
         location_type: str | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Returns LMP at a previous date.
 
         Note:
@@ -550,20 +538,22 @@ class PJM(ISOBase):
                 interval_duration_min=interval_duration_min,
             )
 
-            data["system_energy_price_rt"] = (
-                data["total_lmp_rt"]
-                - data["congestion_price_rt"]
-                - data["marginal_loss_price_rt"]
+            data = data.with_columns(
+                (
+                    pl.col("total_lmp_rt")
+                    - pl.col("congestion_price_rt")
+                    - pl.col("marginal_loss_price_rt")
+                ).alias("system_energy_price_rt"),
             )
 
         # API cannot filter location type for rt 5 min
-        data = data.rename(columns={"type": "Location Type"})
+        data = data.rename({"type": "Location Type"})
         if location_type and market == Markets.REAL_TIME_5_MIN:
-            data = data[data["Location Type"] == location_type]
+            data = data.filter(pl.col("Location Type") == location_type)
 
         if locations is not None and locations != "ALL":
             # make sure Location is defined
-            data["Location"] = data["pnode_id"]
+            data = data.with_columns(pl.col("pnode_id").alias("Location"))
             data = utils.filter_lmp_locations(
                 data,
                 map(int, locations),
@@ -572,7 +562,7 @@ class PJM(ISOBase):
         data = self._add_pnode_info_to_lmp_data(data)
 
         data = data.rename(
-            columns={
+            {
                 "pnode_id": "Location Id",
                 "pnode_name": "Location Name",
                 "pnode_short_name": "Location Short Name",
@@ -582,9 +572,9 @@ class PJM(ISOBase):
                 f"marginal_loss_price_{market_type}": "Loss",
             },
         )
-        data["Market"] = market.value
+        data = data.with_columns(pl.lit(market.value).alias("Market"))
 
-        data = data[
+        data = data.select(
             [
                 "Time",
                 "Interval Start",
@@ -598,10 +588,10 @@ class PJM(ISOBase):
                 "Energy",
                 "Congestion",
                 "Loss",
-            ]
-        ]
+            ],
+        )
 
-        data = data.sort_values("Interval Start")
+        data = data.sort("Interval Start")
 
         return data
 
@@ -620,7 +610,7 @@ class PJM(ISOBase):
         locations: str = "hubs",
         location_type: str | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Deprecated. Use the per-dataset methods instead:
         :meth:`get_lmp_real_time_5_min`, :meth:`get_lmp_real_time_hourly`,
         :meth:`get_lmp_day_ahead_hourly`.
@@ -646,7 +636,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get real-time 5-minute LMPs for all nodes."""
         return self._get_lmp(
             date,
@@ -661,7 +651,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get real-time hourly LMPs for all nodes."""
         return self._get_lmp(
             date,
@@ -676,7 +666,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get day-ahead hourly LMPs for all nodes."""
         return self._get_lmp(
             date,
@@ -686,17 +676,17 @@ class PJM(ISOBase):
             verbose=verbose,
         )
 
-    def _add_pnode_info_to_lmp_data(self, data: pd.DataFrame) -> pd.DataFrame:
+    def _add_pnode_info_to_lmp_data(self, data: pl.DataFrame) -> pl.DataFrame:
         # the pnode_name in the lmp data isn't always full name
         # so, let drop it for now
         # will get full name by merge with pnode data later
-        data = data.drop(columns=["pnode_name"])
+        data = data.drop("pnode_name")
 
-        p_nodes = self.get_pnode_ids()[
-            ["pnode_id", "pnode_name", "voltage_level", "pnode_short_name"]
-        ]
+        p_nodes = self.get_pnode_ids().select(
+            ["pnode_id", "pnode_name", "voltage_level", "pnode_short_name"],
+        )
 
-        data = data.merge(p_nodes, on="pnode_id")
+        data = data.join(p_nodes, on="pnode_id")
 
         return data
 
@@ -708,7 +698,7 @@ class PJM(ISOBase):
         locations: str | list | None = "hubs",
         location_type: str | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get real-time unverified 5-minute LMPs for a date range.
 
         Mirrors the output shape of ``get_lmp(market=REAL_TIME_5_MIN)`` but
@@ -753,24 +743,26 @@ class PJM(ISOBase):
             interval_duration_min=5,
         )
 
-        data["system_energy_price_rt"] = (
-            data["total_lmp_rt"]
-            - data["congestion_price_rt"]
-            - data["marginal_loss_price_rt"]
+        data = data.with_columns(
+            (
+                pl.col("total_lmp_rt")
+                - pl.col("congestion_price_rt")
+                - pl.col("marginal_loss_price_rt")
+            ).alias("system_energy_price_rt"),
         )
 
-        data = data.rename(columns={"type": "Location Type"})
+        data = data.rename({"type": "Location Type"})
         if location_type:
-            data = data[data["Location Type"] == location_type]
+            data = data.filter(pl.col("Location Type") == location_type)
 
         if locations is not None and locations != "ALL":
-            data["Location"] = data["pnode_id"]
+            data = data.with_columns(pl.col("pnode_id").alias("Location"))
             data = utils.filter_lmp_locations(data, map(int, locations))
 
         data = self._add_pnode_info_to_lmp_data(data)
 
         data = data.rename(
-            columns={
+            {
                 "pnode_id": "Location Id",
                 "pnode_name": "Location Name",
                 "pnode_short_name": "Location Short Name",
@@ -780,9 +772,9 @@ class PJM(ISOBase):
                 "marginal_loss_price_rt": "Loss",
             },
         )
-        data["Market"] = Markets.REAL_TIME_5_MIN.value
+        data = data.with_columns(pl.lit(Markets.REAL_TIME_5_MIN.value).alias("Market"))
 
-        return data[
+        return data.select(
             [
                 "Time",
                 "Interval Start",
@@ -796,8 +788,8 @@ class PJM(ISOBase):
                 "Energy",
                 "Congestion",
                 "Loss",
-            ]
-        ].sort_values("Interval Start")
+            ],
+        ).sort("Interval Start")
 
     @support_date_range(frequency="365D")
     def get_lmp_real_time_unverified_hourly(
@@ -807,7 +799,7 @@ class PJM(ISOBase):
         locations: str | None = None,
         location_type: str | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get real-time unverified hourly LMPs"""
 
         params = {
@@ -834,20 +826,22 @@ class PJM(ISOBase):
         elif locations == "zones":
             locations = self.zone_node_ids
         if locations is not None and locations != "ALL":
-            data["Location"] = data["pnode_name"]
+            data = data.with_columns(pl.col("pnode_name").alias("Location"))
             data = utils.filter_lmp_locations(
                 data,
                 map(int, locations),
             )
 
-        data["system_energy_price_rt"] = (
-            data["total_lmp_rt"]
-            - data["congestion_price_rt"]
-            - data["marginal_loss_price_rt"]
+        data = data.with_columns(
+            (
+                pl.col("total_lmp_rt")
+                - pl.col("congestion_price_rt")
+                - pl.col("marginal_loss_price_rt")
+            ).alias("system_energy_price_rt"),
         )
 
         df = data.rename(
-            columns={
+            {
                 "pnode_name": "Location",
                 "type": "Location Type",
                 "total_lmp_rt": "LMP",
@@ -856,9 +850,9 @@ class PJM(ISOBase):
                 "marginal_loss_price_rt": "Loss",
             },
         )
-        df = df.sort_values("Interval Start").reset_index(drop=True)
+        df = df.sort("Interval Start")
 
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -868,8 +862,8 @@ class PJM(ISOBase):
                 "Energy",
                 "Congestion",
                 "Loss",
-            ]
-        ]
+            ],
+        )
 
     @support_date_range(frequency=None)
     def get_it_sced_lmp_5_min(
@@ -877,7 +871,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get 5 minute LMPs from the Integrated Forward Market (IFM)"""
 
         params = {
@@ -897,10 +891,10 @@ class PJM(ISOBase):
 
         df = self._add_pnode_info_to_lmp_data(df)
 
-        df.columns = df.columns.map(lambda x: x.replace("_", " ").title())
+        df = df.rename({c: c.replace("_", " ").title() for c in df.columns})
 
         df = df.rename(
-            columns={
+            {
                 "Case Approval Datetime Utc": "Case Approval Time",
                 "Itsced Lmp": "LMP",
                 "Pnode Id": "Location Id",
@@ -912,9 +906,11 @@ class PJM(ISOBase):
         )
 
         # LMP = Energy + Congestion + Loss so Energy = LMP - Congestion - Loss
-        df["Energy"] = df["LMP"] - df["Congestion"] - df["Loss"]
+        df = df.with_columns(
+            (pl.col("LMP") - pl.col("Congestion") - pl.col("Loss")).alias("Energy"),
+        )
 
-        df = df[
+        df = df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -926,13 +922,14 @@ class PJM(ISOBase):
                 "Energy",
                 "Congestion",
                 "Loss",
-            ]
-        ]
+            ],
+        )
 
-        df["Case Approval Time"] = pd.to_datetime(
-            df["Case Approval Time"],
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
+        df = df.with_columns(
+            pl.col("Case Approval Time")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone),
+        )
 
         return df
 
@@ -942,7 +939,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         df = self._get_pjm_json(
             "rt_fivemin_mnt_lmps",
             start=date,
@@ -959,8 +956,8 @@ class PJM(ISOBase):
 
     def _handle_settlements_verified_lmp_5_min(
         self,
-        data: pd.DataFrame,
-    ) -> pd.DataFrame:
+        data: pl.DataFrame,
+    ) -> pl.DataFrame:
         rename = {
             "Interval Start": "Interval Start",
             "Interval End": "Interval End",
@@ -976,12 +973,12 @@ class PJM(ISOBase):
             "marginal_loss_price_rt": "Loss",
         }
 
-        data = data.rename(columns=rename)[rename.values()]
+        data = data.rename(rename).select(list(rename.values()))
 
         for col in ["Location Type", "Zone"]:
-            data[col] = data[col].astype("category")
+            data = data.with_columns(pl.col(col).cast(pl.Categorical))
 
-        return data.sort_values(["Interval Start", "Location Name"])
+        return data.sort(["Interval Start", "Location Name"])
 
     @support_date_range(frequency=None)
     def get_settlements_verified_lmp_hourly(
@@ -989,7 +986,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         df = self._get_pjm_json(
             "rt_da_monthly_lmps",
             start=date,
@@ -1006,8 +1003,8 @@ class PJM(ISOBase):
 
     def _handle_settlements_verified_lmp_hourly(
         self,
-        data: pd.DataFrame,
-    ) -> pd.DataFrame:
+        data: pl.DataFrame,
+    ) -> pl.DataFrame:
         rename = {
             "Interval Start": "Interval Start",
             "Interval End": "Interval End",
@@ -1027,12 +1024,12 @@ class PJM(ISOBase):
             "marginal_loss_price_da": "Loss DA",
         }
 
-        data = data.rename(columns=rename)[rename.values()]
+        data = data.rename(rename).select(list(rename.values()))
 
         for col in ["Location Type", "Zone"]:
-            data[col] = data[col].astype("category")
+            data = data.with_columns(pl.col(col).cast(pl.Categorical))
 
-        return data.sort_values(["Interval Start", "Location Name"])
+        return data.sort(["Interval Start", "Location Name"])
 
     def _make_api_call(
         self,
@@ -1138,7 +1135,7 @@ class PJM(ISOBase):
         if r["totalRows"] == 0:
             raise NoDataFoundException(f"No data found for {endpoint}")
 
-        df = pd.DataFrame(r["items"])
+        df = pl.from_dicts(r["items"])
 
         num_pages = math.ceil(r["totalRows"] / row_count)
         if num_pages > 1:
@@ -1151,52 +1148,47 @@ class PJM(ISOBase):
                         "Ocp-Apim-Subscription-Key": self.api_key,
                     },
                 )
-                to_add.append(pd.DataFrame(r["items"]))
+                to_add.append(pl.from_dicts(r["items"]))
 
-            df = pd.concat(to_add)
+            df = pl.concat(to_add, how="diagonal")
 
         if "datetime_beginning_utc" in df.columns:
-            df["Interval Start"] = (
-                # Some datetimes from the source have milliseconds. Parsing these
-                # requires specifying the format.
-                pd.to_datetime(df["datetime_beginning_utc"], format="ISO8601")
-                .dt.tz_localize(
-                    "UTC",
-                )
-                .dt.tz_convert(self.default_timezone)
+            df = df.with_columns(
+                pl.col("datetime_beginning_utc")
+                .str.to_datetime(time_zone="UTC")
+                .dt.convert_time_zone(self.default_timezone)
+                .alias("Interval Start"),
             )
 
-            # drop datetime_beginning_utc
-            df = df.drop(columns=["datetime_beginning_utc"])
+            df = df.drop("datetime_beginning_utc")
 
-            # PJM API is inclusive of end,
-            # so we need to drop where end timestamp is included
             if end is not None:
-                df = df[
-                    df["Interval Start"].dt.strftime(
-                        "%Y-%m-%d %H:%M",
-                    )
-                    != end.strftime("%Y-%m-%d %H:%M")
-                ]
-
-            if "datetime_ending_utc" in df.columns:
-                df["Interval End"] = (
-                    pd.to_datetime(df["datetime_ending_utc"], format="ISO8601")
-                    .dt.tz_localize(
-                        "UTC",
-                    )
-                    .dt.tz_convert(self.default_timezone)
+                end_str = end.strftime("%Y-%m-%d %H:%M")
+                df = df.filter(
+                    pl.col("Interval Start").dt.strftime("%Y-%m-%d %H:%M") != end_str,
                 )
 
-                # drop datetime_ending_utc
-                df = df.drop(columns=["datetime_ending_utc"])
+            if "datetime_ending_utc" in df.columns:
+                df = df.with_columns(
+                    pl.col("datetime_ending_utc")
+                    .str.to_datetime(time_zone="UTC")
+                    .dt.convert_time_zone(self.default_timezone)
+                    .alias("Interval End"),
+                )
+                df = df.drop("datetime_ending_utc")
             elif interval_duration_min:
-                df["Interval End"] = df["Interval Start"] + pd.Timedelta(
-                    minutes=interval_duration_min,
+                if interval_duration_min < 1:
+                    duration_expr = pl.duration(
+                        seconds=int(interval_duration_min * 60),
+                    )
+                else:
+                    duration_expr = pl.duration(minutes=int(interval_duration_min))
+                df = df.with_columns(
+                    (pl.col("Interval Start") + duration_expr).alias("Interval End"),
                 )
 
         if "Interval Start" in df.columns:
-            df["Time"] = df["Interval Start"]
+            df = df.with_columns(pl.col("Interval Start").alias("Time"))
 
         return df
 
@@ -1215,11 +1207,13 @@ class PJM(ISOBase):
         )
         return utils.get_response_blob(response)
 
-    def get_interconnection_queue(self, verbose: bool = False) -> pd.DataFrame:
+    def get_interconnection_queue(self, verbose: bool = False) -> pl.DataFrame:
         raw_data = self.get_raw_interconnection_queue(verbose)
-        queue = pd.read_excel(raw_data)
+        queue = utils.read_excel_via_pandas(raw_data)
 
-        queue["Capacity (MW)"] = queue[["MFO", "MW In Service"]].min(axis=1)
+        queue = queue.with_columns(
+            pl.min_horizontal("MFO", "MW In Service").alias("Capacity (MW)"),
+        )
 
         rename = {
             "Project ID": "Queue ID",
@@ -1278,7 +1272,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the hourly solar forecast including behind the meter solar forecast.
         From: https://dataminer2.pjm.com/feed/hourly_solar_power_forecast/definition
@@ -1290,7 +1284,7 @@ class PJM(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pd.DataFrame: A DataFrame with the solar forecast data.
+            pl.DataFrame: A DataFrame with the solar forecast data.
         """
 
         df = self._get_pjm_json(
@@ -1315,7 +1309,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the 5-min solar forecast including behind the meter solar forecast.
         From: https://dataminer2.pjm.com/feed/five_min_solar_power_forecast/definition
@@ -1327,7 +1321,7 @@ class PJM(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pd.DataFrame: A DataFrame with the solar forecast data.
+            pl.DataFrame: A DataFrame with the solar forecast data.
         """
 
         df = self._get_pjm_json(
@@ -1346,31 +1340,32 @@ class PJM(ISOBase):
 
         return self._parse_solar_forecast(df)
 
-    def _parse_solar_forecast(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _parse_solar_forecast(self, df: pl.DataFrame) -> pl.DataFrame:
         df = df.rename(
-            columns={
+            {
                 "evaluated_at_utc": "Publish Time",
                 "solar_forecast_btm_mwh": "Solar Forecast BTM",
                 "solar_forecast_mwh": "Solar Forecast",
             },
         )
 
-        df["Publish Time"] = pd.to_datetime(
-            df["Publish Time"],
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
+        df = df.with_columns(
+            pl.col("Publish Time")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone),
+        )
 
-        df = df[
+        df = df.select(
             [
                 "Interval Start",
                 "Interval End",
                 "Publish Time",
                 "Solar Forecast BTM",
                 "Solar Forecast",
-            ]
-        ]
+            ],
+        )
 
-        return df.sort_values("Interval Start").reset_index(drop=True)
+        return df.sort("Interval Start")
 
     @support_date_range(frequency=None)
     def get_wind_forecast_hourly(
@@ -1378,7 +1373,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the hourly wind forecast
         From: https://dataminer2.pjm.com/feed/hourly_wind_power_forecast/definition
@@ -1390,7 +1385,7 @@ class PJM(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pd.DataFrame: A DataFrame with the wind forecast data.
+            pl.DataFrame: A DataFrame with the wind forecast data.
         """
 
         df = self._get_pjm_json(
@@ -1415,7 +1410,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the 5-min wind forecast
         From: https://dataminer2.pjm.com/feed/five_min_wind_power_forecast/definition
@@ -1427,7 +1422,7 @@ class PJM(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pd.DataFrame: A DataFrame with the wind forecast data.
+            pl.DataFrame: A DataFrame with the wind forecast data.
         """
 
         df = self._get_pjm_json(
@@ -1446,29 +1441,30 @@ class PJM(ISOBase):
 
         return self._parse_wind_forecast(df)
 
-    def _parse_wind_forecast(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _parse_wind_forecast(self, df: pl.DataFrame) -> pl.DataFrame:
         df = df.rename(
-            columns={
+            {
                 "evaluated_at_utc": "Publish Time",
                 "wind_forecast_mwh": "Wind Forecast",
             },
         )
 
-        df["Publish Time"] = pd.to_datetime(
-            df["Publish Time"],
-            utc=True,
-        ).dt.tz_convert(self.default_timezone)
+        df = df.with_columns(
+            pl.col("Publish Time")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone),
+        )
 
-        df = df[
+        df = df.select(
             [
                 "Interval Start",
                 "Interval End",
                 "Publish Time",
                 "Wind Forecast",
-            ]
-        ]
+            ],
+        )
 
-        return df.sort_values("Interval Start").reset_index(drop=True)
+        return df.sort("Interval Start")
 
     @support_date_range(frequency=None)
     def get_gen_outages_by_type(
@@ -1476,7 +1472,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the generation outage data
         From: https://dataminer2.pjm.com/feed/gen_outages_by_type/definition
@@ -1497,9 +1493,9 @@ class PJM(ISOBase):
 
         return self._parse_gen_outages_by_type(df)
 
-    def _parse_gen_outages_by_type(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _parse_gen_outages_by_type(self, df: pl.DataFrame) -> pl.DataFrame:
         df = df.rename(
-            columns={
+            {
                 "forecast_execution_date_ept": "Publish Time",
                 "forecast_date": "Interval Start",
                 "region": "Region",
@@ -1510,11 +1506,17 @@ class PJM(ISOBase):
             },
         )
 
-        df["Interval Start"] = self.to_local_datetime(df, "Interval Start")
-        df["Interval End"] = df["Interval Start"] + pd.DateOffset(days=1)
-        df["Publish Time"] = self.to_local_datetime(df, "Publish Time")
+        df = df.with_columns(
+            self.to_local_datetime(df, "Interval Start").alias("Interval Start"),
+        )
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(days=1)).alias("Interval End"),
+        )
+        df = df.with_columns(
+            self.to_local_datetime(df, "Publish Time").alias("Publish Time"),
+        )
 
-        df = df[
+        df = df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -1524,10 +1526,10 @@ class PJM(ISOBase):
                 "Maintenance Outages MW",
                 "Forced Outages MW",
                 "Total Outages MW",
-            ]
-        ]
+            ],
+        )
 
-        return df.sort_values("Interval Start").reset_index(drop=True)
+        return df.sort("Interval Start")
 
     # Can retrieve a max of 365 days at a time.
     @support_date_range(frequency="365D")
@@ -1536,7 +1538,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """RTO-wide projected data for the peak of the day
 
         https://dataminer2.pjm.com/feed/ops_sum_frcst_peak_rto/definition
@@ -1561,17 +1563,21 @@ class PJM(ISOBase):
 
     def _handle_projected_rto_statistics_at_peak(
         self,
-        df: pd.DataFrame,
-    ) -> pd.DataFrame:
-        df["projected_peak_datetime_ept"] = pd.to_datetime(
-            df["projected_peak_datetime_ept"],
-        ).dt.tz_localize(self.default_timezone)
-        df["generated_at_ept"] = pd.to_datetime(df["generated_at_ept"]).dt.tz_localize(
-            self.default_timezone,
+        df: pl.DataFrame,
+    ) -> pl.DataFrame:
+        df = df.with_columns(
+            pl.col("projected_peak_datetime_ept")
+            .str.to_datetime()
+            .dt.replace_time_zone(self.default_timezone)
+            .alias("projected_peak_datetime_ept"),
+            pl.col("generated_at_ept")
+            .str.to_datetime()
+            .dt.replace_time_zone(self.default_timezone)
+            .alias("generated_at_ept"),
         )
 
         df = df.rename(
-            columns={
+            {
                 "projected_peak_datetime_ept": "Projected Peak Time",
                 "generated_at_ept": "Publish Time",
                 "area": "Area",
@@ -1583,17 +1589,21 @@ class PJM(ISOBase):
                 "operating_reserve": "Operating Reserve",
                 "unscheduled_steam_capacity": "Unscheduled Steam Capacity",
             },
-        ).drop(columns=["projected_peak_datetime_utc"])
+        ).drop(["projected_peak_datetime_utc"])
 
-        df["Interval Start"] = df["Projected Peak Time"].dt.floor("D")
-        df["Interval End"] = df["Interval Start"] + pd.DateOffset(days=1)
+        df = df.with_columns(
+            pl.col("Projected Peak Time").dt.truncate("1d").alias("Interval Start"),
+        )
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(days=1)).alias("Interval End"),
+        )
 
         df = utils.move_cols_to_front(
             df,
             ["Interval Start", "Interval End", "Publish Time"],
         )
 
-        return df.sort_values("Publish Time").reset_index(drop=True)
+        return df.sort("Publish Time")
 
     @support_date_range(frequency="365D")
     def get_projected_area_statistics_at_peak(
@@ -1601,7 +1611,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Area projected data for the peak of the day
 
         https://dataminer2.pjm.com/feed/ops_sum_frcst_peak_area/definition
@@ -1624,18 +1634,21 @@ class PJM(ISOBase):
 
     def _handle_projected_area_statistics_at_peak(
         self,
-        df: pd.DataFrame,
-    ) -> pd.DataFrame:
-        df["projected_peak_datetime_ept"] = pd.to_datetime(
-            df["projected_peak_datetime_ept"],
-        ).dt.tz_localize(self.default_timezone)
-
-        df["generated_at_ept"] = pd.to_datetime(df["generated_at_ept"]).dt.tz_localize(
-            self.default_timezone,
+        df: pl.DataFrame,
+    ) -> pl.DataFrame:
+        df = df.with_columns(
+            pl.col("projected_peak_datetime_ept")
+            .str.to_datetime()
+            .dt.replace_time_zone(self.default_timezone)
+            .alias("projected_peak_datetime_ept"),
+            pl.col("generated_at_ept")
+            .str.to_datetime()
+            .dt.replace_time_zone(self.default_timezone)
+            .alias("generated_at_ept"),
         )
 
         df = df.rename(
-            columns={
+            {
                 "projected_peak_datetime_ept": "Projected Peak Time",
                 "generated_at_ept": "Publish Time",
                 "area": "Area",
@@ -1643,21 +1656,29 @@ class PJM(ISOBase):
                 "pjm_load_forecast": "PJM Load Forecast",
                 "unscheduled_steam_capacity": "Unscheduled Steam Capacity",
             },
-        ).drop(columns=["projected_peak_datetime_utc"])
+        ).drop(["projected_peak_datetime_utc"])
 
-        df["Interval Start"] = df["Projected Peak Time"].dt.floor("D")
-        df["Interval End"] = df["Interval Start"] + pd.DateOffset(days=1)
+        df = df.with_columns(
+            pl.col("Projected Peak Time").dt.truncate("1d").alias("Interval Start"),
+        )
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(days=1)).alias("Interval End"),
+        )
 
         df = utils.move_cols_to_front(
             df,
             ["Interval Start", "Interval End", "Publish Time"],
         )
 
-        return df.sort_values("Publish Time").reset_index(drop=True)
+        return df.sort("Publish Time")
 
-    def to_local_datetime(self, df: pd.DataFrame, column_name: str) -> pd.Series:
-        return pd.to_datetime(df[column_name]).dt.tz_localize(
-            self.default_timezone,
+    def to_local_datetime(self, df: pl.DataFrame, column_name: str) -> pl.Expr:
+        return (
+            pl.col(column_name)
+            .str.to_datetime()
+            .dt.replace_time_zone(
+                self.default_timezone,
+            )
         )
 
     @support_date_range(frequency=None)
@@ -1666,7 +1687,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the 5 min solar generation data from:
         https://dataminer2.pjm.com/feed/five_min_solar_generation/definition
@@ -1679,7 +1700,7 @@ class PJM(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with 5 minute solar generation data.
+            polars.DataFrame: A DataFrame with 5 minute solar generation data.
         """
 
         df = self._get_pjm_json(
@@ -1697,22 +1718,22 @@ class PJM(ISOBase):
 
         return self._parse_solar_generation_5_min(df)
 
-    def _parse_solar_generation_5_min(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _parse_solar_generation_5_min(self, df: pl.DataFrame) -> pl.DataFrame:
         df = df.rename(
-            columns={
+            {
                 "solar_generation_mw": "Solar Generation",
             },
         )
 
-        df = df[
+        df = df.select(
             [
                 "Interval Start",
                 "Interval End",
                 "Solar Generation",
-            ]
-        ]
+            ],
+        )
 
-        return df.sort_values("Interval Start").reset_index(drop=True)
+        return df.sort("Interval Start")
 
     @support_date_range(frequency=None)
     def get_wind_generation_instantaneous(
@@ -1720,7 +1741,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the instantaneous wind generation data from:
         https://dataminer2.pjm.com/feed/instantaneous_wind_gen/definition
@@ -1733,7 +1754,7 @@ class PJM(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with instantaneous wind generation data
+            polars.DataFrame: A DataFrame with instantaneous wind generation data
                 in 15 second intervals.
         """
 
@@ -1752,22 +1773,22 @@ class PJM(ISOBase):
 
         return self._parse_wind_generation_instantaneous(df)
 
-    def _parse_wind_generation_instantaneous(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _parse_wind_generation_instantaneous(self, df: pl.DataFrame) -> pl.DataFrame:
         df = df.rename(
-            columns={
+            {
                 "wind_generation_mw": "Wind Generation",
             },
         )
 
-        df = df[
+        df = df.select(
             [
                 "Interval Start",
                 "Interval End",
                 "Wind Generation",
-            ]
-        ]
+            ],
+        )
 
-        return df.sort_values("Interval Start").reset_index(drop=True)
+        return df.sort("Interval Start")
 
     @support_date_range(frequency=None)
     def get_operational_reserves(
@@ -1775,7 +1796,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the reserve market quantities in Megawatts from:
         https://dataminer2.pjm.com/feed/operational_reserves/definition
@@ -1788,7 +1809,7 @@ class PJM(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with reserve market quantities
+            polars.DataFrame: A DataFrame with reserve market quantities
                 in 15 second intervals.
         """
 
@@ -1807,24 +1828,24 @@ class PJM(ISOBase):
 
         return self._parse_operational_reserves(df)
 
-    def _parse_operational_reserves(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _parse_operational_reserves(self, df: pl.DataFrame) -> pl.DataFrame:
         df = df.rename(
-            columns={
+            {
                 "reserve_name": "Reserve Name",
                 "reserve_mw": "Reserve",
             },
         )
 
-        df = df[
+        df = df.select(
             [
                 "Interval Start",
                 "Interval End",
                 "Reserve Name",
                 "Reserve",
-            ]
-        ]
+            ],
+        )
 
-        return df.sort_values("Interval Start").reset_index(drop=True)
+        return df.sort("Interval Start")
 
     @support_date_range(frequency=None)
     def get_transfer_interface_information_5_min(
@@ -1832,7 +1853,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the transfer interface information from:
         https://dataminer2.pjm.com/feed/transfer_interface_infor/definition
@@ -1845,7 +1866,7 @@ class PJM(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with transfer interface information
+            polars.DataFrame: A DataFrame with transfer interface information
             in 5 minute intervals.
         """
 
@@ -1866,10 +1887,10 @@ class PJM(ISOBase):
 
     def _parse_transfer_interface_information_5_min(
         self,
-        df: pd.DataFrame,
-    ) -> pd.DataFrame:
+        df: pl.DataFrame,
+    ) -> pl.DataFrame:
         df = df.rename(
-            columns={
+            {
                 "name": "Interface Name",
                 "actual_flow": "Actual Flow",
                 "warning_level": "Warning Level",
@@ -1877,7 +1898,7 @@ class PJM(ISOBase):
             },
         )
 
-        df = df[
+        df = df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -1885,10 +1906,10 @@ class PJM(ISOBase):
                 "Actual Flow",
                 "Warning Level",
                 "Transfer Limit",
-            ]
-        ]
+            ],
+        )
 
-        return df.sort_values("Interval Start").reset_index(drop=True)
+        return df.sort("Interval Start")
 
     @support_date_range(frequency=None)
     def get_transmission_limits(
@@ -1896,7 +1917,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the current transmission limit information from:
         https://dataminer2.pjm.com/feed/transfer_interface_infor/definition
@@ -1910,7 +1931,7 @@ class PJM(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with transmission limit information
+            polars.DataFrame: A DataFrame with transmission limit information
             in 5 minute intervals, when data is available.
         """
 
@@ -1931,12 +1952,12 @@ class PJM(ISOBase):
 
     def _parse_transmission_limits(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         df = df.rename(
-            columns={
+            {
                 "constraint_name": "Constraint Name",
                 "constraint_type": "Constraint Type",
                 "contingency": "Contingency",
@@ -1944,7 +1965,7 @@ class PJM(ISOBase):
             },
         )
 
-        df = df[
+        df = df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -1952,19 +1973,19 @@ class PJM(ISOBase):
                 "Constraint Type",
                 "Contingency",
                 "Shadow Price",
-            ]
-        ]
+            ],
+        )
 
         # When there are no binding constraints, PJM publishes rows with "Constraint
         # Name" == "none". We do not want to return these rows.
-        df = df[df["Constraint Name"] != "none"]
+        df = df.filter(pl.col("Constraint Name") != "none")
 
-        if df.empty:
+        if df.height == 0:
             raise NoDataFoundException(
                 f"No transmission limits found for {date} to {end}",
             )
 
-        return df.sort_values("Interval Start").reset_index(drop=True)
+        return df.sort("Interval Start")
 
     @support_date_range(frequency=None)
     def get_solar_generation_by_area(
@@ -1972,7 +1993,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the current solar generation information from:
         https://dataminer2.pjm.com/feed/solar_gen/definition
@@ -1985,7 +2006,7 @@ class PJM(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with solar generation information.
+            polars.DataFrame: A DataFrame with solar generation information.
         """
 
         df = self._get_pjm_json(
@@ -2003,15 +2024,15 @@ class PJM(ISOBase):
 
         return self._parse_solar_generation_by_area(df)
 
-    def _parse_solar_generation_by_area(self, df: pd.DataFrame) -> pd.DataFrame:
-        df = df.pivot_table(
+    def _parse_solar_generation_by_area(self, df: pl.DataFrame) -> pl.DataFrame:
+        df = df.pivot(
             index=["Time", "Interval Start", "Interval End"],
-            columns="area",
+            on="area",
             values="solar_generation_mw",
-            aggfunc="first",
-        ).reset_index()
+            aggregate_function="first",
+        )
 
-        df = df[
+        df = df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -2021,10 +2042,10 @@ class PJM(ISOBase):
                 "RTO",
                 "SOUTH",
                 "WEST",
-            ]
-        ]
+            ],
+        )
 
-        return df.sort_values("Interval Start").reset_index(drop=True)
+        return df.sort("Interval Start")
 
     @support_date_range(frequency=None)
     def get_wind_generation_by_area(
@@ -2045,7 +2066,7 @@ class PJM(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with wind generation information.
+            polars.DataFrame: A DataFrame with wind generation information.
         """
 
         df = self._get_pjm_json(
@@ -2063,22 +2084,21 @@ class PJM(ISOBase):
 
         return self._parse_wind_generation_by_area(df)
 
-    def _parse_wind_generation_by_area(self, df: pd.DataFrame) -> pd.DataFrame:
-        df = df.pivot_table(
+    def _parse_wind_generation_by_area(self, df: pl.DataFrame) -> pl.DataFrame:
+        df = df.pivot(
             index=["Time", "Interval Start", "Interval End"],
-            columns="area",
+            on="area",
             values="wind_generation_mw",
-            aggfunc="first",
-        ).reset_index()
+            aggregate_function="first",
+        )
 
         # SOUTH and OTHER columns did not exist at the start of the
         # data, but we want them to be present, so make sure they exist.
-        cols = ["SOUTH", "OTHER"]
-        for col in cols:
+        for col in ["SOUTH", "OTHER"]:
             if col not in df.columns:
-                df[col] = pd.NA
+                df = df.with_columns(pl.lit(None).cast(pl.Float64).alias(col))
 
-        df = df[
+        df = df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -2088,10 +2108,10 @@ class PJM(ISOBase):
                 "RTO",
                 "SOUTH",
                 "WEST",
-            ]
-        ]
+            ],
+        )
 
-        return df.sort_values("Interval Start").reset_index(drop=True)
+        return df.sort("Interval Start")
 
     @support_date_range(frequency=None)
     def get_dam_as_market_results(
@@ -2112,7 +2132,7 @@ class PJM(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with day-ahead ancillary service
+            polars.DataFrame: A DataFrame with day-ahead ancillary service
             market results.
         """
 
@@ -2132,9 +2152,9 @@ class PJM(ISOBase):
 
         return self._parse_dam_as_market_results(df)
 
-    def _parse_dam_as_market_results(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _parse_dam_as_market_results(self, df: pl.DataFrame) -> pl.DataFrame:
         df = df.rename(
-            columns={
+            {
                 "locale": "Locale",
                 "service": "Service Type",
                 "mcp": "Market Clearing Price",
@@ -2153,13 +2173,15 @@ class PJM(ISOBase):
         locale_full_name_to_abbreviation = {
             v: k for k, v in self.locale_abbreviated_to_full.items()
         }
-        df["Ancillary Service"] = (
-            df["Locale"].replace(locale_full_name_to_abbreviation)
-            + "-"
-            + df["Service Type"]
+        df = df.with_columns(
+            (
+                pl.col("Locale").replace(locale_full_name_to_abbreviation)
+                + "-"
+                + pl.col("Service Type")
+            ).alias("Ancillary Service"),
         )
 
-        df = df[
+        df = df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -2175,10 +2197,10 @@ class PJM(ISOBase):
                 "Interface Reserve Capability MW",
                 "Demand Response MW Assigned",
                 "Non-Synchronized Reserve MW Assigned",
-            ]
-        ]
+            ],
+        )
 
-        return df.sort_values("Interval Start").reset_index(drop=True)
+        return df.sort("Interval Start")
 
     @support_date_range(frequency=None)
     def get_real_time_as_market_results(
@@ -2203,7 +2225,7 @@ class PJM(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with real-time ancillary service
+            polars.DataFrame: A DataFrame with real-time ancillary service
             market results.
         """
 
@@ -2237,9 +2259,9 @@ class PJM(ISOBase):
 
         return self._parse_real_time_as_market_results(df)
 
-    def _parse_real_time_as_market_results(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _parse_real_time_as_market_results(self, df: pl.DataFrame) -> pl.DataFrame:
         df = df.rename(
-            columns={
+            {
                 "locale": "Locale",
                 "service": "Service Type",
                 "mcp": "Market Clearing Price",
@@ -2258,22 +2280,26 @@ class PJM(ISOBase):
             },
         )
         # Replace abbreviated locale values will full values
-        df = df.replace({"Locale": self.locale_abbreviated_to_full})
+        df = df.with_columns(pl.col("Locale").replace(self.locale_abbreviated_to_full))
 
         # Replace abbreviated service type values with full values
-        df = df.replace({"Service Type": self.service_type_abbreviated_to_full})
+        df = df.with_columns(
+            pl.col("Service Type").replace(self.service_type_abbreviated_to_full),
+        )
 
         # Add new Ancillary Service column
         locale_full_name_to_abbreviation = {
             v: k for k, v in self.locale_abbreviated_to_full.items()
         }
-        df["Ancillary Service"] = (
-            df["Locale"].replace(locale_full_name_to_abbreviation)
-            + "-"
-            + df["Service Type"]
+        df = df.with_columns(
+            (
+                pl.col("Locale").replace(locale_full_name_to_abbreviation)
+                + "-"
+                + pl.col("Service Type")
+            ).alias("Ancillary Service"),
         )
 
-        df = df[
+        df = df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -2293,10 +2319,10 @@ class PJM(ISOBase):
                 "Demand Response MW Assigned",
                 "Non-Synchronized Reserve MW Assigned",
                 "REGD MW",
-            ]
-        ]
+            ],
+        )
 
-        return df.sort_values("Interval Start").reset_index(drop=True)
+        return df.sort("Interval Start")
 
     @support_date_range(frequency=None)
     def get_as_market_results_real_time_hourly(
@@ -2380,9 +2406,9 @@ class PJM(ISOBase):
 
         return self._parse_load_metered_hourly(df)
 
-    def _parse_load_metered_hourly(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _parse_load_metered_hourly(self, df: pl.DataFrame) -> pl.DataFrame:
         df = df.rename(
-            columns={
+            {
                 "load_area": "Load Area",
                 "mkt_region": "Mkt Region",
                 "mw": "MW",
@@ -2392,7 +2418,7 @@ class PJM(ISOBase):
             },
         )
 
-        df = df[
+        df = df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -2402,10 +2428,10 @@ class PJM(ISOBase):
                 "Load Area",
                 "MW",
                 "Is Verified",
-            ]
-        ]
+            ],
+        )
 
-        return df.sort_values("Interval Start").reset_index(drop=True)
+        return df.sort("Interval Start")
 
     @support_date_range(frequency=None)
     def get_forecasted_generation_outages(
@@ -2434,9 +2460,9 @@ class PJM(ISOBase):
 
         return self._parse_forecasted_generation_outages(df)
 
-    def _parse_forecasted_generation_outages(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _parse_forecasted_generation_outages(self, df: pl.DataFrame) -> pl.DataFrame:
         df = df.rename(
-            columns={
+            {
                 "forecast_execution_date_ept": "Publish Time",
                 "forecast_date": "Interval Start",
                 "forecast_gen_outage_mw_rto": "RTO MW",
@@ -2445,11 +2471,17 @@ class PJM(ISOBase):
             },
         )
 
-        df["Interval Start"] = self.to_local_datetime(df, "Interval Start")
-        df["Interval End"] = df["Interval Start"] + pd.DateOffset(days=1)
-        df["Publish Time"] = self.to_local_datetime(df, "Publish Time")
+        df = df.with_columns(
+            self.to_local_datetime(df, "Interval Start").alias("Interval Start"),
+        )
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(days=1)).alias("Interval End"),
+        )
+        df = df.with_columns(
+            self.to_local_datetime(df, "Publish Time").alias("Publish Time"),
+        )
 
-        df = df[
+        df = df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -2457,10 +2489,10 @@ class PJM(ISOBase):
                 "RTO MW",
                 "West MW",
                 "Other MW",
-            ]
-        ]
+            ],
+        )
 
-        return df.sort_values("Interval Start").reset_index(drop=True)
+        return df.sort("Interval Start")
 
     @support_date_range(frequency=None)
     def get_marginal_value_real_time_5_min(
@@ -2468,7 +2500,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the marginal value data from:
         https://dataminer2.pjm.com/feed/rt_marginal_value/definition
@@ -2486,7 +2518,7 @@ class PJM(ISOBase):
         )
 
         df = df.rename(
-            columns={
+            {
                 "monitored_facility": "Monitored Facility",
                 "contingency_facility": "Contingency Facility",
                 "transmission_constraint_penalty_factor": "Transmission Constraint Penalty Factor",
@@ -2495,7 +2527,7 @@ class PJM(ISOBase):
             },
         )
 
-        df = df[
+        df = df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -2504,8 +2536,8 @@ class PJM(ISOBase):
                 "Transmission Constraint Penalty Factor",
                 "Limit Control Percentage",
                 "Shadow Price",
-            ]
-        ]
+            ],
+        )
         return df
 
     @support_date_range(frequency=None)
@@ -2514,7 +2546,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the marginal value data from:
         https://dataminer2.pjm.com/feed/da_marginal_value/definition
@@ -2531,21 +2563,21 @@ class PJM(ISOBase):
             verbose=verbose,
         )
         df = df.rename(
-            columns={
+            {
                 "monitored_facility": "Monitored Facility",
                 "contingency_facility": "Contingency Facility",
                 "shadow_price": "Shadow Price",
             },
         )
-        df = df[
+        df = df.select(
             [
                 "Interval Start",
                 "Interval End",
                 "Monitored Facility",
                 "Contingency Facility",
                 "Shadow Price",
-            ]
-        ]
+            ],
+        )
         return df
 
     @support_date_range(frequency=None)
@@ -2554,7 +2586,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the transmission constraints data from:
         https://dataminer2.pjm.com/feed/da_transconstraints/definition
@@ -2571,14 +2603,14 @@ class PJM(ISOBase):
             verbose=verbose,
         )
         df = df.rename(
-            columns={
+            {
                 "duration": "Duration",
                 "day_ahead_congestion_event": "Day Ahead Congestion Event",
                 "monitored_facility": "Monitored Facility",
                 "contingency_facility": "Contingency Facility",
             },
         )
-        df = df[
+        df = df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -2586,8 +2618,8 @@ class PJM(ISOBase):
                 "Day Ahead Congestion Event",
                 "Monitored Facility",
                 "Contingency Facility",
-            ]
-        ]
+            ],
+        )
         return df
 
     @support_date_range(frequency=None)
@@ -2596,7 +2628,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the day ahead demand bids data from:
         https://dataminer2.pjm.com/feed/hrl_dmd_bids/definition
@@ -2613,13 +2645,13 @@ class PJM(ISOBase):
             interval_duration_min=60,
             verbose=verbose,
         ).rename(
-            columns={
+            {
                 "hrly_da_demand_bid": "Demand Bid",
                 "area": "Area",
             },
         )
 
-        df = df[["Interval Start", "Interval End", "Area", "Demand Bid"]].sort_values(
+        df = df.select(["Interval Start", "Interval End", "Area", "Demand Bid"]).sort(
             ["Interval Start", "Area"],
         )
 
@@ -2631,7 +2663,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the area control error data from:
         https://dataminer2.pjm.com/feed/area_control_error/definition
@@ -2647,11 +2679,11 @@ class PJM(ISOBase):
             verbose=verbose,
         )
         df = df.rename(
-            columns={
+            {
                 "ace_mw": "Area Control Error",
             },
         )
-        return df[["Time", "Area Control Error"]]
+        return df.select(["Time", "Area Control Error"])
 
     @support_date_range(frequency=None)
     def get_dispatched_reserves_prelim(
@@ -2659,7 +2691,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the dispatched reserves preliminary data from:
         https://dataminer2.pjm.com/feed/dispatched_reserves/definition
@@ -2677,7 +2709,7 @@ class PJM(ISOBase):
         )
 
         df = df.rename(
-            columns={
+            {
                 "area": "Area",
                 "reserve_type": "Reserve Type",
                 "reserve_quantity": "Reserve Quantity",
@@ -2690,12 +2722,18 @@ class PJM(ISOBase):
             },
         )
 
-        df["Area"] = df["Area"].str.replace("Mid-Atlantic/Dominion", "MAD")
-        df["Ancillary Service"] = df["Area"] + "-" + df["Reserve Type"]
+        df = df.with_columns(
+            pl.col("Area").str.replace("Mid-Atlantic/Dominion", "MAD"),
+            (
+                pl.col("Area").str.replace("Mid-Atlantic/Dominion", "MAD")
+                + "-"
+                + pl.col("Reserve Type")
+            ).alias("Ancillary Service"),
+        )
 
-        df = df.replace({"Area": self.locale_abbreviated_to_full})
+        df = df.with_columns(pl.col("Area").replace(self.locale_abbreviated_to_full))
 
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -2709,8 +2747,8 @@ class PJM(ISOBase):
                 "MW Adjustment",
                 "Market Clearing Price",
                 "Shortage Indicator",
-            ]
-        ]
+            ],
+        )
 
     @support_date_range(frequency=None)
     def get_dispatched_reserves_verified(
@@ -2718,7 +2756,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the dispatched reserves verified data from:
         https://dataminer2.pjm.com/feed/rt_dispatch_reserves/definition
@@ -2736,7 +2774,7 @@ class PJM(ISOBase):
         )
 
         df = df.rename(
-            columns={
+            {
                 "area": "Area",
                 "reserve_type": "Reserve Type",
                 "total_reserve_mw": "Total Reserve",
@@ -2750,11 +2788,15 @@ class PJM(ISOBase):
         full_name_to_abbreviation = {
             v: k for k, v in self.locale_abbreviated_to_full.items()
         }
-        df["Ancillary Service"] = (
-            df["Area"].replace(full_name_to_abbreviation) + "-" + df["Reserve Type"]
+        df = df.with_columns(
+            (
+                pl.col("Area").replace(full_name_to_abbreviation)
+                + "-"
+                + pl.col("Reserve Type")
+            ).alias("Ancillary Service"),
         )
 
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -2767,8 +2809,8 @@ class PJM(ISOBase):
                 "Extended Requirement",
                 "Additional Extended Requirement",
                 "Deficit",
-            ]
-        ]
+            ],
+        )
 
     @support_date_range(frequency=None)
     def get_regulation_market_monthly(
@@ -2776,7 +2818,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the PJM Regulation Market Monthly data from:
         https://dataminer2.pjm.com/feed/reg_market_results/definition
@@ -2792,9 +2834,11 @@ class PJM(ISOBase):
             interval_duration_min=60,
             verbose=verbose,
         )
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(minutes=60)
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(minutes=60)).alias("Interval End"),
+        )
         df = df.rename(
-            columns={
+            {
                 "datetime_beginning_utc": "Interval Start",
                 "rega_procure": "RegA Procure",
                 "regd_procure": "RegD Procure",
@@ -2813,29 +2857,26 @@ class PJM(ISOBase):
             },
         )
 
-        df = df.astype(
-            {
-                "RegD SSMW": float,
-                "RegA SSMW": float,
-                "RegD Procure": float,
-                "RegA Procure": float,
-                "Total MW": float,
-                "Deficiency": float,
-                "RTO Perfscore": float,
-                "RegA Mileage": float,
-                "RegD Mileage": float,
-                "RegA Hourly": float,
-                "RegD Hourly": float,
-                "Is Approved": int,
-            },
+        df = df.with_columns(
+            pl.col("RegD SSMW").cast(pl.Float64),
+            pl.col("RegA SSMW").cast(pl.Float64),
+            pl.col("RegD Procure").cast(pl.Float64),
+            pl.col("RegA Procure").cast(pl.Float64),
+            pl.col("Total MW").cast(pl.Float64),
+            pl.col("Deficiency").cast(pl.Float64),
+            pl.col("RTO Perfscore").cast(pl.Float64),
+            pl.col("RegA Mileage").cast(pl.Float64),
+            pl.col("RegD Mileage").cast(pl.Float64),
+            pl.col("RegA Hourly").cast(pl.Float64),
+            pl.col("RegD Hourly").cast(pl.Float64),
+            pl.col("Is Approved").cast(pl.Int64),
         )
 
-        df["Modified Datetime UTC"] = pd.to_datetime(
-            df["Modified Datetime UTC"],
-            utc=True,
+        df = df.with_columns(
+            pl.col("Modified Datetime UTC").str.to_datetime(time_zone="UTC"),
         )
 
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -2853,8 +2894,8 @@ class PJM(ISOBase):
                 "RegD Hourly",
                 "Is Approved",
                 "Modified Datetime UTC",
-            ]
-        ]
+            ],
+        )
 
     @support_date_range(frequency=None)
     def get_regulation_prices_5_min(
@@ -2862,7 +2903,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves 5-minute regulation pricing data from:
         https://api.pjm.com/api/v1/reg_prices
@@ -2884,7 +2925,7 @@ class PJM(ISOBase):
         )
 
         df = df.rename(
-            columns={
+            {
                 "area": "Area",
                 "reserve_quantity": "Regulation Quantity",
                 "reserve_requirement": "Regulation Requirement",
@@ -2895,7 +2936,7 @@ class PJM(ISOBase):
             },
         )
 
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -2906,8 +2947,8 @@ class PJM(ISOBase):
                 "Market Capped Clearing Price",
                 "Capability Clearing Price",
                 "Performance Clearing Price",
-            ]
-        ]
+            ],
+        )
 
     @support_date_range(frequency=None)
     def get_tie_flows_5_min(
@@ -2915,7 +2956,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the PJM Tie Flows 5 Minute data from:
         https://dataminer2.pjm.com/feed/tie_flows/definition
@@ -2932,7 +2973,7 @@ class PJM(ISOBase):
             verbose=verbose,
         )
         df = df.rename(
-            columns={
+            {
                 "tie_flow_name": "Tie Flow Name",
                 "actual_mw": "Actual",
                 "scheduled_mw": "Scheduled",
@@ -2942,20 +2983,20 @@ class PJM(ISOBase):
         # NB: The data has an extra second on each timestamp like 2025-05-20 12:00:01,
         # so we need to floor to the minute. The flooring needs to be done on UTC
         # timestamps to avoid DST transition issues
-        df["Interval Start"] = (
-            pd.to_datetime(df["Interval Start"], utc=True)
-            .dt.floor("min")
-            .dt.tz_convert(self.default_timezone)
-        )
-        df["Interval End"] = (
-            pd.to_datetime(df["Interval End"], utc=True)
-            .dt.floor("min")
-            .dt.tz_convert(self.default_timezone)
+        df = df.with_columns(
+            pl.col("Interval Start")
+            .dt.convert_time_zone("UTC")
+            .dt.truncate("1m")
+            .dt.convert_time_zone(self.default_timezone),
+            pl.col("Interval End")
+            .dt.convert_time_zone("UTC")
+            .dt.truncate("1m")
+            .dt.convert_time_zone(self.default_timezone),
         )
 
-        return df[
-            ["Interval Start", "Interval End", "Tie Flow Name", "Actual", "Scheduled"]
-        ]
+        return df.select(
+            ["Interval Start", "Interval End", "Tie Flow Name", "Actual", "Scheduled"],
+        )
 
     @support_date_range(frequency=None)
     def get_instantaneous_dispatch_rates(
@@ -2963,7 +3004,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the instantaneous dispatch rate data from:
         https://dataminer2.pjm.com/feed/inst_dispatch_rate/definition
@@ -2981,22 +3022,18 @@ class PJM(ISOBase):
         )
 
         df = df.rename(
-            columns={"zone": "Zone", "dispatch_rate": "Instantaneous Dispatch Rate"},
+            {"zone": "Zone", "dispatch_rate": "Instantaneous Dispatch Rate"},
         )
 
-        return (
-            df[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Zone",
-                    "Instantaneous Dispatch Rate",
-                ]
-            ]
-            .sort_values(
+        return df.select(
+            [
                 "Interval Start",
-            )
-            .reset_index(drop=True)
+                "Interval End",
+                "Zone",
+                "Instantaneous Dispatch Rate",
+            ],
+        ).sort(
+            "Interval Start",
         )
 
     @support_date_range(frequency=None)
@@ -3005,7 +3042,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the hourly net exports by state data from:
         https://dataminer2.pjm.com/feed/state_net_interchange/definition
@@ -3022,12 +3059,12 @@ class PJM(ISOBase):
             verbose=verbose,
         )
         df = df.rename(
-            columns={
+            {
                 "state": "State",
                 "net_interchange": "Net Interchange",
             },
         )
-        return df[["Interval Start", "Interval End", "State", "Net Interchange"]]
+        return df.select(["Interval Start", "Interval End", "State", "Net Interchange"])
 
     @support_date_range(frequency=None)
     def get_hourly_transfer_limits_and_flows(
@@ -3035,7 +3072,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the hourly transfer limits and flows data from:
         https://dataminer2.pjm.com/feed/transfer_limits_and_flows/definition
@@ -3052,21 +3089,21 @@ class PJM(ISOBase):
             verbose=verbose,
         )
         df = df.rename(
-            columns={
+            {
                 "transfer_limit_area": "Transfer Limit Area",
                 "transfers": "Average Transfers",
                 "transfer_limit": "Average Transfer Limit",
             },
         )
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
                 "Transfer Limit Area",
                 "Average Transfers",
                 "Average Transfer Limit",
-            ]
-        ]
+            ],
+        )
 
     @support_date_range(frequency=None)
     def get_actual_and_scheduled_interchange_summary(
@@ -3074,7 +3111,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the actual and scheduled interchange summary data from:
         https://dataminer2.pjm.com/feed/actual_and_scheduled_interchange_summary/definition
@@ -3091,14 +3128,14 @@ class PJM(ISOBase):
             verbose=verbose,
         )
         df = df.rename(
-            columns={
+            {
                 "tie_line": "Tie Line",
                 "actual_flow": "Actual Flow",
                 "sched_flow": "Scheduled Flow",
                 "inadv_flow": "Inadvertent Flow",
             },
         )
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -3106,8 +3143,8 @@ class PJM(ISOBase):
                 "Actual Flow",
                 "Scheduled Flow",
                 "Inadvertent Flow",
-            ]
-        ]
+            ],
+        )
 
     @support_date_range(frequency=None)
     def get_scheduled_interchange_real_time(
@@ -3115,7 +3152,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the scheduled interchange real time data from:
         https://dataminer2.pjm.com/feed/rt_scheduled_interchange/definition
@@ -3132,14 +3169,14 @@ class PJM(ISOBase):
             verbose=verbose,
         )
         df = df.rename(
-            columns={
+            {
                 "tie_line": "Tie Line",
                 "hrly_net_tie_sched": "Hourly Net Tie Schedule",
             },
-        ).sort_values("Interval Start")
-        return df[
-            ["Interval Start", "Interval End", "Tie Line", "Hourly Net Tie Schedule"]
-        ]
+        ).sort("Interval Start")
+        return df.select(
+            ["Interval Start", "Interval End", "Tie Line", "Hourly Net Tie Schedule"],
+        )
 
     @support_date_range(frequency=None)
     def get_interface_flows_and_limits_day_ahead(
@@ -3147,7 +3184,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the interface flows and limit day ahead data from:
         https://dataminer2.pjm.com/feed/da_interface_flows_and_limits/definition
@@ -3164,15 +3201,15 @@ class PJM(ISOBase):
             verbose=verbose,
         )
         df = df.rename(
-            columns={
+            {
                 "interface_limit_name": "Interface Limit Name",
                 "flow_mw": "Flow",
                 "limit_mw": "Limit",
             },
         )
-        return df[
-            ["Interval Start", "Interval End", "Interface Limit Name", "Flow", "Limit"]
-        ]
+        return df.select(
+            ["Interval Start", "Interval End", "Interface Limit Name", "Flow", "Limit"],
+        )
 
     @support_date_range(frequency=None)
     def get_projected_peak_tie_flow(
@@ -3180,7 +3217,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the projected peak tie flow data from:
         https://dataminer2.pjm.com/feed/ops_sum_prjctd_tie_flow/definition
@@ -3198,28 +3235,30 @@ class PJM(ISOBase):
             filter_timestamp_name="generated_at",
         )
 
-        df["Publish Time"] = pd.to_datetime(df["generated_at_ept"]).dt.tz_localize(
-            self.default_timezone,
+        df = df.with_columns(
+            pl.col("generated_at_ept")
+            .str.to_datetime()
+            .dt.replace_time_zone(self.default_timezone)
+            .alias("Publish Time"),
+            pl.col("projected_peak_datetime_utc")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Projected Peak Time"),
         )
 
-        df["Projected Peak Time"] = (
-            pd.to_datetime(
-                df["projected_peak_datetime_utc"],
-                format="ISO8601",
-            )
-            .dt.tz_localize("UTC")
-            .dt.tz_convert(self.default_timezone)
+        df = df.with_columns(
+            pl.col("Projected Peak Time").dt.truncate("1d").alias("Interval Start"),
         )
-
-        df["Interval Start"] = df["Projected Peak Time"].dt.floor("D")
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(days=1)
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(days=1)).alias("Interval End"),
+        )
         df = df.rename(
-            columns={
+            {
                 "interface": "Interface",
                 "scheduled_tie_flow": "Scheduled Tie Flow",
             },
         )
-        return df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -3227,8 +3266,8 @@ class PJM(ISOBase):
                 "Projected Peak Time",
                 "Interface",
                 "Scheduled Tie Flow",
-            ]
-        ]
+            ],
+        )
 
     @support_date_range(frequency=None)
     def get_actual_operational_statistics(
@@ -3236,7 +3275,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the actual operational statistics data from:
         https://dataminer2.pjm.com/feed/ops_sum_prev_period/definition
@@ -3254,7 +3293,7 @@ class PJM(ISOBase):
         )
 
         df = df.rename(
-            columns={
+            {
                 "generated_at_ept": "Publish Time",
                 "area": "Area",
                 "area_load_forecast": "Area Load Forecast",
@@ -3262,60 +3301,59 @@ class PJM(ISOBase):
                 "dispatch_rate": "Dispatch Rate",
             },
         )
-        df["Publish Time"] = pd.to_datetime(df["Publish Time"]).dt.tz_localize(
-            self.default_timezone,
+        df = df.with_columns(
+            pl.col("Publish Time")
+            .str.to_datetime()
+            .dt.replace_time_zone(self.default_timezone),
         )
 
-        return (
-            df[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Publish Time",
-                    "Area",
-                    "Area Load Forecast",
-                    "Actual Load",
-                    "Dispatch Rate",
-                ]
-            ]
-            .sort_values(["Interval Start", "Area"])
-            .reset_index(drop=True)
-        )
+        return df.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "Publish Time",
+                "Area",
+                "Area Load Forecast",
+                "Actual Load",
+                "Dispatch Rate",
+            ],
+        ).sort(["Interval Start", "Area"])
 
     def _filter_active_records(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         as_of: pd.Timestamp | None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Filter out records that are terminated before the given date"""
-        df["Effective Date"] = pd.to_datetime(
-            df["Effective Date"],
-            errors="coerce",
-        ).dt.tz_localize(
-            self.default_timezone,
+        df = df.with_columns(
+            pl.col("Effective Date")
+            .str.to_datetime(strict=False)
+            .dt.replace_time_zone(self.default_timezone)
+            .alias("Effective Date"),
+            pl.when(pl.col("Termination Date") == "9999-12-31T00:00:00")
+            .then(None)
+            .otherwise(pl.col("Termination Date"))
+            .alias("Termination Date"),
         )
-
-        df["Termination Date"] = df["Termination Date"].replace(
-            "9999-12-31T00:00:00",
-            None,
-        )
-        df["Termination Date"] = pd.to_datetime(
-            df["Termination Date"],
-            errors="coerce",
-        ).dt.tz_localize(
-            self.default_timezone,
+        df = df.with_columns(
+            pl.col("Termination Date")
+            .str.to_datetime(strict=False)
+            .dt.replace_time_zone(self.default_timezone)
+            .alias("Termination Date"),
         )
 
         if as_of is None:
             return df
 
-        return df[(df["Termination Date"].isna()) | (df["Termination Date"] > as_of)]
+        return df.filter(
+            pl.col("Termination Date").is_null() | (pl.col("Termination Date") > as_of),
+        )
 
     def get_pricing_nodes(
         self,
         as_of: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the pricing nodes data from:
         https://dataminer2.pjm.com/feed/pnode/definition
@@ -3337,7 +3375,7 @@ class PJM(ISOBase):
         )
 
         df = df.rename(
-            columns={
+            {
                 "pnode_id": "Pricing Node ID",
                 "pnode_name": "Pricing Node Name",
                 "pnode_type": "Pricing Node Type",
@@ -3351,28 +3389,24 @@ class PJM(ISOBase):
 
         df = self._filter_active_records(df, as_of)
 
-        return (
-            df[
-                [
-                    "Pricing Node ID",
-                    "Pricing Node Name",
-                    "Pricing Node Type",
-                    "Pricing Node SubType",
-                    "Zone",
-                    "Voltage Level",
-                    "Effective Date",
-                    "Termination Date",
-                ]
-            ]
-            .sort_values(["Effective Date", "Pricing Node Name"])
-            .reset_index(drop=True)
-        )
+        return df.select(
+            [
+                "Pricing Node ID",
+                "Pricing Node Name",
+                "Pricing Node Type",
+                "Pricing Node SubType",
+                "Zone",
+                "Voltage Level",
+                "Effective Date",
+                "Termination Date",
+            ],
+        ).sort(["Effective Date", "Pricing Node Name"])
 
     def get_reserve_subzone_resources(
         self,
         as_of: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the reserve subzone resources data from:
         https://dataminer2.pjm.com/feed/sync_pri_reserves_resources_list/definition
@@ -3394,7 +3428,7 @@ class PJM(ISOBase):
         )
 
         df = df.rename(
-            columns={
+            {
                 "effective_date": "Effective Date",
                 "terminate_date": "Termination Date",
                 "subzone": "Subzone",
@@ -3407,27 +3441,23 @@ class PJM(ISOBase):
 
         df = self._filter_active_records(df, as_of)
 
-        return (
-            df[
-                [
-                    "Resource ID",
-                    "Resource Name",
-                    "Resource Type",
-                    "Zone",
-                    "Subzone",
-                    "Effective Date",
-                    "Termination Date",
-                ]
-            ]
-            .sort_values("Effective Date")
-            .reset_index(drop=True)
-        )
+        return df.select(
+            [
+                "Resource ID",
+                "Resource Name",
+                "Resource Type",
+                "Zone",
+                "Subzone",
+                "Effective Date",
+                "Termination Date",
+            ],
+        ).sort("Effective Date")
 
     def get_reserve_subzone_buses(
         self,
         as_of: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the reserve subzone buses data from:
         https://dataminer2.pjm.com/feed/sync_pri_reserves_buses_list/definition
@@ -3449,7 +3479,7 @@ class PJM(ISOBase):
         )
 
         df = df.rename(
-            columns={
+            {
                 "effective_date": "Effective Date",
                 "terminate_date": "Termination Date",
                 "subzone": "Subzone",
@@ -3460,26 +3490,22 @@ class PJM(ISOBase):
         )
 
         df = self._filter_active_records(df, as_of)
-        return (
-            df[
-                [
-                    "Pricing Node ID",
-                    "Pricing Node Name",
-                    "Pricing Node Type",
-                    "Subzone",
-                    "Effective Date",
-                    "Termination Date",
-                ]
-            ]
-            .sort_values(["Effective Date", "Pricing Node Name"])
-            .reset_index(drop=True)
-        )
+        return df.select(
+            [
+                "Pricing Node ID",
+                "Pricing Node Name",
+                "Pricing Node Type",
+                "Subzone",
+                "Effective Date",
+                "Termination Date",
+            ],
+        ).sort(["Effective Date", "Pricing Node Name"])
 
     def get_weight_average_aggregation_definition(
         self,
         as_of: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the weight average aggregation definition data from:
         https://dataminer2.pjm.com/feed/agg_definitions/definition
@@ -3502,7 +3528,7 @@ class PJM(ISOBase):
         )
 
         df = df.rename(
-            columns={
+            {
                 "effective_date_ept": "Effective Date",
                 "terminate_date_ept": "Termination Date",
                 "agg_pnode_id": "Aggregate Node ID",
@@ -3515,21 +3541,17 @@ class PJM(ISOBase):
 
         df = self._filter_active_records(df, as_of)
 
-        return (
-            df[
-                [
-                    "Aggregate Node ID",
-                    "Aggregate Node Name",
-                    "Bus Node ID",
-                    "Bus Node Name",
-                    "Bus Node Factor",
-                    "Effective Date",
-                    "Termination Date",
-                ]
-            ]
-            .sort_values(["Effective Date", "Aggregate Node Name"])
-            .reset_index(drop=True)
-        )
+        return df.select(
+            [
+                "Aggregate Node ID",
+                "Aggregate Node Name",
+                "Bus Node ID",
+                "Bus Node Name",
+                "Bus Node Factor",
+                "Effective Date",
+                "Termination Date",
+            ],
+        ).sort(["Effective Date", "Aggregate Node Name"])
 
     @support_date_range(frequency=None)
     def get_generation_capacity_daily(
@@ -3537,7 +3559,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the daily generation capacity data from:
         https://dataminer2.pjm.com/feed/day_gen_capacity/definition
@@ -3554,34 +3576,33 @@ class PJM(ISOBase):
             verbose=verbose,
         )
 
-        df["Interval Start"] = (
-            pd.to_datetime(df["bid_datetime_beginning_utc"], format="ISO8601")
-            .dt.tz_localize("UTC")
-            .dt.tz_convert(self.default_timezone)
+        df = df.with_columns(
+            pl.col("bid_datetime_beginning_utc")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Interval Start"),
         )
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(hours=1)
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(hours=1)).alias("Interval End"),
+        )
 
         df = df.rename(
-            columns={
+            {
                 "eco_max": "Economic Max MW",
                 "emerg_max": "Emergency Max MW",
                 "total_committed": "Total Committed MW",
             },
         )
 
-        return (
-            df[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Economic Max MW",
-                    "Emergency Max MW",
-                    "Total Committed MW",
-                ]
-            ]
-            .sort_values("Interval Start")
-            .reset_index(drop=True)
-        )
+        return df.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "Economic Max MW",
+                "Emergency Max MW",
+                "Total Committed MW",
+            ],
+        ).sort("Interval Start")
 
     @support_date_range(frequency=None)
     def get_cleared_virtuals_daily(
@@ -3589,7 +3610,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the daily cleared virtual transactions data from:
         https://dataminer2.pjm.com/feed/day_inc_dec_utc/definition
@@ -3624,38 +3645,42 @@ class PJM(ISOBase):
         if r["totalRows"] == 0:
             raise NoDataFoundException("No data found for day_inc_dec_utc")
 
-        df = pd.DataFrame(r["items"])
+        df = pl.from_dicts(r["items"])
 
-        df["Interval Start"] = pd.to_datetime(
-            df["day_ahead_market_date"],
-        ).dt.tz_localize(
-            self.default_timezone,
-            ambiguous="infer",
-            nonexistent="shift_forward",
+        df = df.with_columns(
+            pl.col("day_ahead_market_date").str.to_datetime().alias("Interval Start"),
         )
-        df["Interval End"] = df["Interval Start"] + pd.DateOffset(days=1)
+        df = utils.localize_shift_forward_polars(
+            df,
+            "Interval Start",
+            self.default_timezone,
+        )
+        df = utils.localize_ambiguous_infer_polars(
+            df,
+            "Interval Start",
+            self.default_timezone,
+        )
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(days=1)).alias("Interval End"),
+        )
 
         df = df.rename(
-            columns={
+            {
                 "dec_mw": "Dec MW",
                 "inc_mw": "Inc MW",
                 "utc_mw": "UTC MW",
             },
         )
 
-        return (
-            df[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Dec MW",
-                    "Inc MW",
-                    "UTC MW",
-                ]
-            ]
-            .sort_values("Interval Start")
-            .reset_index(drop=True)
-        )
+        return df.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "Dec MW",
+                "Inc MW",
+                "UTC MW",
+            ],
+        ).sort("Interval Start")
 
     @support_date_range(frequency=None)
     def get_inc_and_dec_bids_day_ahead_hourly(
@@ -3663,7 +3688,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the hourly day-ahead increment and decrement bids data from:
         https://dataminer2.pjm.com/feed/hrl_da_incs_decs/definition
@@ -3682,15 +3707,18 @@ class PJM(ISOBase):
             verbose=verbose,
         )
 
-        df["Interval Start"] = (
-            pd.to_datetime(df["bid_datetime_beginning_utc"], format="ISO8601")
-            .dt.tz_localize("UTC")
-            .dt.tz_convert(self.default_timezone)
+        df = df.with_columns(
+            pl.col("bid_datetime_beginning_utc")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone)
+            .alias("Interval Start"),
         )
-        df["Interval End"] = df["Interval Start"] + pd.Timedelta(hours=1)
+        df = df.with_columns(
+            (pl.col("Interval Start") + pl.duration(hours=1)).alias("Interval End"),
+        )
 
         df = df.rename(
-            columns={
+            {
                 "modified_datetime_utc": "Publish Time",
                 "price_point": "Price Point",
                 "inc_mw": "Inc MW",
@@ -3698,31 +3726,27 @@ class PJM(ISOBase):
             },
         )
 
-        df["Publish Time"] = (
-            pd.to_datetime(df["Publish Time"], format="ISO8601")
-            .dt.tz_localize("UTC")
-            .dt.tz_convert(self.default_timezone)
+        df = df.with_columns(
+            pl.col("Publish Time")
+            .str.to_datetime(time_zone="UTC")
+            .dt.convert_time_zone(self.default_timezone),
         )
 
-        return (
-            df[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Publish Time",
-                    "Price Point",
-                    "Inc MW",
-                    "Dec MW",
-                ]
-            ]
-            .sort_values(["Interval Start", "Publish Time", "Price Point"])
-            .reset_index(drop=True)
-        )
+        return df.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "Publish Time",
+                "Price Point",
+                "Inc MW",
+                "Dec MW",
+            ],
+        ).sort(["Interval Start", "Publish Time", "Price Point"])
 
     def get_sync_reserve_events(
         self,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the synchronized reserve events data from:
         https://dataminer2.pjm.com/feed/sync_reserve_events/definition
@@ -3737,47 +3761,63 @@ class PJM(ISOBase):
             verbose=verbose,
         )
 
-        df["Interval Start"] = pd.to_datetime(df["event_start_ept"]).dt.tz_localize(
-            self.default_timezone,
-            ambiguous="infer",
-            nonexistent="shift_forward",
+        df = df.with_columns(
+            pl.col("event_start_ept").str.to_datetime().alias("Interval Start"),
+            pl.col("event_end_ept").str.to_datetime().alias("Interval End"),
         )
-        df["Interval End"] = pd.to_datetime(df["event_end_ept"]).dt.tz_localize(
+        df = utils.localize_shift_forward_polars(
+            df,
+            "Interval Start",
             self.default_timezone,
-            ambiguous="infer",
-            nonexistent="shift_forward",
+        )
+        df = utils.localize_ambiguous_infer_polars(
+            df,
+            "Interval Start",
+            self.default_timezone,
+        )
+        df = utils.localize_shift_forward_polars(
+            df,
+            "Interval End",
+            self.default_timezone,
+        )
+        df = utils.localize_ambiguous_infer_polars(
+            df,
+            "Interval End",
+            self.default_timezone,
         )
 
         df = df.rename(
-            columns={
+            {
                 "duration": "Duration",
                 "synchronized_reserve_zone": "Synchronized Reserve Zone",
                 "synchronized_sub_zone": "Synchronized Subzone",
                 "percent_deployed": "Percent Deployed",
             },
         )
-        df["Duration"] = df["Duration"].astype(str)
-        df["Duration Minutes"] = (
-            pd.to_timedelta(df["Duration"]).dt.total_seconds().astype(int) // 60
+        df = df.with_columns(pl.col("Duration").cast(pl.Utf8))
+
+        def _duration_minutes(duration: str) -> int:
+            return int(pd.to_timedelta(duration).total_seconds()) // 60
+
+        df = df.with_columns(
+            pl.col("Duration")
+            .map_elements(_duration_minutes, return_dtype=pl.Int64)
+            .alias("Duration Minutes"),
         )
 
-        return (
-            df[
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Duration",
-                    "Duration Minutes",
-                    "Synchronized Reserve Zone",
-                    "Synchronized Subzone",
-                    "Percent Deployed",
-                ]
-            ]
-            .sort_values("Interval Start")
-            .reset_index(drop=True)
-        )
+        return df.select(
+            [
+                "Interval Start",
+                "Interval End",
+                "Duration",
+                "Duration Minutes",
+                "Synchronized Reserve Zone",
+                "Synchronized Subzone",
+                "Percent Deployed",
+            ],
+        ).sort("Interval Start")
 
-    def get_emergency_postings(self, url: str | None = None) -> pd.DataFrame:
+    def get_emergency_postings(self, url: str | None = None) -> pl.DataFrame:
         """
         Retrieves PJM emergency procedure postings by triggering the public
         "Export To XML" button on the guest dashboard.
@@ -3835,7 +3875,7 @@ class PJM(ISOBase):
 
         return xml_resp.content
 
-    def _parse_emergency_xml(self, xml_bytes: bytes) -> pd.DataFrame:
+    def _parse_emergency_xml(self, xml_bytes: bytes) -> pl.DataFrame:
         root = ET.fromstring(xml_bytes)
         rows: list[dict] = []
         for msg in root.iter("EmergencyMessage"):
@@ -3868,7 +3908,7 @@ class PJM(ISOBase):
         if not rows:
             raise NoDataFoundException("No emergency procedure messages found in XML")
 
-        df = pd.DataFrame(rows)
+        df = pl.from_dicts(rows)
         for col in (
             "Effective Start",
             "Effective End",
@@ -3877,29 +3917,27 @@ class PJM(ISOBase):
             "Publish Time",
             "Canceled Time",
         ):
-            df[col] = pd.to_datetime(df[col], utc=True).dt.tz_convert(
-                self.default_timezone,
+            df = df.with_columns(
+                pl.col(col)
+                .str.to_datetime(time_zone="UTC")
+                .dt.convert_time_zone(self.default_timezone),
             )
 
-        return (
-            df[
-                [
-                    "Message ID",
-                    "Applicable Start",
-                    "Applicable End",
-                    "Publish Time",
-                    "Message Type",
-                    "Priority",
-                    "Region",
-                    "Effective Start",
-                    "Effective End",
-                    "Canceled Time",
-                    "Emergency Message",
-                ]
-            ]
-            .sort_values(["Effective Start", "Message ID", "Region"])
-            .reset_index(drop=True)
-        )
+        return df.select(
+            [
+                "Message ID",
+                "Applicable Start",
+                "Applicable End",
+                "Publish Time",
+                "Message Type",
+                "Priority",
+                "Region",
+                "Effective Start",
+                "Effective End",
+                "Canceled Time",
+                "Emergency Message",
+            ],
+        ).sort(["Effective Start", "Message ID", "Region"])
 
     @support_date_range(frequency=None)
     def get_pai_intervals_5_min(
@@ -3907,7 +3945,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the 5-minute Performance Assessment Intervals (PAI) data from PJM.
 
@@ -3926,7 +3964,7 @@ class PJM(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with 5-minute PAI intervals data.
+            polars.DataFrame: A DataFrame with 5-minute PAI intervals data.
         """
 
         df = self._get_pjm_json(
@@ -3942,20 +3980,20 @@ class PJM(ISOBase):
         )
 
         df = df.rename(
-            columns={
+            {
                 "pai_description": "Performance Assessment Interval",
             },
         )
 
-        df = df[
+        df = df.select(
             [
                 "Interval Start",
                 "Interval End",
                 "Performance Assessment Interval",
-            ]
-        ]
+            ],
+        )
 
-        return df.sort_values("Interval Start").reset_index(drop=True)
+        return df.sort("Interval Start")
 
     @support_date_range(frequency=None)
     def get_marginal_emission_rates_5_min(
@@ -3963,7 +4001,7 @@ class PJM(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Retrieves the 5-minute marginal emission rates data from PJM.
 
@@ -3982,7 +4020,7 @@ class PJM(ISOBase):
             verbose (bool, optional): print verbose output. Defaults to False.
 
         Returns:
-            pandas.DataFrame: A DataFrame with 5-minute marginal emission rates data.
+            polars.DataFrame: A DataFrame with 5-minute marginal emission rates data.
         """
 
         date_ts = utils._handle_date(date)
@@ -4006,7 +4044,7 @@ class PJM(ISOBase):
         )
 
         df = df.rename(
-            columns={
+            {
                 "pnode_name": "Pnode Name",
                 "pnode_id": "Pnode ID",
                 "marginal_co2_rate": "Marginal CO2 Rate",
@@ -4015,7 +4053,7 @@ class PJM(ISOBase):
             },
         )
 
-        df = df[
+        df = df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -4024,17 +4062,17 @@ class PJM(ISOBase):
                 "Marginal CO2 Rate",
                 "Marginal SO2 Rate",
                 "Marginal NOx Rate",
-            ]
-        ]
+            ],
+        )
 
-        return df.sort_values(["Interval Start", "Pnode Name"]).reset_index(drop=True)
+        return df.sort(["Interval Start", "Pnode Name"])
 
     # NOTE: This file can only be accessed once per 30 minutes from the same IP address.
     # Otherwise the CSV will return a rate limit message inside the file.
     def get_voltage_limits(
         self,
         verbose: bool = False,
-    ) -> str:
+    ) -> pl.DataFrame:
         """
         Downloads the raw voltage limits CSV file from EDART.
 
@@ -4074,7 +4112,7 @@ class PJM(ISOBase):
     def _parse_voltage_limits(
         self,
         csv_content: str,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         lines = csv_content.split("\n")
 
         timestamp_str = lines[0].strip().replace("TIMESTAMP:", "").strip()
@@ -4090,12 +4128,12 @@ class PJM(ISOBase):
             raise ValueError("Could not find header row starting with 'Company'")
 
         csv_clean = "\n".join(lines[header_row_idx:])
-        df = pd.read_csv(io.StringIO(csv_clean))
+        df = utils.read_csv_exotic_via_pandas(io.StringIO(csv_clean))
 
-        df.columns = df.columns.str.strip()
+        df = df.rename({c: c.strip() for c in df.columns})
 
         df = df.rename(
-            columns={
+            {
                 "Emergency Low(KV)": "Emergency Low",
                 "Normal Low(KV)": "Normal Low",
                 "Normal High(KV)": "Normal High",
@@ -4105,9 +4143,9 @@ class PJM(ISOBase):
             },
         )
 
-        df["Publish Time"] = publish_time
+        df = df.with_columns(pl.lit(publish_time).alias("Publish Time"))
 
-        df = df[
+        df = df.select(
             [
                 "Publish Time",
                 "Company",
@@ -4121,7 +4159,7 @@ class PJM(ISOBase):
                 "Emergency High",
                 "Voltage Drop Warning Percent",
                 "Voltage Drop Limit Percent",
-            ]
-        ]
+            ],
+        )
 
         return df

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -4,6 +4,7 @@ from enum import StrEnum
 from typing import BinaryIO, Callable
 
 import pandas as pd
+import polars as pl
 import pytz
 import requests
 import tqdm
@@ -127,7 +128,61 @@ class BAAEnum(StrEnum):
     SWPW = "SWPW"
 
 
-def fill_baa_column(df, load_col):
+def _timedelta_duration(td: pd.Timedelta) -> pl.Expr:
+    return pl.duration(microseconds=int(td / pd.Timedelta(microseconds=1)))
+
+
+def _parse_utc_to_local(df: pl.DataFrame, column: str, tz: str) -> pl.Series:
+    parsed = pd.to_datetime(
+        df.get_column(column).to_pandas(),
+        utc=True,
+    ).dt.tz_convert(tz)
+    return pl.Series(column, parsed)
+
+
+def _drop_cols(df: pl.DataFrame, cols: list[str]) -> pl.DataFrame:
+    existing = [c for c in cols if c in df.columns]
+    return df.drop(existing) if existing else df
+
+
+def _select_cols(df: pl.DataFrame, cols: list[str]) -> pl.DataFrame:
+    return df.select([c for c in cols if c in df.columns])
+
+
+def _rename_cols(df: pl.DataFrame, mapping: dict[str, str]) -> pl.DataFrame:
+    existing = {k: v for k, v in mapping.items() if k in df.columns}
+    return df.rename(existing) if existing else df
+
+
+def _strip_columns(df: pl.DataFrame) -> pl.DataFrame:
+    return df.rename({c: c.strip() for c in df.columns})
+
+
+def _ensure_columns(
+    df: pl.DataFrame,
+    cols: list[str],
+    defaults: dict[str, object] | None = None,
+) -> pl.DataFrame:
+    defaults = defaults or {}
+    for col in cols:
+        if col not in df.columns:
+            default = defaults.get(col, None)
+            df = df.with_columns(pl.lit(default).alias(col))
+    return df.select(cols)
+
+
+def _sum_across_cols(df: pl.DataFrame, cols: list[str], out_col: str) -> pl.DataFrame:
+    exprs = [
+        pl.col(c).cast(pl.Float64, strict=False).fill_null(0)
+        for c in cols
+        if c in df.columns
+    ]
+    if not exprs:
+        return df.with_columns(pl.lit(None).cast(pl.Float64).alias(out_col))
+    return df.with_columns(pl.sum_horizontal(*exprs).alias(out_col))
+
+
+def fill_baa_column(df: pl.DataFrame, load_col: str) -> pl.DataFrame:
     """Fill missing BAA values based on load magnitude.
 
     If the BAA column doesn't exist, creates it. If it exists but has NaN values,
@@ -141,24 +196,23 @@ def fill_baa_column(df, load_col):
     Returns:
         The DataFrame with BAA column filled in-place.
     """
+    if load_col not in df.columns:
+        raise KeyError(load_col)
+    inferred_baa = (
+        pl.when(
+            pl.col(load_col).is_not_null() & (pl.col(load_col) < BAA_LOAD_THRESHOLD_MW),
+        )
+        .then(pl.lit(BAAEnum.SWPW.value))
+        .otherwise(pl.lit(BAAEnum.SPP.value))
+    )
     if "BAA" not in df.columns:
-        df["BAA"] = df[load_col].apply(
-            lambda x: (
-                BAAEnum.SWPW.value
-                if pd.notna(x) and x < BAA_LOAD_THRESHOLD_MW
-                else BAAEnum.SPP.value
-            ),
-        )
-    else:
-        mask = df["BAA"].isna()
-        df.loc[mask, "BAA"] = df.loc[mask, load_col].apply(
-            lambda x: (
-                BAAEnum.SWPW.value
-                if pd.notna(x) and x < BAA_LOAD_THRESHOLD_MW
-                else BAAEnum.SPP.value
-            ),
-        )
-    return df
+        return df.with_columns(inferred_baa.alias("BAA"))
+    return df.with_columns(
+        pl.when(pl.col("BAA").is_null())
+        .then(inferred_baa)
+        .otherwise(pl.col("BAA"))
+        .alias("BAA"),
+    )
 
 
 def _binding_constraints_real_time_5_min_frequency(args_dict: dict) -> str:
@@ -218,7 +272,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get combined fuel mix summed across SPP and SWPW BAAs
 
         Args:
@@ -226,7 +280,7 @@ class SPP(ISOBase):
             end: optional end date for range queries
 
         Returns:
-            pd.DataFrame: fuel mix summed across both BAAs
+            pl.DataFrame: fuel mix summed across both BAAs
         """
         return self._get_combined_fuel_mix(
             date=date,
@@ -242,7 +296,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get combined detailed fuel mix summed across SPP and SWPW BAAs
 
         Breaks out self scheduled and market scheduled generation.
@@ -252,7 +306,7 @@ class SPP(ISOBase):
             end: optional end date for range queries
 
         Returns:
-            pd.DataFrame: detailed fuel mix summed across both BAAs
+            pl.DataFrame: detailed fuel mix summed across both BAAs
         """
         return self._get_combined_fuel_mix(
             date=date,
@@ -268,7 +322,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get fuel mix for both SPP and SWPW BAAs with a BAA column
 
         Args:
@@ -276,7 +330,7 @@ class SPP(ISOBase):
             end: optional end date for range queries
 
         Returns:
-            pd.DataFrame: fuel mix with BAA column differentiating SPP and SWPW
+            pl.DataFrame: fuel mix with BAA column differentiating SPP and SWPW
         """
         return self._get_combined_fuel_mix(
             date=date,
@@ -292,7 +346,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get detailed fuel mix for both SPP and SWPW BAAs with a BAA column
 
         Breaks out self scheduled and market scheduled generation.
@@ -302,7 +356,7 @@ class SPP(ISOBase):
             end: optional end date for range queries
 
         Returns:
-            pd.DataFrame: detailed fuel mix with BAA column
+            pl.DataFrame: detailed fuel mix with BAA column
         """
         return self._get_combined_fuel_mix(
             date=date,
@@ -319,7 +373,7 @@ class SPP(ISOBase):
         detailed: bool = False,
         verbose: bool = False,
         by_baa: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Fetch fuel mix for both SPP and SWPW BAAs and combine them.
 
         Args:
@@ -330,7 +384,7 @@ class SPP(ISOBase):
             by_baa: if True, keep BAA column; if False, sum across BAAs
 
         Returns:
-            pd.DataFrame: combined fuel mix
+            pl.DataFrame: combined fuel mix
         """
         spp_df = self._get_fuel_mix(
             date=date,
@@ -348,36 +402,32 @@ class SPP(ISOBase):
         )
 
         if by_baa:
-            df = pd.concat([spp_df, swpw_df], ignore_index=True)
-            df = df.sort_values(
+            return pl.concat([spp_df, swpw_df], how="diagonal").sort(
                 ["Interval Start", "BAA"],
-                ignore_index=True,
             )
-            return df
 
-        # Sum fuel columns across BAAs for each interval
         time_cols = ["Interval Start", "Interval End"]
         fuel_cols = [c for c in spp_df.columns if c not in time_cols + ["BAA"]]
 
-        spp_df = spp_df.drop(columns=["BAA"], errors="ignore")
-        swpw_df = swpw_df.drop(columns=["BAA"], errors="ignore")
+        spp_df = _drop_cols(spp_df, ["BAA"])
+        swpw_df = _drop_cols(swpw_df, ["BAA"])
 
-        df = pd.merge(
-            spp_df,
-            swpw_df,
-            on=time_cols,
-            suffixes=("_spp", "_swpw"),
-            how="outer",
-        )
+        spp_renamed = spp_df.rename({c: f"{c}_spp" for c in fuel_cols})
+        swpw_renamed = swpw_df.rename({c: f"{c}_swpw" for c in fuel_cols})
+        df = spp_renamed.join(swpw_renamed, on=time_cols, how="full", coalesce=True)
 
         for col in fuel_cols:
             spp_col = f"{col}_spp"
             swpw_col = f"{col}_swpw"
-            df[col] = df[spp_col].fillna(0) + df[swpw_col].fillna(0)
-            df = df.drop(columns=[spp_col, swpw_col])
+            df = df.with_columns(
+                (
+                    pl.col(spp_col).cast(pl.Float64, strict=False).fill_null(0)
+                    + pl.col(swpw_col).cast(pl.Float64, strict=False).fill_null(0)
+                ).alias(col),
+            ).drop([spp_col, swpw_col])
 
-        df = df.sort_values("Interval Start", ignore_index=True)
-        return df
+        result_cols = time_cols + fuel_cols
+        return df.select(result_cols).sort("Interval Start")
 
     def _get_fuel_mix(
         self,
@@ -386,7 +436,7 @@ class SPP(ISOBase):
         detailed: bool = False,
         verbose: bool = False,
         baa: BAAEnum = BAAEnum.SPP,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         now = pd.Timestamp.now(tz=self.default_timezone)
         two_hours_ago = now - pd.Timedelta(hours=2)
         one_year_ago = now - pd.Timedelta(days=365)
@@ -411,20 +461,21 @@ class SPP(ISOBase):
         if verbose:
             logger.info(f"Downloading fuel mix from {url}")
 
-        df_raw = pd.read_csv(url)
+        df_raw = pl.read_csv(url, infer_schema_length=None)
         df = process_gen_mix(df_raw, detailed=detailed)
 
-        df = df.drop(
-            columns=["Short Term Load Forecast", "Average Actual Load", "Time"],
-            errors="ignore",
+        df = _drop_cols(
+            df,
+            ["Short Term Load Forecast", "Average Actual Load", "Time"],
         )
 
         if date != "latest" and isinstance(date, pd.Timestamp):
-            df = df[df["Interval Start"] >= date]
             if end is None:
                 end = date.normalize() + pd.Timedelta(days=1)
-            df = df[df["Interval Start"] < end]
-            df = df.reset_index(drop=True)
+            df = df.filter(
+                (pl.col("Interval Start") >= pl.lit(date))
+                & (pl.col("Interval Start") < pl.lit(end)),
+            )
 
         return df
 
@@ -433,21 +484,17 @@ class SPP(ISOBase):
         date: str | pd.Timestamp,
         end: str | pd.Timestamp | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Returns total RTO load in 5 minute intervals from STLF data."""
         baa_df = self.get_load_by_baa(date=date, end=end, verbose=verbose)
 
-        if baa_df.empty:
+        if baa_df.is_empty():
             raise NoDataFoundException(f"No load data found for date {date}")
 
         return (
-            baa_df.groupby(
-                ["Interval Start", "Interval End"],
-                as_index=False,
-            )["Load"]
-            .sum()
-            .sort_values("Interval Start")
-            .reset_index(drop=True)
+            baa_df.group_by(["Interval Start", "Interval End"])
+            .agg(pl.col("Load").cast(pl.Float64, strict=False).sum())
+            .sort("Interval Start")
         )
 
     def get_load_forecast(
@@ -455,22 +502,19 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Returns total RTO load forecast in hourly intervals from MTLF data."""
         baa_df = self.get_load_forecast_by_baa(date=date, end=end, verbose=verbose)
 
-        if baa_df.empty:
+        if baa_df.is_empty():
             raise NoDataFoundException(
                 f"No load forecast by BAA data found for date {date}",
             )
 
-        summed = baa_df.groupby(
-            ["Interval Start", "Interval End", "Publish Time"],
-            as_index=False,
-        )["Load Forecast"].sum()
-
-        return summed.sort_values(["Interval Start", "Publish Time"]).reset_index(
-            drop=True,
+        return (
+            baa_df.group_by(["Interval Start", "Interval End", "Publish Time"])
+            .agg(pl.col("Load Forecast").cast(pl.Float64, strict=False).sum())
+            .sort(["Interval Start", "Publish Time"])
         )
 
     @support_date_range("5_MIN")
@@ -480,7 +524,7 @@ class SPP(ISOBase):
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         drop_null_forecast_rows: bool = True,
-    ) -> pd.DataFrame | None:
+    ) -> pl.DataFrame | None:
         """
         5-minute load forecast data for the SPP footprint (system-wide) for +/- 10
         minutes. Also includes actual load.
@@ -494,7 +538,7 @@ class SPP(ISOBase):
             drop_null_forecast_rows (bool): if True, drop rows with null forecast values
 
         Returns:
-            pd.DataFrame: forecast as dataframe.
+            pl.DataFrame: forecast as dataframe.
         """
         result = self._get_short_term_forecast_data(
             date,
@@ -520,7 +564,7 @@ class SPP(ISOBase):
             drop_null_forecast_rows=drop_null_forecast_rows,
         )
 
-        fill_baa_column(df, "STLF")
+        df = fill_baa_column(df, "STLF")
 
         return df
 
@@ -530,7 +574,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame | None:
+    ) -> pl.DataFrame | None:
         """
         Returns load forecast for +7 days in hourly intervals. Includes actual load
         for the past 24 hours. Data from https://portal.spp.org/pages/mtlf-vs-actual
@@ -540,7 +584,7 @@ class SPP(ISOBase):
             verbose (bool): print info
 
         Returns:
-            pd.DataFrame: forecast as dataframe.
+            pl.DataFrame: forecast as dataframe.
         """
         result = self._get_mid_term_forecast_data(
             date,
@@ -570,23 +614,22 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Returns hourly load forecast by BAA from MTLF data."""
         df = self._get_load_forecast_by_baa_raw(date=date, end=end, verbose=verbose)
 
-        if df is None or df.empty:
+        if df is None or df.is_empty():
             raise NoDataFoundException(
                 f"No load forecast by BAA data found for {date}",
             )
 
         return (
-            df.dropna(subset=["Load Forecast"])
-            .drop_duplicates(
+            df.filter(pl.col("Load Forecast").is_not_null())
+            .unique(
                 subset=["Interval Start", "Interval End", "Publish Time", "BAA"],
                 keep="last",
             )
-            .sort_values(["Interval Start", "Publish Time"])
-            .reset_index(drop=True)
+            .sort(["Interval Start", "Publish Time"])
         )
 
     @support_date_range("HOUR_START")
@@ -595,7 +638,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame | None:
+    ) -> pl.DataFrame | None:
         result = self._get_mid_term_forecast_data(
             date=date,
             base_url=BASE_LOAD_FORECAST_MID_TERM_URL,
@@ -617,11 +660,14 @@ class SPP(ISOBase):
             interval_duration=pd.Timedelta(hours=1),
         )
 
-        fill_baa_column(df, "MTLF")
+        df = fill_baa_column(df, "MTLF")
 
-        return df[
-            ["Interval Start", "Interval End", "Publish Time", "BAA", "MTLF"]
-        ].rename(columns={"MTLF": "Load Forecast"})
+        return _rename_cols(
+            df.select(
+                ["Interval Start", "Interval End", "Publish Time", "BAA", "MTLF"],
+            ),
+            {"MTLF": "Load Forecast"},
+        )
 
     def _handle_dst_floor_date(
         self,
@@ -650,7 +696,7 @@ class SPP(ISOBase):
         base_url: str,
         file_prefix: str,
         buffer_minutes: int = 2,
-    ) -> tuple[pd.DataFrame, str] | None:
+    ) -> tuple[pl.DataFrame, str] | None:
         """Get short-term forecast data with common DST handling logic.
 
         Args:
@@ -691,7 +737,7 @@ class SPP(ISOBase):
         )
 
         logger.info(f"Downloading {url}")
-        df = pd.read_csv(url)
+        df = pl.read_csv(url, infer_schema_length=None)
 
         return df, url
 
@@ -701,7 +747,7 @@ class SPP(ISOBase):
         base_url: str,
         file_prefix: str,
         buffer_minutes: int = 10,
-    ) -> tuple[pd.DataFrame, str] | None:
+    ) -> tuple[pl.DataFrame, str] | None:
         """Get mid-term forecast data with common DST handling logic.
 
         Args:
@@ -737,50 +783,46 @@ class SPP(ISOBase):
         )
 
         logger.info(f"Downloading {url}")
-        df = pd.read_csv(url)
+        df = pl.read_csv(url, infer_schema_length=None)
 
         return df, url
 
     def _post_process_load_forecast(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         url: str,
         forecast_type: str,
         forecast_col: str,
         end_time_col: str,
         interval_duration: pd.Timedelta,
         drop_null_forecast_rows: bool = True,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         df = self._handle_market_end_to_interval(df, end_time_col, interval_duration)
 
-        # Assume the publish time is in the name of the file. There are different
-        # times on the webpage, but these could be the posting time.
-        df["Publish Time"] = pd.Timestamp(
+        publish_time = pd.Timestamp(
             re.search(r"[0-9]{12}", url).group(0),
         ).tz_localize(
             tz=self.default_timezone,
-            # Assume the "d" file occurs during CST and Pandas wants ambiguous=True
-            # during DST.
             ambiguous=not url.endswith("d.csv"),
         )
 
-        df.columns = [col.strip() for col in df.columns]
+        df = _strip_columns(df).with_columns(
+            pl.lit(publish_time).alias("Publish Time"),
+            pl.lit(forecast_type).alias("Forecast Type"),
+        )
 
-        df["Forecast Type"] = forecast_type
-
-        df = (
-            utils.move_cols_to_front(
-                df,
-                ["Interval Start", "Interval End", "Publish Time", "Forecast Type"],
-            )
-            .drop(columns=["Time", "Interval"])
-            .sort_values(["Interval Start", "Publish Time"])
+        df = utils.move_cols_to_front(
+            df,
+            ["Interval Start", "Interval End", "Publish Time", "Forecast Type"],
+        )
+        df = _drop_cols(df, ["Time", "Interval"]).sort(
+            ["Interval Start", "Publish Time"],
         )
 
         if drop_null_forecast_rows:
-            df = df.dropna(subset=[forecast_col])
+            df = df.filter(pl.col(forecast_col).is_not_null())
 
-        return df.reset_index(drop=True)
+        return df
 
     @support_date_range("5_MIN")
     def get_solar_and_wind_forecast_short_term(
@@ -788,7 +830,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame | None:
+    ) -> pl.DataFrame | None:
         """
         Returns solar and wind generation forecast for +4 hours in 5 minute intervals.
         Include actuals for past day in 5 minute intervals.
@@ -800,7 +842,7 @@ class SPP(ISOBase):
             verbose (bool): print info
 
         Returns:
-            pd.DataFrame: forecast as dataframe.
+            pl.DataFrame: forecast as dataframe.
         """
         result = self._get_short_term_forecast_data(
             date,
@@ -832,7 +874,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame | None:
+    ) -> pl.DataFrame | None:
         """
         Returns solar and wind generation forecast for +7 days in hourly intervals.
 
@@ -843,7 +885,7 @@ class SPP(ISOBase):
             verbose (bool): print info
 
         Returns:
-            pd.DataFrame: forecast as dataframe.
+            pl.DataFrame: forecast as dataframe.
         """
         result = self._get_mid_term_forecast_data(
             date,
@@ -873,7 +915,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame | None:
+    ) -> pl.DataFrame | None:
         """Returns hourly solar and wind forecasts and actuals by reserve zone.
 
         Data from https://portal.spp.org/pages/resource-forecast-by-reserve-zone.
@@ -903,23 +945,27 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Returns actual load by BAA from short-term load forecast data."""
         df = self._get_load_by_baa_raw(date=date, end=end, verbose=verbose)
 
-        if df is None or df.empty:
-            return pd.DataFrame(
-                columns=["Interval Start", "Interval End", "BAA", "Load"],
+        if df is None or df.is_empty():
+            return pl.DataFrame(
+                schema={
+                    "Interval Start": pl.Datetime("us", SPP.default_timezone),
+                    "Interval End": pl.Datetime("us", SPP.default_timezone),
+                    "BAA": pl.Utf8,
+                    "Load": pl.Float64,
+                },
             )
 
         return (
-            df.dropna(subset=["Load"])
-            .drop_duplicates(
+            df.filter(pl.col("Load").is_not_null())
+            .unique(
                 subset=["Interval Start", "Interval End", "BAA"],
                 keep="last",
             )
-            .sort_values("Interval Start")
-            .reset_index(drop=True)
+            .sort("Interval Start")
         )
 
     @support_date_range(frequency="5_MIN")
@@ -928,7 +974,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame | None:
+    ) -> pl.DataFrame | None:
         result = self._get_short_term_forecast_data(
             date=date,
             base_url=BASE_LOAD_FORECAST_SHORT_TERM_URL,
@@ -951,12 +997,11 @@ class SPP(ISOBase):
             drop_null_forecast_rows=False,
         )
 
-        fill_baa_column(df, "Actual")
+        df = fill_baa_column(df, "Actual")
 
-        return (
-            df[["Interval Start", "Interval End", "BAA", "Actual"]]
-            .rename(columns={"Actual": "Load"})
-            .copy()
+        return _rename_cols(
+            df.select(["Interval Start", "Interval End", "BAA", "Actual"]),
+            {"Actual": "Load"},
         )
 
     @support_date_range("DAY_START")
@@ -965,7 +1010,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame | None:
+    ) -> pl.DataFrame | None:
         """Returns hourly actual load by BAA from mid-term load forecast data."""
 
         if date == "latest":
@@ -986,8 +1031,13 @@ class SPP(ISOBase):
         )
 
         if result is None:
-            return pd.DataFrame(
-                columns=["Interval Start", "Interval End", "BAA", "Load"],
+            return pl.DataFrame(
+                schema={
+                    "Interval Start": pl.Datetime("us", SPP.default_timezone),
+                    "Interval End": pl.Datetime("us", SPP.default_timezone),
+                    "BAA": pl.Utf8,
+                    "Load": pl.Float64,
+                },
             )
 
         df, url = result
@@ -1001,89 +1051,83 @@ class SPP(ISOBase):
             forecast_col="MTLF",
         )
 
-        fill_baa_column(df, "Averaged Actual")
+        df = fill_baa_column(df, "Averaged Actual")
 
-        result_df = (
-            df[["Interval Start", "Interval End", "BAA", "Averaged Actual"]]
-            .rename(columns={"Averaged Actual": "Load"})
-            .copy()
+        result_df = _rename_cols(
+            df.select(["Interval Start", "Interval End", "BAA", "Averaged Actual"]),
+            {"Averaged Actual": "Load"},
         )
 
         if date != "latest":
             date_ts = utils._handle_date(date, self.default_timezone)
             day_start = date_ts.normalize()
             day_end = day_start + pd.Timedelta(days=1)
-            result_df = result_df[
-                (result_df["Interval Start"] >= day_start)
-                & (result_df["Interval Start"] < day_end)
-            ]
+            result_df = result_df.filter(
+                (pl.col("Interval Start") >= pl.lit(day_start))
+                & (pl.col("Interval Start") < pl.lit(day_end)),
+            )
 
-        return (
-            result_df.dropna(subset=["Load"])
-            .sort_values("Interval Start")
-            .reset_index(drop=True)
-        )
+        return result_df.filter(pl.col("Load").is_not_null()).sort("Interval Start")
 
     def _post_process_solar_and_wind_forecast(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         url: str,
         forecast_type: str,
         end_time_col: str,
         interval_duration: pd.Timedelta,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         df = self._handle_market_end_to_interval(df, end_time_col, interval_duration)
 
-        # Assume the publish time is in the name of the file. There are different
-        # times on the webpage, but these could be the posting time.
-        df["Publish Time"] = pd.Timestamp(
+        publish_time = pd.Timestamp(
             re.search(r"[0-9]{12}", url).group(0),
         ).tz_localize(
             tz=self.default_timezone,
-            # Assume the "d" file occurs during CST and Pandas wants ambiguous=True
-            # during DST.
             ambiguous=not url.endswith("d.csv"),
         )
 
-        df.columns = [col.strip() for col in df.columns]
-
-        df["Forecast Type"] = forecast_type
-
-        df = (
-            utils.move_cols_to_front(
-                df,
-                ["Interval Start", "Interval End", "Publish Time", "Forecast Type"],
-            )
-            .drop(columns=["Time", "Interval"])
-            .sort_values(["Interval Start", "Publish Time"])
+        df = _strip_columns(df).with_columns(
+            pl.lit(publish_time).alias("Publish Time"),
+            pl.lit(forecast_type).alias("Forecast Type"),
         )
 
-        return df.dropna(subset=["Wind Forecast MW", "Solar Forecast MW"]).reset_index(
-            drop=True,
+        df = utils.move_cols_to_front(
+            df,
+            ["Interval Start", "Interval End", "Publish Time", "Forecast Type"],
+        )
+        return (
+            _drop_cols(df, ["Time", "Interval"])
+            .sort(["Interval Start", "Publish Time"])
+            .filter(
+                pl.col("Wind Forecast MW").is_not_null()
+                & pl.col("Solar Forecast MW").is_not_null(),
+            )
         )
 
     def _post_process_solar_and_wind_forecast_by_reserve_zone(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         url: str,
         end_time_col: str,
         interval_duration: pd.Timedelta,
-    ) -> pd.DataFrame:
-        df.columns = [col.strip() for col in df.columns]
-
+    ) -> pl.DataFrame:
+        df = _strip_columns(df)
         df = self._handle_market_end_to_interval(df, end_time_col, interval_duration)
 
-        df["Publish Time"] = pd.Timestamp(
+        publish_time = pd.Timestamp(
             re.search(r"[0-9]{12}", url).group(0),
         ).tz_localize(
             tz=self.default_timezone,
             ambiguous=not url.endswith("d.csv"),
         )
 
-        df.columns = [col.strip() for col in df.columns]
+        df = _strip_columns(df).with_columns(
+            pl.lit(publish_time).alias("Publish Time"),
+        )
 
-        df = df.rename(
-            columns={
+        df = _rename_cols(
+            df,
+            {
                 "ReserveZone": "Reserve Zone",
                 "WindForecastMW": "Wind Forecast",
                 "WindActualMW": "Wind Actual",
@@ -1092,30 +1136,29 @@ class SPP(ISOBase):
             },
         )
 
-        df = (
-            utils.move_cols_to_front(
-                df,
-                [
-                    "Interval Start",
-                    "Interval End",
-                    "Publish Time",
-                    "BAA",
-                    "Reserve Zone",
-                ],
-            )
-            .drop(columns=["Time", "IntervalEnd", "Interval"], errors="ignore")
-            .sort_values(["Interval Start", "Publish Time", "Reserve Zone"])
+        df = utils.move_cols_to_front(
+            df,
+            [
+                "Interval Start",
+                "Interval End",
+                "Publish Time",
+                "BAA",
+                "Reserve Zone",
+            ],
+        )
+        df = _drop_cols(df, ["Time", "IntervalEnd", "Interval"]).sort(
+            ["Interval Start", "Publish Time", "Reserve Zone"],
         )
 
-        return df.dropna(
-            subset=[
-                "Wind Forecast",
-                "Wind Actual",
-                "Solar Forecast",
-                "Solar Actual",
-            ],
-            how="all",
-        ).reset_index(drop=True)
+        value_cols = [
+            "Wind Forecast",
+            "Wind Actual",
+            "Solar Forecast",
+            "Solar Actual",
+        ]
+        return df.filter(
+            pl.any_horizontal([pl.col(c).is_not_null() for c in value_cols]),
+        )
 
     def _mid_term_solar_and_wind_url(self, date: pd.Timestamp) -> str:
         # Explicitly set the minutes to 00.
@@ -1131,32 +1174,31 @@ class SPP(ISOBase):
 
     def _handle_market_end_to_interval(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         column: str,
         interval_duration: pd.Timedelta,
         format: str | None = None,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Converts market end time to interval end time"""
 
-        df = df.rename(
-            columns={
-                column: "Interval End",
-            },
+        df = _rename_cols(df, {column: "Interval End"})
+        duration = _timedelta_duration(interval_duration)
+
+        interval_end = pl.Series(
+            "Interval End",
+            pd.to_datetime(
+                df.get_column("Interval End").to_pandas(),
+                utc=True,
+                format=format,
+            ).dt.tz_convert(self.default_timezone),
         )
+        df = df.with_columns(interval_end)
+        df = df.with_columns(
+            (pl.col("Interval End") - duration).alias("Interval Start"),
+        )
+        df = df.with_columns(pl.col("Interval Start").alias("Time"))
 
-        df["Interval End"] = pd.to_datetime(
-            df["Interval End"],
-            utc=True,
-            format=format,
-        ).dt.tz_convert(self.default_timezone)
-
-        df["Interval Start"] = df["Interval End"] - interval_duration
-
-        df["Time"] = df["Interval Start"]
-
-        df = utils.move_cols_to_front(df, ["Time", "Interval Start", "Interval End"])
-
-        return df
+        return utils.move_cols_to_front(df, ["Time", "Interval Start", "Interval End"])
 
     _ver_curtailment_numerical_cols = [
         "Wind Redispatch Curtailments",
@@ -1167,9 +1209,10 @@ class SPP(ISOBase):
         "Solar Curtailed For Energy",
     ]
 
-    def _process_ver_curtailments(self, df: pd.DataFrame) -> pd.DataFrame:
-        df = df.rename(
-            columns={
+    def _process_ver_curtailments(self, df: pl.DataFrame) -> pl.DataFrame:
+        df = _rename_cols(
+            df,
+            {
                 "WindRedispatchCurtailments": "Wind Redispatch Curtailments",
                 "WindManualCurtailments": "Wind Manual Curtailments",
                 "WindCurtailedForEnergy": "Wind Curtailed For Energy",
@@ -1197,33 +1240,29 @@ class SPP(ISOBase):
             "BAA",
         ]
 
-        # historical data doesnt have all columns
-        for col in cols:
-            if col not in df.columns:
-                # Default BAA to SPP for historical data
-                df[col] = pd.NA if col != "BAA" else BAAEnum.SPP
+        defaults = {col: BAAEnum.SPP for col in cols if col == "BAA"}
+        df = _ensure_columns(df, cols, defaults=defaults)
 
-        df = df[cols]
-
-        # Drop rows where all numerical curtailment columns are NaN
-        df = df.dropna(subset=self._ver_curtailment_numerical_cols, how="all")
-
-        df = df[~df["Interval Start"].isnull()]
-        df = df.sort_values("Interval Start").reset_index(drop=True)
-
-        return df
-
-    def _aggregate_ver_curtailments(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Sum VER curtailment numerical columns across BAAs."""
-        df = (
-            df.groupby(["Interval Start", "Interval End"], as_index=False)[
-                self._ver_curtailment_numerical_cols
-            ]
-            .sum()
-            .sort_values("Interval Start")
-            .reset_index(drop=True)
+        df = df.filter(
+            pl.any_horizontal(
+                [pl.col(c).is_not_null() for c in self._ver_curtailment_numerical_cols],
+            ),
         )
-        return df
+        df = df.filter(pl.col("Interval Start").is_not_null())
+        return df.sort("Interval Start")
+
+    def _aggregate_ver_curtailments(self, df: pl.DataFrame) -> pl.DataFrame:
+        """Sum VER curtailment numerical columns across BAAs."""
+        return (
+            df.group_by(["Interval Start", "Interval End"])
+            .agg(
+                [
+                    pl.col(c).cast(pl.Float64, strict=False).sum()
+                    for c in self._ver_curtailment_numerical_cols
+                ],
+            )
+            .sort("Interval Start")
+        )
 
     @support_date_range("DAY_START")
     def get_capacity_of_generation_on_outage(
@@ -1231,7 +1270,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Capacity of Generation on Outage.
 
         Published daily at 8am CT for next 7 days
@@ -1246,7 +1285,7 @@ class SPP(ISOBase):
 
         logger.info(f"Downloading {url}")
 
-        df = pd.read_csv(url)
+        df = pl.read_csv(url, infer_schema_length=None)
 
         return self._process_capacity_of_generation_on_outage(df, publish_time=date)
 
@@ -1254,7 +1293,7 @@ class SPP(ISOBase):
         self,
         year: int,
         verbose: bool = True,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get VER Curtailments for a year. Starting 2014.
         Recent data use get_capacity_of_generation_on_outage
 
@@ -1263,21 +1302,17 @@ class SPP(ISOBase):
             verbose: print url
 
         Returns:
-            pd.DataFrame: VER Curtailments
+            pl.DataFrame: VER Curtailments
         """
         url = f"{FILE_BROWSER_DOWNLOAD_URL}/capacity-of-generation-on-outage?path=/{year}/{year}.zip"  # noqa
 
-        def process_csv(df, file_name):
-            # infer date from '2020/01/Capacity-Gen-Outage-20200101.csv'
-
+        def process_csv(df: pl.DataFrame, file_name: str) -> pl.DataFrame:
             publish_time_str = file_name.split(".")[0].split("-")[-1]
             publish_time = pd.to_datetime(publish_time_str).tz_localize(
                 self.default_timezone,
             )
 
-            df = self._process_capacity_of_generation_on_outage(df, publish_time)
-
-            return df
+            return self._process_capacity_of_generation_on_outage(df, publish_time)
 
         df = utils.download_csvs_from_zip_url(
             url,
@@ -1285,17 +1320,14 @@ class SPP(ISOBase):
             verbose=verbose,
         )
 
-        df = df.sort_values("Interval Start")
-
-        return df
+        return df.sort("Interval Start")
 
     def _process_capacity_of_generation_on_outage(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         publish_time: pd.Timestamp,
-    ) -> pd.DataFrame:
-        # strip whitespace from column names
-        df = df.rename(columns=lambda x: x.strip())
+    ) -> pl.DataFrame:
+        df = _strip_columns(df)
 
         df = self._handle_market_end_to_interval(
             df,
@@ -1303,33 +1335,29 @@ class SPP(ISOBase):
             interval_duration=pd.Timedelta(minutes=60),
         )
 
-        df = df.rename(
-            columns={
-                "Outaged MW": "Total Outaged MW",
-            },
-        )
+        df = _rename_cols(df, {"Outaged MW": "Total Outaged MW"})
 
         publish_time = pd.to_datetime(publish_time.normalize())
 
-        df.insert(0, "Publish Time", publish_time)
+        df = df.with_columns(pl.lit(publish_time).alias("Publish Time"))
 
-        # drop Time column
-        df = df.drop(columns=["Time"])
+        return utils.move_cols_to_front(
+            _drop_cols(df, ["Time"]),
+            ["Publish Time"],
+        )
 
-        return df
-
-    def _fetch_ver_curtailments_daily(self, date: pd.Timestamp) -> pd.DataFrame:
+    def _fetch_ver_curtailments_daily(self, date: pd.Timestamp) -> pl.DataFrame:
         """Fetch and process a single day's VER curtailments CSV."""
         url = f"{FILE_BROWSER_DOWNLOAD_URL}/ver-curtailments?path=/{date.strftime('%Y')}/{date.strftime('%m')}/VER-Curtailments-{date.strftime('%Y%m%d')}.csv"  # noqa
         logger.info(f"Downloading {url}")
-        df = pd.read_csv(url)
+        df = pl.read_csv(url, infer_schema_length=None)
         return self._process_ver_curtailments(df)
 
     def _fetch_ver_curtailments_annual(
         self,
         year: int,
         verbose: bool = True,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Fetch and process a full year's VER curtailments zip."""
         url = f"{FILE_BROWSER_DOWNLOAD_URL}/ver-curtailments?path=/{year}/{year}.zip"  # noqa
         df = utils.download_csvs_from_zip_url(url, verbose=verbose)
@@ -1341,7 +1369,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get VER Curtailments summed across BAAs.
 
         Supports recent data. For historical annual data use
@@ -1359,7 +1387,7 @@ class SPP(ISOBase):
         self,
         year: int,
         verbose: bool = True,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get VER Curtailments summed across BAAs for a year. Starting 2014.
 
         Recent data use get_ver_curtailments. For data broken down by BAA use
@@ -1370,7 +1398,7 @@ class SPP(ISOBase):
             verbose: print url
 
         Returns:
-            pd.DataFrame: VER Curtailments
+            pl.DataFrame: VER Curtailments
         """
         df = self._fetch_ver_curtailments_annual(year, verbose=verbose)
         return self._aggregate_ver_curtailments(df)
@@ -1381,7 +1409,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get VER Curtailments broken down by BAA.
 
         Supports recent data. For historical annual data use
@@ -1397,7 +1425,7 @@ class SPP(ISOBase):
         self,
         year: int,
         verbose: bool = True,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get VER Curtailments broken down by BAA for a year. Starting 2014.
 
         Recent data use get_ver_curtailments_by_baa.
@@ -1407,11 +1435,11 @@ class SPP(ISOBase):
             verbose: print url
 
         Returns:
-            pd.DataFrame: VER Curtailments
+            pl.DataFrame: VER Curtailments
         """
         return self._fetch_ver_curtailments_annual(year, verbose=verbose)
 
-    def _get_load_and_forecast(self, verbose: bool = False) -> pd.DataFrame:
+    def _get_load_and_forecast(self, verbose: bool = False) -> pl.DataFrame:
         url = f"{MARKETPLACE_BASE_URL}/chart-api/load-forecast/asChart"
 
         logger.info(f"Getting load and forecast from {url}")
@@ -1427,11 +1455,11 @@ class SPP(ISOBase):
             elif d["label"] == "Short-Term Load Forecast":
                 data["Short-Term Forecast"] = d["data"]
 
-        df = pd.DataFrame(data)
+        df = pl.DataFrame(data)
 
-        df["Time"] = pd.to_datetime(
-            df["Time"],
-        ).dt.tz_convert(self.default_timezone)
+        df = df.with_columns(
+            _parse_utc_to_local(df, "Time", self.default_timezone).alias("Time"),
+        )
 
         return df
 
@@ -1453,37 +1481,38 @@ class SPP(ISOBase):
         response = requests.get(url)
         return utils.get_response_blob(response)
 
-    def get_interconnection_queue(self, verbose: bool = False) -> pd.DataFrame:
+    def get_interconnection_queue(self, verbose: bool = False) -> pl.DataFrame:
         """Get interconnection queue
 
         Returns:
             pandas.DataFrame: Interconnection queue
         """
         raw_data = self.get_raw_interconnection_queue(verbose)
-        queue = pd.read_csv(raw_data, skiprows=1)
+        queue = pl.from_pandas(pd.read_csv(raw_data, skiprows=1))
 
-        queue["Status (Original)"] = queue["Status"]
         completed_val = InterconnectionQueueStatus.COMPLETED.value
         active_val = InterconnectionQueueStatus.ACTIVE.value
         withdrawn_val = InterconnectionQueueStatus.WITHDRAWN.value
-        queue["Status"] = queue["Status"].map(
-            {
-                "IA FULLY EXECUTED/COMMERCIAL OPERATION": completed_val,
-                "IA FULLY EXECUTED/ON SCHEDULE": completed_val,
-                "IA FULLY EXECUTED/ON SUSPENSION": completed_val,
-                "IA PENDING": active_val,
-                "DISIS STAGE": active_val,
-                "None": active_val,
-                "WITHDRAWN": withdrawn_val,
-            },
+        queue = queue.with_columns(
+            pl.col("Status").alias("Status (Original)"),
+            pl.col("Status").replace(
+                {
+                    "IA FULLY EXECUTED/COMMERCIAL OPERATION": completed_val,
+                    "IA FULLY EXECUTED/ON SCHEDULE": completed_val,
+                    "IA FULLY EXECUTED/ON SUSPENSION": completed_val,
+                    "IA PENDING": active_val,
+                    "DISIS STAGE": active_val,
+                    "None": active_val,
+                    "WITHDRAWN": withdrawn_val,
+                },
+            ),
+            pl.concat_str(
+                [pl.col("Generation Type"), pl.col("Fuel Type")],
+                separator=" - ",
+                ignore_nulls=True,
+            ).alias("Generation Type"),
+            pl.col("Commercial Operation Date").alias("Proposed Completion Date"),
         )
-
-        queue["Generation Type"] = queue[["Generation Type", "Fuel Type"]].apply(
-            lambda x: " - ".join(x.dropna()),
-            axis=1,
-        )
-
-        queue["Proposed Completion Date"] = queue["Commercial Operation Date"]
 
         rename = {
             "Generation Interconnection Number": "Queue ID",
@@ -1534,7 +1563,7 @@ class SPP(ISOBase):
         location_type: str = LOCATION_TYPE_ALL,
         verbose: bool = False,
         use_daily_files: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get LMP data by location for the Real-Time 5 Minute Market
 
         Args:
@@ -1555,10 +1584,10 @@ class SPP(ISOBase):
                 location_type=location_type,
                 verbose=verbose,
             )
-            df.columns = df.columns.str.strip()
-
-            df = df.rename(
-                columns={
+            df = _strip_columns(df)
+            df = _rename_cols(
+                df,
+                {
                     "GMT Interval": "GMTIntervalEnd",
                     "Settlement Location Name": "Settlement Location",
                     "PNODE Name": "PNode",
@@ -1584,7 +1613,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get LMP data by bus for the Real-Time 5 Minute Market
 
         Args:
@@ -1614,7 +1643,7 @@ class SPP(ISOBase):
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         location_type: str = LOCATION_TYPE_ALL,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Internal function that consolidates logic for getting LMP data for the
         Real-Time 5 Minute Market
@@ -1637,7 +1666,7 @@ class SPP(ISOBase):
 
         logger.info(f"Getting data for {date} from {url}")
 
-        df = pd.read_csv(url)
+        df = pl.read_csv(url, infer_schema_length=None)
 
         return df
 
@@ -1648,7 +1677,7 @@ class SPP(ISOBase):
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         location_type: str = LOCATION_TYPE_ALL,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Internal function that consolidates logic for getting LMP data for the
         Real-Time 5 Minute Market
@@ -1667,7 +1696,7 @@ class SPP(ISOBase):
 
         logger.info(f"Getting data for {date} from {url} (daily file)")
 
-        df = pd.read_csv(url)
+        df = pl.read_csv(url, infer_schema_length=None)
 
         return df
 
@@ -1678,7 +1707,7 @@ class SPP(ISOBase):
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         location_type: str = LOCATION_TYPE_ALL,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get day ahead hourly LMP data
 
         Supported Location Types:
@@ -1708,7 +1737,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get day ahead hourly LMP data by bus (pnode-level).
 
         Args:
@@ -1732,11 +1761,11 @@ class SPP(ISOBase):
             include_baa=True,
         )
 
-    def _get_feature_data(self, base_url: str, verbose: bool = False) -> pd.DataFrame:
+    def _get_feature_data(self, base_url: str, verbose: bool = False) -> pl.DataFrame:
         """Fetches data from ArcGIS Map Service with Feature Data
 
         Returns:
-            pd.DataFrame of features
+            pl.DataFrame of features
         """
         args = {
             "f": "json",
@@ -1745,15 +1774,14 @@ class SPP(ISOBase):
             "outFields": "*",
         }
         doc = self._get_json(base_url, verbose=verbose, params=args)
-        df = pd.DataFrame([feature["attributes"] for feature in doc["features"]])
-        return df
+        return pl.DataFrame([feature["attributes"] for feature in doc["features"]])
 
     def _get_dam_lmp(
         self,
         date: pd.Timestamp,
         location_type: str = LOCATION_TYPE_ALL,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if location_type == LOCATION_TYPE_BUS:
             endpoint = FS_DAM_LMP_BY_BUS
             file_prefix = "DA-LMP-B"
@@ -1763,17 +1791,17 @@ class SPP(ISOBase):
 
         url = f"{FILE_BROWSER_DOWNLOAD_URL}/{endpoint}?path=/{date.strftime('%Y')}/{date.strftime('%m')}/By_Day/{file_prefix}-{date.strftime('%Y%m%d')}0100.csv"  # noqa
         logger.info(f"Downloading {url}")
-        df = pd.read_csv(url)
+        df = pl.read_csv(url, infer_schema_length=None)
         return df
 
     def _finalize_spp_df(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         market: Markets,
         location_type: str,
         verbose: bool = False,
         include_baa: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Finalizes DataFrame:
 
@@ -1805,27 +1833,31 @@ class SPP(ISOBase):
             interval_duration=interval_duration,
         )
 
-        df["Market"] = market.value
+        df = df.with_columns(pl.lit(market.value).alias("Market"))
 
         if location_type != LOCATION_TYPE_BUS:
-            df["Location"] = df["Settlement Location"]
-            df["Location Type"] = (
-                df["Location"]
-                .map(
+            df = df.with_columns(
+                pl.col("Settlement Location").alias("Location"),
+                pl.col("Settlement Location")
+                .replace_strict(
                     LMP_HUBS_AND_INTERFACES,
+                    default=LOCATION_TYPE_SETTLEMENT_LOCATION,
+                    return_dtype=pl.Utf8,
                 )
-                .fillna(LOCATION_TYPE_SETTLEMENT_LOCATION)
+                .alias("Location Type"),
             )
-
             df = utils.filter_lmp_locations(df, location_type=location_type)
         else:
-            df["Location"] = df["Pnode"]
-            df["Location Type"] = LOCATION_TYPE_BUS
+            df = df.with_columns(
+                pl.col("Pnode").alias("Location"),
+                pl.lit(LOCATION_TYPE_BUS).alias("Location Type"),
+            )
 
-        df = df.rename(
-            columns={
+        df = _rename_cols(
+            df,
+            {
                 "Pnode": "PNode",
-                "LMP": "LMP",  # for posterity
+                "LMP": "LMP",
                 "MLC": "Loss",
                 "MCC": "Congestion",
                 "MEC": "Energy",
@@ -1833,9 +1865,8 @@ class SPP(ISOBase):
         )
 
         if include_baa and "BAA" not in df.columns:
-            df["BAA"] = "SPP"
+            df = df.with_columns(pl.lit("SPP").alias("BAA"))
 
-        # Insert BAA before location if it exists
         cols = [
             "Time",
             "Interval Start",
@@ -1853,14 +1884,12 @@ class SPP(ISOBase):
         if "BAA" in df.columns:
             cols.insert(cols.index("Location"), "BAA")
 
-        df = df[cols]
-        df = df.reset_index(drop=True)
+        df = df.select(cols)
 
-        # Since Location = PNode for bus, we can drop PNode
         if location_type == LOCATION_TYPE_BUS:
-            df = df.drop(columns=["PNode"])
+            df = _drop_cols(df, ["PNode"])
 
-        return df.sort_values(["Time", "Location"])
+        return df.sort(["Time", "Location"])
 
     @support_date_range("5_MIN")
     def get_operating_reserves(
@@ -1868,7 +1897,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         if date == "latest":
             url = f"{FILE_BROWSER_DOWNLOAD_URL}/operating-reserves?path=/RTBM-OR-latestInterval.csv"  # noqa
         else:
@@ -1881,21 +1910,21 @@ class SPP(ISOBase):
             )
 
         logger.info(f"Downloading {url}")
-        df = pd.read_csv(url)
+        df = pl.read_csv(url, infer_schema_length=None)
         return self._process_operating_reserves(df)
 
-    def _process_operating_reserves(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _process_operating_reserves(self, df: pl.DataFrame) -> pl.DataFrame:
         df = self._handle_market_end_to_interval(
             df,
             column="GMTIntervalEnd",
             interval_duration=pd.Timedelta(minutes=5),
         )
 
-        # don't need this column
-        df = df.drop(columns=["Interval"])
+        df = _drop_cols(df, ["Interval"])
 
-        df = df.rename(
-            columns={
+        return _rename_cols(
+            df,
+            {
                 "RegUP_Clr": "Reg_Up_Cleared",
                 "RegDN_Clr": "Reg_Dn_Cleared",
                 "RampUP_Clr": "Ramp_Up_Cleared",
@@ -1907,15 +1936,13 @@ class SPP(ISOBase):
             },
         )
 
-        return df
-
     def get_as_prices_real_time_5_min(
         self,
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
         use_daily_files: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """
         Provides Marginal Clearing Price information by Reserve Zone for each
         Real-Time 5-minute Market solution.
@@ -1927,7 +1954,7 @@ class SPP(ISOBase):
             use_daily_files: if True, use daily files instead of 5 minute files.
 
         Returns:
-            pd.DataFrame: Real-Time 5-minute Marginal Clearing Prices
+            pl.DataFrame: Real-Time 5-minute Marginal Clearing Prices
         """
         if use_daily_files:
             return self._get_as_prices_real_time_5_min_from_daily_files(
@@ -1948,7 +1975,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get AS prices from 5-minute interval files."""
         if date == "latest":
             url = f"{FILE_BROWSER_DOWNLOAD_URL}/rtbm-mcp?path=/RTBM-MCP-latestInterval.csv"
@@ -1962,7 +1989,7 @@ class SPP(ISOBase):
             )
 
         logger.info(f"Downloading {url}")
-        df = pd.read_csv(url)
+        df = pl.read_csv(url, infer_schema_length=None)
         return self._process_as_prices_real_time(df)
 
     @support_date_range("DAY_START")
@@ -1971,29 +1998,26 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get AS prices from daily files."""
         if date == "latest":
             raise ValueError("Latest not supported with daily files")
 
         url = self._format_daily_mcp_url(date, end)
         logger.info(f"Downloading {url}")
-        df = pd.read_csv(url)
+        df = pl.read_csv(url, infer_schema_length=None)
 
-        # Strip whitespace from column names for daily files
-        df.columns = df.columns.str.strip()
-        return self._process_as_prices_real_time(df)
+        return self._process_as_prices_real_time(_strip_columns(df))
 
-    def _process_as_prices_real_time(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _process_as_prices_real_time(self, df: pl.DataFrame) -> pl.DataFrame:
         df = self._handle_market_end_to_interval(
             df,
             column="GMTIntervalEnd",
             interval_duration=pd.Timedelta(minutes=5),
         )
 
-        df.columns = df.columns.str.strip()
+        df = _strip_columns(df)
 
-        # Column mapping to match day-ahead format
         column_mapping = {
             "RegUPService": "Reg Up Service",
             "RegDNService": "Reg DN Service",
@@ -2006,7 +2030,7 @@ class SPP(ISOBase):
             "UncUP": "Unc Up",
         }
 
-        df = df.rename(columns=column_mapping)
+        df = _rename_cols(df, column_mapping)
 
         cols_to_keep = [
             "Interval Start",
@@ -2014,9 +2038,9 @@ class SPP(ISOBase):
             "Reserve Zone",
         ] + list(column_mapping.values())
 
-        return df.sort_values(["Interval Start", "Reserve Zone"]).reset_index(
-            drop=True,
-        )[cols_to_keep]
+        return df.sort(["Interval Start", "Reserve Zone"]).select(
+            [c for c in cols_to_keep if c in df.columns],
+        )
 
     def _format_daily_mcp_url(
         self,
@@ -2046,7 +2070,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Provides Marginal Clearing Price information by Reserve Zone for each
         Day-Ahead Market solution for each Operating Day.
         Posting is updated each day after the DA Market results are posted.
@@ -2058,7 +2082,7 @@ class SPP(ISOBase):
             verbose: print url
 
         Returns:
-            pd.DataFrame: Day Ahead Marginal Clearing Prices
+            pl.DataFrame: Day Ahead Marginal Clearing Prices
         """
         if date == "latest":
             raise ValueError(
@@ -2068,19 +2092,19 @@ class SPP(ISOBase):
         url = f"{FILE_BROWSER_DOWNLOAD_URL}/da-mcp?path=/{date.strftime('%Y')}/{date.strftime('%m')}/DA-MCP-{date.strftime('%Y%m%d')}0100.csv"  # noqa
 
         logger.info(f"Downloading {url}")
-        df = pd.read_csv(url)
+        df = pl.read_csv(url, infer_schema_length=None)
 
         return self._process_day_ahead_operating_reserve_prices(df)
 
     def _process_day_ahead_operating_reserve_prices(
         self,
-        df: pd.DataFrame,
-    ) -> pd.DataFrame:
+        df: pl.DataFrame,
+    ) -> pl.DataFrame:
         df = self._handle_market_end_to_interval(
             df,
             column="GMTIntervalEnd",
             interval_duration=pd.Timedelta(hours=1),
-        ).assign(Market="DAM")
+        ).with_columns(pl.lit("DAM").alias("Market"))
 
         column_mapping = {
             "RegUP": "Reg_Up",
@@ -2092,19 +2116,16 @@ class SPP(ISOBase):
             "UncUP": "Unc_Up",
         }
 
-        df = df.rename(columns=column_mapping)
+        df = _rename_cols(df, column_mapping)
 
         cols_to_keep = [
             "Interval Start",
             "Interval End",
             "Market",
             "Reserve Zone",
-        ] + list(
-            column_mapping.values(),
-        )
+        ] + list(column_mapping.values())
 
-        # Older datasets might not have all the reserve types
-        return df[[c for c in cols_to_keep if c in df]]
+        return df.select([c for c in cols_to_keep if c in df.columns])
 
     @support_date_range("5_MIN")
     def get_lmp_real_time_weis(
@@ -2112,7 +2133,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get LMP data for real time WEIS
 
         Args:
@@ -2136,16 +2157,15 @@ class SPP(ISOBase):
         logger.info(f"Downloading {url}")
 
         try:
-            df = pd.read_csv(url)
+            df = pl.read_csv(url, infer_schema_length=None)
         except ConnectionResetError as e:
             logger.error(f"Error downloading {url}: {e}")
-            return pd.DataFrame()
+            return pl.DataFrame()
 
         return self._process_lmp_real_time_weis(df)
 
-    def _process_lmp_real_time_weis(self, df: pd.DataFrame) -> pd.DataFrame:
-        # strip whitespace from column names
-        df = df.rename(columns=lambda x: x.strip())
+    def _process_lmp_real_time_weis(self, df: pl.DataFrame) -> pl.DataFrame:
+        df = _strip_columns(df)
 
         df = self._handle_market_end_to_interval(
             df,
@@ -2153,21 +2173,24 @@ class SPP(ISOBase):
             interval_duration=pd.Timedelta(minutes=5),
         )
 
-        df["Location Type"] = LOCATION_TYPE_SETTLEMENT_LOCATION
-        df["Market"] = "REAL_TIME_WEIS"
+        df = df.with_columns(
+            pl.lit(LOCATION_TYPE_SETTLEMENT_LOCATION).alias("Location Type"),
+            pl.lit("REAL_TIME_WEIS").alias("Market"),
+        )
 
-        df = df.rename(
-            columns={
+        df = _rename_cols(
+            df,
+            {
                 "Settlement Location": "Location",
                 "Pnode": "PNode",
-                "LMP": "LMP",  # for posterity
+                "LMP": "LMP",
                 "MLC": "Loss",
                 "MCC": "Congestion",
                 "MEC": "Energy",
             },
         )
 
-        df = df[
+        return df.select(
             [
                 "Interval Start",
                 "Interval End",
@@ -2179,10 +2202,8 @@ class SPP(ISOBase):
                 "Energy",
                 "Congestion",
                 "Loss",
-            ]
-        ]
-
-        return df
+            ],
+        )
 
     def _format_5_min_url(
         self,
@@ -2271,13 +2292,13 @@ class SPP(ISOBase):
         self,
         urls: list[str],
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         all_dfs = []
         for url in tqdm.tqdm(urls):
             logger.info(f"Fetching {url}")
-            df = pd.read_csv(url)
+            df = pl.read_csv(url, infer_schema_length=None)
             all_dfs.append(df)
-        return pd.concat(all_dfs)
+        return pl.concat(all_dfs, how="diagonal")
 
     def _get_marketplace_session(self) -> dict:
         """
@@ -2317,7 +2338,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Hourly Load in the legacy wide format (before 2026-03-24).
 
         Deprecated: SPP changed the hourly load data format on 2026-03-24.
@@ -2328,7 +2349,7 @@ class SPP(ISOBase):
             end: end date
 
         Returns:
-            pd.DataFrame: Hourly Load in wide format
+            pl.DataFrame: Hourly Load in wide format
         """
         if date >= HOURLY_LOAD_WIDE_FORMAT_END_DATE:
             raise NotSupported(
@@ -2338,7 +2359,7 @@ class SPP(ISOBase):
 
         url = f"{FILE_BROWSER_DOWNLOAD_URL}/hourly-load?path=/{date.strftime('%Y')}/DAILY_HOURLY_LOAD-{date.strftime('%Y%m%d')}.csv"  # noqa
         logger.info(f"Downloading {url}")
-        df = pd.read_csv(url)
+        df = pl.read_csv(url, infer_schema_length=None)
 
         return self._process_hourly_load(df)
 
@@ -2348,7 +2369,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Hourly Load in the long format (on or after 2026-03-24).
 
         Args:
@@ -2356,7 +2377,7 @@ class SPP(ISOBase):
             end: end date
 
         Returns:
-            pd.DataFrame: Hourly Load with columns Time, Interval Start,
+            pl.DataFrame: Hourly Load with columns Time, Interval Start,
                 Interval End, Balancing Area Name, Control Zone Name,
                 Forecast Area Type, Load
         """
@@ -2374,11 +2395,11 @@ class SPP(ISOBase):
 
         url = f"{FILE_BROWSER_DOWNLOAD_URL}/hourly-load?path=/{date.strftime('%Y')}/DAILY_HOURLY_LOAD-{date.strftime('%Y%m%d')}.csv"  # noqa
         logger.info(f"Downloading {url}")
-        df = pd.read_csv(url)
+        df = pl.read_csv(url, infer_schema_length=None)
 
         return self._process_hourly_load_long(df)
 
-    def get_hourly_load_annual(self, year: int, verbose: bool = True) -> pd.DataFrame:
+    def get_hourly_load_annual(self, year: int, verbose: bool = True) -> pl.DataFrame:
         """Get Hourly Load for a year. Starting 2011.
         For recent data use `get_hourly_load`
 
@@ -2387,7 +2408,7 @@ class SPP(ISOBase):
             verbose: print url
 
         Returns:
-            pd.DataFrame: Hourly Load
+            pl.DataFrame: Hourly Load
         """
         url = f"{FILE_BROWSER_DOWNLOAD_URL}/hourly-load?path=/{year}/{year}.zip"  # noqa
         df = utils.download_csvs_from_zip_url(
@@ -2398,7 +2419,7 @@ class SPP(ISOBase):
 
         return self._process_hourly_load(df)
 
-    def _process_hourly_load(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _process_hourly_load(self, df: pl.DataFrame) -> pl.DataFrame:
         """Process hourly load data in the legacy wide format.
 
         Deprecated: This method handles the wide format used before 2026-03-24.
@@ -2412,21 +2433,21 @@ class SPP(ISOBase):
                 "for the new long format.",
             )
 
-        # Some column names contain leading whitespace in some files - remove it
-        df = df.rename(columns=lambda x: x.strip())
+        df = _strip_columns(df)
+        df = df.filter(~pl.all_horizontal(pl.all().is_null()))
 
-        # Some files contain null rows. Drop them.
-        df = df.dropna(how="all")
-
-        # Some files don't have time 00:00 for the first interval in a day
-        # for example 12/2/2016 instead of 12/2/2016 00:00. This causes datetime
-        # conversion problems. This fixes it.
-        def clean_market_hour(val):
+        def clean_market_hour(val: str | None) -> str | None:
+            if val is None:
+                return val
             if val.endswith(":00"):
                 return val
             return val + " 00:00"
 
-        df["MarketHour"] = df["MarketHour"].apply(clean_market_hour)
+        df = df.with_columns(
+            pl.col("MarketHour")
+            .map_elements(clean_market_hour, return_dtype=pl.Utf8)
+            .alias("MarketHour"),
+        )
 
         df = self._handle_market_end_to_interval(
             df,
@@ -2462,29 +2483,19 @@ class SPP(ISOBase):
         ]
         all_cols = time_cols + load_cols
 
-        # historical data doesn't have all columns
-        for c in all_cols:
-            if c not in df.columns:
-                df[c] = pd.NA
+        df = _ensure_columns(df, all_cols)
+        df = df.filter(pl.col("Interval Start").is_not_null()).unique()
+        df = _sum_across_cols(df, load_cols, "System Total")
+        return df.sort("Time")
 
-        df = df[all_cols]
-
-        df = df[~df["Interval Start"].isnull()].drop_duplicates()
-
-        df = df.sort_values("Time")
-        df["System Total"] = df[load_cols].sum(axis=1, skipna=True)
-
-        return df
-
-    def _process_hourly_load_long(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _process_hourly_load_long(self, df: pl.DataFrame) -> pl.DataFrame:
         """Process hourly load data in the new long format (starting 2026-03-24).
 
         The new format has columns: Market Hour, Balancing Area Name,
         Control Zone Name, Forecast Area Type, Load MW.
         """
-        df = df.rename(columns=lambda x: x.strip())
-
-        df = df.dropna(how="all")
+        df = _strip_columns(df)
+        df = df.filter(~pl.all_horizontal(pl.all().is_null()))
 
         df = self._handle_market_end_to_interval(
             df,
@@ -2493,13 +2504,9 @@ class SPP(ISOBase):
             format="mixed",
         )
 
-        df = df[~df["Interval Start"].isnull()].drop_duplicates()
+        df = df.filter(pl.col("Interval Start").is_not_null()).unique()
 
-        df = df.rename(
-            columns={
-                "Load MW": "Load",
-            },
-        )
+        df = _rename_cols(df, {"Load MW": "Load"})
 
         col_order = [
             "Interval Start",
@@ -2510,18 +2517,14 @@ class SPP(ISOBase):
             "Load",
         ]
 
-        df = df[col_order]
-
-        df = df.sort_values(
+        return df.select(col_order).sort(
             [
                 "Interval Start",
                 "Balancing Area Name",
                 "Control Zone Name",
                 "Forecast Area Type",
             ],
-        ).reset_index(drop=True)
-
-        return df
+        )
 
     @support_date_range("DAY_START")
     def get_market_clearing_real_time(
@@ -2529,7 +2532,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Market Clearing Real Time
 
         Args:
@@ -2537,7 +2540,7 @@ class SPP(ISOBase):
             end: end date
 
         Returns:
-            pd.DataFrame: Market Clearing Real Time
+            pl.DataFrame: Market Clearing Real Time
         """
         if date == "latest":
             try:
@@ -2552,7 +2555,7 @@ class SPP(ISOBase):
         url = f"{FILE_BROWSER_DOWNLOAD_URL}/market-clearing-rtbm?path=/{date.strftime('%Y')}/{date.strftime('%m')}/RTBM-MC-{date.strftime('%Y%m%d')}.csv"  # noqa
 
         logger.info(f"Downloading {url}")
-        df = pd.read_csv(url)
+        df = pl.read_csv(url, infer_schema_length=None)
 
         return self._process_market_clearing(df, 5)
 
@@ -2562,7 +2565,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Market Clearing Day Ahead
 
         Args:
@@ -2570,7 +2573,7 @@ class SPP(ISOBase):
             end: end date
 
         Returns:
-            pd.DataFrame: Market Clearing Day Ahead
+            pl.DataFrame: Market Clearing Day Ahead
         """
         if date == "latest":
             date = self.local_now().normalize() + pd.DateOffset(days=1)
@@ -2585,30 +2588,33 @@ class SPP(ISOBase):
         url = f"{FILE_BROWSER_DOWNLOAD_URL}/market-clearing?path=/{date.strftime('%Y')}/{date.strftime('%m')}/DA-MC-{date.strftime('%Y%m%d')}0100.csv"  # noqa
 
         logger.info(f"Downloading {url}")
-        df = pd.read_csv(url)
+        df = pl.read_csv(url, infer_schema_length=None)
 
         return self._process_market_clearing(df, 60)
 
-    def _process_market_clearing(self, df: pd.DataFrame, interval_minutes: int):
+    def _process_market_clearing(
+        self,
+        df: pl.DataFrame,
+        interval_minutes: int,
+    ) -> pl.DataFrame:
         df = self._handle_market_end_to_interval(
             df,
             column="GMTIntervalEnd",
             interval_duration=pd.Timedelta(minutes=interval_minutes),
         )
 
-        df.columns = df.columns.str.strip()
-
-        df = df.rename(
-            columns={
+        df = _strip_columns(df)
+        df = _rename_cols(
+            df,
+            {
                 "RegUP": "Reg Up",
                 "RegDN": "Reg Dn",
                 "RampUP": "Ramp Up",
                 "RampDN": "Ramp Dn",
                 "UncUP": "Unc Up",
             },
-        ).drop(columns=["Time", "Interval"])
-
-        return df.sort_values("Interval Start")
+        )
+        return _drop_cols(df, ["Time", "Interval"]).sort("Interval Start")
 
     @support_date_range("DAY_START")
     def get_binding_constraints_day_ahead_hourly(
@@ -2616,7 +2622,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Day-Ahead Binding Constraints
 
         Args:
@@ -2625,7 +2631,7 @@ class SPP(ISOBase):
             verbose: print url
 
         Returns:
-            pd.DataFrame: Day-Ahead Binding Constraints
+            pl.DataFrame: Day-Ahead Binding Constraints
         """
         if date == "latest":
             tomorrow = pd.Timestamp.now(
@@ -2643,16 +2649,16 @@ class SPP(ISOBase):
         url = f"{FILE_BROWSER_DOWNLOAD_URL}/{DA_BINDING_CONSTRAINTS}?path=/{date.strftime('%Y')}/{date.strftime('%m')}/By_Day/DA-BC-{date.strftime('%Y%m%d')}0100.csv"  # noqa
         return self._process_binding_constraints_day_ahead_hourly(url)
 
-    def _process_binding_constraints_day_ahead_hourly(self, url: str) -> pd.DataFrame:
+    def _process_binding_constraints_day_ahead_hourly(self, url: str) -> pl.DataFrame:
         logger.info(f"Downloading {url}...")
         try:
-            df = pd.read_csv(url)
+            df = pl.read_csv(url, infer_schema_length=None)
         except urllib.error.HTTPError as e:
             if e.code == 404:
                 raise NoDataFoundException(f"No data found for {url}")
             raise
 
-        df.columns = df.columns.str.strip()
+        df = _strip_columns(df)
 
         df = self._handle_market_end_to_interval(
             df,
@@ -2660,10 +2666,12 @@ class SPP(ISOBase):
             interval_duration=pd.Timedelta(hours=1),
         )
 
-        df = df.rename(columns={"NERCID": "NERC ID"})
-
-        df["NERC ID"] = pd.to_numeric(df["NERC ID"], errors="coerce").astype(
-            pd.Int64Dtype(),
+        df = _rename_cols(df, {"NERCID": "NERC ID"})
+        df = df.with_columns(
+            pl.col("NERC ID")
+            .cast(pl.Float64, strict=False)
+            .cast(pl.Int64, strict=False)
+            .alias("NERC ID"),
         )
 
         cols_to_keep = [
@@ -2679,7 +2687,7 @@ class SPP(ISOBase):
             "Contingency Name",
         ]
 
-        return df[cols_to_keep].sort_values(["Interval Start", "Constraint Name"])
+        return df.select(cols_to_keep).sort(["Interval Start", "Constraint Name"])
 
     # NB: SPP RTBM publishes per-interval CSVs and daily aggregates. Both are
     # aligned to local midnight. Interval files live under
@@ -2696,7 +2704,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Real-Time Binding Constraints
 
         Args:
@@ -2705,7 +2713,7 @@ class SPP(ISOBase):
             verbose: print url
 
         Returns:
-            pd.DataFrame: Real-Time Binding Constraints
+            pl.DataFrame: Real-Time Binding Constraints
         """
         if date == "latest":
             return self._get_binding_constraints_real_time_5_min_from_intervals(
@@ -2728,9 +2736,10 @@ class SPP(ISOBase):
         if end_ts is None:
             return df
 
-        return df[
-            (df["Interval Start"] >= start_ts) & (df["Interval Start"] < end_ts)
-        ].reset_index(drop=True)
+        return df.filter(
+            (pl.col("Interval Start") >= pl.lit(start_ts))
+            & (pl.col("Interval Start") < pl.lit(end_ts)),
+        )
 
     @support_date_range(_binding_constraints_real_time_5_min_frequency)
     def _fetch_binding_constraints_real_time_5_min(
@@ -2738,7 +2747,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Per-chunk fetch dispatching to interval or daily-file source."""
         start = utils._handle_date(date, self.default_timezone)
         if not utils.is_within_last_days(start, 1, self.default_timezone):
@@ -2787,7 +2796,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Real-Time Binding Constraints from daily files."""
 
         folder_year = date.strftime("%Y")
@@ -2796,9 +2805,8 @@ class SPP(ISOBase):
         url = f"{FILE_BROWSER_DOWNLOAD_URL}/{RTBM_BINDING_CONSTRAINTS}?path=/{folder_year}/{folder_month}/By_Day/RTBM-DAILY-BC-{date.strftime('%Y%m%d')}.csv"
 
         logger.info(f"Downloading {url} (daily file)...")
-        df = pd.read_csv(url)
-        df.columns = df.columns.str.strip()
-        return self._process_binding_constraints_real_time(df)
+        df = pl.read_csv(url, infer_schema_length=None)
+        return self._process_binding_constraints_real_time(_strip_columns(df))
 
     @support_date_range("5_MIN")
     def _get_binding_constraints_real_time_5_min_from_intervals(
@@ -2806,7 +2814,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get Real-Time Binding Constraints from 5-minute interval files."""
         if date == "latest":
             url = f"{FILE_BROWSER_DOWNLOAD_URL}/{RTBM_BINDING_CONSTRAINTS}?path=/RTBM-BC-latestInterval.csv"  # noqa
@@ -2819,16 +2827,17 @@ class SPP(ISOBase):
             )
 
         logger.info(f"Downloading {url}...")
-        df = pd.read_csv(url)
+        df = pl.read_csv(url, infer_schema_length=None)
         return self._process_binding_constraints_real_time(df)
 
-    def _process_binding_constraints_real_time(self, df: pd.DataFrame) -> pd.DataFrame:
-        df.columns = df.columns.str.strip()
-
-        # Convert to title case to handle nonstandard input
-        df.columns = df.columns.str.title().str.replace("_", " ")
+    def _process_binding_constraints_real_time(self, df: pl.DataFrame) -> pl.DataFrame:
+        df = _strip_columns(df)
         df = df.rename(
-            columns={
+            {c: c.strip().title().replace("_", " ") for c in df.columns},
+        )
+        df = _rename_cols(
+            df,
+            {
                 "Gmtintervalend": "GMTIntervalEnd",
                 "Nercid": "NERC ID",
                 "Tlr Level": "TLR Level",
@@ -2841,7 +2850,12 @@ class SPP(ISOBase):
             interval_duration=pd.Timedelta(minutes=5),
         )
 
-        df["NERC ID"] = pd.to_numeric(df["NERC ID"], errors="coerce").astype("Int64")
+        df = df.with_columns(
+            pl.col("NERC ID")
+            .cast(pl.Float64, strict=False)
+            .cast(pl.Int64, strict=False)
+            .alias("NERC ID"),
+        )
 
         cols_to_keep = [
             "Interval Start",
@@ -2856,7 +2870,7 @@ class SPP(ISOBase):
             "Contingent Facility",
         ]
 
-        return df[cols_to_keep].sort_values(["Interval Start", "Constraint Name"])
+        return df.select(cols_to_keep).sort(["Interval Start", "Constraint Name"])
 
     @support_date_range("MONTH_START")
     def get_interchange_real_time(
@@ -2864,7 +2878,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get real-time interchange (tie flow) data.
 
         For "latest" and "today", returns ~2 days of 1-minute interchange data
@@ -2883,15 +2897,14 @@ class SPP(ISOBase):
             verbose: print info
 
         Returns:
-            pd.DataFrame: interchange data
+            pl.DataFrame: interchange data
         """
         if date == "latest":
             return self.get_interchange_real_time(
                 "today",
                 verbose=verbose,
-            ).reset_index(drop=True)
+            )
 
-        # Handle tuple date ranges by checking if the start is recent
         if isinstance(date, tuple):
             start = date[0]
         else:
@@ -2900,7 +2913,7 @@ class SPP(ISOBase):
         if utils.is_within_last_days(start, days=2, tz=self.default_timezone):
             url = f"{MARKETPLACE_BASE_URL}/chart-api/interchange-trend/asFile"
             logger.info(f"Downloading {url}")
-            df = pd.read_csv(url)
+            df = pl.read_csv(url, infer_schema_length=None)
             return self._process_interchange_real_time(df)
 
         # Historical data: download monthly CSV
@@ -2914,7 +2927,7 @@ class SPP(ISOBase):
 
         logger.info(f"Downloading {url}")
         try:
-            df = pd.read_csv(url)
+            df = pl.read_csv(url, infer_schema_length=None)
         except urllib.error.HTTPError as e:
             if e.code == 404:
                 raise NoDataFoundException(
@@ -2924,8 +2937,9 @@ class SPP(ISOBase):
             raise
 
         # Normalize historical column names to match real-time format
-        df = df.rename(
-            columns={
+        df = _rename_cols(
+            df,
+            {
                 "GMTTIME": "GMTTime",
                 "SPP_NSI": "SPP NSI",
                 "SPP_NAI": "SPP NAI",
@@ -2940,7 +2954,7 @@ class SPP(ISOBase):
         date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
         end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
         verbose: bool = False,
-    ) -> pd.DataFrame:
+    ) -> pl.DataFrame:
         """Get real-time interchange (tie flow) data for SPP West (SWPW).
 
         For "latest" and "today", returns ~2 days of 1-minute interchange data
@@ -2959,15 +2973,14 @@ class SPP(ISOBase):
             verbose: print info
 
         Returns:
-            pd.DataFrame: interchange data
+            pl.DataFrame: interchange data
         """
         if date == "latest":
             return self.get_west_interchange_real_time(
                 "today",
                 verbose=verbose,
-            ).reset_index(drop=True)
+            )
 
-        # Handle tuple date ranges by checking if the start is recent
         if isinstance(date, tuple):
             start = date[0]
         else:
@@ -2976,7 +2989,7 @@ class SPP(ISOBase):
         if utils.is_within_last_days(start, days=2, tz=self.default_timezone):
             url = f"{MARKETPLACE_BASE_URL}/chart-api/interchange-trend-swpw/asFile"
             logger.info(f"Downloading {url}")
-            df = pd.read_csv(url)
+            df = pl.read_csv(url, infer_schema_length=None)
             return self._process_interchange_real_time(df)
 
         # Historical data: download monthly CSV
@@ -2988,7 +3001,7 @@ class SPP(ISOBase):
 
         logger.info(f"Downloading {url}")
         try:
-            df = pd.read_csv(url)
+            df = pl.read_csv(url, infer_schema_length=None)
         except urllib.error.HTTPError as e:
             if e.code == 404:
                 raise NoDataFoundException(
@@ -2998,8 +3011,9 @@ class SPP(ISOBase):
             raise
 
         # Normalize historical column names to match real-time format
-        df = df.rename(
-            columns={
+        df = _rename_cols(
+            df,
+            {
                 "GMTTIME": "GMTTime",
                 "SPP_NSI": "SWPW NSI",
                 "SPP_NAI": "SWPW NAI",
@@ -3008,71 +3022,55 @@ class SPP(ISOBase):
 
         return self._process_interchange_real_time(df)
 
-    def _process_interchange_real_time(self, df: pd.DataFrame) -> pd.DataFrame:
-        df["Time"] = pd.to_datetime(
-            df["GMTTime"],
-            utc=True,
-            format="ISO8601",
-        ).dt.tz_convert(self.default_timezone)
+    def _process_interchange_real_time(self, df: pl.DataFrame) -> pl.DataFrame:
+        df = df.with_columns(
+            _parse_utc_to_local(df, "GMTTime", self.default_timezone).alias("Time"),
+        )
+        df = _drop_cols(df, ["GMTTime"])
+        df = df.filter(pl.col("Time").is_not_null())
 
-        df = df.drop(columns=["GMTTime"])
-
-        # Drop rows with null timestamps (bad data in some historical files)
-        df = df.dropna(subset=["Time"])
-
-        # Drop rows where all data columns are null (future forecast rows)
         data_cols = [c for c in df.columns if c != "Time"]
-        df = df.dropna(subset=data_cols, how="all")
+        df = df.filter(
+            pl.any_horizontal([pl.col(c).is_not_null() for c in data_cols]),
+        )
 
-        # Melt from wide to long format so schema is stable across time periods
-        id_cols = ["Time"]
-        value_cols = [c for c in df.columns if c not in id_cols]
-        df = df.melt(
-            id_vars=id_cols,
-            value_vars=value_cols,
-            var_name="Region",
+        df = df.unpivot(
+            index=["Time"],
+            on=data_cols,
+            variable_name="Region",
             value_name="Interchange",
         )
 
-        # Drop rows where interchange is null (region didn't exist in this period)
-        df = df.dropna(subset=["Interchange"])
-
-        return df.sort_values(["Time", "Region"]).reset_index(drop=True)
+        return df.filter(pl.col("Interchange").is_not_null()).sort(["Time", "Region"])
 
 
-def process_gen_mix(df: pd.DataFrame, detailed: bool = False) -> pd.DataFrame:
+def process_gen_mix(df: pl.DataFrame, detailed: bool = False) -> pl.DataFrame:
     """Parse SPP generation mix data from
     https://marketplace.spp.org/pages/generation-mix-historical
 
     Args:
-        df (pd.DataFrame): raw data
+        df (pl.DataFrame): raw data
         detailed (bool): whether to combine market and self columns
 
     Returns:
-        pd.DataFrame: processed data
+        pl.DataFrame: processed data
     """
-    new_df = df.copy()
+    new_df = _strip_columns(df)
 
-    # remove whitespace from column names
-    new_df.columns = new_df.columns.str.strip()
-
-    # rename columns to standardize
-    new_df = new_df.rename(
-        columns={
+    new_df = _rename_cols(
+        new_df,
+        {
             "GMTTime": "Time",
             "GMT MKT Interval": "Time",
             "Gas Self": "Natural Gas Self",
-            # rename below is based on documenation
             "Load": "Short Term Load Forecast",
         },
     )
 
-    # parse time
-    new_df["Time"] = pd.to_datetime(new_df["Time"], utc=True).dt.tz_convert(
-        SPP.default_timezone,
+    new_df = new_df.with_columns(
+        _parse_utc_to_local(new_df, "Time", SPP.default_timezone).alias("Time"),
     )
 
-    # combine market and self columns
     columns_to_combine = [
         "Coal",
         "Diesel Fuel Oil",
@@ -3094,22 +3092,22 @@ def process_gen_mix(df: pd.DataFrame, detailed: bool = False) -> pd.DataFrame:
             if market_col not in new_df.columns or self_col not in new_df.columns:
                 continue
 
-            new_df[col] = new_df[market_col] + new_df[self_col]
-            new_df = new_df.drop([market_col, self_col], axis=1)
+            new_df = new_df.with_columns(
+                (
+                    pl.col(market_col).cast(pl.Float64, strict=False).fill_null(0)
+                    + pl.col(self_col).cast(pl.Float64, strict=False).fill_null(0)
+                ).alias(col),
+            ).drop([market_col, self_col])
 
-    new_df = add_interval(new_df, 5)
-
-    return new_df
+    return add_interval(new_df, 5)
 
 
-def add_interval(df: pd.DataFrame, interval_min: int) -> pd.DataFrame:
+def add_interval(df: pl.DataFrame, interval_min: int) -> pl.DataFrame:
     """Adds Interval Start and Interval End columns to df"""
-    df["Interval Start"] = df["Time"]
-    df["Interval End"] = df["Interval Start"] + pd.Timedelta(minutes=interval_min)
-
-    df = utils.move_cols_to_front(
-        df,
-        ["Time", "Interval Start", "Interval End"],
+    duration = pl.duration(minutes=interval_min)
+    df = df.with_columns(
+        pl.col("Time").alias("Interval Start"),
+        (pl.col("Time") + duration).alias("Interval End"),
     )
 
-    return df
+    return utils.move_cols_to_front(df, ["Time", "Interval Start", "Interval End"])

--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -137,7 +137,7 @@ def _parse_utc_to_local(df: pl.DataFrame, column: str, tz: str) -> pl.Series:
         df.get_column(column).to_pandas(),
         utc=True,
     ).dt.tz_convert(tz)
-    return pl.Series(column, parsed)
+    return pl.Series(column, parsed).cast(pl.Datetime("us", tz))
 
 
 def _drop_cols(df: pl.DataFrame, cols: list[str]) -> pl.DataFrame:
@@ -1191,7 +1191,7 @@ class SPP(ISOBase):
                 utc=True,
                 format=format,
             ).dt.tz_convert(self.default_timezone),
-        )
+        ).cast(pl.Datetime("us", self.default_timezone))
         df = df.with_columns(interval_end)
         df = df.with_columns(
             (pl.col("Interval End") - duration).alias("Interval Start"),

--- a/gridstatus/tests/base_test_iso.py
+++ b/gridstatus/tests/base_test_iso.py
@@ -1,6 +1,6 @@
 import pandas as pd
+import polars as pl
 import pytest
-from pandas.core.dtypes.common import is_numeric_dtype
 
 import gridstatus
 from gridstatus.base import GridStatus, _interconnection_columns
@@ -11,9 +11,20 @@ class TestHelperMixin:
 
     @staticmethod
     def _as_pandas(df):
-        """Accept either a pandas or polars frame, returning pandas for assertions."""
-        if type(df).__module__.split(".")[0] == "polars":
+        """Accept either a pandas or polars frame, returning pandas for assertions.
+
+        Transitional helper for source-specific tests that still assert with
+        pandas idioms; remove call sites as each ISO's tests convert to polars.
+        """
+        if isinstance(df, pl.DataFrame):
             return df.to_pandas()
+        return df
+
+    @staticmethod
+    def _as_polars(df):
+        """Accept either a pandas or polars frame, returning polars for assertions."""
+        if isinstance(df, pd.DataFrame):
+            return pl.from_pandas(df)
         return df
 
     def local_now(self):
@@ -29,10 +40,10 @@ class TestHelperMixin:
         return self.local_start_of_day(self.local_today())
 
     def _check_ordered_by_time(self, df, col):
-        df = self._as_pandas(df)
-        assert isinstance(df, pd.DataFrame)
-        assert df.shape[0] > 0
-        assert df[col].is_monotonic_increasing
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
+        assert df.height > 0
+        assert df[col].is_sorted()
 
     def _check_time_columns(
         self,
@@ -41,8 +52,8 @@ class TestHelperMixin:
         skip_column_named_time=False,
         sced=False,
     ):
-        df = self._as_pandas(df)
-        assert isinstance(df, pd.DataFrame)
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
 
         if instant_or_interval == "interval":
             # TODO: remove "Time" from time_cols for "interval"
@@ -65,11 +76,12 @@ class TestHelperMixin:
         if skip_column_named_time:
             time_cols.remove("Time")
 
-        assert time_cols == df.columns[: len(time_cols)].tolist()
+        assert time_cols == df.columns[: len(time_cols)]
         # check all time cols are localized timestamps
         for col in time_cols:
-            assert isinstance(df.loc[0][col], pd.Timestamp)
-            assert df.loc[0][col].tz is not None
+            dtype = df.schema[col]
+            assert isinstance(dtype, pl.Datetime)
+            assert dtype.time_zone is not None
 
         self._check_ordered_by_time(df, ordered_by_col)
 
@@ -106,31 +118,31 @@ class BaseTestISO(TestHelperMixin):
     def test_get_fuel_mix_historical(self, time_column="Time"):
         # date string works
         date_str = "04/03/2022"
-        df = self._as_pandas(self.iso.get_fuel_mix(date_str))
+        df = self._as_polars(self.iso.get_fuel_mix(date_str))
 
-        assert isinstance(df, pd.DataFrame)
-        assert df.loc[0][time_column].strftime("%m/%d/%Y") == date_str
-        assert df.loc[0][time_column].tz is not None
+        assert isinstance(df, pl.DataFrame)
+        assert df[0, time_column].strftime("%m/%d/%Y") == date_str
+        assert df[0, time_column].tzinfo is not None
         self._check_fuel_mix(df)
 
         # timestamp object works
         date_obj = pd.to_datetime("2019/11/19")
-        df = self._as_pandas(self.iso.get_fuel_mix(date_obj))
-        assert isinstance(df, pd.DataFrame)
-        assert df.loc[0][time_column].strftime(
+        df = self._as_polars(self.iso.get_fuel_mix(date_obj))
+        assert isinstance(df, pl.DataFrame)
+        assert df[0, time_column].strftime(
             "%Y%m%d",
         ) == date_obj.strftime("%Y%m%d")
-        assert df.loc[0][time_column].tz is not None
+        assert df[0, time_column].tzinfo is not None
         self._check_fuel_mix(df)
 
         # datetime object works
         date_obj = pd.to_datetime("2021/05/09").date()
-        df = self._as_pandas(self.iso.get_fuel_mix(date_obj))
-        assert isinstance(df, pd.DataFrame)
-        assert df.loc[0][time_column].strftime(
+        df = self._as_polars(self.iso.get_fuel_mix(date_obj))
+        assert isinstance(df, pl.DataFrame)
+        assert df[0, time_column].strftime(
             "%Y%m%d",
         ) == date_obj.strftime("%Y%m%d")
-        assert df.loc[0][time_column].tz is not None
+        assert df[0, time_column].tzinfo is not None
         self._check_fuel_mix(df)
 
     def test_get_fuel_mix_historical_with_date_range(self, time_column="Time"):
@@ -141,13 +153,13 @@ class BaseTestISO(TestHelperMixin):
         ) + pd.Timedelta(days=1)
         start = end - pd.Timedelta(days=num_days)
 
-        df = self._as_pandas(
+        df = self._as_polars(
             self.iso.get_fuel_mix(date=start.date(), end=end.date()),
         )
         self._check_fuel_mix(df)
 
         # make sure right number of days are returned
-        assert df[time_column].dt.day.nunique() == num_days
+        assert df[time_column].dt.day().n_unique() == num_days
 
     def test_get_fuel_mix_range_two_days_with_day_start_endpoint(
         self,
@@ -162,7 +174,7 @@ class BaseTestISO(TestHelperMixin):
 
         # add one minute since pjm is exclusive of end date
         # and does not include the whole day like other isos
-        df = self._as_pandas(
+        df = self._as_polars(
             self.iso.get_fuel_mix(start=start, end=yesterday + pd.Timedelta(minutes=1)),
         )
 
@@ -178,16 +190,17 @@ class BaseTestISO(TestHelperMixin):
         ) - pd.Timedelta(days=1)
         start = yesterday.replace(hour=0, minute=5, second=0, microsecond=0)
         end = yesterday.replace(hour=6, minute=5, second=0, microsecond=0)
-        df = self._as_pandas(self.iso.get_fuel_mix(start=start, end=end))
+        df = self._as_polars(self.iso.get_fuel_mix(start=start, end=end))
         # ignore last row, since it is sometime midnight of next day
-        assert df[time_column].iloc[:-1].dt.date.unique().tolist() == [yesterday.date()]
+        assert df[time_column][:-1].dt.date().unique(
+            maintain_order=True,
+        ).to_list() == [yesterday.date()]
         self._check_fuel_mix(df)
 
     def test_get_fuel_mix_latest(self, time_column="Time"):
-        df = self._as_pandas(self.iso.get_fuel_mix("latest"))
-        assert isinstance(df, pd.DataFrame)
-        assert isinstance(df[time_column].iloc[0], pd.Timestamp)
-        assert df.index.name is None
+        df = self._as_polars(self.iso.get_fuel_mix("latest"))
+        assert isinstance(df, pl.DataFrame)
+        assert isinstance(df.schema[time_column], pl.Datetime)
         self._check_fuel_mix(df)
 
     def test_get_fuel_mix_today(self):
@@ -197,10 +210,10 @@ class BaseTestISO(TestHelperMixin):
     """get_interconnection_queue"""
 
     def test_get_interconnection_queue(self):
-        queue = self.iso.get_interconnection_queue()
+        queue = self._as_polars(self.iso.get_interconnection_queue())
         # todo make sure datetime columns are right type
-        assert isinstance(queue, pd.DataFrame)
-        assert queue.shape[0] > 0
+        assert isinstance(queue, pl.DataFrame)
+        assert queue.height > 0
         assert set(_interconnection_columns).issubset(queue.columns)
 
     """get_lmp"""
@@ -223,22 +236,22 @@ class BaseTestISO(TestHelperMixin):
     # is not available for the selected date.
     def test_get_lmp_historical(self, market=None, date_str="2022-07-22"):
         if market is not None:
-            hist = self._as_pandas(self.iso.get_lmp(date_str, market=market))
-            assert isinstance(hist, pd.DataFrame)
+            hist = self._as_polars(self.iso.get_lmp(date_str, market=market))
+            assert isinstance(hist, pl.DataFrame)
             self._check_lmp_columns(hist, market)
 
     # @pytest.mark.parametrize in ISO
     def test_get_lmp_latest(self, market=None):
         if market is not None:
-            df = self._as_pandas(self.iso.get_lmp("latest", market=market))
-            assert isinstance(df, pd.DataFrame)
+            df = self._as_polars(self.iso.get_lmp("latest", market=market))
+            assert isinstance(df, pl.DataFrame)
             self._check_lmp_columns(df, market)
 
     # @pytest.mark.parametrize in ISO
     def test_get_lmp_today(self, market=None):
         if market is not None:
-            df = self._as_pandas(self.iso.get_lmp("today", market=market))
-            assert isinstance(df, pd.DataFrame)
+            df = self._as_polars(self.iso.get_lmp("today", market=market))
+            assert isinstance(df, pl.DataFrame)
             self._check_lmp_columns(df, market)
 
     """get_load"""
@@ -251,14 +264,14 @@ class BaseTestISO(TestHelperMixin):
         ) + pd.Timedelta(days=1)
         start = end - pd.Timedelta(days=num_days)
 
-        data = self._as_pandas(
+        data = self._as_polars(
             self.iso.get_load(date=start.date(), end=end.date()),
         )
         self._check_load(data)
         # make sure right number of days are returned
-        assert data["Time"].dt.day.nunique() == num_days
+        assert data["Time"].dt.day().n_unique() == num_days
 
-        data_tuple = self._as_pandas(
+        data_tuple = self._as_polars(
             self.iso.get_load(date=(start.date(), end.date())),
         )
 
@@ -271,41 +284,41 @@ class BaseTestISO(TestHelperMixin):
 
         # date string works
         date_str = test_date.strftime("%Y%m%d")
-        df = self._as_pandas(self.iso.get_load(date_str))
+        df = self._as_polars(self.iso.get_load(date_str))
         self._check_load(df)
-        assert df.loc[0]["Time"].strftime("%Y%m%d") == date_str
+        assert df[0, "Time"].strftime("%Y%m%d") == date_str
 
         # timestamp object works
-        df = self._as_pandas(self.iso.get_load(test_date))
+        df = self._as_polars(self.iso.get_load(test_date))
 
         self._check_load(df)
-        assert df.loc[0]["Time"].strftime(
+        assert df[0, "Time"].strftime(
             "%Y%m%d",
         ) == test_date.strftime("%Y%m%d")
 
         # datetime object works
-        df = self._as_pandas(self.iso.get_load(test_date))
+        df = self._as_polars(self.iso.get_load(test_date))
         self._check_load(df)
-        assert df.loc[0]["Time"].strftime(
+        assert df[0, "Time"].strftime(
             "%Y%m%d",
         ) == test_date.strftime("%Y%m%d")
 
     def test_get_load_latest(self):
-        df = self._as_pandas(self.iso.get_load("latest"))
+        df = self._as_polars(self.iso.get_load("latest"))
         self._check_load(df)
         today = pd.Timestamp.now(tz=self.iso.default_timezone).date()
         assert df["Time"].max().date() == today
 
     def test_get_load_today(self):
-        df = self._as_pandas(self.iso.get_load("today"))
+        df = self._as_polars(self.iso.get_load("today"))
         self._check_load(df)
         today = pd.Timestamp.now(tz=self.iso.default_timezone).date()
 
         # okay as long as one of these columns is only today
         assert (
-            (df["Time"].dt.date == today).all()
-            or (df["Interval Start"].dt.date == today).all()
-            or (df["Interval End"].dt.date == today).all()
+            (df["Time"].dt.date() == today).all()
+            or (df["Interval Start"].dt.date() == today).all()
+            or (df["Interval End"].dt.date() == today).all()
         )
 
     """get_load_forecast"""
@@ -351,9 +364,8 @@ class BaseTestISO(TestHelperMixin):
     """other"""
 
     def _check_fuel_mix(self, df):
-        df = self._as_pandas(df)
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.name is None
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
 
         time_type = "interval"
         if self.iso.iso_id in ["nyiso", "isone", "ercot"]:
@@ -365,9 +377,9 @@ class BaseTestISO(TestHelperMixin):
         self._check_time_columns(df, instant_or_interval=time_type)
 
     def _check_load(self, df):
-        df = self._as_pandas(df)
-        assert isinstance(df, pd.DataFrame)
-        assert df.shape[0] >= 0
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
+        assert df.height >= 0
 
         if self.iso.iso_id in ["nyiso"]:
             time_type = "instant"
@@ -383,10 +395,10 @@ class BaseTestISO(TestHelperMixin):
             time_type = "interval"
         self._check_time_columns(df, instant_or_interval=time_type)
         assert "Load" in df.columns
-        assert is_numeric_dtype(df["Load"])
+        assert df.schema["Load"].is_numeric()
 
     def _check_forecast(self, df, expected_columns=None):
-        df = self._as_pandas(df)
+        df = self._as_polars(df)
         if expected_columns is not None:
             assert set(df.columns) == set(expected_columns)
         else:
@@ -411,10 +423,11 @@ class BaseTestISO(TestHelperMixin):
         assert self._check_is_datetime_type(df["Time"])
 
     def _check_is_datetime_type(self, series):
-        # any_dtype allows for TZ-aware or naive datetimes
-        return pd.api.types.is_datetime64_any_dtype(
-            series,
-        ) | pd.api.types.is_timedelta64_dtype(series)
+        # TZ-aware or naive datetimes, or durations
+        return isinstance(series.dtype, pl.Datetime) or isinstance(
+            series.dtype,
+            pl.Duration,
+        )
 
     lmp_cols = [
         "Time",
@@ -430,7 +443,7 @@ class BaseTestISO(TestHelperMixin):
     ]
 
     def _check_lmp_columns(self, df, market):
-        df = self._as_pandas(df)
+        df = self._as_polars(df)
         # todo in future all ISO should return same columns
         # maybe with the exception of "LMP" breakdown
         self._check_time_columns(df)
@@ -439,11 +452,12 @@ class BaseTestISO(TestHelperMixin):
             self.lmp_cols,
         ).issubset(df.columns)
 
-        assert len(df["Market"].unique()) == 1
-        assert df["Market"].unique()[0] == market.value
-        assert df.shape[0] >= 0
+        assert df["Market"].n_unique() == 1
+        assert df["Market"][0] == market.value
+        assert df.height >= 0
 
     def _check_storage(self, df):
+        df = self._as_polars(df)
         assert set(["Time", "Interval Start", "Interval End", "Supply"]).issubset(
             df.columns,
         )

--- a/gridstatus/tests/schema_snapshots/isone.json
+++ b/gridstatus/tests/schema_snapshots/isone.json
@@ -1,0 +1,114 @@
+{
+  "iso": "ISONE",
+  "fixed_date": "2026-06-15",
+  "methods": {
+    "get_fuel_mix": {
+      "columns": [
+        "Time",
+        "Batteries",
+        "Hydro",
+        "Landfill Gas",
+        "Natural Gas",
+        "Nuclear",
+        "Oil",
+        "Other",
+        "Refuse",
+        "Solar",
+        "Wind",
+        "Wood"
+      ],
+      "dtypes": {
+        "Time": "datetime[US/Eastern]",
+        "Batteries": "float",
+        "Hydro": "float",
+        "Landfill Gas": "float",
+        "Natural Gas": "float",
+        "Nuclear": "float",
+        "Oil": "float",
+        "Other": "float",
+        "Refuse": "float",
+        "Solar": "float",
+        "Wind": "float",
+        "Wood": "float"
+      },
+      "row_count": 194,
+      "frame_type": "polars"
+    },
+    "get_lmp": {
+      "columns": [
+        "Time",
+        "Interval Start",
+        "Interval End",
+        "Market",
+        "Location",
+        "Location Type",
+        "LMP",
+        "Energy",
+        "Congestion",
+        "Loss"
+      ],
+      "dtypes": {
+        "Time": "datetime[US/Eastern]",
+        "Interval Start": "datetime[US/Eastern]",
+        "Interval End": "datetime[US/Eastern]",
+        "Market": "string",
+        "Location": "string",
+        "Location Type": "string",
+        "LMP": "float",
+        "Energy": "float",
+        "Congestion": "float",
+        "Loss": "float"
+      },
+      "row_count": 29016,
+      "frame_type": "polars"
+    },
+    "get_load": {
+      "columns": [
+        "Time",
+        "Interval Start",
+        "Interval End",
+        "Load"
+      ],
+      "dtypes": {
+        "Time": "datetime[US/Eastern]",
+        "Interval Start": "datetime[US/Eastern]",
+        "Interval End": "datetime[US/Eastern]",
+        "Load": "float"
+      },
+      "row_count": 288,
+      "frame_type": "polars"
+    },
+    "get_solar_forecast": {
+      "columns": [
+        "Interval Start",
+        "Interval End",
+        "Publish Time",
+        "Solar Forecast"
+      ],
+      "dtypes": {
+        "Interval Start": "datetime[US/Eastern]",
+        "Interval End": "datetime[US/Eastern]",
+        "Publish Time": "datetime[US/Eastern]",
+        "Solar Forecast": "float"
+      },
+      "row_count": 168,
+      "frame_type": "polars"
+    },
+    "get_wind_forecast": {
+      "columns": [
+        "Interval Start",
+        "Interval End",
+        "Publish Time",
+        "Wind Forecast"
+      ],
+      "dtypes": {
+        "Interval Start": "datetime[US/Eastern]",
+        "Interval End": "datetime[US/Eastern]",
+        "Publish Time": "datetime[US/Eastern]",
+        "Wind Forecast": "float"
+      },
+      "row_count": 120,
+      "frame_type": "polars"
+    }
+  }
+}

--- a/gridstatus/tests/schema_snapshots/miso.json
+++ b/gridstatus/tests/schema_snapshots/miso.json
@@ -1,0 +1,112 @@
+{
+  "iso": "MISO",
+  "fixed_date": "2026-06-15",
+  "methods": {
+    "get_fuel_mix": {
+      "error": "NotSupported: Only 'latest', 'today', and yesterday's date are supported"
+    },
+    "get_lmp": {
+      "columns": [
+        "Time",
+        "Interval Start",
+        "Interval End",
+        "Market",
+        "Location",
+        "Location Type",
+        "LMP",
+        "Energy",
+        "Congestion",
+        "Loss"
+      ],
+      "dtypes": {
+        "Time": "datetime[EST]",
+        "Interval Start": "datetime[EST]",
+        "Interval End": "datetime[EST]",
+        "Market": "string",
+        "Location": "string",
+        "Location Type": "string",
+        "LMP": "float",
+        "Energy": "float",
+        "Congestion": "float",
+        "Loss": "float"
+      },
+      "row_count": 62688,
+      "frame_type": "polars"
+    },
+    "get_load": {
+      "error": "NotSupported: "
+    },
+    "get_load_forecast": {
+      "columns": [
+        "Interval Start",
+        "Interval End",
+        "Publish Time",
+        "LRZ1 MTLF",
+        "LRZ2_7 MTLF",
+        "LRZ3_5 MTLF",
+        "LRZ4 MTLF",
+        "LRZ6 MTLF",
+        "LRZ8_9_10 MTLF",
+        "MISO MTLF"
+      ],
+      "dtypes": {
+        "Interval Start": "datetime[EST]",
+        "Interval End": "datetime[EST]",
+        "Publish Time": "datetime[EST]",
+        "LRZ1 MTLF": "int",
+        "LRZ2_7 MTLF": "int",
+        "LRZ3_5 MTLF": "int",
+        "LRZ4 MTLF": "int",
+        "LRZ6 MTLF": "int",
+        "LRZ8_9_10 MTLF": "int",
+        "MISO MTLF": "int"
+      },
+      "row_count": 144,
+      "frame_type": "polars"
+    },
+    "get_solar_forecast": {
+      "columns": [
+        "Interval Start",
+        "Interval End",
+        "Publish Time",
+        "North",
+        "Central",
+        "South",
+        "MISO"
+      ],
+      "dtypes": {
+        "Interval Start": "datetime[EST]",
+        "Interval End": "datetime[EST]",
+        "Publish Time": "datetime[UTC]",
+        "North": "float",
+        "Central": "float",
+        "South": "float",
+        "MISO": "float"
+      },
+      "row_count": 168,
+      "frame_type": "polars"
+    },
+    "get_wind_forecast": {
+      "columns": [
+        "Interval Start",
+        "Interval End",
+        "Publish Time",
+        "North",
+        "Central",
+        "South",
+        "MISO"
+      ],
+      "dtypes": {
+        "Interval Start": "datetime[EST]",
+        "Interval End": "datetime[EST]",
+        "Publish Time": "datetime[UTC]",
+        "North": "float",
+        "Central": "float",
+        "South": "float",
+        "MISO": "float"
+      },
+      "row_count": 168,
+      "frame_type": "polars"
+    }
+  }
+}

--- a/gridstatus/tests/schema_snapshots/nyiso.json
+++ b/gridstatus/tests/schema_snapshots/nyiso.json
@@ -1,0 +1,170 @@
+{
+  "iso": "NYISO",
+  "fixed_date": "2026-06-15",
+  "methods": {
+    "get_as_prices_day_ahead_hourly": {
+      "columns": [
+        "Interval Start",
+        "Interval End",
+        "Zone",
+        "10 Min Spin Reserves",
+        "10 Min Non-Spin Reserves",
+        "30 Min Reserves",
+        "Regulation Capacity"
+      ],
+      "dtypes": {
+        "Interval Start": "datetime[US/Eastern]",
+        "Interval End": "datetime[US/Eastern]",
+        "Zone": "string",
+        "10 Min Spin Reserves": "float",
+        "10 Min Non-Spin Reserves": "float",
+        "30 Min Reserves": "float",
+        "Regulation Capacity": "float"
+      },
+      "row_count": 264,
+      "frame_type": "polars"
+    },
+    "get_btm_solar": {
+      "columns": [
+        "Time",
+        "Interval Start",
+        "Interval End",
+        "SYSTEM",
+        "CAPITL",
+        "CENTRL",
+        "DUNWOD",
+        "GENESE",
+        "HUD VL",
+        "LONGIL",
+        "MHK VL",
+        "MILLWD",
+        "N.Y.C.",
+        "NORTH",
+        "WEST"
+      ],
+      "dtypes": {
+        "Time": "datetime[US/Eastern]",
+        "Interval Start": "datetime[US/Eastern]",
+        "Interval End": "datetime[US/Eastern]",
+        "SYSTEM": "float",
+        "CAPITL": "float",
+        "CENTRL": "float",
+        "DUNWOD": "float",
+        "GENESE": "float",
+        "HUD VL": "float",
+        "LONGIL": "float",
+        "MHK VL": "float",
+        "MILLWD": "float",
+        "N.Y.C.": "float",
+        "NORTH": "float",
+        "WEST": "float"
+      },
+      "row_count": 24,
+      "frame_type": "polars"
+    },
+    "get_fuel_mix": {
+      "columns": [
+        "Time",
+        "Dual Fuel",
+        "Hydro",
+        "Natural Gas",
+        "Nuclear",
+        "Other Fossil Fuels",
+        "Other Renewables",
+        "Wind"
+      ],
+      "dtypes": {
+        "Time": "datetime[US/Eastern]",
+        "Dual Fuel": "float",
+        "Hydro": "float",
+        "Natural Gas": "float",
+        "Nuclear": "float",
+        "Other Fossil Fuels": "float",
+        "Other Renewables": "float",
+        "Wind": "float"
+      },
+      "row_count": 288,
+      "frame_type": "polars"
+    },
+    "get_lmp": {
+      "columns": [
+        "Time",
+        "Interval Start",
+        "Interval End",
+        "Market",
+        "Location",
+        "Location Type",
+        "LMP",
+        "Energy",
+        "Congestion",
+        "Loss"
+      ],
+      "dtypes": {
+        "Time": "datetime[US/Eastern]",
+        "Interval Start": "datetime[US/Eastern]",
+        "Interval End": "datetime[US/Eastern]",
+        "Market": "string",
+        "Location": "string",
+        "Location Type": "string",
+        "LMP": "float",
+        "Energy": "float",
+        "Congestion": "float",
+        "Loss": "float"
+      },
+      "row_count": 360,
+      "frame_type": "polars"
+    },
+    "get_load": {
+      "columns": [
+        "Time",
+        "Load",
+        "CAPITL",
+        "CENTRL",
+        "DUNWOD",
+        "GENESE",
+        "HUD VL",
+        "LONGIL",
+        "MHK VL",
+        "MILLWD",
+        "N.Y.C.",
+        "NORTH",
+        "WEST"
+      ],
+      "dtypes": {
+        "Time": "datetime[US/Eastern]",
+        "Load": "float",
+        "CAPITL": "float",
+        "CENTRL": "float",
+        "DUNWOD": "float",
+        "GENESE": "float",
+        "HUD VL": "float",
+        "LONGIL": "float",
+        "MHK VL": "float",
+        "MILLWD": "float",
+        "N.Y.C.": "float",
+        "NORTH": "float",
+        "WEST": "float"
+      },
+      "row_count": 288,
+      "frame_type": "polars"
+    },
+    "get_load_forecast": {
+      "columns": [
+        "Time",
+        "Interval Start",
+        "Interval End",
+        "Forecast Time",
+        "Load Forecast"
+      ],
+      "dtypes": {
+        "Time": "datetime[US/Eastern]",
+        "Interval Start": "datetime[US/Eastern]",
+        "Interval End": "datetime[US/Eastern]",
+        "Forecast Time": "datetime[US/Eastern]",
+        "Load Forecast": "int"
+      },
+      "row_count": 144,
+      "frame_type": "polars"
+    }
+  }
+}

--- a/gridstatus/tests/source_specific/test_aeso.py
+++ b/gridstatus/tests/source_specific/test_aeso.py
@@ -1,6 +1,7 @@
 import os
 
 import pandas as pd
+import polars as pl
 import pytest
 
 from gridstatus.aeso.aeso import AESO
@@ -25,35 +26,37 @@ class TestAESO(TestHelperMixin):
     def setup_class(cls):
         cls.iso = AESO(api_key=os.getenv("AESO_API_KEY"))
 
-    def _check_supply_and_demand(self, df: pd.DataFrame) -> None:
+    def _check_tz_datetime(self, df: pl.DataFrame, col: str) -> None:
+        assert isinstance(df.schema[col], pl.Datetime)
+        assert df.schema[col].time_zone == self.iso.default_timezone
+
+    def _check_supply_and_demand(self, df: pl.DataFrame) -> None:
         expected_columns = list(SUPPLY_DEMAND_COLUMN_MAPPING.values())
         for col in expected_columns:
             assert col in df.columns, f"Expected column {col} not found in DataFrame"
 
-        assert df.dtypes["Time"] == f"datetime64[ns, {self.iso.default_timezone}]"
+        self._check_tz_datetime(df, "Time")
 
     def test_get_supply_and_demand(self):
         with api_vcr.use_cassette("test_get_supply_and_demand.yaml"):
             df = self.iso.get_supply_and_demand()
             self._check_supply_and_demand(df)
 
-    def _check_fuel_mix(self, df: pd.DataFrame) -> None:
+    def _check_fuel_mix(self, df: pl.DataFrame) -> None:
         expected_columns = list(FUEL_MIX_COLUMN_MAPPING.values())
-        assert df.columns.tolist() == expected_columns
-        assert df.dtypes["Time"] == f"datetime64[ns, {self.iso.default_timezone}]"
+        assert df.columns == expected_columns
+        self._check_tz_datetime(df, "Time")
 
-        numeric_cols = df.columns.drop("Time")
+        numeric_cols = [col for col in df.columns if col != "Time"]
         for col in numeric_cols:
-            assert pd.api.types.is_numeric_dtype(df[col]), (
-                f"Column {col} should be numeric"
-            )
+            assert df.schema[col].is_numeric(), f"Column {col} should be numeric"
 
     def test_get_fuel_mix(self):
         with api_vcr.use_cassette("test_get_fuel_mix.yaml"):
             df = self.iso.get_fuel_mix()
             self._check_fuel_mix(df)
 
-    def _check_interchange(self, df: pd.DataFrame) -> None:
+    def _check_interchange(self, df: pl.DataFrame) -> None:
         expected_columns = [
             "Time",
             "Net Interchange Flow",
@@ -61,51 +64,49 @@ class TestAESO(TestHelperMixin):
             "Montana Flow",
             "Saskatchewan Flow",
         ]
-        assert df.columns.tolist() == expected_columns
-        assert df.dtypes["Time"] == f"datetime64[ns, {self.iso.default_timezone}]"
+        assert df.columns == expected_columns
+        self._check_tz_datetime(df, "Time")
 
         flow_columns = [col for col in df.columns if col != "Time"]
         for col in flow_columns:
-            assert pd.api.types.is_numeric_dtype(df[col]), (
-                f"Column {col} should be numeric"
-            )
+            assert df.schema[col].is_numeric(), f"Column {col} should be numeric"
 
         individual_flows = [
             col for col in flow_columns if col != "Net Interchange Flow"
         ]
-        assert (df["Net Interchange Flow"] == df[individual_flows].sum(axis=1)).all(), (
-            "Net Interchange Flow should be the sum of individual flows"
-        )
+        assert (
+            df.select(
+                pl.col("Net Interchange Flow")
+                == pl.sum_horizontal([pl.col(col) for col in individual_flows]),
+            )
+            .to_series()
+            .all()
+        ), "Net Interchange Flow should be the sum of individual flows"
 
     def test_get_interchange(self):
         with api_vcr.use_cassette("test_get_interchange.yaml"):
             df = self.iso.get_interchange()
             self._check_interchange(df)
 
-    def _check_reserves(self, df: pd.DataFrame) -> None:
+    def _check_reserves(self, df: pl.DataFrame) -> None:
         expected_columns = list(RESERVES_COLUMN_MAPPING.values())
-        assert df.columns.tolist() == expected_columns
+        assert df.columns == expected_columns
 
-        assert df.dtypes["Time"] == f"datetime64[ns, {self.iso.default_timezone}]"
+        self._check_tz_datetime(df, "Time")
 
     def test_get_reserves(self):
         with api_vcr.use_cassette("test_get_reserves.yaml"):
             df = self.iso.get_reserves()
             self._check_reserves(df)
 
-    def _check_asset_list(self, df: pd.DataFrame) -> None:
+    def _check_asset_list(self, df: pl.DataFrame) -> None:
         expected_columns = list(ASSET_LIST_COLUMN_MAPPING.values())
         for col in expected_columns:
             assert col in df.columns, f"Expected column {col} not found in DataFrame"
 
-        assert df["Asset ID"].dtype == "object"
-        assert df["Asset Name"].dtype == "object"
-        assert df["Asset Type"].dtype == "object"
-        assert df["Operating Status"].dtype == "object"
-        assert df["Pool Participant ID"].dtype == "object"
-        assert df["Pool Participant Name"].dtype == "object"
-        assert df["Net To Grid Asset Flag"].dtype == "object"
-        assert df["Asset Include Storage Flag"].dtype == "object"
+        string_columns = list(ASSET_LIST_COLUMN_MAPPING.values())
+        for col in string_columns:
+            assert df.schema[col] == pl.String
 
     def test_get_asset_list(self):
         with api_vcr.use_cassette("test_get_asset_list.yaml"):
@@ -116,9 +117,9 @@ class TestAESO(TestHelperMixin):
         with api_vcr.use_cassette("test_get_asset_list_empty.yaml"):
             df = self.iso.get_asset_list(asset_id="NONEXISTENT")
             self._check_asset_list(df)
-            assert len(df) == 0
+            assert df.height == 0
 
-    def _check_pool_price(self, df: pd.DataFrame) -> None:
+    def _check_pool_price(self, df: pl.DataFrame) -> None:
         """Check pool price DataFrame structure and types."""
         expected_columns = [
             "Interval Start",
@@ -126,20 +127,20 @@ class TestAESO(TestHelperMixin):
             "Pool Price",
             "Rolling 30 Day Average Pool Price",
         ]
-        assert df.columns.tolist() == expected_columns
+        assert df.columns == expected_columns
+        self._check_tz_datetime(df, "Interval Start")
+        self._check_tz_datetime(df, "Interval End")
+        assert df.schema["Pool Price"].is_numeric()
         assert (
-            df.dtypes["Interval Start"]
-            == f"datetime64[ns, {self.iso.default_timezone}]"
+            df.select(
+                pl.col("Interval End") - pl.col("Interval Start")
+                == pl.duration(hours=1),
+            )
+            .to_series()
+            .all()
         )
-        assert (
-            df.dtypes["Interval End"] == f"datetime64[ns, {self.iso.default_timezone}]"
-        )
-        assert pd.api.types.is_numeric_dtype(df["Pool Price"])
-        assert (
-            df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
-        ).all()
 
-    def _check_forecast_pool_price(self, df: pd.DataFrame) -> None:
+    def _check_forecast_pool_price(self, df: pl.DataFrame) -> None:
         """Check forecast pool price DataFrame structure and types."""
         expected_columns = [
             "Interval Start",
@@ -147,30 +148,27 @@ class TestAESO(TestHelperMixin):
             "Publish Time",
             "Forecast Pool Price",
         ]
-        assert df.columns.tolist() == expected_columns
+        assert df.columns == expected_columns
+        self._check_tz_datetime(df, "Interval Start")
+        self._check_tz_datetime(df, "Interval End")
+        self._check_tz_datetime(df, "Publish Time")
+        assert df.schema["Forecast Pool Price"].is_numeric()
         assert (
-            df.dtypes["Interval Start"]
-            == f"datetime64[ns, {self.iso.default_timezone}]"
+            df.select(
+                pl.col("Interval End") - pl.col("Interval Start")
+                == pl.duration(hours=1),
+            )
+            .to_series()
+            .all()
         )
-        assert (
-            df.dtypes["Interval End"] == f"datetime64[ns, {self.iso.default_timezone}]"
-        )
-        assert (
-            df.dtypes["Publish Time"] == f"datetime64[ns, {self.iso.default_timezone}]"
-        )
-        assert pd.api.types.is_numeric_dtype(df["Forecast Pool Price"])
-        assert (
-            df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
-        ).all()
 
         request_time = pd.Timestamp.now(tz=self.iso.default_timezone)
-        for _, row in df.iterrows():
-            if row["Interval Start"] > request_time:
-                # For future intervals: use request time floored to 5 minutes
+        for row in df.iter_rows(named=True):
+            interval_start = pd.Timestamp(row["Interval Start"])
+            if interval_start > request_time:
                 assert row["Publish Time"] == request_time.floor("5min")
             else:
-                # For past/current intervals: use 5 minutes before interval start
-                assert row["Publish Time"] == row["Interval Start"] - pd.Timedelta(
+                assert row["Publish Time"] == interval_start - pd.Timedelta(
                     minutes=5,
                 )
 
@@ -179,7 +177,7 @@ class TestAESO(TestHelperMixin):
         with api_vcr.use_cassette("test_get_pool_price_latest.yaml"):
             df = self.iso.get_pool_price(date="latest")
             self._check_pool_price(df)
-            assert len(df) > 0
+            assert df.height > 0
 
     @pytest.mark.parametrize(
         "start_date,end_date,expected_hours",
@@ -206,14 +204,14 @@ class TestAESO(TestHelperMixin):
                 end=end_date,
             )
             self._check_pool_price(df)
-            assert len(df) == expected_hours
+            assert df.height == expected_hours
 
     def test_get_forecast_pool_price_latest(self):
         """Test getting latest forecast pool price data."""
         with api_vcr.use_cassette("test_get_forecast_pool_price_latest.yaml"):
             df = self.iso.get_forecast_pool_price(date="latest")
             self._check_forecast_pool_price(df)
-            assert len(df) > 0
+            assert df.height > 0
 
     @pytest.mark.parametrize(
         "start_date,end_date,expected_hours",
@@ -240,9 +238,9 @@ class TestAESO(TestHelperMixin):
                 end=end_date,
             )
             self._check_forecast_pool_price(df)
-            assert len(df) == expected_hours
+            assert df.height == expected_hours
 
-    def _check_system_marginal_price(self, df: pd.DataFrame) -> None:
+    def _check_system_marginal_price(self, df: pl.DataFrame) -> None:
         """Check system marginal price DataFrame structure and types."""
         expected_columns = [
             "Interval Start",
@@ -250,31 +248,31 @@ class TestAESO(TestHelperMixin):
             "System Marginal Price",
             "Volume",
         ]
-        assert df.columns.tolist() == expected_columns
-        assert (
-            df.dtypes["Interval Start"]
-            == f"datetime64[ns, {self.iso.default_timezone}]"
-        )
-        assert (
-            df.dtypes["Interval End"] == f"datetime64[ns, {self.iso.default_timezone}]"
-        )
-        assert pd.api.types.is_numeric_dtype(df["System Marginal Price"])
-        assert pd.api.types.is_numeric_dtype(df["Volume"])
+        assert df.columns == expected_columns
+        self._check_tz_datetime(df, "Interval Start")
+        self._check_tz_datetime(df, "Interval End")
+        assert df.schema["System Marginal Price"].is_numeric()
+        assert df.schema["Volume"].is_numeric()
 
         assert (
-            df["Interval End"] - df["Interval Start"] == pd.Timedelta(minutes=1)
-        ).all()
-        assert df["Interval Start"].is_monotonic_increasing
-        assert df["Interval End"].is_monotonic_increasing
-        assert not df["System Marginal Price"].isna().any()
-        assert not df["Volume"].isna().any()
+            df.select(
+                pl.col("Interval End") - pl.col("Interval Start")
+                == pl.duration(minutes=1),
+            )
+            .to_series()
+            .all()
+        )
+        assert df["Interval Start"].is_sorted()
+        assert df["Interval End"].is_sorted()
+        assert not df["System Marginal Price"].is_null().any()
+        assert not df["Volume"].is_null().any()
 
     def test_get_system_marginal_price_latest(self):
         """Test getting latest system marginal price data."""
         with api_vcr.use_cassette("test_get_system_marginal_price_latest.yaml"):
             df = self.iso.get_system_marginal_price(date="latest")
             self._check_system_marginal_price(df)
-            assert len(df) > 0
+            assert df.height > 0
 
             current_time = pd.Timestamp.now(tz=self.iso.default_timezone)
             assert df["Interval End"].max() >= current_time.floor("min")
@@ -311,27 +309,27 @@ class TestAESO(TestHelperMixin):
                 end=end_date,
             )
             self._check_system_marginal_price(df)
-            assert len(df) == expected_minutes
+            assert df.height == expected_minutes
             assert df["Interval Start"].min() == start_date
             assert df["Interval End"].max() == end_date
 
-    def _check_load(self, df: pd.DataFrame) -> None:
+    def _check_load(self, df: pl.DataFrame) -> None:
         """Check load DataFrame structure and types."""
         expected_columns = ["Interval Start", "Interval End", "Load"]
-        assert df.columns.tolist() == expected_columns
+        assert df.columns == expected_columns
+        self._check_tz_datetime(df, "Interval Start")
+        self._check_tz_datetime(df, "Interval End")
+        assert df.schema["Load"].is_numeric()
         assert (
-            df.dtypes["Interval Start"]
-            == f"datetime64[ns, {self.iso.default_timezone}]"
+            df.select(
+                pl.col("Interval End") - pl.col("Interval Start")
+                == pl.duration(hours=1),
+            )
+            .to_series()
+            .all()
         )
-        assert (
-            df.dtypes["Interval End"] == f"datetime64[ns, {self.iso.default_timezone}]"
-        )
-        assert pd.api.types.is_numeric_dtype(df["Load"])
-        assert (
-            df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
-        ).all()
 
-    def _check_load_forecast(self, df: pd.DataFrame) -> None:
+    def _check_load_forecast(self, df: pl.DataFrame) -> None:
         """Check load forecast DataFrame structure and types."""
         expected_columns = [
             "Interval Start",
@@ -340,28 +338,27 @@ class TestAESO(TestHelperMixin):
             "Load",
             "Load Forecast",
         ]
-        assert df.columns.tolist() == expected_columns
+        assert df.columns == expected_columns
+        self._check_tz_datetime(df, "Interval Start")
+        self._check_tz_datetime(df, "Interval End")
+        self._check_tz_datetime(df, "Publish Time")
+        assert df.schema["Load"].is_numeric()
+        assert df.schema["Load Forecast"].is_numeric()
         assert (
-            df.dtypes["Interval Start"]
-            == f"datetime64[ns, {self.iso.default_timezone}]"
+            df.select(
+                pl.col("Interval End") - pl.col("Interval Start")
+                == pl.duration(hours=1),
+            )
+            .to_series()
+            .all()
         )
-        assert (
-            df.dtypes["Interval End"] == f"datetime64[ns, {self.iso.default_timezone}]"
-        )
-        assert (
-            df.dtypes["Publish Time"] == f"datetime64[ns, {self.iso.default_timezone}]"
-        )
-        assert pd.api.types.is_numeric_dtype(df["Load"])
-        assert pd.api.types.is_numeric_dtype(df["Load Forecast"])
-        assert (
-            df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
-        ).all()
 
         current_time = pd.Timestamp.now(tz=self.iso.default_timezone)
         today_7am = current_time.floor("D") + pd.Timedelta(hours=7)
 
-        for _, row in df.iterrows():
-            if row["Interval Start"] > current_time:
+        for row in df.iter_rows(named=True):
+            interval_start = pd.Timestamp(row["Interval Start"])
+            if interval_start > current_time:
                 expected_publish = (
                     today_7am
                     if current_time >= today_7am
@@ -369,13 +366,12 @@ class TestAESO(TestHelperMixin):
                 )
                 assert row["Publish Time"] == expected_publish
             else:
-                # Historical intervals should have 7am on their day or previous day
-                interval_day_7am = row["Interval Start"].floor("D") + pd.Timedelta(
+                interval_day_7am = interval_start.floor("D") + pd.Timedelta(
                     hours=7,
                 )
                 expected_publish = (
                     interval_day_7am
-                    if row["Interval Start"] >= interval_day_7am
+                    if interval_start >= interval_day_7am
                     else interval_day_7am - pd.Timedelta(days=1)
                 )
                 assert row["Publish Time"] == expected_publish
@@ -385,8 +381,8 @@ class TestAESO(TestHelperMixin):
         with api_vcr.use_cassette("test_get_load_latest.yaml"):
             df = self.iso.get_load(date="latest")
             self._check_load(df)
-            assert len(df) > 0
-            assert not df["Load"].isna().any()
+            assert df.height > 0
+            assert not df["Load"].is_null().any()
 
     @pytest.mark.parametrize(
         "start_date,end_date,expected_hours",
@@ -413,14 +409,14 @@ class TestAESO(TestHelperMixin):
                 end=end_date,
             )
             self._check_load(df)
-            assert len(df) == expected_hours
+            assert df.height == expected_hours
 
     def test_get_load_forecast_latest(self):
         """Test getting latest load forecast data."""
         with api_vcr.use_cassette("test_get_load_forecast_latest.yaml"):
             df = self.iso.get_load_forecast(date="latest")
             self._check_load_forecast(df)
-            assert len(df) > 0
+            assert df.height > 0
 
     @pytest.mark.parametrize(
         "start_date,end_date,expected_hours",
@@ -447,7 +443,7 @@ class TestAESO(TestHelperMixin):
                 end=end_date,
             )
             self._check_load_forecast(df)
-            assert len(df) == expected_hours
+            assert df.height == expected_hours
 
     def test_get_load_forecast_future_publish_times(self):
         """Test that future intervals have correct publish times."""
@@ -487,18 +483,19 @@ class TestAESO(TestHelperMixin):
         ):
             df = self.iso.get_load_forecast(date=date, end=end)
 
-            for _, row in df.iterrows():
-                interval_day_7am = row["Interval Start"].floor("D") + pd.Timedelta(
+            for row in df.iter_rows(named=True):
+                interval_start = pd.Timestamp(row["Interval Start"])
+                interval_day_7am = interval_start.floor("D") + pd.Timedelta(
                     hours=7,
                 )
                 expected_publish = (
                     interval_day_7am
-                    if row["Interval Start"] >= interval_day_7am
+                    if interval_start >= interval_day_7am
                     else interval_day_7am - pd.Timedelta(days=1)
                 )
                 assert row["Publish Time"] == expected_publish
 
-    def _check_unit_status(self, df: pd.DataFrame) -> None:
+    def _check_unit_status(self, df: pl.DataFrame) -> None:
         """Check unit status DataFrame structure and types."""
         expected_columns = [
             "Time",
@@ -509,11 +506,11 @@ class TestAESO(TestHelperMixin):
             "Net Generation",
             "Dispatched Contingency Reserve",
         ]
-        assert df.columns.tolist() == expected_columns
-        assert df.dtypes["Time"] == f"datetime64[ns, {self.iso.default_timezone}]"
-        assert df["Asset"].dtype == "object"
-        assert df["Fuel Type"].dtype == "object"
-        assert df["Sub Fuel Type"].dtype == "object"
+        assert df.columns == expected_columns
+        self._check_tz_datetime(df, "Time")
+        assert df.schema["Asset"] == pl.String
+        assert df.schema["Fuel Type"] == pl.String
+        assert df.schema["Sub Fuel Type"] == pl.String
 
         numeric_columns = [
             "Maximum Capability",
@@ -521,18 +518,16 @@ class TestAESO(TestHelperMixin):
             "Dispatched Contingency Reserve",
         ]
         for col in numeric_columns:
-            assert pd.api.types.is_numeric_dtype(df[col]), (
-                f"Column {col} should be numeric"
-            )
+            assert df.schema[col].is_numeric(), f"Column {col} should be numeric"
 
     def test_get_unit_status(self):
         """Test getting current unit status data."""
         with api_vcr.use_cassette("test_get_unit_status.yaml"):
             df = self.iso.get_unit_status(date="latest")
             self._check_unit_status(df)
-            assert len(df) > 0
+            assert df.height > 0
 
-    def _check_generator_outages_hourly(self, df: pd.DataFrame) -> None:
+    def _check_generator_outages_hourly(self, df: pl.DataFrame) -> None:
         """Check generator outages DataFrame structure and types."""
         expected_columns = [
             "Interval Start",
@@ -551,20 +546,18 @@ class TestAESO(TestHelperMixin):
             "Biomass and Other",
             "Mothball Outage",
         ]
-        assert df.columns.tolist() == expected_columns
+        assert df.columns == expected_columns
+        self._check_tz_datetime(df, "Interval Start")
+        self._check_tz_datetime(df, "Interval End")
+        self._check_tz_datetime(df, "Publish Time")
         assert (
-            df.dtypes["Interval Start"]
-            == f"datetime64[ns, {self.iso.default_timezone}]"
+            df.select(
+                pl.col("Interval End") - pl.col("Interval Start")
+                == pl.duration(hours=1),
+            )
+            .to_series()
+            .all()
         )
-        assert (
-            df.dtypes["Interval End"] == f"datetime64[ns, {self.iso.default_timezone}]"
-        )
-        assert (
-            df.dtypes["Publish Time"] == f"datetime64[ns, {self.iso.default_timezone}]"
-        )
-        assert (
-            df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
-        ).all()
 
         numeric_columns = [
             col
@@ -572,24 +565,28 @@ class TestAESO(TestHelperMixin):
             if col not in ["Interval Start", "Interval End", "Publish Time"]
         ]
         for col in numeric_columns:
-            assert pd.api.types.is_numeric_dtype(df[col]), (
-                f"Column {col} should be numeric"
-            )
+            assert df.schema[col].is_numeric(), f"Column {col} should be numeric"
 
-        # NB: Total Outage should be sum of all numeric columns except Mothball Outage and Total Outage
         outage_columns = [
             col
             for col in numeric_columns
             if col not in ["Mothball Outage", "Total Outage"]
         ]
-        assert (df["Total Outage"] == df[outage_columns].sum(axis=1)).all()
+        assert (
+            df.select(
+                pl.col("Total Outage")
+                == pl.sum_horizontal([pl.col(col) for col in outage_columns]),
+            )
+            .to_series()
+            .all()
+        )
 
     def test_get_generator_outages_hourly_latest(self):
         """Test getting latest generator outages data."""
         with api_vcr.use_cassette("test_get_generator_outages_hourly_latest.yaml"):
             df = self.iso.get_generator_outages_hourly(date="latest")
             self._check_generator_outages_hourly(df)
-            assert len(df) > 0
+            assert df.height > 0
 
     @pytest.mark.parametrize(
         "start_date,end_date",
@@ -621,7 +618,7 @@ class TestAESO(TestHelperMixin):
                 self.iso.default_timezone,
             )
 
-    def _check_transmission_outages(self, df: pd.DataFrame) -> None:
+    def _check_transmission_outages(self, df: pl.DataFrame) -> None:
         """Check transmission outages DataFrame structure and types."""
         expected_columns = [
             "Interval Start",
@@ -634,17 +631,10 @@ class TestAESO(TestHelperMixin):
             "Date Time Comments",
             "Interconnection",
         ]
-        assert df.columns.tolist() == expected_columns
-        assert (
-            df.dtypes["Interval Start"]
-            == f"datetime64[ns, {self.iso.default_timezone}]"
-        )
-        assert (
-            df.dtypes["Interval End"] == f"datetime64[ns, {self.iso.default_timezone}]"
-        )
-        assert (
-            df.dtypes["Publish Time"] == f"datetime64[ns, {self.iso.default_timezone}]"
-        )
+        assert df.columns == expected_columns
+        self._check_tz_datetime(df, "Interval Start")
+        self._check_tz_datetime(df, "Interval End")
+        self._check_tz_datetime(df, "Publish Time")
         string_columns = [
             "Transmission Owner",
             "Type",
@@ -654,19 +644,25 @@ class TestAESO(TestHelperMixin):
             "Interconnection",
         ]
         for col in string_columns:
-            assert df[col].dtype == "object", (
+            assert df.schema[col] == pl.String, (
                 f"Column {col} should be object/string type"
             )
 
-        assert (df["Interval End"] >= df["Interval Start"]).all()
+        assert (
+            df.select(
+                pl.col("Interval End") >= pl.col("Interval Start"),
+            )
+            .to_series()
+            .all()
+        )
 
     def test_get_transmission_outages_latest(self):
         """Test getting latest transmission outages data."""
         with api_vcr.use_cassette("test_get_transmission_outages_latest.yaml"):
             df = self.iso.get_transmission_outages(date="latest")
             self._check_transmission_outages(df)
-            assert len(df) > 0
-            assert df["Publish Time"].nunique() == 1
+            assert df.height > 0
+            assert df["Publish Time"].n_unique() == 1
 
     @pytest.mark.parametrize(
         "start_date,end_date",
@@ -691,7 +687,7 @@ class TestAESO(TestHelperMixin):
                 end=end_date,
             )
             self._check_transmission_outages(df)
-            assert df["Publish Time"].nunique() > 1
+            assert df["Publish Time"].n_unique() > 1
             assert df["Publish Time"].min().date() >= start_date.date()
             assert df["Publish Time"].max().date() <= end_date.date()
 
@@ -711,14 +707,14 @@ class TestAESO(TestHelperMixin):
         ):
             df = self.iso.get_transmission_outages(date=target_date)
             self._check_transmission_outages(df)
-            assert len(df) > 0
-            assert df["Publish Time"].nunique() == 1
-            publish_time = df["Publish Time"].iloc[0]
+            assert df.height > 0
+            assert df["Publish Time"].n_unique() == 1
+            publish_time = df[0, "Publish Time"]
             assert publish_time.date() < target_date.date(), (
                 f"Publish time {publish_time.date()} should be before target date {target_date.date()}"
             )
 
-    def _check_wind_solar_forecast(self, df: pd.DataFrame, forecast_type: str) -> None:
+    def _check_wind_solar_forecast(self, df: pl.DataFrame, forecast_type: str) -> None:
         """Check wind/solar forecast DataFrame structure and types."""
         expected_columns = [
             "Interval Start",
@@ -732,17 +728,10 @@ class TestAESO(TestHelperMixin):
             "Most Likely Generation Percentage",
             "Maximum Generation Percentage",
         ]
-        assert df.columns.tolist() == expected_columns
-        assert (
-            df.dtypes["Interval Start"]
-            == f"datetime64[ns, {self.iso.default_timezone}]"
-        )
-        assert (
-            df.dtypes["Interval End"] == f"datetime64[ns, {self.iso.default_timezone}]"
-        )
-        assert (
-            df.dtypes["Publish Time"] == f"datetime64[ns, {self.iso.default_timezone}]"
-        )
+        assert df.columns == expected_columns
+        self._check_tz_datetime(df, "Interval Start")
+        self._check_tz_datetime(df, "Interval End")
+        self._check_tz_datetime(df, "Publish Time")
 
         numeric_columns = [
             "Minimum Generation Forecast",
@@ -754,40 +743,42 @@ class TestAESO(TestHelperMixin):
             "Maximum Generation Percentage",
         ]
         for col in numeric_columns:
-            assert pd.api.types.is_numeric_dtype(df[col]), (
-                f"Column {col} should be numeric"
-            )
+            assert df.schema[col].is_numeric(), f"Column {col} should be numeric"
 
-        assert df["Interval Start"].is_monotonic_increasing
-        assert (df["Interval End"] > df["Interval Start"]).all()
+        assert df["Interval Start"].is_sorted()
+        assert (
+            df.select(pl.col("Interval End") > pl.col("Interval Start"))
+            .to_series()
+            .all()
+        )
 
     def test_get_wind_forecast_12_hour_latest(self):
         """Test getting latest 12-hour wind forecast data."""
         with api_vcr.use_cassette("test_get_wind_forecast_12_hour_latest.yaml"):
             df = self.iso.get_wind_forecast_12_hour(date="latest")
             self._check_wind_solar_forecast(df, "wind")
-            assert len(df) > 0
+            assert df.height > 0
 
     def test_get_wind_forecast_7_day_latest(self):
         """Test getting latest 7-day wind forecast data."""
         with api_vcr.use_cassette("test_get_wind_forecast_7_day_latest.yaml"):
             df = self.iso.get_wind_forecast_7_day(date="latest")
             self._check_wind_solar_forecast(df, "wind")
-            assert len(df) > 0
+            assert df.height > 0
 
     def test_get_solar_forecast_12_hour_latest(self):
         """Test getting latest 12-hour solar forecast data."""
         with api_vcr.use_cassette("test_get_solar_forecast_12_hour_latest.yaml"):
             df = self.iso.get_solar_forecast_12_hour(date="latest")
             self._check_wind_solar_forecast(df, "solar")
-            assert len(df) > 0
+            assert df.height > 0
 
     def test_get_solar_forecast_7_day_latest(self):
         """Test getting latest 7-day solar forecast data."""
         with api_vcr.use_cassette("test_get_solar_forecast_7_day_latest.yaml"):
             df = self.iso.get_solar_forecast_7_day(date="latest")
             self._check_wind_solar_forecast(df, "solar")
-            assert len(df) > 0
+            assert df.height > 0
 
     def test_get_wind_forecast_12_hour_historical(self):
         """Test that historical 12-hour wind forecast raises NotSupported."""
@@ -822,7 +813,7 @@ class TestAESO(TestHelperMixin):
                 end=end_date,
             )
             self._check_wind_solar_forecast(df, "wind")
-            assert len(df) > 0
+            assert df.height > 0
             assert df["Interval Start"].min().date() >= start_date.date()
             assert df["Interval Start"].max().date() <= end_date.date()
 
@@ -868,7 +859,7 @@ class TestAESO(TestHelperMixin):
                 end=end_date,
             )
             self._check_wind_solar_forecast(df, "solar")
-            assert len(df) > 0
+            assert df.height > 0
             assert df["Interval Start"].min().date() >= start_date.date()
             assert df["Interval Start"].max().date() <= end_date.date()
 
@@ -881,7 +872,7 @@ class TestAESO(TestHelperMixin):
         ):
             self.iso.get_solar_forecast_7_day(date="2022-01-01")
 
-    def _check_daily_average_pool_price(self, df: pd.DataFrame) -> None:
+    def _check_daily_average_pool_price(self, df: pl.DataFrame) -> None:
         """Check daily average pool price DataFrame structure and types."""
         expected_columns = [
             "Interval Start",
@@ -891,16 +882,18 @@ class TestAESO(TestHelperMixin):
             "Daily Off Peak Average",
             "30 Day Average",
         ]
-        assert df.columns.tolist() == expected_columns
-        assert (
-            df.dtypes["Interval Start"]
-            == f"datetime64[ns, {self.iso.default_timezone}]"
-        )
-        assert (
-            df.dtypes["Interval End"] == f"datetime64[ns, {self.iso.default_timezone}]"
-        )
+        assert df.columns == expected_columns
+        self._check_tz_datetime(df, "Interval Start")
+        self._check_tz_datetime(df, "Interval End")
 
-        assert (df["Interval End"] - df["Interval Start"] == pd.Timedelta(days=1)).all()
+        assert (
+            df.select(
+                pl.col("Interval End") - pl.col("Interval Start")
+                == pl.duration(days=1),
+            )
+            .to_series()
+            .all()
+        )
 
         price_columns = [
             "Daily Average",
@@ -909,16 +902,14 @@ class TestAESO(TestHelperMixin):
             "30 Day Average",
         ]
         for col in price_columns:
-            assert pd.api.types.is_numeric_dtype(df[col]), (
-                f"Column {col} should be numeric"
-            )
+            assert df.schema[col].is_numeric(), f"Column {col} should be numeric"
 
     def test_get_daily_average_pool_price_latest(self):
         """Test getting latest daily average pool price data."""
         with api_vcr.use_cassette("test_get_daily_average_pool_price_latest.yaml"):
             df = self.iso.get_daily_average_pool_price(date="latest")
             self._check_daily_average_pool_price(df)
-            assert len(df) > 0
+            assert df.height > 0
 
     @pytest.mark.parametrize(
         "start_date,end_date,expected_days",
@@ -942,9 +933,9 @@ class TestAESO(TestHelperMixin):
         ):
             df = self.iso.get_daily_average_pool_price(date=start_date, end=end_date)
             self._check_daily_average_pool_price(df)
-            assert len(df) == expected_days
+            assert df.height == expected_days
 
-    def _check_wind_solar(self, df: pd.DataFrame, generation_type: str) -> None:
+    def _check_wind_solar(self, df: pl.DataFrame, generation_type: str) -> None:
         """Check wind/solar actual generation DataFrame structure and types."""
         expected_columns = [
             "Interval Start",
@@ -952,40 +943,37 @@ class TestAESO(TestHelperMixin):
             "Actual Generation",
             f"Total {generation_type.capitalize()} Capacity",
         ]
-        assert df.columns.tolist() == expected_columns
-        assert (
-            df.dtypes["Interval Start"]
-            == f"datetime64[ns, {self.iso.default_timezone}]"
-        )
-        assert (
-            df.dtypes["Interval End"] == f"datetime64[ns, {self.iso.default_timezone}]"
-        )
+        assert df.columns == expected_columns
+        self._check_tz_datetime(df, "Interval Start")
+        self._check_tz_datetime(df, "Interval End")
 
         numeric_columns = [
             "Actual Generation",
             f"Total {generation_type.capitalize()} Capacity",
         ]
         for col in numeric_columns:
-            assert pd.api.types.is_numeric_dtype(df[col]), (
-                f"Column {col} should be numeric"
-            )
+            assert df.schema[col].is_numeric(), f"Column {col} should be numeric"
 
-        assert df["Interval Start"].is_monotonic_increasing
-        assert (df["Interval End"] > df["Interval Start"]).all()
+        assert df["Interval Start"].is_sorted()
+        assert (
+            df.select(pl.col("Interval End") > pl.col("Interval Start"))
+            .to_series()
+            .all()
+        )
 
     def test_get_wind_10_min_latest(self):
         """Test getting latest wind generation data."""
         with api_vcr.use_cassette("test_get_wind_10_min_latest.yaml"):
             df = self.iso.get_wind_10_min(date="latest")
             self._check_wind_solar(df, "wind")
-            assert len(df) > 0
+            assert df.height > 0
 
     def test_get_solar_10_min_latest(self):
         """Test getting latest solar generation data."""
         with api_vcr.use_cassette("test_get_solar_10_min_latest.yaml"):
             df = self.iso.get_solar_10_min(date="latest")
             self._check_wind_solar(df, "solar")
-            assert len(df) > 0
+            assert df.height > 0
 
     @pytest.mark.parametrize(
         "start_date,end_date",
@@ -1010,7 +998,7 @@ class TestAESO(TestHelperMixin):
                 end=end_date,
             )
             self._check_wind_solar(df, "wind")
-            assert len(df) > 0
+            assert df.height > 0
             assert df["Interval Start"].min().date() >= start_date.date()
             assert df["Interval Start"].max().date() <= end_date.date()
 
@@ -1037,6 +1025,6 @@ class TestAESO(TestHelperMixin):
                 end=end_date,
             )
             self._check_wind_solar(df, "solar")
-            assert len(df) > 0
+            assert df.height > 0
             assert df["Interval Start"].min().date() >= start_date.date()
             assert df["Interval Start"].max().date() <= end_date.date()

--- a/gridstatus/tests/source_specific/test_caiso.py
+++ b/gridstatus/tests/source_specific/test_caiso.py
@@ -1,7 +1,9 @@
 import math
+from datetime import datetime
 
 import numpy as np
 import pandas as pd
+import polars as pl
 import pytest
 
 from gridstatus import CAISO, Markets
@@ -37,10 +39,11 @@ class TestCAISO(BaseTestISO):
         "Thermal",
     ]
 
-    def _check_aggregated_generation_outages(self, df: pd.DataFrame) -> None:
-        assert df.columns.tolist() == self.AGGREGATED_GENERATION_OUTAGES_COLUMNS
-        assert df.shape[0] > 0
-        assert set(df["Trading Hub"].unique()) == {
+    def _check_aggregated_generation_outages(self, df: pl.DataFrame) -> None:
+        df = self._as_polars(df)
+        assert list(df.columns) == self.AGGREGATED_GENERATION_OUTAGES_COLUMNS
+        assert df.height > 0
+        assert set(df["Trading Hub"].unique().to_list()) == {
             "NP15",
             "PACE",
             "PACW",
@@ -50,23 +53,27 @@ class TestCAISO(BaseTestISO):
         interval_minutes = (
             df["Interval End"] - df["Interval Start"]
         ).dt.total_seconds() / 60
-        assert (interval_minutes == 60).all()
-        assert not df.duplicated(
-            subset=[
-                "Interval Start",
-                "Publish Time",
-                "Trading Hub",
-            ],
-        ).any()
-        assert df["Aggregated"].notna().all()
+        assert interval_minutes.eq(60).all()
+        assert (
+            not df.select(
+                pl.struct(
+                    ["Interval Start", "Publish Time", "Trading Hub"],
+                ).is_duplicated(),
+            )
+            .to_series()
+            .any()
+        )
+        assert df["Aggregated"].is_not_null().all()
         breakdown_hubs = {"NP15", "PACE", "PACW", "SP15"}
-        breakdown = df[df["Trading Hub"].isin(breakdown_hubs)]
-        component_sum = breakdown[
-            ["Hydro", "Not Available", "Renewable", "Thermal"]
-        ].sum(axis=1, min_count=1)
+        breakdown = df.filter(pl.col("Trading Hub").is_in(list(breakdown_hubs)))
+        component_sum = breakdown.select(
+            pl.sum_horizontal("Hydro", "Not Available", "Renewable", "Thermal"),
+        ).to_series()
         assert (breakdown["Aggregated"] == component_sum).all()
-        assert df.loc[df["Trading Hub"] == "ZP26", "Aggregated"].notna().all()
-        assert df.loc[df["Trading Hub"] == "ZP26", "Thermal"].isna().all()
+        assert (
+            df.filter(pl.col("Trading Hub") == "ZP26")["Aggregated"].is_not_null().all()
+        )
+        assert df.filter(pl.col("Trading Hub") == "ZP26")["Thermal"].is_null().all()
         for column in [
             "Aggregated",
             "Hydro",
@@ -74,7 +81,7 @@ class TestCAISO(BaseTestISO):
             "Renewable",
             "Thermal",
         ]:
-            assert pd.api.types.is_numeric_dtype(df[column])
+            assert df[column].dtype in {pl.Float64, pl.Int64, pl.Float32, pl.Int32}
 
     @pytest.mark.caiso_oasis
     @pytest.mark.real_sleep
@@ -88,8 +95,8 @@ class TestCAISO(BaseTestISO):
                 sleep=15,
             )
             self._check_aggregated_generation_outages(df)
-            assert df["Publish Time"].nunique() == 1
-            assert df["Publish Time"].iloc[0] == self.local_start_of_day(date)
+            assert df["Publish Time"].n_unique() == 1
+            assert df[0, "Publish Time"] == self.local_start_of_day(date)
             assert df["Interval Start"].min() == self.local_start_of_day(date)
             assert df["Interval End"].max() == self.local_start_of_day(
                 date,
@@ -111,7 +118,7 @@ class TestCAISO(BaseTestISO):
                 sleep=15,
             )
             self._check_aggregated_generation_outages(df)
-            assert df["Publish Time"].nunique() == 2
+            assert df["Publish Time"].n_unique() == 2
 
     """get_as"""
 
@@ -120,9 +127,9 @@ class TestCAISO(BaseTestISO):
         with caiso_vcr.use_cassette(f"test_get_as_prices_{date}.yaml"):
             df = self.iso.get_as_prices(date)
 
-            assert df.shape[0] > 0
+            assert df.height > 0
 
-            assert df.columns.tolist() == [
+            assert list(df.columns) == [
                 "Time",
                 "Interval Start",
                 "Interval End",
@@ -168,15 +175,21 @@ class TestCAISO(BaseTestISO):
         ):
             df = self.iso.get_price_corrections(date=start, end=end)
 
-            assert df.columns.tolist() == self.PRICE_CORRECTIONS_COLUMNS
-            assert df.shape[0] > 0
+            assert list(df.columns) == self.PRICE_CORRECTIONS_COLUMNS
+            assert df.height > 0
 
             # Market comes from the PRC_CORR_GRP MARKET column.
-            assert set(df["Market"].unique()) <= {"DAM", "RTD", "RTPD", "HASP", "RUC"}
+            assert set(df["Market"].unique().to_list()) <= {
+                "DAM",
+                "RTD",
+                "RTPD",
+                "HASP",
+                "RUC",
+            }
 
             # Trade Date and Report Generated are Pacific-localized timestamps.
-            assert str(df["Trade Date"].dt.tz) == "US/Pacific"
-            assert str(df["Report Generated"].dt.tz) == "US/Pacific"
+            assert df["Trade Date"].dtype.time_zone == "US/Pacific"
+            assert df["Report Generated"].dtype.time_zone == "US/Pacific"
 
             # The report is keyed by trade date, so every correction falls in the
             # requested range (end exclusive).
@@ -211,18 +224,29 @@ class TestCAISO(BaseTestISO):
         "Loss",
     ]
 
-    def _check_ir_rc_prices(self, df: pd.DataFrame) -> None:
-        assert df.columns.tolist() == self.IR_RC_PRICES_COLUMNS
-        assert df.shape[0] > 0
-        assert set(df["Product"].unique()) == {"IRU", "IRD", "RCU", "RCD"}
+    def _check_ir_rc_prices(self, df: pl.DataFrame) -> None:
+        df = self._as_polars(df)
+        assert list(df.columns) == self.IR_RC_PRICES_COLUMNS
+        assert df.height > 0
+        assert set(df["Product"].unique().to_list()) == {"IRU", "IRD", "RCU", "RCD"}
         interval_minutes = (
             df["Interval End"] - df["Interval Start"]
         ).dt.total_seconds() / 60
-        assert (interval_minutes == 60).all()
-        assert not df.duplicated(
-            subset=["Interval Start", "Location", "Product"],
-        ).any()
-        ir_loss_null = df.loc[df["Product"].isin(["IRU", "IRD"]), "Loss"].isna().all()
+        assert interval_minutes.eq(60).all()
+        assert (
+            not df.select(
+                pl.struct(["Interval Start", "Location", "Product"]).is_duplicated(),
+            )
+            .to_series()
+            .any()
+        )
+        ir_loss_null = (
+            df.filter(
+                pl.col("Product").is_in(["IRU", "IRD"]),
+            )["Loss"]
+            .is_null()
+            .all()
+        )
         assert ir_loss_null
 
     @pytest.mark.parametrize("date", ["2026-05-01"])
@@ -262,19 +286,26 @@ class TestCAISO(BaseTestISO):
         "MW",
     ]
 
-    def _check_ir_rc_requirements_awards(self, df: pd.DataFrame) -> None:
-        assert df.columns.tolist() == self.IR_RC_REQUIREMENTS_AWARDS_COLUMNS
-        assert df.shape[0] > 0
-        assert set(df["Product"].unique()).issubset({"IRU", "IRD", "RCU", "RCD"})
-        assert set(df["Type"].unique()) == {"Requirement", "Award"}
+    def _check_ir_rc_requirements_awards(self, df: pl.DataFrame) -> None:
+        df = self._as_polars(df)
+        assert list(df.columns) == self.IR_RC_REQUIREMENTS_AWARDS_COLUMNS
+        assert df.height > 0
+        assert set(df["Product"].unique().to_list()).issubset(
+            {"IRU", "IRD", "RCU", "RCD"},
+        )
+        assert set(df["Type"].unique().to_list()) == {"Requirement", "Award"}
         interval_minutes = (
             df["Interval End"] - df["Interval Start"]
         ).dt.total_seconds() / 60
-        assert (interval_minutes == 60).all()
-        assert not df.duplicated(
-            subset=["Interval Start", "BAA", "Product", "Type"],
-        ).any()
-        assert pd.api.types.is_numeric_dtype(df["MW"])
+        assert interval_minutes.eq(60).all()
+        assert (
+            not df.select(
+                pl.struct(["Interval Start", "BAA", "Product", "Type"]).is_duplicated(),
+            )
+            .to_series()
+            .any()
+        )
+        assert df["MW"].dtype in {pl.Float64, pl.Int64, pl.Float32, pl.Int32}
 
     @pytest.mark.parametrize("date", ["2026-05-01"])
     def test_get_ir_rc_requirements_awards_dam(self, date):
@@ -283,7 +314,7 @@ class TestCAISO(BaseTestISO):
         ):
             df = self.iso.get_ir_rc_requirements_awards_dam(date=date)
             self._check_ir_rc_requirements_awards(df)
-            assert set(df["Product"].unique()) == {"IRU", "IRD", "RCU", "RCD"}
+            assert set(df["Product"].unique().to_list()) == {"IRU", "IRD", "RCU", "RCD"}
             assert df["Interval Start"].min() == self.local_start_of_day(date)
             assert df["Interval Start"].max() == self.local_start_of_day(
                 date,
@@ -296,7 +327,7 @@ class TestCAISO(BaseTestISO):
         ):
             df = self.iso.get_ir_rc_requirements_awards_2da(date=date)
             self._check_ir_rc_requirements_awards(df)
-            assert set(df["Product"].unique()) == {"IRU", "IRD"}
+            assert set(df["Product"].unique().to_list()) == {"IRU", "IRD"}
             assert df["Interval Start"].min() == self.local_start_of_day(date)
             assert df["Interval Start"].max() == self.local_start_of_day(
                 date,
@@ -309,7 +340,7 @@ class TestCAISO(BaseTestISO):
         ):
             df = self.iso.get_ir_rc_requirements_awards_3da(date=date)
             self._check_ir_rc_requirements_awards(df)
-            assert set(df["Product"].unique()) == {"IRU", "IRD"}
+            assert set(df["Product"].unique().to_list()) == {"IRU", "IRD"}
             assert df["Interval Start"].min() == self.local_start_of_day(date)
             assert df["Interval Start"].max() == self.local_start_of_day(
                 date,
@@ -359,10 +390,10 @@ class TestCAISO(BaseTestISO):
 
     def _check_load_forecast(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         expected_interval_minutes: int | None = None,
     ):
-        assert df.columns.tolist() == [
+        assert list(df.columns) == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -374,7 +405,7 @@ class TestCAISO(BaseTestISO):
             interval_minutes = (
                 df["Interval End"] - df["Interval Start"]
             ).dt.total_seconds() / 60
-            assert (interval_minutes == expected_interval_minutes).all()
+            assert interval_minutes.eq(expected_interval_minutes).all()
 
         assert df["Publish Time"].max() < self.local_now()
 
@@ -493,14 +524,12 @@ class TestCAISO(BaseTestISO):
             match_on=["method", "scheme", "host", "port", "path"],
         ):
             df = self.iso.get_seven_day_resource_adequacy_outlook(date)
-        assert df.shape[0] > 0
-        assert (
-            df.columns.tolist() == self._seven_day_resource_adequacy_outlook_columns()
-        )
+        assert df.height > 0
+        assert list(df.columns) == self._seven_day_resource_adequacy_outlook_columns()
         assert (
             df["Interval End"] - df["Interval Start"] == pd.Timedelta(minutes=5)
         ).all()
-        assert df["Publish Time"].nunique() == 1
+        assert df["Publish Time"].n_unique() == 1
         expected_pub = pd.Timestamp(date, tz=self.iso.default_timezone).normalize()
         assert (df["Publish Time"] == expected_pub).all()
         self._check_time_columns(
@@ -520,27 +549,22 @@ class TestCAISO(BaseTestISO):
             match_on=["method", "scheme", "host", "port", "path"],
         ):
             df = self.iso.get_seven_day_resource_adequacy_outlook(start, end=end)
-        assert df.shape[0] > 0
-        assert (
-            df.columns.tolist() == self._seven_day_resource_adequacy_outlook_columns()
-        )
-        assert df["Publish Time"].nunique() == 2
-        assert df.columns[:3].tolist() == [
+        assert df.height > 0
+        assert list(df.columns) == self._seven_day_resource_adequacy_outlook_columns()
+        assert df["Publish Time"].n_unique() == 2
+        assert list(df.columns[:3]) == [
             "Interval Start",
             "Interval End",
             "Publish Time",
         ]
         for col in ["Interval Start", "Interval End", "Publish Time"]:
-            assert isinstance(df.loc[0][col], pd.Timestamp)
-            assert df.loc[0][col].tz is not None
+            assert isinstance(df[0, col], (pd.Timestamp, datetime))
+            assert df[0, col].tzinfo is not None
         assert (
             df["Interval End"] - df["Interval Start"] == pd.Timedelta(minutes=5)
         ).all()
-        sorted_df = df.sort_values(
-            by=["Interval Start", "Publish Time"],
-            kind="mergesort",
-        )
-        assert sorted_df["Interval Start"].is_monotonic_increasing
+        sorted_df = df.sort(["Interval Start", "Publish Time"])
+        assert sorted_df["Interval Start"].is_sorted()
 
     def test_get_seven_day_resource_adequacy_outlook_latest_matches_today(self):
         with caiso_vcr.use_cassette(
@@ -551,7 +575,7 @@ class TestCAISO(BaseTestISO):
             today_df = self.iso.get_seven_day_resource_adequacy_outlook("today")
         assert latest_df.equals(today_df)
         assert (
-            latest_df.columns.tolist()
+            list(latest_df.columns)
             == self._seven_day_resource_adequacy_outlook_columns()
         )
         assert (latest_df["Publish Time"] == self.local_start_of_today()).all()
@@ -559,9 +583,9 @@ class TestCAISO(BaseTestISO):
     """get_solar_and_wind_forecast_dam"""
 
     def _check_solar_and_wind_forecast(self, df, expected_count_unique_publish_times):
-        assert df.shape[0] > 0
+        assert df.height > 0
 
-        assert df.columns.tolist() == [
+        assert list(df.columns) == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -570,10 +594,15 @@ class TestCAISO(BaseTestISO):
             "Wind MW",
         ]
 
-        assert df["Location"].unique().tolist() == ["CAISO", "NP15", "SP15", "ZP26"]
+        assert df["Location"].unique(maintain_order=True).to_list() == [
+            "CAISO",
+            "NP15",
+            "SP15",
+            "ZP26",
+        ]
 
-        totals = df.loc[df["Location"] == "CAISO"]
-        non_totals = df.loc[df["Location"] != "CAISO"]
+        totals = df.filter(pl.col("Location") == "CAISO")
+        non_totals = df.filter(pl.col("Location") != "CAISO")
 
         assert math.isclose(
             totals["Solar MW"].sum(),
@@ -595,12 +624,12 @@ class TestCAISO(BaseTestISO):
 
         # Make sure there are no future publish times
         assert df["Publish Time"].max() < self.local_now()
-        assert df["Publish Time"].nunique() == expected_count_unique_publish_times
+        assert df["Publish Time"].n_unique() == expected_count_unique_publish_times
 
-    def _check_edam_wind_solar_forecast(self, df: pd.DataFrame) -> None:
-        assert df.shape[0] > 0
+    def _check_edam_wind_solar_forecast(self, df: pl.DataFrame) -> None:
+        assert df.height > 0
 
-        assert df.columns.tolist() == [
+        assert list(df.columns) == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -615,14 +644,18 @@ class TestCAISO(BaseTestISO):
             skip_column_named_time=True,
         )
 
-        assert isinstance(df.loc[0]["Publish Time"], pd.Timestamp)
-        assert df.loc[0]["Publish Time"].tz is not None
+        assert isinstance(df[0, "Publish Time"], (pd.Timestamp, datetime))
+        assert df[0, "Publish Time"].tzinfo is not None
 
-        assert pd.api.types.is_numeric_dtype(df["Solar"])
-        assert pd.api.types.is_numeric_dtype(df["Wind"])
+        assert df["Solar"].dtype in {pl.Float64, pl.Int64, pl.Float32, pl.Int32}
+        assert df["Wind"].dtype in {pl.Float64, pl.Int64, pl.Float32, pl.Int32}
 
-        assert df["BAA"].notna().all()
-        assert not df.duplicated(subset=["Interval Start", "BAA"]).any()
+        assert df["BAA"].is_not_null().all()
+        assert (
+            not df.select(pl.struct(["Interval Start", "BAA"]).is_duplicated())
+            .to_series()
+            .any()
+        )
 
         assert (
             df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
@@ -724,8 +757,8 @@ class TestCAISO(BaseTestISO):
             "test_get_renewables_forecast_hasp_latest.yaml",
         ):
             df = self.iso.get_renewables_forecast_hasp("latest")
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == [
+            assert df.height > 0
+            assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
                 "Publish Time",
@@ -751,8 +784,8 @@ class TestCAISO(BaseTestISO):
             f"test_get_renewables_forecast_hasp_date_range_{date}_{end}.yaml",
         ):
             df = self.iso.get_renewables_forecast_hasp(date, end=end)
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == [
+            assert df.height > 0
+            assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
                 "Publish Time",
@@ -777,8 +810,8 @@ class TestCAISO(BaseTestISO):
             "test_get_renewables_hourly_latest.yaml",
         ):
             df = self.iso.get_renewables_hourly("latest")
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == [
+            assert df.height > 0
+            assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
                 "Location",
@@ -798,8 +831,8 @@ class TestCAISO(BaseTestISO):
             f"test_get_renewables_hourly_date_range_{date}_{end}.yaml",
         ):
             df = self.iso.get_renewables_hourly(date, end=end)
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == [
+            assert df.height > 0
+            assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
                 "Location",
@@ -820,8 +853,8 @@ class TestCAISO(BaseTestISO):
             "test_get_renewables_forecast_rtd_latest.yaml",
         ):
             df = self.iso.get_renewables_forecast_rtd("latest")
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == [
+            assert df.height > 0
+            assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
                 "Publish Time",
@@ -842,8 +875,8 @@ class TestCAISO(BaseTestISO):
             f"test_get_renewables_forecast_rtd_date_range_{date}_{end}.yaml",
         ):
             df = self.iso.get_renewables_forecast_rtd(date, end=end)
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == [
+            assert df.height > 0
+            assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
                 "Publish Time",
@@ -865,8 +898,8 @@ class TestCAISO(BaseTestISO):
             "test_get_renewables_forecast_rtpd_latest.yaml",
         ):
             df = self.iso.get_renewables_forecast_rtpd("latest")
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == [
+            assert df.height > 0
+            assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
                 "Publish Time",
@@ -887,8 +920,8 @@ class TestCAISO(BaseTestISO):
             f"test_get_renewables_forecast_rtpd_date_range_{date}_{end}.yaml",
         ):
             df = self.iso.get_renewables_forecast_rtpd(date, end=end)
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == [
+            assert df.height > 0
+            assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
                 "Publish Time",
@@ -907,9 +940,9 @@ class TestCAISO(BaseTestISO):
 
     """get_curtailment_legacy"""
 
-    def _check_curtailment_legacy(self, df: pd.DataFrame):
-        assert df.shape[0] > 0
-        assert df.columns.tolist() == [
+    def _check_curtailment_legacy(self, df: pl.DataFrame):
+        assert df.height > 0
+        assert list(df.columns) == [
             "Time",
             "Interval Start",
             "Interval End",
@@ -954,8 +987,8 @@ class TestCAISO(BaseTestISO):
 
     """get_curtailment"""
 
-    def _check_curtailment(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_curtailment(self, df: pl.DataFrame):
+        assert list(df.columns) == [
             "Interval Start",
             "Interval End",
             "Curtailment Type",
@@ -1020,8 +1053,8 @@ class TestCAISO(BaseTestISO):
             df = self.iso.get_gas_prices(date=date)
 
             n_unique = 153
-            assert df["Fuel Region Id"].nunique() == n_unique
-            assert len(df) == n_unique * 24
+            assert df["Fuel Region Id"].n_unique() == n_unique
+            assert df.height == n_unique * 24
 
     @pytest.mark.parametrize("date", ["2022-10-15"])
     def test_get_gas_prices_single_fuel_region(self, date):
@@ -1031,7 +1064,7 @@ class TestCAISO(BaseTestISO):
             test_region_1 = "FRPGE2GHG"
             df = self.iso.get_gas_prices(date=date, fuel_region_id=test_region_1)
             assert df["Fuel Region Id"].unique()[0] == test_region_1
-            assert len(df) == 24
+            assert df.height == 24
 
     @pytest.mark.parametrize("date", ["2022-10-15"])
     def test_get_gas_prices_list_of_fuel_regions(self, date):
@@ -1050,14 +1083,14 @@ class TestCAISO(BaseTestISO):
             assert set(df["Fuel Region Id"].unique()) == set(
                 [test_region_1, test_region_2],
             )
-            assert len(df) == 24 * 2
+            assert df.height == 24 * 2
 
     """get_fuel_regions"""
 
     def test_get_fuel_regions(self):
         with caiso_vcr.use_cassette("test_get_fuel_regions.yaml"):
             df = self.iso.get_fuel_regions()
-            assert df.columns.tolist() == [
+            assert list(df.columns) == [
                 "Fuel Region Id",
                 "Pricing Hub",
                 "Transportation Cost",
@@ -1066,7 +1099,7 @@ class TestCAISO(BaseTestISO):
                 "Miscellaneous Costs",
                 "Balancing Authority",
             ]
-            assert df.shape[0] > 180
+            assert df.height > 180
 
     """get_ghg_allowance"""
 
@@ -1075,8 +1108,8 @@ class TestCAISO(BaseTestISO):
         with caiso_vcr.use_cassette(f"test_get_ghg_allowance_{date}.yaml"):
             df = self.iso.get_ghg_allowance(date)
 
-            assert len(df) == 1
-            assert df.columns.tolist() == [
+            assert df.height == 1
+            assert list(df.columns) == [
                 "Time",
                 "Interval Start",
                 "Interval End",
@@ -1162,7 +1195,7 @@ class TestCAISO(BaseTestISO):
                 market="DAY_AHEAD_HOURLY",
             )
             # assert all days are present
-            assert df["Location"].nunique() == len(locations)
+            assert df["Location"].n_unique() == len(locations)
 
     # all nodes having problems
     # also not working on oasis web portal
@@ -1176,7 +1209,7 @@ class TestCAISO(BaseTestISO):
     #         verbose=True,
     #     )
     #     # assert approx 16000 locations
-    #     assert df["Location"].nunique() > 16000
+    #     assert df["Location"].n_unique() > 16000
 
     @pytest.mark.parametrize(
         "date",
@@ -1192,7 +1225,7 @@ class TestCAISO(BaseTestISO):
                 market="DAY_AHEAD_HOURLY",
             )
             # assert approx 2300 locations
-            assert df["Location"].nunique() > 2300
+            assert df["Location"].n_unique() > 2300
 
     # NOTE(kladar): can't use self.iso.default_timezone because decorator is created before class is initialized
     @pytest.mark.parametrize(
@@ -1241,8 +1274,8 @@ class TestCAISO(BaseTestISO):
                 verbose=True,
             )
             # assert approx 2300 locations
-            assert df["Location"].nunique() > 2300
-            assert df["Interval Start"].dt.hour.nunique() == 2
+            assert df["Location"].n_unique() > 2300
+            assert df["Interval Start"].dt.hour().n_unique() == 2
 
     @pytest.mark.parametrize(
         "date",
@@ -1271,7 +1304,7 @@ class TestCAISO(BaseTestISO):
                 market="REAL_TIME_15_MIN",
             )
 
-        assert not df.empty
+        assert df.height > 0
 
     @pytest.mark.parametrize(
         "start",
@@ -1295,7 +1328,7 @@ class TestCAISO(BaseTestISO):
                     pass
 
     @staticmethod
-    def _check_as_data(df: pd.DataFrame, market: str) -> None:
+    def _check_as_data(df: pl.DataFrame, market: str) -> None:
         columns = [
             "Time",
             "Interval Start",
@@ -1327,9 +1360,9 @@ class TestCAISO(BaseTestISO):
             "Spinning Reserves Total (MW)",
             "Spinning Reserves Total Cost",
         ]
-        assert df.columns.tolist() == columns
-        assert df["Market"].unique()[0] == market
-        assert df.shape[0] > 0
+        assert list(df.columns) == columns
+        assert df["Market"].unique().to_list()[0] == market
+        assert df.height > 0
 
     CURTAILED_GENERATOR_COLUMNS = [
         "Publish Time",
@@ -1353,8 +1386,8 @@ class TestCAISO(BaseTestISO):
             df = self.iso.get_curtailed_non_operational_generator_report(
                 date=date,
             )
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == self.CURTAILED_GENERATOR_COLUMNS
+            assert df.height > 0
+            assert list(df.columns) == self.CURTAILED_GENERATOR_COLUMNS
 
     @pytest.mark.parametrize("date", [pd.Timestamp("today") - pd.Timedelta(days=2)])
     def test_get_curtailed_non_operational_generator_report_two_days_ago(self, date):
@@ -1364,8 +1397,8 @@ class TestCAISO(BaseTestISO):
             df = self.iso.get_curtailed_non_operational_generator_report(
                 date=date,
             )
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == self.CURTAILED_GENERATOR_COLUMNS
+            assert df.height > 0
+            assert list(df.columns) == self.CURTAILED_GENERATOR_COLUMNS
 
     @pytest.mark.parametrize("date", ["2021-11-07"])
     def test_get_curtailed_non_operational_generator_report_duplicates(self, date):
@@ -1375,8 +1408,8 @@ class TestCAISO(BaseTestISO):
             df = self.iso.get_curtailed_non_operational_generator_report(
                 date=date,
             )
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == self.CURTAILED_GENERATOR_COLUMNS
+            assert df.height > 0
+            assert list(df.columns) == self.CURTAILED_GENERATOR_COLUMNS
 
     @pytest.mark.parametrize("date", ["2021-06-16"])
     def test_get_curtailed_non_operational_generator_report_before_2021_06_17(
@@ -1392,20 +1425,20 @@ class TestCAISO(BaseTestISO):
                     date=date,
                 )
 
-                assert df.shape[0] > 0
+                assert df.height > 0
 
         # Change in url format on this date
         date_with_new_format = pd.Timestamp("2025-01-13")
         df = self.iso.get_curtailed_non_operational_generator_report(
             date=date_with_new_format,
         )
-        assert df.shape[0] > 0
-        assert df.columns.tolist() == self.CURTAILED_GENERATOR_COLUMNS
+        assert df.height > 0
+        assert list(df.columns) == self.CURTAILED_GENERATOR_COLUMNS
 
     """get_tie_flows_real_time"""
 
-    def _check_tie_flows_real_time(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_tie_flows_real_time(self, df: pl.DataFrame):
+        assert list(df.columns) == [
             "Interval Start",
             "Interval End",
             "Interface ID",
@@ -1416,15 +1449,21 @@ class TestCAISO(BaseTestISO):
             "MW",
         ]
 
-        assert (df["Interval End"] - df["Interval Start"]).unique() == pd.Timedelta(
-            minutes=5,
+        assert (
+            df["Interval End"] - df["Interval Start"]
+        ).dt.total_seconds().unique().to_list() == [300.0]
+
+        assert df["Market"].unique().to_list() == [REAL_TIME_DISPATCH_MARKET_RUN_ID]
+
+        assert (
+            not df.select(
+                pl.struct(
+                    ["Interval Start", "Tie Name", "From BAA", "To BAA"],
+                ).is_duplicated(),
+            )
+            .to_series()
+            .any()
         )
-
-        assert df["Market"].unique() == REAL_TIME_DISPATCH_MARKET_RUN_ID
-
-        assert not df.duplicated(
-            subset=["Interval Start", "Tie Name", "From BAA", "To BAA"],
-        ).any()
 
     def test_get_tie_flows_real_time_latest(self):
         with caiso_vcr.use_cassette("test_get_tie_flows_real_time_latest.yaml"):
@@ -1471,18 +1510,18 @@ class TestCAISO(BaseTestISO):
                 date=date,
             )
 
-            assert df.empty
+            assert df.is_empty()
 
     def test_get_pnodes(self):
         with caiso_vcr.use_cassette("test_get_pnodes.yaml"):
             df = self.iso.get_pnodes()
-            assert df.shape[0] > 0
+            assert df.height > 0
 
     """get_lmp_scheduling_point_tie_combination"""
 
-    def _check_lmp_scheduling_point_tie(self, df: pd.DataFrame):
-        assert df.shape[0] > 0
-        assert df.columns.tolist() == [
+    def _check_lmp_scheduling_point_tie(self, df: pl.DataFrame):
+        assert df.height > 0
+        assert list(df.columns) == [
             "Interval Start",
             "Interval End",
             "Location",
@@ -1629,9 +1668,9 @@ class TestCAISO(BaseTestISO):
             ).dt.total_seconds() / 60
             assert (interval_minutes == 15).all()
 
-    def _check_lmp_hasp_15_min(self, df: pd.DataFrame):
-        assert df.shape[0] > 0
-        assert df.columns.tolist() == [
+    def _check_lmp_hasp_15_min(self, df: pl.DataFrame):
+        assert df.height > 0
+        assert list(df.columns) == [
             "Interval Start",
             "Interval End",
             "Location",
@@ -1672,8 +1711,8 @@ class TestCAISO(BaseTestISO):
     def test_get_tie_flows_real_time_15_min_latest(self):
         with caiso_vcr.use_cassette("test_get_tie_flows_real_time_15_min_latest.yaml"):
             df = self.iso.get_tie_flows_real_time_15_min("latest")
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == [
+            assert df.height > 0
+            assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
                 "Interface ID",
@@ -1695,8 +1734,8 @@ class TestCAISO(BaseTestISO):
             f"test_get_tie_flows_real_time_15_min_date_range_{date}_{end}.yaml",
         ):
             df = self.iso.get_tie_flows_real_time_15_min(date, end=end)
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == [
+            assert df.height > 0
+            assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
                 "Interface ID",
@@ -1729,8 +1768,8 @@ class TestCAISO(BaseTestISO):
                 date,
                 end=end,
             )
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == [
+            assert df.height > 0
+            assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
                 "Location",
@@ -1740,7 +1779,7 @@ class TestCAISO(BaseTestISO):
                 "Price",
                 "Groups",
             ]
-            assert df["Groups"].apply(type).eq(list).all()
+            assert df["Groups"].map_elements(lambda x: isinstance(x, list)).all()
             assert df["Interval Start"].min() >= pd.Timestamp(
                 date,
                 tz=self.iso.default_timezone,
@@ -1755,8 +1794,8 @@ class TestCAISO(BaseTestISO):
             "test_get_nomogram_branch_shadow_prices_day_ahead_hourly_latest.yaml",
         ):
             df = self.iso.get_nomogram_branch_shadow_prices_day_ahead_hourly("latest")
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == [
+            assert df.height > 0
+            assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
                 "Location",
@@ -1766,7 +1805,7 @@ class TestCAISO(BaseTestISO):
                 "Price",
                 "Groups",
             ]
-            assert df["Groups"].apply(type).eq(list).all()
+            assert df["Groups"].map_elements(lambda x: isinstance(x, list)).all()
             assert df["Interval Start"].min() >= self.local_start_of_today()
 
     @pytest.mark.parametrize(
@@ -1780,8 +1819,8 @@ class TestCAISO(BaseTestISO):
             f"get_nomogram_branch_shadow_prices_hasp_hourly_{date}_{end}.yaml",
         ):
             df = self.iso.get_nomogram_branch_shadow_prices_hasp_hourly(date, end=end)
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == [
+            assert df.height > 0
+            assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
                 "Location",
@@ -1791,7 +1830,7 @@ class TestCAISO(BaseTestISO):
                 "Price",
                 "Groups",
             ]
-            assert df["Groups"].apply(type).eq(list).all()
+            assert df["Groups"].map_elements(lambda x: isinstance(x, list)).all()
             assert df["Interval Start"].min() >= pd.Timestamp(
                 date,
                 tz=self.iso.default_timezone,
@@ -1806,8 +1845,8 @@ class TestCAISO(BaseTestISO):
             "test_get_nomogram_branch_shadow_prices_hasp_hourly_latest.yaml",
         ):
             df = self.iso.get_nomogram_branch_shadow_prices_hasp_hourly("latest")
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == [
+            assert df.height > 0
+            assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
                 "Location",
@@ -1817,7 +1856,7 @@ class TestCAISO(BaseTestISO):
                 "Price",
                 "Groups",
             ]
-            assert df["Groups"].apply(type).eq(list).all()
+            assert df["Groups"].map_elements(lambda x: isinstance(x, list)).all()
             assert df["Interval Start"].min() >= self.local_start_of_today()
 
     @pytest.mark.parametrize(
@@ -1834,8 +1873,8 @@ class TestCAISO(BaseTestISO):
                 date,
                 end=end,
             )
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == [
+            assert df.height > 0
+            assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
                 "Location",
@@ -1845,7 +1884,7 @@ class TestCAISO(BaseTestISO):
                 "Price",
                 "Groups",
             ]
-            assert df["Groups"].apply(type).eq(list).all()
+            assert df["Groups"].map_elements(lambda x: isinstance(x, list)).all()
             assert df["Interval Start"].min() >= pd.Timestamp(
                 date,
                 tz=self.iso.default_timezone,
@@ -1860,8 +1899,8 @@ class TestCAISO(BaseTestISO):
             "test_get_nomogram_branch_shadow_price_forecast_15_min_latest.yaml",
         ):
             df = self.iso.get_nomogram_branch_shadow_price_forecast_15_min("latest")
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == [
+            assert df.height > 0
+            assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
                 "Location",
@@ -1871,7 +1910,7 @@ class TestCAISO(BaseTestISO):
                 "Price",
                 "Groups",
             ]
-            assert df["Groups"].apply(type).eq(list).all()
+            assert df["Groups"].map_elements(lambda x: isinstance(x, list)).all()
             assert df["Interval Start"].min() >= self.local_start_of_today()
 
     @pytest.mark.parametrize(
@@ -1892,8 +1931,8 @@ class TestCAISO(BaseTestISO):
                 date,
                 end=end,
             )
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == [
+            assert df.height > 0
+            assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
                 "Location",
@@ -1902,7 +1941,7 @@ class TestCAISO(BaseTestISO):
                 "Price",
                 "Groups",
             ]
-            assert df["Groups"].apply(type).eq(list).all()
+            assert df["Groups"].map_elements(lambda x: isinstance(x, list)).all()
             assert df["Interval Start"].min() >= pd.Timestamp(
                 date,
                 tz=self.iso.default_timezone,
@@ -1919,8 +1958,8 @@ class TestCAISO(BaseTestISO):
             df = self.iso.get_interval_nomogram_branch_shadow_prices_real_time_5_min(
                 "latest",
             )
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == [
+            assert df.height > 0
+            assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
                 "Location",
@@ -1929,7 +1968,7 @@ class TestCAISO(BaseTestISO):
                 "Price",
                 "Groups",
             ]
-            assert df["Groups"].apply(type).eq(list).all()
+            assert df["Groups"].map_elements(lambda x: isinstance(x, list)).all()
             assert df["Interval Start"].min() >= self.local_start_of_today()
 
     @pytest.mark.parametrize(
@@ -1950,8 +1989,8 @@ class TestCAISO(BaseTestISO):
                 date,
                 end=end,
             )
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == [
+            assert df.height > 0
+            assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
                 "TI ID",
@@ -1961,7 +2000,7 @@ class TestCAISO(BaseTestISO):
                 "Shadow Price",
                 "Groups",
             ]
-            assert df["Groups"].apply(type).eq(list).all()
+            assert df["Groups"].map_elements(lambda x: isinstance(x, list)).all()
             assert df["Interval Start"].min() >= pd.Timestamp(
                 date,
                 tz=self.iso.default_timezone,
@@ -1978,8 +2017,8 @@ class TestCAISO(BaseTestISO):
             df = self.iso.get_intertie_constraint_shadow_prices_real_time_5_min(
                 "latest",
             )
-            assert df.shape[0] > 0
-            assert df.columns.tolist() == [
+            assert df.height > 0
+            assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
                 "TI ID",
@@ -1989,14 +2028,14 @@ class TestCAISO(BaseTestISO):
                 "Shadow Price",
                 "Groups",
             ]
-            assert df["Groups"].apply(type).eq(list).all()
+            assert df["Groups"].map_elements(lambda x: isinstance(x, list)).all()
             assert df["Interval Start"].min() >= self.local_start_of_today()
 
     """get_system_load_and_resource_schedules"""
 
     def _check_system_load_and_resource_schedules(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         interval_minutes: int,
         schedule_columns: list[str],
     ):
@@ -2012,20 +2051,24 @@ class TestCAISO(BaseTestISO):
         )
 
         # Check that interval timestamps are valid
-        assert pd.api.types.is_datetime64_any_dtype(df["Interval Start"])
-        assert pd.api.types.is_datetime64_any_dtype(df["Interval End"])
+        assert df["Interval Start"].dtype == pl.Datetime("us", "US/Pacific") or str(
+            df["Interval Start"].dtype,
+        ).startswith("Datetime")
+        assert df["Interval End"].dtype == pl.Datetime("us", "US/Pacific") or str(
+            df["Interval End"].dtype,
+        ).startswith("Datetime")
 
         assert (
-            (df["Interval End"] - df["Interval Start"])
-            == pd.Timedelta(minutes=interval_minutes)
+            (df["Interval End"] - df["Interval Start"]).dt.total_seconds()
+            == interval_minutes * 60
         ).all()
 
         # Check TAC Name is string
-        assert pd.api.types.is_string_dtype(df["TAC Name"])
+        assert df["TAC Name"].dtype == pl.Utf8
 
         # Check that schedule columns contain numeric data
         for col in schedule_columns:
-            assert pd.api.types.is_numeric_dtype(df[col]), (
+            assert df[col].dtype in {pl.Float64, pl.Int64, pl.Float32, pl.Int32}, (
                 f"Column {col} should be numeric"
             )
 
@@ -2302,7 +2345,7 @@ class TestCAISO(BaseTestISO):
     )
 
     @staticmethod
-    def _assert_daily_energy_storage_frame(method_name: str, df: pd.DataFrame) -> None:
+    def _assert_daily_energy_storage_frame(method_name: str, df: pl.DataFrame) -> None:
         if method_name == "get_storage_awards_fmm":
             assert df.shape == (960, 5)
             assert set(df.columns) == {
@@ -2578,10 +2621,10 @@ class TestCAISO(BaseTestISO):
         report_start = pd.Timestamp("2026-04-06", tz="US/Pacific")
         df = daily_energy_storage.build_storage_soc_hourly(html, report_start)
         assert df.shape == (48, 4)
-        ifm_df = df.loc[df["Schedule"] == "IFM"].sort_values("Interval Start")
-        assert len(ifm_df) == 24
-        deltas = ifm_df["Interval Start"].diff().dropna()
-        assert (deltas == pd.Timedelta(hours=1)).all()
+        ifm_df = df.filter(pl.col("Schedule") == "IFM").sort("Interval Start")
+        assert ifm_df.height == 24
+        deltas = ifm_df.get_column("Interval Start").diff()[1:]
+        assert all(d == pd.Timedelta(hours=1) for d in deltas)
 
 
 NOMOGRAM_GROUP_COLS = [
@@ -2655,23 +2698,23 @@ class TestCollapseGroupToArray:
             133.52,
             [3, 1, 5],
         )
-        df = pd.DataFrame(rows)
+        df = pl.DataFrame(rows)
         result = _collapse_group_to_array(df, NOMOGRAM_GROUP_COLS)
 
-        assert len(result) == 1
-        assert result["Groups"].iloc[0] == [1, 3, 5]
+        assert result.height == 1
+        assert result.row(0, named=True)["Groups"] == [1, 3, 5]
         assert "Group" not in result.columns
 
     def test_intertie_multiple_groups_collapsed(self):
         """Intertie constraint data collapses groups correctly."""
         rows = _make_intertie_rows("EPE_NET_ITC", "E", -51.39, [2, 1])
-        df = pd.DataFrame(rows)
+        df = pl.DataFrame(rows)
         result = _collapse_group_to_array(df, INTERTIE_GROUP_COLS)
 
-        assert len(result) == 1
-        assert result["Groups"].iloc[0] == [1, 2]
-        assert result["TI ID"].iloc[0] == "EPE_NET_ITC"
-        assert result["TI Direction"].iloc[0] == "E"
+        assert result.height == 1
+        assert result.row(0, named=True)["Groups"] == [1, 2]
+        assert result.row(0, named=True)["TI ID"] == "EPE_NET_ITC"
+        assert result.row(0, named=True)["TI Direction"] == "E"
 
     def test_single_group_returns_single_element_list(self):
         rows = _make_nomogram_rows(
@@ -2679,11 +2722,11 @@ class TestCollapseGroupToArray:
             100.0,
             [1],
         )
-        df = pd.DataFrame(rows)
+        df = pl.DataFrame(rows)
         result = _collapse_group_to_array(df, NOMOGRAM_GROUP_COLS)
 
-        assert len(result) == 1
-        assert result["Groups"].iloc[0] == [1]
+        assert result.height == 1
+        assert result.row(0, named=True)["Groups"] == [1]
 
     def test_nan_groups_dropped(self):
         rows = _make_nomogram_rows(
@@ -2691,11 +2734,11 @@ class TestCollapseGroupToArray:
             588.84,
             [1, np.nan, 3],
         )
-        df = pd.DataFrame(rows)
+        df = pl.DataFrame(rows)
         result = _collapse_group_to_array(df, NOMOGRAM_GROUP_COLS)
 
-        assert len(result) == 1
-        assert result["Groups"].iloc[0] == [1, 3]
+        assert result.height == 1
+        assert result.row(0, named=True)["Groups"] == [1, 3]
 
     def test_all_nan_groups_returns_empty_list(self):
         rows = _make_nomogram_rows(
@@ -2703,11 +2746,11 @@ class TestCollapseGroupToArray:
             100.0,
             [np.nan, np.nan],
         )
-        df = pd.DataFrame(rows)
+        df = pl.DataFrame(rows)
         result = _collapse_group_to_array(df, NOMOGRAM_GROUP_COLS)
 
-        assert len(result) == 1
-        assert result["Groups"].iloc[0] == []
+        assert result.height == 1
+        assert result.row(0, named=True)["Groups"] == []
 
     def test_float_groups_converted_to_int(self):
         rows = _make_nomogram_rows(
@@ -2715,10 +2758,10 @@ class TestCollapseGroupToArray:
             100.0,
             [1.0, 2.0],
         )
-        df = pd.DataFrame(rows)
+        df = pl.DataFrame(rows)
         result = _collapse_group_to_array(df, NOMOGRAM_GROUP_COLS)
 
-        groups = result["Groups"].iloc[0]
+        groups = result.row(0, named=True)["Groups"]
         assert groups == [1, 2]
         assert all(isinstance(v, int) for v in groups)
 
@@ -2733,16 +2776,16 @@ class TestCollapseGroupToArray:
             45.0,
             [1],
         )
-        df = pd.DataFrame(rows)
+        df = pl.DataFrame(rows)
         result = _collapse_group_to_array(df, NOMOGRAM_GROUP_COLS)
 
-        assert len(result) == 2
-        row_a = result[
-            result["Location"] == "24723_CONTROL_115_24865_TAP188_115_BR_2_1"
-        ].iloc[0]
-        row_b = result[
-            result["Location"] == "30900_DELANEY_500_24156_N.GILA_500_BR_1_1"
-        ].iloc[0]
+        assert result.height == 2
+        row_a = result.filter(
+            pl.col("Location") == "24723_CONTROL_115_24865_TAP188_115_BR_2_1",
+        ).row(0, named=True)
+        row_b = result.filter(
+            pl.col("Location") == "30900_DELANEY_500_24156_N.GILA_500_BR_1_1",
+        ).row(0, named=True)
         assert row_a["Groups"] == [2, 3, 5]
         assert row_b["Groups"] == [1]
 
@@ -2759,17 +2802,17 @@ class TestCollapseGroupToArray:
             [3, 4],
             ts="2025-01-01 09:00",
         )
-        df = pd.DataFrame(rows)
+        df = pl.DataFrame(rows)
         result = _collapse_group_to_array(df, NOMOGRAM_GROUP_COLS)
 
-        assert len(result) == 2
-        row_08 = result[
-            result["Interval Start"]
-            == pd.Timestamp("2025-01-01 08:00", tz="US/Pacific")
-        ].iloc[0]
-        row_09 = result[
-            result["Interval Start"]
-            == pd.Timestamp("2025-01-01 09:00", tz="US/Pacific")
-        ].iloc[0]
+        assert result.height == 2
+        row_08 = result.filter(
+            pl.col("Interval Start")
+            == pd.Timestamp("2025-01-01 08:00", tz="US/Pacific"),
+        ).row(0, named=True)
+        row_09 = result.filter(
+            pl.col("Interval Start")
+            == pd.Timestamp("2025-01-01 09:00", tz="US/Pacific"),
+        ).row(0, named=True)
         assert row_08["Groups"] == [1, 2]
         assert row_09["Groups"] == [3, 4]

--- a/gridstatus/tests/source_specific/test_eia.py
+++ b/gridstatus/tests/source_specific/test_eia.py
@@ -1,8 +1,8 @@
 import datetime
 from typing import List
 
-import numpy as np
 import pandas as pd
+import polars as pl
 import pytest
 
 import gridstatus
@@ -24,6 +24,10 @@ api_vcr = setup_vcr(
 )
 
 
+def _null_count(df: pl.DataFrame) -> int:
+    return df.null_count().select(pl.sum_horizontal(pl.all())).item()
+
+
 def _check_interchange(df):
     columns = [
         "Interval Start",
@@ -34,11 +38,12 @@ def _check_interchange(df):
         "To BA Name",
         "MW",
     ]
-    # assert interval start and interval end are datetimes in utc
-    assert df["Interval Start"].dtype == "datetime64[ns, UTC]"
-    assert df["Interval End"].dtype == "datetime64[ns, UTC]"
-    assert df.shape[0] > 0
-    assert df.columns.tolist() == columns
+    assert isinstance(df.schema["Interval Start"], pl.Datetime)
+    assert df.schema["Interval Start"].time_zone == "UTC"
+    assert isinstance(df.schema["Interval End"], pl.Datetime)
+    assert df.schema["Interval End"].time_zone == "UTC"
+    assert df.height > 0
+    assert df.columns == columns
 
 
 def _check_region_data(df):
@@ -53,10 +58,12 @@ def _check_region_data(df):
         "Total Interchange",
     ]
 
-    assert df["Interval Start"].dtype == "datetime64[ns, UTC]"
-    assert df["Interval End"].dtype == "datetime64[ns, UTC]"
-    assert df.shape[0] > 0
-    assert df.columns.tolist() == columns
+    assert isinstance(df.schema["Interval Start"], pl.Datetime)
+    assert df.schema["Interval Start"].time_zone == "UTC"
+    assert isinstance(df.schema["Interval End"], pl.Datetime)
+    assert df.schema["Interval End"].time_zone == "UTC"
+    assert df.height > 0
+    assert df.columns == columns
 
 
 def _check_region_subba_data(df):
@@ -70,17 +77,21 @@ def _check_region_subba_data(df):
         "MW",
     ]
 
-    assert df["Interval Start"].dtype == "datetime64[ns, UTC]"
-    assert df["Interval End"].dtype == "datetime64[ns, UTC]"
-    assert df.shape[0] > 0
-    assert df.columns.tolist() == columns
+    assert isinstance(df.schema["Interval Start"], pl.Datetime)
+    assert df.schema["Interval Start"].time_zone == "UTC"
+    assert isinstance(df.schema["Interval End"], pl.Datetime)
+    assert df.schema["Interval End"].time_zone == "UTC"
+    assert df.height > 0
+    assert df.columns == columns
 
 
 def _check_fuel_type(df):
-    assert df["Interval Start"].dtype == "datetime64[ns, UTC]"
-    assert df["Interval End"].dtype == "datetime64[ns, UTC]"
-    assert df.shape[0] > 0
-    assert df.columns.tolist() == EIA_FUEL_MIX_COLUMNS
+    assert isinstance(df.schema["Interval Start"], pl.Datetime)
+    assert df.schema["Interval Start"].time_zone == "UTC"
+    assert isinstance(df.schema["Interval End"], pl.Datetime)
+    assert df.schema["Interval End"].time_zone == "UTC"
+    assert df.height > 0
+    assert df.columns == EIA_FUEL_MIX_COLUMNS
 
 
 @pytest.mark.integration
@@ -117,7 +128,7 @@ def test_rto_interchange():
 
     assert df["Interval End"].min().date() == pd.Timestamp(start).date()
     assert df["Interval End"].max().date() == pd.Timestamp(end).date()
-    assert df.isnull().sum().sum() == 0
+    assert _null_count(df) == 0
 
     _check_interchange(df)
 
@@ -137,9 +148,7 @@ def test_rto_region_data():
 
     assert df["Interval End"].min().date() == pd.Timestamp(start).date()
     assert df["Interval End"].max().date() == pd.Timestamp(end).date()
-    # pick a respondent that we know has no nulls
-    # this check that pagination is working
-    assert df[df["Respondent"] == "BPAT"].isnull().sum().sum() == 0
+    assert _null_count(df.filter(pl.col("Respondent") == "BPAT")) == 0
     _check_region_data(df)
 
 
@@ -158,9 +167,7 @@ def test_rto_region_subba_data():
 
     assert df["Interval End"].min().date() == pd.Timestamp(start).date()
     assert df["Interval End"].max().date() == pd.Timestamp(end).date()
-    # pick a respondent that we know has no nulls
-    # this check that pagination is working
-    assert df[df["Subregion"] == "PGAE"].isnull().sum().sum() == 0
+    assert _null_count(df.filter(pl.col("Subregion") == "PGAE")) == 0
     _check_region_subba_data(df)
 
 
@@ -171,7 +178,6 @@ def test_fuel_type():
     start = (pd.Timestamp.utcnow() - pd.Timedelta(days=2)).normalize()
     end = start + pd.Timedelta(days=1)
 
-    # dataset that doesnt have a handler yet
     df = eia.get_dataset(
         dataset="electricity/rto/fuel-type-data",
         start=start,
@@ -192,7 +198,6 @@ def test_facets():
     start = "2025-01-01"
     end = "2025-01-04"
 
-    # dataset that doesnt have a handler yet
     df = eia.get_dataset(
         dataset="electricity/rto/fuel-type-data",
         start=start,
@@ -203,7 +208,7 @@ def test_facets():
 
     assert (df["Respondent Name"] == "PacifiCorp East").all()
 
-    assert df.columns.tolist() == EIA_FUEL_MIX_COLUMNS
+    assert df.columns == EIA_FUEL_MIX_COLUMNS
 
 
 @pytest.mark.integration
@@ -220,8 +225,8 @@ def test_daily_spots_and_futures():
         "percent_change",
     ]
 
-    assert d["petroleum"].columns.tolist() == cols_petrol
-    assert d["petroleum"].shape[0] > 0
+    assert d["petroleum"].columns == cols_petrol
+    assert d["petroleum"].height > 0
     cols_ng = [
         "date",
         "region",
@@ -232,8 +237,8 @@ def test_daily_spots_and_futures():
         "spark_spread",
     ]
 
-    assert d["natural_gas"].columns.tolist() == cols_ng
-    assert d["natural_gas"].shape[0] > 0
+    assert d["natural_gas"].columns == cols_ng
+    assert d["natural_gas"].height > 0
 
 
 @pytest.mark.integration
@@ -270,14 +275,14 @@ def test_get_coal_spots():
         "coke_exports",
     ]
 
-    assert d["weekly_spots"].columns.tolist() == cols_spot_price
-    assert d["weekly_spots"].shape[0] > 0
+    assert d["weekly_spots"].columns == cols_spot_price
+    assert d["weekly_spots"].height > 0
 
-    assert d["coal_exports"].columns.tolist() == cols_coal
-    assert d["coal_exports"].shape[0] > 0
+    assert d["coal_exports"].columns == cols_coal
+    assert d["coal_exports"].height > 0
 
-    assert d["coke_exports"].columns.tolist() == cols_coke
-    assert d["coke_exports"].shape[0] > 0
+    assert d["coke_exports"].columns == cols_coke
+    assert d["coke_exports"].height > 0
 
 
 @pytest.mark.integration
@@ -320,11 +325,11 @@ def test_eia_grid_monitor():
     ]
     df = eia.get_grid_monitor(area_id="CISO")
 
-    assert df.columns.tolist() == cols
+    assert df.columns == cols
 
 
 def _check_henry_hub_natural_gas_spot_prices(df):
-    assert df.columns.tolist() == [
+    assert df.columns == [
         "Interval Start",
         "Interval End",
         "period",
@@ -340,10 +345,14 @@ def _check_henry_hub_natural_gas_spot_prices(df):
         "units",
     ]
 
-    assert (df["Interval End"] - df["Interval Start"]).unique() == pd.Timedelta(days=1)
+    unique_deltas = (
+        (df["Interval End"] - df["Interval Start"])
+        .unique(maintain_order=True)
+        .to_list()
+    )
+    assert all(delta == pd.Timedelta(days=1) for delta in unique_deltas)
 
-    # Only RNGWHHD is present after 2024-04-05
-    assert set(df["series"].unique()) == set(
+    assert set(df["series"].unique(maintain_order=True).to_list()) == set(
         [
             "RNGWHHD",
             "RNGC1",
@@ -353,11 +362,11 @@ def _check_henry_hub_natural_gas_spot_prices(df):
         ],
     )
 
-    assert df["area_name"].isna().any()
-    assert not df["price"].isna().any()
-    assert not df["series"].isna().any()
+    assert df["area_name"].null_count() > 0
+    assert df["price"].null_count() == 0
+    assert df["series"].null_count() == 0
 
-    assert np.issubdtype(df["price"], np.float64)
+    assert df.schema["price"] == pl.Float64
 
 
 @pytest.mark.integration
@@ -393,7 +402,7 @@ def test_get_henry_hub_natural_gas_spot_prices_historical_date_range():
 
 
 def _check_generators_data(
-    df: pd.DataFrame,
+    df: pl.DataFrame,
     generator_status: str,
     columns: List[str] = None,
     expected_rows: int = None,
@@ -401,17 +410,19 @@ def _check_generators_data(
     expected_updated_at: pd.Timestamp = None,
     expected_all_na_columns: List[str] = None,
 ):
-    assert df.columns.tolist() == columns
+    assert df.columns == columns
     if expected_rows is not None:
-        assert df.shape[0] == expected_rows
+        assert df.height == expected_rows
 
-    assert df["Period"].unique() == expected_period
-    assert df["Entity ID"].notna().all()
-    assert df["Plant ID"].notna().all()
-    assert df["Generator ID"].notna().all()
+    assert df["Period"].unique(maintain_order=True).to_list() == [expected_period]
+    assert df["Entity ID"].null_count() == 0
+    assert df["Plant ID"].null_count() == 0
+    assert df["Generator ID"].null_count() == 0
 
     if expected_updated_at is not None:
-        assert df["Updated At"].unique() == expected_updated_at
+        assert df["Updated At"].unique(maintain_order=True).to_list() == [
+            expected_updated_at.to_pydatetime(),
+        ]
 
     # These columns should not be all empty
     if generator_status in ["operating", "retired"]:
@@ -423,11 +434,10 @@ def _check_generators_data(
             "Net Winter Capacity",
             "Unit Code",
         ]:
-            # Earlier datasets may not have all columns so we add them as pd.NA values
             if expected_all_na_columns is not None and col in expected_all_na_columns:
-                assert df[col].isna().all()
+                assert df[col].null_count() == df.height
             else:
-                assert df[col].notna().any()
+                assert df[col].null_count() < df.height
 
     # Different generator_status datasets have different columns
     elif generator_status in ["planned", "canceled_or_postponed"]:
@@ -438,17 +448,17 @@ def _check_generators_data(
             "Unit Code",
         ]:
             if expected_all_na_columns is not None and col in expected_all_na_columns:
-                assert df[col].isna().all()
+                assert df[col].null_count() == df.height
             else:
-                assert df[col].notna().any()
+                assert df[col].null_count() < df.height
 
     for col in GENERATOR_FLOAT_COLUMNS:
         if col in df.columns:
-            assert pd.api.types.is_float_dtype(df[col])
+            assert df.schema[col] == pl.Float64
 
     for col in GENERATOR_INT_COLUMNS:
         if col in df.columns:
-            assert pd.api.types.is_integer_dtype(df[col])
+            assert df.schema[col] == pl.Int64
 
 
 def test_get_generators_relative_date():

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import numpy as np
 import pandas as pd
+import polars as pl
 import pytest
 
 from gridstatus import Markets, NoDataFoundException, NotSupported
@@ -107,8 +108,10 @@ class TestErcot(BaseTestISO):
         self._check_dam_system_lambda(df)
         today = pd.Timestamp.now(tz=self.iso.default_timezone).date()
         # Published yesterday
-        assert df["Publish Time"].dt.date.unique() == [today - pd.Timedelta(days=1)]
-        assert df["Interval Start"].dt.date.unique() == [today]
+        assert df["Publish Time"].dt.date().unique().to_list() == [
+            today - pd.Timedelta(days=1),
+        ]
+        assert df["Interval Start"].dt.date().unique().to_list() == [today]
 
     @pytest.mark.integration
     def test_get_dam_system_lambda_historical(self):
@@ -117,7 +120,7 @@ class TestErcot(BaseTestISO):
         ).date() - pd.Timedelta(days=2)
         df = self.iso.get_dam_system_lambda(two_days_ago)
         self._check_dam_system_lambda(df)
-        assert list(df["Publish Time"].dt.date.unique()) == [
+        assert list(df["Publish Time"].dt.date().unique()) == [
             two_days_ago - pd.Timedelta(days=1),
         ]
 
@@ -133,7 +136,7 @@ class TestErcot(BaseTestISO):
             verbose=True,
         )
         self._check_dam_system_lambda(df)
-        assert list(df["Publish Time"].dt.date.unique()) == [
+        assert list(df["Publish Time"].dt.date().unique()) == [
             three_days_ago - pd.Timedelta(days=1),
             two_days_ago - pd.Timedelta(days=1),
         ]
@@ -144,7 +147,7 @@ class TestErcot(BaseTestISO):
     def test_get_sced_system_lambda(self):
         df = self.iso.get_sced_system_lambda("today", verbose=True)
         assert df.shape[0] >= 0
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "SCED Timestamp",
@@ -174,19 +177,19 @@ class TestErcot(BaseTestISO):
         today = pd.Timestamp.now(tz=self.iso.default_timezone).date()
         df = self.iso.get_as_prices(today)
         assert df.shape[0] >= 0
-        assert df.columns.tolist() == as_cols
+        assert df.columns == as_cols
         assert df["Time"].unique()[0].date() == today
 
         date = today - pd.Timedelta(days=3)
         df = self.iso.get_as_prices(date)
         assert df.shape[0] >= 0
-        assert df.columns.tolist() == as_cols
+        assert df.columns == as_cols
         assert df["Time"].unique()[0].date() == date
 
     """get_as_plan"""
 
     def _check_as_plan(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -205,7 +208,7 @@ class TestErcot(BaseTestISO):
         assert df["Interval End"].max() == self.local_start_of_today() + pd.DateOffset(
             days=7,
         )
-        assert df["Publish Time"].dt.date.unique().tolist() == [self.local_today()]
+        assert df["Publish Time"].dt.date().unique().to_list() == [self.local_today()]
 
     @pytest.mark.integration
     def test_get_as_plan_historical_date(self):
@@ -216,7 +219,7 @@ class TestErcot(BaseTestISO):
         assert df["Interval End"].max() == self.local_start_of_day(
             date,
         ) + pd.DateOffset(days=7)
-        assert df["Publish Time"].dt.date.unique().tolist() == [date]
+        assert df["Publish Time"].dt.date().unique().to_list() == [date]
 
     @pytest.mark.integration
     def test_get_as_plan_historical_date_range(self):
@@ -229,7 +232,7 @@ class TestErcot(BaseTestISO):
             end_date,
             # Not inclusive of end date
         ) + pd.DateOffset(days=6)
-        assert df["Publish Time"].dt.date.unique().tolist() == [
+        assert df["Publish Time"].dt.date().unique().to_list() == [
             start_date,
             (start_date + pd.DateOffset(days=1)).date(),
         ]
@@ -240,7 +243,7 @@ class TestErcot(BaseTestISO):
         # asset length is 1, 49 columns
         assert df.shape == (1, 49)
         # assert every colunn but the first is int dtype
-        assert df.iloc[:, 1:].dtypes.unique() == "int64"
+        assert all(dt == pl.Int64 for dt in df[:, 1:].dtypes)
         assert df.columns[0] == "Time"
 
     @pytest.mark.integration
@@ -258,7 +261,7 @@ class TestErcot(BaseTestISO):
         "Status",
     ]
 
-    SAMPLE_OPS_MESSAGES_DF = pd.DataFrame(
+    SAMPLE_OPS_MESSAGES_DF = pl.DataFrame(
         {
             "Date & Time": [
                 "Apr 14, 2026 2:23:50 AM",
@@ -282,29 +285,29 @@ class TestErcot(BaseTestISO):
     def test_get_operations_messages(self):
         with mock.patch(
             "gridstatus.ercot.pd.read_html",
-            return_value=[self.SAMPLE_OPS_MESSAGES_DF.copy()],
+            return_value=[self.SAMPLE_OPS_MESSAGES_DF.clone()],
         ):
             df = self.iso.get_operations_messages()
 
-        assert df.columns.tolist() == self.expected_operations_messages_cols
+        assert df.columns == self.expected_operations_messages_cols
         assert len(df) == 2
-        assert isinstance(df["Time"].dtype, pd.DatetimeTZDtype)
-        assert str(df["Time"].dt.tz) == str(self.iso.default_timezone)
-        assert df["Notice"].iloc[0] is not None
-        assert df["Type"].iloc[0] == "Operational Information"
+        assert isinstance(df.schema["Time"], pl.Datetime)
+        assert str(df.schema["Time"].time_zone) == str(self.iso.default_timezone)
+        assert df["Notice"][0] is not None
+        assert df["Type"][0] == "Operational Information"
         assert set(df["Status"]) == {"Active", "Cancelled"}
 
     def test_get_operations_messages_sorted_by_time(self):
         with mock.patch(
             "gridstatus.ercot.pd.read_html",
-            return_value=[self.SAMPLE_OPS_MESSAGES_DF.copy()],
+            return_value=[self.SAMPLE_OPS_MESSAGES_DF.clone()],
         ):
             df = self.iso.get_operations_messages()
 
-        assert df["Time"].is_monotonic_increasing
+        assert df["Time"].is_sorted()
 
     def test_get_operations_messages_single_row(self):
-        single_row_df = pd.DataFrame(
+        single_row_df = pl.DataFrame(
             {
                 "Date & Time": ["Mar 10, 2026 9:00:00 AM"],
                 "Notice": ["Advisory issued due to tool unavailability."],
@@ -319,11 +322,11 @@ class TestErcot(BaseTestISO):
             df = self.iso.get_operations_messages()
 
         assert len(df) == 1
-        assert df.columns.tolist() == self.expected_operations_messages_cols
-        assert df["Type"].iloc[0] == "Advisory"
+        assert df.columns == self.expected_operations_messages_cols
+        assert df["Type"][0] == "Advisory"
 
     def test_get_operations_messages_historical_deduplicates(self):
-        snap1 = pd.DataFrame(
+        snap1 = pl.DataFrame(
             {
                 "Date & Time": [
                     "Jan 10, 2026 2:00:00 PM",
@@ -334,7 +337,7 @@ class TestErcot(BaseTestISO):
                 "Status": ["Active", "Active"],
             },
         )
-        snap2 = pd.DataFrame(
+        snap2 = pl.DataFrame(
             {
                 "Date & Time": [
                     "Jan 15, 2026 8:00:00 AM",
@@ -368,11 +371,11 @@ class TestErcot(BaseTestISO):
                 )
 
         assert len(df) == 3
-        assert df["Notice"].tolist() == ["Msg B", "Msg A", "Msg C"]
-        assert df["Time"].is_monotonic_increasing
+        assert df["Notice"].to_list() == ["Msg B", "Msg A", "Msg C"]
+        assert df["Time"].is_sorted()
 
     def test_get_operations_messages_historical_filters_to_range(self):
-        snap = pd.DataFrame(
+        snap = pl.DataFrame(
             {
                 "Date & Time": [
                     "Jan 15, 2026 8:00:00 AM",
@@ -405,7 +408,7 @@ class TestErcot(BaseTestISO):
                 )
 
         assert len(df) == 1
-        assert df["Notice"].iloc[0] == "In range"
+        assert df["Notice"][0] == "In range"
 
     def test_get_operations_messages_historical_wayback(self):
         with api_vcr.use_cassette(
@@ -415,18 +418,18 @@ class TestErcot(BaseTestISO):
                 date="2026-01-01",
                 end="2026-01-15",
             )
-        assert df.columns.tolist() == self.expected_operations_messages_cols
+        assert df.columns == self.expected_operations_messages_cols
         assert len(df) > 0
-        assert isinstance(df["Time"].dtype, pd.DatetimeTZDtype)
+        assert isinstance(df.schema["Time"], pl.Datetime)
         assert df["Time"].min() >= pd.Timestamp("2026-01-01", tz="US/Central")
         assert df["Time"].max() < pd.Timestamp("2026-01-15", tz="US/Central")
-        assert df["Time"].is_monotonic_increasing
-        assert df.duplicated(subset=["Time", "Notice"]).sum() == 0
+        assert df["Time"].is_sorted()
+        assert df.select(["Time", "Notice"]).is_duplicated().sum() == 0
 
     @pytest.mark.integration
     def test_get_energy_storage_resources(self):
         df = self.iso.get_energy_storage_resources()
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Time",
             "Total Charging",
             "Total Discharging",
@@ -452,16 +455,16 @@ class TestErcot(BaseTestISO):
             df = self.iso.get_fuel_mix("today")
         self._check_fuel_mix(df)
         assert df.shape[0] >= 0
-        assert df.columns.tolist() == self.fuel_mix_cols
+        assert df.columns == self.fuel_mix_cols
 
     def test_get_fuel_mix_latest(self):
         with api_vcr.use_cassette("test_get_fuel_mix_latest.yaml"):
             df = self.iso.get_fuel_mix("latest")
         self._check_fuel_mix(df)
         # returns two days of data
-        assert df["Time"].dt.date.nunique() == 2
+        assert df["Time"].dt.date().n_unique() == 2
         assert df.shape[0] >= 0
-        assert df.columns.tolist() == self.fuel_mix_cols
+        assert df.columns == self.fuel_mix_cols
 
     @pytest.mark.skip(reason="Not Applicable")
     def test_get_fuel_mix_date_or_start(self):
@@ -515,14 +518,14 @@ class TestErcot(BaseTestISO):
     def test_get_fuel_mix_detailed_latest(self):
         with api_vcr.use_cassette("test_get_fuel_mix_detailed_latest.yaml"):
             df = self.iso.get_fuel_mix_detailed("latest")
-        assert df.columns.tolist() == self.fuel_mix_detailed_columns
-        assert df["Time"].dt.date.nunique() == 2
+        assert df.columns == self.fuel_mix_detailed_columns
+        assert df["Time"].dt.date().n_unique() == 2
 
     def test_get_fuel_mix_detailed_today(self):
         with api_vcr.use_cassette("test_get_fuel_mix_detailed_today.yaml"):
             df = self.iso.get_fuel_mix_detailed("today")
-        assert df.columns.tolist() == self.fuel_mix_detailed_columns
-        assert df["Time"].dt.date.nunique() == 1
+        assert df.columns == self.fuel_mix_detailed_columns
+        assert df["Time"].dt.date().n_unique() == 1
 
     """get_lmp"""
 
@@ -562,7 +565,7 @@ class TestErcot(BaseTestISO):
             + ["System Total"]
         )
 
-        assert df.columns.tolist() == cols
+        assert df.columns == cols
 
         # test 5 days ago
         five_days_ago = pd.Timestamp.now(
@@ -572,7 +575,7 @@ class TestErcot(BaseTestISO):
         self._check_time_columns(df, instant_or_interval="interval")
         assert df["Time"].unique()[0].date() == five_days_ago
 
-        assert df.columns.tolist() == cols
+        assert df.columns == cols
 
     @pytest.mark.integration
     def test_get_load_by_forecast_zone_today(self):
@@ -588,7 +591,7 @@ class TestErcot(BaseTestISO):
             "HOUSTON",
             "TOTAL",
         ]
-        assert df.columns.tolist() == columns
+        assert df.columns == columns
 
         five_days_ago = pd.Timestamp.now(
             tz=self.iso.default_timezone,
@@ -690,7 +693,7 @@ class TestErcot(BaseTestISO):
         self._check_load_forecast_by_model(df)
 
         # One day of data
-        assert df["Publish Time"].nunique() == 24
+        assert df["Publish Time"].n_unique() == 24
 
     """get_capacity_committed"""
 
@@ -698,7 +701,7 @@ class TestErcot(BaseTestISO):
     def test_get_capacity_committed(self):
         df = self.iso.get_capacity_committed("latest")
 
-        assert df.columns.tolist() == ["Interval Start", "Interval End", "Capacity"]
+        assert df.columns == ["Interval Start", "Interval End", "Capacity"]
 
         assert df["Interval Start"].min() == self.local_start_of_today()
         # The end time is approximately now
@@ -708,9 +711,11 @@ class TestErcot(BaseTestISO):
             < self.local_now() + pd.Timedelta(minutes=5)
         )
 
-        assert (df["Interval End"] - df["Interval Start"]).unique() == pd.Timedelta(
-            minutes=5,
-        )
+        assert (df["Interval End"] - df["Interval Start"]).unique().to_list() == [
+            pd.Timedelta(
+                minutes=5,
+            ),
+        ]
 
     """get_capacity_forecast"""
 
@@ -718,7 +723,7 @@ class TestErcot(BaseTestISO):
     def test_get_capacity_forecast(self):
         df = self.iso.get_capacity_forecast("latest")
 
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -737,9 +742,11 @@ class TestErcot(BaseTestISO):
             self.local_today() + pd.Timedelta(days=1),
         )
 
-        assert (df["Interval End"] - df["Interval Start"]).unique() == pd.Timedelta(
-            minutes=5,
-        )
+        assert (df["Interval End"] - df["Interval Start"]).unique().to_list() == [
+            pd.Timedelta(
+                minutes=5,
+            ),
+        ]
 
     """get_available_seasonal_capacity_forecast"""
 
@@ -747,7 +754,7 @@ class TestErcot(BaseTestISO):
     def test_get_available_seasonal_capacity_forecast(self):
         df = self.iso.get_available_seasonal_capacity_forecast("latest")
 
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -766,9 +773,11 @@ class TestErcot(BaseTestISO):
         )
 
         # This can use a timedelta because it doesn't span a day
-        assert (df["Interval End"] - df["Interval Start"]).unique() == pd.Timedelta(
-            hours=1,
-        )
+        assert (df["Interval End"] - df["Interval Start"]).unique().to_list() == [
+            pd.Timedelta(
+                hours=1,
+            ),
+        ]
 
     """get_spp"""
 
@@ -827,7 +836,7 @@ class TestErcot(BaseTestISO):
 
         # two unique days
         # should be today and yesterday since published one day ahead
-        assert set(df["Interval Start"].dt.date.unique()) == {
+        assert set(df["Interval Start"].dt.date().unique()) == {
             today.date(),
             today.date() - pd.Timedelta(days=1),
         }
@@ -911,7 +920,7 @@ class TestErcot(BaseTestISO):
     @pytest.mark.integration
     def test_get_spp_rtm_historical(self):
         rtm = self.iso.get_rtm_spp(2020)
-        assert isinstance(rtm, pd.DataFrame)
+        assert isinstance(rtm, pl.DataFrame)
         assert len(rtm) > 0
 
     @pytest.mark.slow
@@ -983,9 +992,9 @@ class TestErcot(BaseTestISO):
         gen_resource = df_dict[SCED_GEN_RESOURCE_KEY]
         smne = df_dict[SCED_SMNE_KEY]
 
-        assert load_resource["SCED Timestamp"].dt.date.unique()[0] == days_ago_65
-        assert gen_resource["SCED Timestamp"].dt.date.unique()[0] == days_ago_65
-        assert smne["Interval Time"].dt.date.unique()[0] == days_ago_65
+        assert load_resource["SCED Timestamp"].dt.date().unique()[0] == days_ago_65
+        assert gen_resource["SCED Timestamp"].dt.date().unique()[0] == days_ago_65
+        assert smne["Interval Time"].dt.date().unique()[0] == days_ago_65
 
         check_60_day_sced_disclosure(df_dict)
 
@@ -1019,17 +1028,17 @@ class TestErcot(BaseTestISO):
 
         check_60_day_sced_disclosure(df_dict)
 
-        assert load_resource["SCED Timestamp"].dt.date.unique().tolist() == [
+        assert load_resource["SCED Timestamp"].dt.date().unique().to_list() == [
             days_ago_66,
             days_ago_65,
         ]
 
-        assert gen_resource["SCED Timestamp"].dt.date.unique().tolist() == [
+        assert gen_resource["SCED Timestamp"].dt.date().unique().to_list() == [
             days_ago_66,
             days_ago_65,
         ]
 
-        assert smne["Interval Time"].dt.date.unique().tolist() == [
+        assert smne["Interval Time"].dt.date().unique().to_list() == [
             days_ago_66,
             days_ago_65,
         ]
@@ -1064,10 +1073,10 @@ class TestErcot(BaseTestISO):
         assert SCED_ESR_KEY in df_dict
         esr = df_dict[SCED_ESR_KEY]
 
-        assert esr.columns.tolist() == SCED_ESR_COLUMNS
+        assert esr.columns == SCED_ESR_COLUMNS
         assert len(esr) > 0
-        assert esr["Resource Type"].unique().tolist() == ["ESR"]
-        assert esr["SCED Timestamp"].dt.date.unique()[0] == date
+        assert esr["Resource Type"].unique().to_list() == ["ESR"]
+        assert esr["SCED Timestamp"].dt.date().unique()[0] == date
 
         # Verify offer curves are parsed
         assert esr["SCED1 Offer Curve"].apply(lambda x: isinstance(x, list)).any()
@@ -1107,11 +1116,11 @@ class TestErcot(BaseTestISO):
         load = df_dict[SCED_LOAD_RESOURCE_KEY]
         resource_as_offers = df_dict[SCED_RESOURCE_AS_OFFERS_KEY]
 
-        assert esr["SCED Timestamp"].dt.date.unique()[0] == date
-        assert gen["SCED Timestamp"].dt.date.unique()[0] == date
-        assert load["SCED Timestamp"].dt.date.unique()[0] == date
-        assert resource_as_offers["SCED Timestamp"].dt.date.unique()[0] == date
-        assert resource_as_offers.columns.tolist() == SCED_RESOURCE_AS_OFFERS_COLUMNS
+        assert esr["SCED Timestamp"].dt.date().unique()[0] == date
+        assert gen["SCED Timestamp"].dt.date().unique()[0] == date
+        assert load["SCED Timestamp"].dt.date().unique()[0] == date
+        assert resource_as_offers["SCED Timestamp"].dt.date().unique()[0] == date
+        assert resource_as_offers.columns == SCED_RESOURCE_AS_OFFERS_COLUMNS
 
         # SMNE should still come from the normal disclosure
         smne = df_dict[SCED_SMNE_KEY]
@@ -1139,13 +1148,13 @@ class TestErcot(BaseTestISO):
         gen_resource = df_dict[SCED_GEN_RESOURCE_KEY]
 
         assert len(gen_resource) > 0
-        assert gen_resource.columns.tolist() == SCED_GEN_RESOURCE_COLUMNS
+        assert gen_resource.columns == SCED_GEN_RESOURCE_COLUMNS
 
         # The critical assertion: Telemetered Net Output must contain real
         # data, not all NaN. On main, the column name mismatch causes
         # this to be filled with NaN for dates where the raw data has no
         # trailing space.
-        assert gen_resource["Telemetered Net Output"].notna().any(), (
+        assert gen_resource["Telemetered Net Output"].is_not_null().any(), (
             "Telemetered Net Output is all NaN - column name mismatch"
         )
 
@@ -1193,9 +1202,9 @@ class TestErcot(BaseTestISO):
         assert DAM_ESR_KEY in df_dict
         dam_esr = df_dict[DAM_ESR_KEY]
 
-        assert dam_esr.columns.tolist() == DAM_ESR_COLUMNS
+        assert dam_esr.columns == DAM_ESR_COLUMNS
         assert len(dam_esr) > 0
-        assert dam_esr["Resource Type"].unique().tolist() == ["ESR"]
+        assert dam_esr["Resource Type"].unique().to_list() == ["ESR"]
 
         # Verify offer curves are parsed
         assert (
@@ -1209,19 +1218,23 @@ class TestErcot(BaseTestISO):
         assert DAM_ESR_AS_OFFERS_KEY in df_dict
         dam_esr_as_offers = df_dict[DAM_ESR_AS_OFFERS_KEY]
 
-        assert dam_esr_as_offers.columns.tolist() == DAM_ESR_AS_OFFERS_COLUMNS
+        assert dam_esr_as_offers.columns == DAM_ESR_AS_OFFERS_COLUMNS
         assert len(dam_esr_as_offers) > 0
 
         # Verify no duplicates
-        assert not dam_esr_as_offers.duplicated(
-            subset=[
-                "Interval Start",
-                "Interval End",
-                "QSE",
-                "DME",
-                "Resource Name",
-            ],
-        ).any()
+        assert (
+            not dam_esr_as_offers.select(
+                [
+                    "Interval Start",
+                    "Interval End",
+                    "QSE",
+                    "DME",
+                    "Resource Name",
+                ],
+            )
+            .is_duplicated()
+            .any()
+        )
 
         # AS Only Awards/Offers (ENG-3684/ENG-3688) landed in the bundle on the
         # same 2025-12-06 operating day as ESR, so we check them here too.
@@ -1236,10 +1249,10 @@ class TestErcot(BaseTestISO):
 
     def _check_nonspin_offer_curve(self, df, column_name, dataset_name):
         """Verify a NONSPIN offer curve column has valid data."""
-        assert df[column_name].notna().any(), (
+        assert df[column_name].is_not_null().any(), (
             f"{column_name} should have non-null values in {dataset_name}"
         )
-        curve = df[column_name].dropna().iloc[0]
+        curve = df[column_name].drop_nulls().to_list()[0]
         assert isinstance(curve, list)
         assert len(curve) > 0
         assert len(curve[0]) == 2
@@ -1265,7 +1278,7 @@ class TestErcot(BaseTestISO):
         col = "ONLINE NONSPIN Offer Curve"
 
         gen_as_offers = df_dict[DAM_GEN_RESOURCE_AS_OFFERS_KEY]
-        assert gen_as_offers.columns.tolist() == DAM_RESOURCE_AS_OFFERS_COLUMNS
+        assert gen_as_offers.columns == DAM_RESOURCE_AS_OFFERS_COLUMNS
         self._check_nonspin_offer_curve(
             gen_as_offers,
             col,
@@ -1273,7 +1286,7 @@ class TestErcot(BaseTestISO):
         )
 
         load_as_offers = df_dict[DAM_LOAD_RESOURCE_AS_OFFERS_KEY]
-        assert load_as_offers.columns.tolist() == DAM_RESOURCE_AS_OFFERS_COLUMNS
+        assert load_as_offers.columns == DAM_RESOURCE_AS_OFFERS_COLUMNS
         self._check_nonspin_offer_curve(
             load_as_offers,
             col,
@@ -1281,7 +1294,7 @@ class TestErcot(BaseTestISO):
         )
 
         esr_as_offers = df_dict[DAM_ESR_AS_OFFERS_KEY]
-        assert esr_as_offers.columns.tolist() == DAM_ESR_AS_OFFERS_COLUMNS
+        assert esr_as_offers.columns == DAM_ESR_AS_OFFERS_COLUMNS
         self._check_nonspin_offer_curve(
             esr_as_offers,
             col,
@@ -1309,7 +1322,7 @@ class TestErcot(BaseTestISO):
         col = "OFFLINE NONSPIN Offer Curve"
 
         gen_as_offers = df_dict[DAM_GEN_RESOURCE_AS_OFFERS_KEY]
-        assert gen_as_offers.columns.tolist() == DAM_RESOURCE_AS_OFFERS_COLUMNS
+        assert gen_as_offers.columns == DAM_RESOURCE_AS_OFFERS_COLUMNS
         self._check_nonspin_offer_curve(
             gen_as_offers,
             col,
@@ -1332,7 +1345,7 @@ class TestErcot(BaseTestISO):
         ]
         df = self.iso.get_sara(verbose=True)
         assert df.shape[0] > 0
-        assert df.columns.tolist() == columns
+        assert df.columns == columns
 
     @pytest.mark.integration
     def test_spp_real_time_parse_retry_file_name(self):
@@ -1349,7 +1362,7 @@ class TestErcot(BaseTestISO):
     def _check_unplanned_resource_outages(self, df):
         assert df.shape[0] >= 0
 
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Current As Of",
             "Publish Time",
             "Actual Outage Start",
@@ -1374,7 +1387,7 @@ class TestErcot(BaseTestISO):
         ]
 
         for col in time_cols:
-            assert df[col].dt.tz.zone == self.iso.default_timezone
+            assert df.schema[col].time_zone == self.iso.default_timezone
 
     @pytest.mark.integration
     def test_get_unplanned_resource_outages_historical_date(self):
@@ -1383,10 +1396,10 @@ class TestErcot(BaseTestISO):
 
         self._check_unplanned_resource_outages(df)
 
-        assert df["Current As Of"].dt.date.unique() == [
+        assert df["Current As Of"].dt.date().unique().to_list() == [
             (five_days_ago - pd.DateOffset(days=3)).date(),
         ]
-        assert df["Publish Time"].dt.date.unique() == [five_days_ago.date()]
+        assert df["Publish Time"].dt.date().unique().to_list() == [five_days_ago.date()]
 
     @pytest.mark.integration
     def test_get_unplanned_resource_outages_historical_range(self):
@@ -1399,7 +1412,7 @@ class TestErcot(BaseTestISO):
 
         self._check_unplanned_resource_outages(df_2_days)
 
-        assert df_2_days["Current As Of"].dt.date.nunique() == 2
+        assert df_2_days["Current As Of"].dt.date().n_unique() == 2
         assert (
             df_2_days["Current As Of"].min().date()
             == (start - pd.DateOffset(days=3)).date()
@@ -1409,7 +1422,7 @@ class TestErcot(BaseTestISO):
             == (start - pd.DateOffset(days=2)).date()
         )
 
-        assert df_2_days["Publish Time"].dt.date.nunique() == 2
+        assert df_2_days["Publish Time"].dt.date().n_unique() == 2
         assert df_2_days["Publish Time"].min().date() == start.date()
         assert (
             df_2_days["Publish Time"].max().date() == (start + pd.DateOffset(1)).date()
@@ -1417,8 +1430,8 @@ class TestErcot(BaseTestISO):
 
     """test get_highest_price_as_offer_selected"""
 
-    def _check_highest_price_as_offer_selected(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_highest_price_as_offer_selected(self, df: pl.DataFrame):
+        assert df.columns == [
             "Time",
             "Interval Start",
             "Interval End",
@@ -1444,7 +1457,7 @@ class TestErcot(BaseTestISO):
                 start=date,
             )
 
-        assert (df["Interval Start"].dt.date.unique() == [date.date()]).all()
+        assert df["Interval Start"].dt.date().unique().to_list() == [date.date()]
 
         self._check_highest_price_as_offer_selected(df)
 
@@ -1457,16 +1470,20 @@ class TestErcot(BaseTestISO):
         ):
             df = self.iso.get_highest_price_as_offer_selected(dst_end_date)
 
-        assert df["Interval Start"].nunique() == 25
-        assert "2025-11-02 01:00:00-05:00" in df["Interval Start"].astype(str).values
-        assert "2025-11-02 01:00:00-06:00" in df["Interval Start"].astype(str).values
+        assert df["Interval Start"].n_unique() == 25
+        assert "2025-11-02 01:00:00-05:00" in [
+            str(x) for x in df["Interval Start"].to_list()
+        ]
+        assert "2025-11-02 01:00:00-06:00" in [
+            str(x) for x in df["Interval Start"].to_list()
+        ]
 
         self._check_highest_price_as_offer_selected(df)
 
     """get_highest_price_as_offer_selected_dam"""
 
     def _check_highest_price_as_offer_selected_dam(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "QSE",
@@ -1480,7 +1497,7 @@ class TestErcot(BaseTestISO):
         ]
 
         for col in ["Interval Start", "Interval End"]:
-            assert df.dtypes[col] == "datetime64[ns, US/Central]"
+            assert df.schema[col] == pl.Datetime("ns", "US/Central")
 
         for col in [
             "QSE",
@@ -1488,12 +1505,13 @@ class TestErcot(BaseTestISO):
             "Resource Name",
             "AS Type",
             "Block Indicator",
-            "Offered Quantities",
         ]:
-            assert df.dtypes[col] == "object"
+            assert df.schema[col] in (pl.String, pl.Categorical, pl.Object)
+
+        assert df.schema["Offered Quantities"] in (pl.List(pl.Float64), pl.Object)
 
         for col in ["Offered Price", "Total Offered Quantity"]:
-            assert df.dtypes[col] == "float64"
+            assert df.schema[col] == pl.Float64
 
     def test_get_highest_price_as_offer_selected_dam(self):
         # Test the new DAM-specific method
@@ -1506,14 +1524,14 @@ class TestErcot(BaseTestISO):
 
         assert df["Interval Start"].min() == date
         assert df["Interval Start"].max() == date + pd.DateOffset(days=1, hours=-1)
-        assert df["Interval Start"].nunique() == 24
+        assert df["Interval Start"].n_unique() == 24
 
         self._check_highest_price_as_offer_selected_dam(df)
 
     """get_highest_price_as_offer_selected_sced"""
 
     def _check_highest_price_as_offer_selected_sced(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "SCED Timestamp",
             "QSE",
             "DME",
@@ -1524,19 +1542,20 @@ class TestErcot(BaseTestISO):
             "Offered Quantities",
         ]
 
-        assert df.dtypes["SCED Timestamp"] == "datetime64[ns, US/Central]"
+        assert df.schema["SCED Timestamp"] == pl.Datetime("ns", "US/Central")
 
         for col in [
             "QSE",
             "DME",
             "Resource Name",
             "AS Type",
-            "Offered Quantities",
         ]:
-            assert df.dtypes[col] == "object"
+            assert df.schema[col] in (pl.String, pl.Categorical, pl.Object)
+
+        assert df.schema["Offered Quantities"] in (pl.List(pl.Float64), pl.Object)
 
         for col in ["Offered Price", "Total Offered Quantity"]:
-            assert df.dtypes[col] == "float64"
+            assert df.schema[col] == pl.Float64
 
     def test_get_highest_price_as_offer_selected_sced(self):
         date = self.local_start_of_today() - pd.DateOffset(days=4)
@@ -1547,15 +1566,15 @@ class TestErcot(BaseTestISO):
             df = self.iso.get_highest_price_as_offer_selected_sced(date)
 
         # This is a SCED dataset so data points are not on 5 minute intervals
-        assert df["SCED Timestamp"].nunique() >= 288
-        assert df["SCED Timestamp"].dt.date.unique() == [date.date()]
+        assert df["SCED Timestamp"].n_unique() >= 288
+        assert df["SCED Timestamp"].dt.date().unique().to_list() == [date.date()]
 
         self._check_highest_price_as_offer_selected_sced(df)
 
     """get_3_day_highest_price_bids_selected_sced"""
 
-    def _check_3_day_highest_price_bids_selected_sced(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_3_day_highest_price_bids_selected_sced(self, df: pl.DataFrame):
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "SCED Timestamp",
@@ -1565,12 +1584,12 @@ class TestErcot(BaseTestISO):
             "Highest Price Dispatched by SCED",
             "Proxy Extension",
         ]
-        assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["SCED Timestamp"] == "datetime64[ns, US/Central]"
+        assert df.schema["Interval Start"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["Interval End"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["SCED Timestamp"] == pl.Datetime("ns", "US/Central")
         for col in ["QSE", "DME", "Load Resource", "Proxy Extension"]:
-            assert df.dtypes[col] == "object"
-        assert df.dtypes["Highest Price Dispatched by SCED"] == "float64"
+            assert df.schema[col] in (pl.String, pl.Categorical, pl.Object)
+        assert df.schema["Highest Price Dispatched by SCED"] == pl.Float64
         assert (
             (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(minutes=5)
         ).all()
@@ -1585,12 +1604,12 @@ class TestErcot(BaseTestISO):
             df = self.iso.get_3_day_highest_price_bids_selected_sced(date)
 
         self._check_3_day_highest_price_bids_selected_sced(df)
-        assert df["SCED Timestamp"].dt.date.unique() == [date.date()]
+        assert df["SCED Timestamp"].dt.date().unique().to_list() == [date.date()]
 
     """get_3_day_highest_price_offered_sced"""
 
-    def _check_3_day_highest_price_offered_sced(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_3_day_highest_price_offered_sced(self, df: pl.DataFrame):
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "SCED Timestamp",
@@ -1601,9 +1620,9 @@ class TestErcot(BaseTestISO):
             "Proxy Extension",
             "Power Balance Penalty Flag",
         ]
-        assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["SCED Timestamp"] == "datetime64[ns, US/Central]"
+        assert df.schema["Interval Start"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["Interval End"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["SCED Timestamp"] == pl.Datetime("ns", "US/Central")
         for col in [
             "QSE",
             "DME",
@@ -1611,8 +1630,8 @@ class TestErcot(BaseTestISO):
             "Proxy Extension",
             "Power Balance Penalty Flag",
         ]:
-            assert df.dtypes[col] == "object"
-        assert df.dtypes["LMP"] == "float64"
+            assert df.schema[col] in (pl.String, pl.Categorical, pl.Object)
+        assert df.schema["LMP"] == pl.Float64
         assert (
             (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(minutes=5)
         ).all()
@@ -1628,7 +1647,7 @@ class TestErcot(BaseTestISO):
             df = self.iso.get_3_day_highest_price_offered_sced(date)
 
         self._check_3_day_highest_price_offered_sced(df)
-        assert df["SCED Timestamp"].dt.date.unique() == [date.date()]
+        assert df["SCED Timestamp"].dt.date().unique().to_list() == [date.date()]
 
     """test get_as_reports"""
 
@@ -1644,7 +1663,7 @@ class TestErcot(BaseTestISO):
         ):
             df = self.iso.get_as_reports(start=date)
 
-        assert (df["Interval Start"].dt.date.unique() == [date.date()]).all()
+        assert df["Interval Start"].dt.date().unique().to_list() == [date.date()]
 
         bid_curve_columns = [
             "Bid Curve - RRSPFR",
@@ -1681,23 +1700,33 @@ class TestErcot(BaseTestISO):
             "Total Self-Arranged AS - NSPNM",
         ] + bid_curve_columns
 
-        assert df.columns.tolist() == cols
+        assert df.columns == cols
 
         for col in bid_curve_columns:
             # Check that the first non-null value is a list of lists
-            first_non_null_value = df[col].dropna().iloc[0]
+            first_non_null_value = df[col].drop_nulls()[0]
             assert isinstance(first_non_null_value, list)
             assert all(isinstance(x, list) for x in first_non_null_value)
 
     """get_as_reports_dam"""
 
     def _check_as_reports_dam(self, df):
-        assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["AS Type"] == "object"
-        assert df.dtypes["Cleared"] == "float64"
-        assert df.dtypes["Self Arranged"] == "float64"
-        assert df.dtypes["Offer Curve"] == "object"
+        assert df.schema["Interval Start"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["Interval End"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["AS Type"] in (
+            pl.String,
+            pl.Categorical,
+            pl.Object,
+            pl.List(pl.List(pl.Float64)),
+        )
+        assert df.schema["Cleared"] == pl.Float64
+        assert df.schema["Self Arranged"] == pl.Float64
+        assert df.schema["Offer Curve"] in (
+            pl.String,
+            pl.Categorical,
+            pl.Object,
+            pl.List(pl.List(pl.Float64)),
+        )
 
         # Check that AS Type contains expected products
         expected_products = {
@@ -1716,9 +1745,9 @@ class TestErcot(BaseTestISO):
         assert expected_products == actual_products
 
         # Check that offer curves are lists of [MW, Price] pairs
-        offer_curves = df["Offer Curve"].dropna()
+        offer_curves = df["Offer Curve"].drop_nulls()
         if len(offer_curves) > 0:
-            first_curve = offer_curves.iloc[0]
+            first_curve = offer_curves.head(1).to_list()[0]
             assert isinstance(first_curve, list)
             if first_curve:
                 assert all(isinstance(x, list) and len(x) == 2 for x in first_curve)
@@ -1734,14 +1763,24 @@ class TestErcot(BaseTestISO):
 
         self._check_as_reports_dam(df)
 
-        assert df["Interval Start"].dt.date.unique() == start.date()
+        assert df["Interval Start"].dt.date().unique().to_list() == [start.date()]
 
     """get_as_reports_sced"""
 
     def _check_as_reports_sced(self, df):
-        assert df.dtypes["SCED Timestamp"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["AS Type"] == "object"
-        assert df.dtypes["Offer Curve"] == "object"
+        assert df.schema["SCED Timestamp"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["AS Type"] in (
+            pl.String,
+            pl.Categorical,
+            pl.Object,
+            pl.List(pl.List(pl.Float64)),
+        )
+        assert df.schema["Offer Curve"] in (
+            pl.String,
+            pl.Categorical,
+            pl.Object,
+            pl.List(pl.List(pl.Float64)),
+        )
 
         # Check that AS Type contains expected products
         expected_products = {
@@ -1759,7 +1798,7 @@ class TestErcot(BaseTestISO):
         assert expected_products == actual_products
 
         # Check that offer curves are lists of [MW, Price] pairs
-        first_curve = df["Offer Curve"].iloc[0]
+        first_curve = df["Offer Curve"].to_list()[0]
         assert isinstance(first_curve, list)
         if first_curve:
             assert all(isinstance(x, list) and len(x) == 2 for x in first_curve)
@@ -1777,7 +1816,7 @@ class TestErcot(BaseTestISO):
 
         self._check_as_reports_sced(df)
 
-        assert df["SCED Timestamp"].dt.date.unique() == test_date.date()
+        assert df["SCED Timestamp"].dt.date().unique().to_list() == [test_date.date()]
 
     """get_reported_outages"""
 
@@ -1785,7 +1824,7 @@ class TestErcot(BaseTestISO):
     def test_get_reported_outages(self):
         df = self.iso.get_reported_outages()
 
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Time",
             "Combined Unplanned",
             "Combined Planned",
@@ -1853,12 +1892,12 @@ class TestErcot(BaseTestISO):
         df = self.iso.get_hourly_resource_outage_capacity(date)
 
         assert df.shape[0] >= 0
-        assert df.columns.tolist() == cols
+        assert df.columns == cols
 
         # test latest and confirm published in last 2 hours
         df = self.iso.get_hourly_resource_outage_capacity("latest")
         assert df.shape[0] >= 0
-        assert df.columns.tolist() == cols
+        assert df.columns == cols
 
         assert df["Publish Time"].min() >= pd.Timestamp.now(
             tz=self.iso.default_timezone,
@@ -1876,8 +1915,8 @@ class TestErcot(BaseTestISO):
         )
 
         assert df.shape[0] >= 0
-        assert df.columns.tolist() == cols
-        assert df["Publish Time"].nunique() == 3
+        assert df.columns == cols
+        assert df["Publish Time"].n_unique() == 3
 
     """get_planned_outage_capacity_7_day"""
 
@@ -1897,18 +1936,22 @@ class TestErcot(BaseTestISO):
     ]
 
     def _check_planned_outage_capacity(self, df):
-        assert df.columns.tolist() == self.PLANNED_OUTAGE_CAPACITY_COLUMNS
+        assert df.columns == self.PLANNED_OUTAGE_CAPACITY_COLUMNS
 
-        assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["Publish Time"] == "datetime64[s, US/Central]"
+        assert df.schema["Interval Start"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["Interval End"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["Publish Time"].time_zone == "US/Central"
 
-        assert not df.duplicated(
-            subset=["Publish Time", "Interval Start"],
-        ).any()
+        assert (
+            not df.select(
+                ["Publish Time", "Interval Start"],
+            )
+            .is_duplicated()
+            .any()
+        )
 
         assert df.equals(
-            df.sort_values(["Interval Start", "Publish Time"]).reset_index(drop=True),
+            df.sort(["Interval Start", "Publish Time"]),
         )
 
     def test_get_planned_outage_capacity_7_day(self):
@@ -1928,7 +1971,7 @@ class TestErcot(BaseTestISO):
 
         self._check_planned_outage_capacity(df)
 
-        assert df["Publish Time"].nunique() == 3
+        assert df["Publish Time"].n_unique() == 3
         assert (
             (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(hours=1)
         ).all()
@@ -1950,20 +1993,18 @@ class TestErcot(BaseTestISO):
 
         self._check_planned_outage_capacity(df)
 
-        assert df["Publish Time"].nunique() >= 1
+        assert df["Publish Time"].n_unique() >= 1
         # Daily intervals are day-aligned. A fixed 24h delta does not hold across
         # DST transitions, so we check that each interval spans one calendar day.
-        assert (df["Interval Start"] == df["Interval Start"].dt.normalize()).all()
-        assert (
-            df["Interval End"] == df["Interval Start"] + pd.DateOffset(days=1)
-        ).all()
+        assert (df["Interval Start"] == df["Interval Start"].dt.truncate("1d")).all()
+        assert (df["Interval End"] == df["Interval Start"].dt.offset_by("1d")).all()
         assert (df["Interval Start"] > end).all()
 
     """get_wind_actual_and_forecast_hourly"""
 
     def _check_hourly_wind_report(self, df, geographic_data=False):
         assert (
-            df.columns.tolist() == WIND_ACTUAL_AND_FORECAST_COLUMNS
+            df.columns == WIND_ACTUAL_AND_FORECAST_COLUMNS
             if not geographic_data
             else WIND_ACTUAL_AND_FORECAST_BY_GEOGRAPHICAL_REGION_COLUMNS
         )
@@ -1982,7 +2023,7 @@ class TestErcot(BaseTestISO):
             self.local_now() - self.local_start_of_today()
         ) // pd.Timedelta(hours=1)
 
-        assert df["Publish Time"].nunique() == hours_since_local_midnight
+        assert df["Publish Time"].n_unique() == hours_since_local_midnight
 
     @pytest.mark.integration
     def test_get_wind_actual_and_forecast_hourly_latest(self):
@@ -1990,7 +2031,7 @@ class TestErcot(BaseTestISO):
 
         self._check_hourly_wind_report(df)
 
-        assert df["Publish Time"].nunique() == 1
+        assert df["Publish Time"].n_unique() == 1
 
     @pytest.mark.integration
     def test_get_wind_actual_and_forecast_hourly_historical_date(self):
@@ -1999,7 +2040,7 @@ class TestErcot(BaseTestISO):
 
         self._check_hourly_wind_report(df)
 
-        assert df["Publish Time"].nunique() == 24  # One for each hour
+        assert df["Publish Time"].n_unique() == 24  # One for each hour
         assert df["Publish Time"].min().hour == 0
         assert df["Publish Time"].max().hour == 23
 
@@ -2011,7 +2052,7 @@ class TestErcot(BaseTestISO):
 
         self._check_hourly_wind_report(df)
 
-        assert df["Publish Time"].nunique() == 48
+        assert df["Publish Time"].n_unique() == 48
         assert df["Publish Time"].min().hour == 0
         assert df["Publish Time"].max().hour == 23
 
@@ -2032,7 +2073,7 @@ class TestErcot(BaseTestISO):
             self.local_now() - self.local_start_of_today()
         ) // pd.Timedelta(hours=1)
 
-        assert df["Publish Time"].nunique() == hours_since_local_midnight
+        assert df["Publish Time"].n_unique() == hours_since_local_midnight
 
     def test_get_wind_actual_and_forecast_by_geographical_region_hourly_historical_date_range(  # noqa: E501
         self,
@@ -2051,7 +2092,7 @@ class TestErcot(BaseTestISO):
 
         self._check_hourly_wind_report(df, geographic_data=True)
 
-        assert df["Publish Time"].nunique() == 48
+        assert df["Publish Time"].n_unique() == 48
         assert df["Publish Time"].min().hour == 0
         assert df["Publish Time"].max().hour == 23
 
@@ -2069,7 +2110,7 @@ class TestErcot(BaseTestISO):
             self.local_now() - self.local_start_of_today()
         ) // pd.Timedelta(hours=1)
 
-        assert df["Publish Time"].nunique() == hours_since_local_midnight
+        assert df["Publish Time"].n_unique() == hours_since_local_midnight
 
     def test_get_solar_actual_and_forecast_hourly_historical_date_range(self):
         start = self.local_today() - pd.Timedelta(days=3)
@@ -2082,7 +2123,7 @@ class TestErcot(BaseTestISO):
 
         self._check_hourly_solar_report(df)
 
-        assert df["Publish Time"].nunique() == 48
+        assert df["Publish Time"].n_unique() == 48
         assert df["Publish Time"].min().hour == 0
         assert df["Publish Time"].max().hour == 23
 
@@ -2090,7 +2131,7 @@ class TestErcot(BaseTestISO):
 
     def _check_hourly_solar_report(self, df, geographic_data=False):
         assert (
-            df.columns.tolist() == SOLAR_ACTUAL_AND_FORECAST_COLUMNS
+            df.columns == SOLAR_ACTUAL_AND_FORECAST_COLUMNS
             if not geographic_data
             else SOLAR_ACTUAL_AND_FORECAST_BY_GEOGRAPHICAL_REGION_COLUMNS
         )
@@ -2111,7 +2152,7 @@ class TestErcot(BaseTestISO):
             self.local_now() - self.local_start_of_today()
         ) // pd.Timedelta(hours=1)
 
-        assert df["Publish Time"].nunique() == hours_since_local_midnight
+        assert df["Publish Time"].n_unique() == hours_since_local_midnight
 
     @pytest.mark.integration
     def test_get_solar_actual_and_forecast_by_geographical_region_hourly_latest(self):
@@ -2122,7 +2163,7 @@ class TestErcot(BaseTestISO):
 
         self._check_hourly_solar_report(df, geographic_data=True)
 
-        assert df["Publish Time"].nunique() == 1
+        assert df["Publish Time"].n_unique() == 1
 
     @pytest.mark.integration
     def test_get_solar_actual_and_forecast_by_geographical_region_hourly_historical_date(  # noqa: E501
@@ -2136,7 +2177,7 @@ class TestErcot(BaseTestISO):
 
         self._check_hourly_solar_report(df, geographic_data=True)
 
-        assert df["Publish Time"].nunique() == 24  # One for each hour
+        assert df["Publish Time"].n_unique() == 24  # One for each hour
         assert df["Publish Time"].min().hour == 0
         assert df["Publish Time"].max().hour == 23
 
@@ -2154,7 +2195,7 @@ class TestErcot(BaseTestISO):
 
         self._check_hourly_solar_report(df, geographic_data=True)
 
-        assert df["Publish Time"].nunique() == 48
+        assert df["Publish Time"].n_unique() == 48
         assert df["Publish Time"].min().hour == 0
         assert df["Publish Time"].max().hour == 23
 
@@ -2185,7 +2226,7 @@ class TestErcot(BaseTestISO):
         ]
 
         assert df.shape[0] >= 0
-        assert df.columns.tolist() == cols
+        assert df.columns == cols
 
     # TODO: this url has no DocumentList
     # https://www.ercot.com/misapp/servlets/IceDocListJsonWS?reportTypeId=13044
@@ -2205,7 +2246,7 @@ class TestErcot(BaseTestISO):
         ]
 
         assert df.shape[0] >= 0
-        assert df.columns.tolist() == cols
+        assert df.columns == cols
 
     @pytest.mark.integration
     def test_get_mcpc_dam_price_corrections(self):
@@ -2222,14 +2263,14 @@ class TestErcot(BaseTestISO):
         ]
 
         assert df.shape[0] >= 0
-        assert df.columns.tolist() == cols
+        assert df.columns == cols
 
-        assert pd.api.types.is_datetime64_any_dtype(df["Price Correction Time"])
-        assert pd.api.types.is_datetime64_any_dtype(df["Interval Start"])
-        assert pd.api.types.is_datetime64_any_dtype(df["Interval End"])
-        assert pd.api.types.is_object_dtype(df["AS Type"])
-        assert pd.api.types.is_float_dtype(df["MCPC Original"])
-        assert pd.api.types.is_float_dtype(df["MCPC Corrected"])
+        assert isinstance(df.schema["Price Correction Time"], pl.Datetime)
+        assert isinstance(df.schema["Interval Start"], pl.Datetime)
+        assert isinstance(df.schema["Interval End"], pl.Datetime)
+        assert df.schema["AS Type"] in (pl.String, pl.Categorical, pl.Object)
+        assert df.schema["MCPC Original"] == pl.Float64
+        assert df.schema["MCPC Corrected"] == pl.Float64
 
     """get_system_wide_actuals"""
 
@@ -2250,7 +2291,7 @@ class TestErcot(BaseTestISO):
         )
 
         cols = ["Time", "Interval Start", "Interval End", "Demand"]
-        assert df.columns.tolist() == cols
+        assert df.columns == cols
 
     @pytest.mark.integration
     def test_get_system_wide_actual_load_date_range(self):
@@ -2273,7 +2314,7 @@ class TestErcot(BaseTestISO):
             today,
             tz=self.iso.default_timezone,
         ) - pd.Timedelta(minutes=15)
-        assert df.columns.tolist() == cols
+        assert df.columns == cols
 
     @pytest.mark.integration
     def test_get_system_wide_actual_load_today(self):
@@ -2287,12 +2328,12 @@ class TestErcot(BaseTestISO):
         )
         # 1 Hour of data
         assert df.shape[0] == 4
-        assert df.columns.tolist() == cols
+        assert df.columns == cols
 
     """get_short_term_system_adequacy"""
 
     def _check_short_term_system_adequacy(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -2335,7 +2376,7 @@ class TestErcot(BaseTestISO):
 
         # At least one published per hour
         assert (
-            df["Publish Time"].nunique()
+            df["Publish Time"].n_unique()
             >= (self.local_now() - self.local_start_of_today()).total_seconds() // 3600
         )
         assert df["Interval Start"].min() == self.local_start_of_today()
@@ -2349,7 +2390,7 @@ class TestErcot(BaseTestISO):
 
         self._check_short_term_system_adequacy(df)
 
-        assert df["Publish Time"].nunique() == 1
+        assert df["Publish Time"].n_unique() == 1
 
         assert df["Interval Start"].min() == self.local_start_of_today()
         assert df["Interval End"].max() == self.local_start_of_today() + pd.DateOffset(
@@ -2361,7 +2402,7 @@ class TestErcot(BaseTestISO):
         date = self.local_today() - pd.DateOffset(days=15)
         df = self.iso.get_short_term_system_adequacy(date)
 
-        assert df["Publish Time"].nunique() >= 24
+        assert df["Publish Time"].n_unique() >= 24
 
         assert df["Interval Start"].min() == self.local_start_of_day(date)
         assert df["Interval End"].max() == self.local_start_of_day(
@@ -2379,7 +2420,7 @@ class TestErcot(BaseTestISO):
             end=end,
         )
 
-        assert df["Publish Time"].nunique() >= 24
+        assert df["Publish Time"].n_unique() >= 24
         assert df["Interval Start"].min() == self.local_start_of_day(start)
         assert df["Interval End"].max() == self.local_start_of_day(end) + pd.DateOffset(
             days=6,
@@ -2390,7 +2431,7 @@ class TestErcot(BaseTestISO):
     """get_real_time_adders_and_reserves"""
 
     def _check_real_time_adders_and_reserves(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "SCED Timestamp",
             "Interval Start",
             "Interval End",
@@ -2483,7 +2524,7 @@ class TestErcot(BaseTestISO):
 
     def _check_temperature_forecast_by_weather_zone(self, df):
         assert (
-            df.columns.tolist()
+            df.columns
             == [
                 "Interval Start",
                 "Interval End",
@@ -2501,7 +2542,7 @@ class TestErcot(BaseTestISO):
 
     def _assert_temperature_forecast_start_window(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         anchor: pd.Timestamp,
     ) -> None:
         expected_start = (
@@ -2515,7 +2556,7 @@ class TestErcot(BaseTestISO):
 
     def _assert_temperature_forecast_end_window(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         anchor: pd.Timestamp,
     ) -> None:
         expected_end = (
@@ -2529,7 +2570,7 @@ class TestErcot(BaseTestISO):
 
     def _assert_temperature_forecast_window(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         anchor: pd.Timestamp,
     ) -> None:
         self._assert_temperature_forecast_start_window(df, anchor)
@@ -2543,7 +2584,7 @@ class TestErcot(BaseTestISO):
         df = self.iso.get_temperature_forecast_by_weather_zone("today")
         self._check_temperature_forecast_by_weather_zone(df)
 
-        assert df["Publish Time"].nunique() == 1
+        assert df["Publish Time"].n_unique() == 1
         self._assert_temperature_forecast_window(df, self.local_today())
 
     @pytest.mark.integration
@@ -2551,7 +2592,7 @@ class TestErcot(BaseTestISO):
         date = self.local_today() - pd.DateOffset(days=22)
         df = self.iso.get_temperature_forecast_by_weather_zone(date)
 
-        assert df["Publish Time"].nunique() == 1
+        assert df["Publish Time"].n_unique() == 1
         self._assert_temperature_forecast_window(df, date)
         self._check_temperature_forecast_by_weather_zone(df)
 
@@ -2565,7 +2606,7 @@ class TestErcot(BaseTestISO):
             end=end,
         )
 
-        assert df["Publish Time"].nunique() == 3
+        assert df["Publish Time"].n_unique() == 3
         self._assert_temperature_forecast_start_window(df, start)
         self._assert_temperature_forecast_end_window(
             df,
@@ -2574,7 +2615,7 @@ class TestErcot(BaseTestISO):
         self._check_temperature_forecast_by_weather_zone(df)
 
     def test_get_temperature_forecast_by_weather_zone_dst_end_2025(self) -> None:
-        dst_raw_data = pd.DataFrame(
+        dst_raw_data = pl.DataFrame(
             {
                 "DeliveryDate": ["11/02/2025"] * 4,
                 "HourEnding": ["01:00", "02:00", "03:00", "03:00"],
@@ -2657,24 +2698,36 @@ class TestErcot(BaseTestISO):
 
         df = self.iso.parse_doc(df)
 
-        assert df["Interval Start"].min() == pd.Timestamp(
-            "2016-11-06 00:45:00-0500",
-            tz="US/Central",
+        assert (
+            df["Interval Start"].min().timestamp()
+            == pd.Timestamp(
+                "2016-11-06 00:45:00-0500",
+                tz="US/Central",
+            ).timestamp()
         )
 
-        assert df["Interval Start"].max() == pd.Timestamp(
-            "2016-11-06 01:45:00-0600",
-            tz="US/Central",
+        assert (
+            df["Interval Start"].max().timestamp()
+            == pd.Timestamp(
+                "2016-11-06 01:45:00-0600",
+                tz="US/Central",
+            ).timestamp()
         )
 
-        assert df["Interval End"].min() == pd.Timestamp(
-            "2016-11-06 01:00:00-0500",
-            tz="US/Central",
+        assert (
+            df["Interval End"].min().timestamp()
+            == pd.Timestamp(
+                "2016-11-06 01:00:00-0500",
+                tz="US/Central",
+            ).timestamp()
         )
 
-        assert df["Interval End"].max() == pd.Timestamp(
-            "2016-11-06 02:00:00-0600",
-            tz="US/Central",
+        assert (
+            df["Interval End"].max().timestamp()
+            == pd.Timestamp(
+                "2016-11-06 02:00:00-0600",
+                tz="US/Central",
+            ).timestamp()
         )
 
     def test_parse_doc_delivery_interval_timedelta(self):
@@ -2695,17 +2748,17 @@ class TestErcot(BaseTestISO):
 
         # First interval: hour 0 (HourBeginning = DeliveryHour - 1 = 0),
         # interval 1 -> 00:00 CT
-        assert df["Interval Start"].iloc[0] == pd.Timestamp(
+        assert df["Interval Start"][0] == pd.Timestamp(
             "2023-01-15 00:00:00-0600",
             tz="US/Central",
         )
         # Second interval of hour 1: 00:15 CT
-        assert df["Interval Start"].iloc[1] == pd.Timestamp(
+        assert df["Interval Start"][1] == pd.Timestamp(
             "2023-01-15 00:15:00-0600",
             tz="US/Central",
         )
         # First interval of hour 2: 01:00 CT
-        assert df["Interval Start"].iloc[4] == pd.Timestamp(
+        assert df["Interval Start"][4] == pd.Timestamp(
             "2023-01-15 01:00:00-0600",
             tz="US/Central",
         )
@@ -2730,7 +2783,7 @@ class TestErcot(BaseTestISO):
         )
 
         assert df.shape[0] >= 0
-        assert df.columns.tolist() == cols
+        assert df.columns == cols
 
         now = pd.Timestamp.now(tz=self.iso.default_timezone)
         start = now - pd.Timedelta(hours=1)
@@ -2744,10 +2797,10 @@ class TestErcot(BaseTestISO):
         # There should be at least 12 intervals in the last hour
         # sometimes there are more if sced is run more frequently
         # subtracting 1 to allow for some flexibility
-        assert df["SCED Timestamp"].nunique() >= 12 - 1
+        assert df["SCED Timestamp"].n_unique() >= 12 - 1
 
         assert df.shape[0] >= 0
-        assert df.columns.tolist() == cols
+        assert df.columns == cols
         assert df["SCED Timestamp"].min() >= start
         assert df["SCED Timestamp"].max() <= now
 
@@ -2769,7 +2822,7 @@ class TestErcot(BaseTestISO):
         ]
 
         assert df.shape[0] >= 0
-        assert df.columns.tolist() == cols
+        assert df.columns == cols
 
         assert (df["Interval Start"] == df["SCED Timestamp"].dt.floor("5min")).all()
         assert (
@@ -2792,9 +2845,9 @@ class TestErcot(BaseTestISO):
             "Location Type",
             "LMP",
         ]
-        assert df.columns.tolist() == cols
+        assert df.columns == cols
         assert df.shape[0] >= 0
-        assert df["Location Type"].notna().all()
+        assert df["Location Type"].is_not_null().all()
         assert (
             df["Interval End"] - df["Interval Start"] == pd.Timedelta(minutes=5)
         ).all()
@@ -2811,12 +2864,12 @@ class TestErcot(BaseTestISO):
     ]
 
     def _check_lmp_by_bus_dam(self, df):
-        assert df.columns.tolist() == self.expected_lmp_by_bus_dam_columns
-        assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
+        assert df.columns == self.expected_lmp_by_bus_dam_columns
+        assert df.schema["Interval Start"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["Interval End"] == pl.Datetime("ns", "US/Central")
         assert (df["Market"] == Markets.DAY_AHEAD_HOURLY.value).all()
         assert (df["Location Type"] == ELECTRICAL_BUS_LOCATION_TYPE).all()
-        assert df.dtypes["LMP"] == "float64"
+        assert df.schema["LMP"] == pl.Float64
         assert (
             (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(hours=1)
         ).all()
@@ -2845,10 +2898,13 @@ class TestErcot(BaseTestISO):
         assert df["Interval End"].max() == end
 
     def test_read_docs_return_empty_df(self):
-        df = self.iso.read_docs(docs=[], empty_df=pd.DataFrame(columns=["test"]))
+        df = self.iso.read_docs(
+            docs=[],
+            empty_df=pl.DataFrame(schema={"test": pl.Null}),
+        )
 
         assert df.shape[0] == 0
-        assert df.columns.tolist() == ["test"]
+        assert df.columns == ["test"]
 
     @staticmethod
     def _check_ercot_spp(df, market, location_type):
@@ -2867,7 +2923,7 @@ class TestErcot(BaseTestISO):
             "SPP",
         ]
         assert df.shape[0] >= 0
-        assert df.columns.tolist() == cols
+        assert df.columns == cols
         markets = df["Market"].unique()
         assert len(markets) == 1
         assert markets[0] == market.value
@@ -2885,9 +2941,9 @@ class TestErcot(BaseTestISO):
             "System Lambda",
         ]
         assert df.shape[0] >= 0
-        assert df.columns.tolist() == cols
+        assert df.columns == cols
 
-        assert df["System Lambda"].dtype == float
+        assert df.schema["System Lambda"] == pl.Float64
 
     def test_get_documents_raises_exception_when_no_docs(self):
         with pytest.raises(NoDataFoundException):
@@ -2911,7 +2967,7 @@ class TestErcot(BaseTestISO):
         ):
             df = self.iso.get_indicative_lmp_by_settlement_point(date, end)
 
-            assert df.columns.tolist() == [
+            assert df.columns == [
                 "RTD Timestamp",
                 "Interval Start",
                 "Interval End",
@@ -2920,9 +2976,9 @@ class TestErcot(BaseTestISO):
                 "LMP",
             ]
 
-            assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
-            assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
-            assert df.dtypes["LMP"] == "float64"
+            assert df.schema["Interval Start"] == pl.Datetime("ns", "US/Central")
+            assert df.schema["Interval End"] == pl.Datetime("ns", "US/Central")
+            assert df.schema["LMP"] == pl.Float64
             assert (
                 (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(minutes=5)
             ).all()
@@ -2936,7 +2992,7 @@ class TestErcot(BaseTestISO):
     """get_dam_total_energy_purchased"""
 
     def _check_dam_total_energy_purchased(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Location",
@@ -2946,8 +3002,8 @@ class TestErcot(BaseTestISO):
         assert (
             df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
         ).all()
-        assert df["Total"].dtype == float
-        assert df["Location"].dtype == object
+        assert df.schema["Total"] == pl.Float64
+        assert df.schema["Location"] in (pl.String, pl.Categorical, pl.Object)
 
     def test_get_dam_total_energy_purchased_today(self):
         with api_vcr.use_cassette(
@@ -2983,7 +3039,7 @@ class TestErcot(BaseTestISO):
     """get_dam_total_energy_sold"""
 
     def _check_dam_total_energy_sold(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Location",
@@ -2993,8 +3049,8 @@ class TestErcot(BaseTestISO):
         assert (
             df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
         ).all()
-        assert df["Total"].dtype == float
-        assert df["Location"].dtype == object
+        assert df.schema["Total"] == pl.Float64
+        assert df.schema["Location"] in (pl.String, pl.Categorical, pl.Object)
 
     def test_get_dam_total_energy_sold_today(self):
         with api_vcr.use_cassette(
@@ -3028,7 +3084,7 @@ class TestErcot(BaseTestISO):
     """get_cop_adjustment_period_snapshot_60_day"""
 
     def _check_cop_adjustment_period_snapshot_60_day(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Resource Name",
@@ -3055,11 +3111,11 @@ class TestErcot(BaseTestISO):
             df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
         ).all()
 
-        assert df["Resource Name"].dtype == object
-        assert df["QSE"].dtype == object
+        assert df.schema["Resource Name"] in (pl.String, pl.Categorical, pl.Object)
+        assert df.schema["QSE"] in (pl.String, pl.Categorical, pl.Object)
 
         # Column not in newer data so it's added as null
-        assert df["RRS"].isnull().all()
+        assert df["RRS"].is_null().all()
 
         # Columns not in older data but should be present in newer data
         for col in [
@@ -3075,7 +3131,7 @@ class TestErcot(BaseTestISO):
             "NSPIN",
             "ECRS",
         ]:
-            assert df[col].notnull().all()
+            assert df[col].is_not_null().all()
 
     def test_get_cop_adjustment_period_snapshot_60_day_raises_error(self):
         with pytest.raises(ValueError):
@@ -3119,15 +3175,15 @@ class TestErcot(BaseTestISO):
             "ERCOT",
         ]
 
-        assert df.columns.tolist() == expected_columns
+        assert df.columns == expected_columns
         assert df.shape[0] > 0
         assert (
             df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
         ).all()
 
         # Check timezone
-        assert df["Interval Start"].dt.tz.zone == self.iso.default_timezone
-        assert df["Interval End"].dt.tz.zone == self.iso.default_timezone
+        assert df.schema["Interval Start"].time_zone == self.iso.default_timezone
+        assert df.schema["Interval End"].time_zone == self.iso.default_timezone
 
         # Check numeric columns are numeric
         numeric_columns = [
@@ -3137,7 +3193,7 @@ class TestErcot(BaseTestISO):
         ]
         for col in numeric_columns:
             if col in df.columns:
-                assert pd.api.types.is_numeric_dtype(df[col])
+                assert df.schema[col].is_numeric()
 
     @pytest.mark.parametrize("date, end", [("2010-03-01", "2010-08-02")])
     def test_get_hourly_load_post_settlements_xls(self, date, end):
@@ -3165,16 +3221,16 @@ class TestErcot(BaseTestISO):
 
     """get_mcpc_dam"""
 
-    def _check_get_mcpc_dam(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_get_mcpc_dam(self, df: pl.DataFrame):
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "AS Type",
             "MCPC",
         ]
-        assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["MCPC"] == "float64"
+        assert df.schema["Interval Start"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["Interval End"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["MCPC"] == pl.Float64
         assert (
             (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(hours=1)
         ).all()
@@ -3223,15 +3279,12 @@ class TestErcot(BaseTestISO):
     ]
 
     def _check_shadow_prices_dam(self, df):
-        assert df.columns.tolist() == self.expected_shadow_prices_dam_columns
-        assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
+        assert df.columns == self.expected_shadow_prices_dam_columns
+        assert df.schema["Interval Start"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["Interval End"] == pl.Datetime("ns", "US/Central")
         assert (
-            df.loc[
-                df["Contingency Name"] == "BASE CASE",
-                "Limiting Facility",
-            ]
-            .isna()
+            df.filter(pl.col("Contingency Name") == "BASE CASE")["Limiting Facility"]
+            .is_null()
             .all()
         )
         for col in [
@@ -3240,7 +3293,8 @@ class TestErcot(BaseTestISO):
             "From Station",
             "To Station",
         ]:
-            assert df[col].dropna().str.strip().equals(df[col].dropna())
+            values = df[col].drop_nulls()
+            assert values.str.strip_chars().to_list() == values.to_list()
 
     def test_get_shadow_prices_dam_today(self):
         with api_vcr.use_cassette("test_get_shadow_prices_dam_today.yaml"):
@@ -3267,15 +3321,20 @@ class TestErcot(BaseTestISO):
 
     """get_mcpc_sced"""
 
-    def _check_get_mcpc_sced(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_get_mcpc_sced(self, df: pl.DataFrame):
+        assert df.columns == [
             "SCED Timestamp",
             "AS Type",
             "MCPC",
         ]
-        assert df.dtypes["SCED Timestamp"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["AS Type"] == "object"
-        assert df.dtypes["MCPC"] == "float64"
+        assert df.schema["SCED Timestamp"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["AS Type"] in (
+            pl.String,
+            pl.Categorical,
+            pl.Object,
+            pl.List(pl.List(pl.Float64)),
+        )
+        assert df.schema["MCPC"] == pl.Float64
 
     def test_get_mcpc_sced_date_range(self):
         # Choose a date range that spans two days to test we handle day transitions
@@ -3295,21 +3354,26 @@ class TestErcot(BaseTestISO):
         assert df["SCED Timestamp"].max().date() == end.date()
 
         # 2 hours / 15 minutes/interval = 24 intervals
-        assert df["SCED Timestamp"].nunique() == 24
+        assert df["SCED Timestamp"].n_unique() == 24
 
     """get_mcpc_real_time_15_min"""
 
-    def _check_get_mcpc_real_time_15_min(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_get_mcpc_real_time_15_min(self, df: pl.DataFrame):
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "AS Type",
             "MCPC",
         ]
-        assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["AS Type"] == "object"
-        assert df.dtypes["MCPC"] == "float64"
+        assert df.schema["Interval Start"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["Interval End"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["AS Type"] in (
+            pl.String,
+            pl.Categorical,
+            pl.Object,
+            pl.List(pl.List(pl.Float64)),
+        )
+        assert df.schema["MCPC"] == pl.Float64
 
     def test_get_mcpc_real_time_15_min_date_range(self):
         # Choose a date range that spans two days to test we handle day transitions
@@ -3329,12 +3393,12 @@ class TestErcot(BaseTestISO):
         assert df["Interval Start"].max().date() == end.date()
 
         # 2 hours / 15 minutes/interval = 8 intervals
-        assert df["Interval Start"].nunique() == 8
+        assert df["Interval Start"].n_unique() == 8
 
     """get_as_demand_curves_dam_and_sced"""
 
-    def _check_get_as_demand_curves_dam_and_sced(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_get_as_demand_curves_dam_and_sced(self, df: pl.DataFrame):
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -3343,13 +3407,18 @@ class TestErcot(BaseTestISO):
             "Quantity",
             "Price",
         ]
-        assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["Publish Time"] == "datetime64[s, US/Central]"
-        assert df.dtypes["AS Type"] == "object"
-        assert df.dtypes["Demand Curve Point"] == "int64"
-        assert df.dtypes["Quantity"] == "int64"
-        assert df.dtypes["Price"] == "float64"
+        assert df.schema["Interval Start"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["Interval End"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["Publish Time"].time_zone == "US/Central"
+        assert df.schema["AS Type"] in (
+            pl.String,
+            pl.Categorical,
+            pl.Object,
+            pl.List(pl.List(pl.Float64)),
+        )
+        assert df.schema["Demand Curve Point"] == pl.Int64
+        assert df.schema["Quantity"] == pl.Int64
+        assert df.schema["Price"] == pl.Float64
 
     def test_get_as_demand_curves_dam_and_sced_date_range(self):
         date = pd.Timestamp.now().normalize() - pd.Timedelta(days=2)
@@ -3387,19 +3456,24 @@ class TestErcot(BaseTestISO):
         "NSPNM",
     }
 
-    def _check_get_dam_asdc_aggregated(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_get_dam_asdc_aggregated(self, df: pl.DataFrame):
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "AS Type",
             "Price",
             "Quantity",
         ]
-        assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["AS Type"] == "object"
-        assert df.dtypes["Price"] == "float64"
-        assert df.dtypes["Quantity"] == "float64"
+        assert df.schema["Interval Start"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["Interval End"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["AS Type"] in (
+            pl.String,
+            pl.Categorical,
+            pl.Object,
+            pl.List(pl.List(pl.Float64)),
+        )
+        assert df.schema["Price"] == pl.Float64
+        assert df.schema["Quantity"] == pl.Float64
         assert (
             (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(hours=1)
         ).all()
@@ -3427,17 +3501,22 @@ class TestErcot(BaseTestISO):
 
     """get_as_deployment_factors_projected"""
 
-    def _check_as_deployment_factors_projected(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_as_deployment_factors_projected(self, df: pl.DataFrame):
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "AS Type",
             "AS Deployment Factors",
         ]
-        assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["AS Type"] == "object"
-        assert df.dtypes["AS Deployment Factors"] == "float64"
+        assert df.schema["Interval Start"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["Interval End"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["AS Type"] in (
+            pl.String,
+            pl.Categorical,
+            pl.Object,
+            pl.List(pl.List(pl.Float64)),
+        )
+        assert df.schema["AS Deployment Factors"] == pl.Float64
 
     def test_get_as_deployment_factors_projected_date_range(self):
         date = self.local_start_of_today() - pd.Timedelta(days=2)
@@ -3459,8 +3538,8 @@ class TestErcot(BaseTestISO):
     """get_as_deployment_factors_weekly_ruc"""
 
     # Check for weekly, daily, and hourly RUC
-    def _check_as_deployment_factors_ruc(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_as_deployment_factors_ruc(self, df: pl.DataFrame):
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "RUC Timestamp",
@@ -3469,10 +3548,15 @@ class TestErcot(BaseTestISO):
         ]
 
         for col in ["Interval Start", "Interval End", "RUC Timestamp"]:
-            assert df.dtypes[col] == "datetime64[ns, US/Central]"
+            assert df.schema[col] == pl.Datetime("ns", "US/Central")
 
-        assert df.dtypes["AS Type"] == "object"
-        assert df.dtypes["AS Deployment Factors"] == "float64"
+        assert df.schema["AS Type"] in (
+            pl.String,
+            pl.Categorical,
+            pl.Object,
+            pl.List(pl.List(pl.Float64)),
+        )
+        assert df.schema["AS Deployment Factors"] == pl.Float64
 
         assert (
             (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(hours=1)
@@ -3489,14 +3573,14 @@ class TestErcot(BaseTestISO):
 
         self._check_as_deployment_factors_ruc(df)
 
-        assert df["RUC Timestamp"].nunique() == 2
+        assert df["RUC Timestamp"].n_unique() == 2
         assert df["Interval Start"].min() == date + pd.DateOffset(days=1)
         assert df["Interval Start"].max() == end + pd.DateOffset(days=5) - pd.Timedelta(
             hours=1,
         )
 
         # Total of 6 days
-        assert df["Interval Start"].nunique() == 144
+        assert df["Interval Start"].n_unique() == 144
 
     """get_as_deployment_factors_daily_ruc"""
 
@@ -3512,14 +3596,14 @@ class TestErcot(BaseTestISO):
 
         self._check_as_deployment_factors_ruc(df)
 
-        assert df["RUC Timestamp"].nunique() == 2
+        assert df["RUC Timestamp"].n_unique() == 2
         assert df["Interval Start"].min() == date + pd.DateOffset(days=1)
         assert df["Interval Start"].max() == end + pd.DateOffset(days=1) - pd.Timedelta(
             hours=1,
         )
 
         # Total of 2 days
-        assert df["Interval Start"].nunique() == 48
+        assert df["Interval Start"].n_unique() == 48
 
     """get_as_deployment_factors_hourly_ruc"""
 
@@ -3535,7 +3619,7 @@ class TestErcot(BaseTestISO):
 
         self._check_as_deployment_factors_ruc(df)
 
-        assert df["RUC Timestamp"].nunique() == 3
+        assert df["RUC Timestamp"].n_unique() == 3
         assert df["Interval Start"].min() == date + pd.Timedelta(hours=1)
         assert df["Interval Start"].max() == self.local_start_of_today() + pd.Timedelta(
             hours=23,
@@ -3543,17 +3627,22 @@ class TestErcot(BaseTestISO):
 
     """get_dam_total_as_sold"""
 
-    def _check_get_dam_total_as_sold(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_get_dam_total_as_sold(self, df: pl.DataFrame):
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "AS Type",
             "Quantity",
         ]
-        assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["AS Type"] == "object"
-        assert df.dtypes["Quantity"] == "float64"
+        assert df.schema["Interval Start"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["Interval End"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["AS Type"] in (
+            pl.String,
+            pl.Categorical,
+            pl.Object,
+            pl.List(pl.List(pl.Float64)),
+        )
+        assert df.schema["Quantity"] == pl.Float64
 
     def test_get_dam_total_as_sold_date_range(self):
         # Data is only available per DAM run so we use a set time we know it exists
@@ -3572,8 +3661,8 @@ class TestErcot(BaseTestISO):
 
     """get_as_demand_curves_hourly_ruc"""
 
-    def _check_hourly_ruc_as_demand_curves(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_hourly_ruc_as_demand_curves(self, df: pl.DataFrame):
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "RUC Timestamp",
@@ -3584,12 +3673,17 @@ class TestErcot(BaseTestISO):
         ]
 
         for col in ["Interval Start", "Interval End", "RUC Timestamp"]:
-            assert df.dtypes[col] == "datetime64[ns, US/Central]"
+            assert df.schema[col] == pl.Datetime("ns", "US/Central")
 
-        assert df.dtypes["AS Type"] == "object"
-        assert df.dtypes["Demand Curve Point"] == "int64"
-        assert df.dtypes["Quantity"] == "int64"
-        assert df.dtypes["Price"] == "float64"
+        assert df.schema["AS Type"] in (
+            pl.String,
+            pl.Categorical,
+            pl.Object,
+            pl.List(pl.List(pl.Float64)),
+        )
+        assert df.schema["Demand Curve Point"] == pl.Int64
+        assert df.schema["Quantity"] == pl.Int64
+        assert df.schema["Price"] == pl.Float64
 
     def test_get_as_demand_curves_hourly_ruc_date_range(self):
         date = self.local_start_of_today() - pd.Timedelta(hours=1)
@@ -3602,7 +3696,7 @@ class TestErcot(BaseTestISO):
 
         self._check_hourly_ruc_as_demand_curves(df)
 
-        assert df["RUC Timestamp"].nunique() == 3
+        assert df["RUC Timestamp"].n_unique() == 3
         assert df["Interval Start"].min() == date + pd.Timedelta(hours=1)
         assert df["Interval Start"].max() == self.local_start_of_today() + pd.Timedelta(
             hours=23,
@@ -3610,8 +3704,8 @@ class TestErcot(BaseTestISO):
 
     """get_as_demand_curves_daily_ruc"""
 
-    def _check_daily_ruc_as_demand_curves(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_daily_ruc_as_demand_curves(self, df: pl.DataFrame):
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "RUC Timestamp",
@@ -3622,12 +3716,17 @@ class TestErcot(BaseTestISO):
         ]
 
         for col in ["Interval Start", "Interval End", "RUC Timestamp"]:
-            assert df.dtypes[col] == "datetime64[ns, US/Central]"
+            assert df.schema[col] == pl.Datetime("ns", "US/Central")
 
-        assert df.dtypes["AS Type"] == "object"
-        assert df.dtypes["Demand Curve Point"] == "int64"
-        assert df.dtypes["Quantity"] == "int64"
-        assert df.dtypes["Price"] == "float64"
+        assert df.schema["AS Type"] in (
+            pl.String,
+            pl.Categorical,
+            pl.Object,
+            pl.List(pl.List(pl.Float64)),
+        )
+        assert df.schema["Demand Curve Point"] == pl.Int64
+        assert df.schema["Quantity"] == pl.Int64
+        assert df.schema["Price"] == pl.Float64
 
     def test_get_as_demand_curves_daily_ruc_date_range(self):
         date = self.local_start_of_today() - pd.Timedelta(days=2)
@@ -3640,14 +3739,14 @@ class TestErcot(BaseTestISO):
 
         self._check_daily_ruc_as_demand_curves(df)
 
-        assert df["RUC Timestamp"].nunique() == 2
+        assert df["RUC Timestamp"].n_unique() == 2
         assert df["Interval Start"].min() == date + pd.Timedelta(days=1)
         assert df["Interval Start"].max() == end + pd.Timedelta(hours=23)
 
     """get_as_demand_curves_weekly_ruc"""
 
-    def _check_weekly_ruc_as_demand_curves(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_weekly_ruc_as_demand_curves(self, df: pl.DataFrame):
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "RUC Timestamp",
@@ -3658,12 +3757,17 @@ class TestErcot(BaseTestISO):
         ]
 
         for col in ["Interval Start", "Interval End", "RUC Timestamp"]:
-            assert df.dtypes[col] == "datetime64[ns, US/Central]"
+            assert df.schema[col] == pl.Datetime("ns", "US/Central")
 
-        assert df.dtypes["AS Type"] == "object"
-        assert df.dtypes["Demand Curve Point"] == "int64"
-        assert df.dtypes["Quantity"] == "int64"
-        assert df.dtypes["Price"] == "float64"
+        assert df.schema["AS Type"] in (
+            pl.String,
+            pl.Categorical,
+            pl.Object,
+            pl.List(pl.List(pl.Float64)),
+        )
+        assert df.schema["Demand Curve Point"] == pl.Int64
+        assert df.schema["Quantity"] == pl.Int64
+        assert df.schema["Price"] == pl.Float64
 
     def test_get_as_demand_curves_weekly_ruc_date_range(self):
         date = self.local_start_of_today() - pd.DateOffset(days=2)
@@ -3677,8 +3781,8 @@ class TestErcot(BaseTestISO):
         self._check_weekly_ruc_as_demand_curves(df)
 
         # 6 total days
-        assert df["Interval Start"].nunique() == 144
-        assert df["RUC Timestamp"].nunique() == 2
+        assert df["Interval Start"].n_unique() == 144
+        assert df["RUC Timestamp"].n_unique() == 2
 
         assert df["Interval Start"].min() == date + pd.DateOffset(days=1)
         assert df["Interval Start"].max() == end + pd.DateOffset(days=4) + pd.Timedelta(
@@ -3687,8 +3791,8 @@ class TestErcot(BaseTestISO):
 
     """get_indicative_mcpc_rtd"""
 
-    def _check_get_indicative_mcpc_rtd(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_get_indicative_mcpc_rtd(self, df: pl.DataFrame):
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "RTD Timestamp",
@@ -3698,12 +3802,12 @@ class TestErcot(BaseTestISO):
             "ECRS",
             "NSPIN",
         ]
-        assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["RTD Timestamp"] == "datetime64[ns, US/Central]"
+        assert df.schema["Interval Start"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["Interval End"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["RTD Timestamp"] == pl.Datetime("ns", "US/Central")
 
         for col in ["REGUP", "REGDN", "RRS", "ECRS", "NSPIN"]:
-            assert df.dtypes[col] == "float64"
+            assert df.schema[col] == pl.Float64
 
     def test_get_indicative_mcpc_rtd_date_range(self):
         # Use a date range that spans two days to test we handle day transitions
@@ -3723,12 +3827,12 @@ class TestErcot(BaseTestISO):
         assert df["Interval Start"].max().date() == end.date()
 
         # 2 hours / 5 minutes/interval = 24 RTD Timestamps
-        assert df["RTD Timestamp"].nunique() == 24
+        assert df["RTD Timestamp"].n_unique() == 24
 
     """get_as_total_capability"""
 
-    def _check_get_as_total_capability(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_get_as_total_capability(self, df: pl.DataFrame):
+        assert df.columns == [
             "SCED Timestamp",
             "Publish Time",
             "Cap RegUp Total",
@@ -3741,7 +3845,7 @@ class TestErcot(BaseTestISO):
             "Cap RegUp RRS ECRS NonSpin Total",
         ]
 
-        assert df.dtypes["SCED Timestamp"] == "datetime64[ns, US/Central]"
+        assert df.schema["SCED Timestamp"] == pl.Datetime("ns", "US/Central")
 
         for col in [
             "Cap RegUp Total",
@@ -3753,7 +3857,7 @@ class TestErcot(BaseTestISO):
             "Cap RegUp RRS ECRS Total",
             "Cap RegUp RRS ECRS NonSpin Total",
         ]:
-            assert df.dtypes[col] == "float64"
+            assert df.schema[col] == pl.Float64
 
     def test_get_as_total_capability_date_range(self):
         # Choose a date range that spans two days to test we handle day transitions
@@ -3775,13 +3879,13 @@ class TestErcot(BaseTestISO):
         # This dataset is odd in that each file has 5 SCED intervals (1 current
         # and 4 previous). This means the number of unique SCED intervals in 2 hours is
         # (2 hours / 5 minutes/interval) + 4 extra intervals = 28 intervals
-        assert df["SCED Timestamp"].nunique() == 28
-        assert df["Publish Time"].nunique() == 24
+        assert df["SCED Timestamp"].n_unique() == 28
+        assert df["Publish Time"].n_unique() == 24
 
     """get_real_time_adders"""
 
-    def _check_real_time_adders(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_real_time_adders(self, df: pl.DataFrame):
+        assert df.columns == [
             "SCED Timestamp",
             "Interval Start",
             "Interval End",
@@ -3804,9 +3908,9 @@ class TestErcot(BaseTestISO):
             "RTOLHSL",
         ]
 
-        assert df.dtypes["SCED Timestamp"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
+        assert df.schema["SCED Timestamp"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["Interval Start"] == pl.Datetime("ns", "US/Central")
+        assert df.schema["Interval End"] == pl.Datetime("ns", "US/Central")
 
         assert (
             df["Interval End"] - df["Interval Start"] == pd.Timedelta(minutes=5)
@@ -3831,7 +3935,7 @@ class TestErcot(BaseTestISO):
             "RTOLLSL",
             "RTOLHSL",
         ]:
-            assert df.dtypes[col] == "float64"
+            assert df.schema[col] == pl.Float64
 
     def test_get_real_time_adders_date_range(self):
         # Choose a date range that spans two days to test we handle day transitions
@@ -3851,19 +3955,19 @@ class TestErcot(BaseTestISO):
         assert df["Interval Start"].max().date() == end.date()
 
         # 2 hours / 5 minutes/interval = 24 Timestamps
-        assert df["Interval Start"].nunique() == 24
+        assert df["Interval Start"].n_unique() == 24
 
     """system_as_capacity_monitor"""
 
-    def _check_system_as_capacity_monitor(self, df: pd.DataFrame) -> None:
+    def _check_system_as_capacity_monitor(self, df: pl.DataFrame) -> None:
         assert df.shape[0] == 1
-        assert df.columns.tolist() == SYSTEM_AS_CAPACITY_MONITOR_COLUMNS
+        assert df.columns == SYSTEM_AS_CAPACITY_MONITOR_COLUMNS
 
-        assert df.dtypes["Time"] == "datetime64[ns, US/Central]"
+        assert df.schema["Time"] == pl.Datetime("ns", "US/Central")
 
         for col in SYSTEM_AS_CAPACITY_MONITOR_COLUMNS[1:]:
-            assert df.dtypes[col] in ["float64", "int64"], (
-                f"{col} has dtype {df.dtypes[col]}"
+            assert df.schema[col] in (pl.Float64, pl.Int64), (
+                f"{col} has dtype {df.schema[col]}"
             )
 
     def test_get_system_as_capacity_monitor_latest(self):
@@ -3993,17 +4097,17 @@ class TestErcot(BaseTestISO):
 
         assert df.shape[0] == 1
         assert "Time" in df.columns
-        assert df.dtypes["Time"] == "datetime64[ns, US/Central]"
-        assert df["Time"].iloc[0] == pd.Timestamp(
+        assert df.schema["Time"] == pl.Datetime("ns", "US/Central")
+        assert df["Time"][0] == pd.Timestamp(
             "2025-12-05 06:30:00",
             tz="US/Central",
         )
 
-        assert df["RRS Capability PFR Gen and ESR"].iloc[0] == 1000.5
-        assert df["Reg Capability Reg Up"].iloc[0] == 800.0
-        assert df["ECRS Capability Gen"].iloc[0] == 600.0
-        assert df["PRC"].iloc[0] == 5000.0
-        assert df["ORDC Online"].iloc[0] == 3500.0
+        assert df["RRS Capability PFR Gen and ESR"][0] == 1000.5
+        assert df["Reg Capability Reg Up"][0] == 800.0
+        assert df["ECRS Capability Gen"][0] == 600.0
+        assert df["PRC"][0] == 5000.0
+        assert df["ORDC Online"][0] == 3500.0
 
     """get_settlement_points_electrical_bus_mapping"""
 
@@ -4027,10 +4131,10 @@ class TestErcot(BaseTestISO):
         ):
             df = self.iso.get_settlement_points_electrical_bus_mapping(date="latest")
         assert df.shape[0] > 0
-        assert df.columns.tolist() == self.settlement_points_electrical_bus_mapping_cols
-        assert df["Publish Date"].notna().all()
-        assert isinstance(df["Publish Date"].iloc[0], datetime.date)
-        assert not isinstance(df["Publish Date"].iloc[0], pd.Timestamp)
+        assert df.columns == self.settlement_points_electrical_bus_mapping_cols
+        assert df["Publish Date"].is_not_null().all()
+        assert isinstance(df["Publish Date"][0], datetime.date)
+        assert not isinstance(df["Publish Date"][0], pd.Timestamp)
 
     """get_ccp_resource_names"""
 
@@ -4044,10 +4148,10 @@ class TestErcot(BaseTestISO):
         with api_vcr.use_cassette("test_get_ccp_resource_names.yaml"):
             df = self.iso.get_ccp_resource_names(date="latest")
         assert df.shape[0] > 0
-        assert df.columns.tolist() == self.ccp_resource_names_cols
-        assert df["Publish Date"].notna().all()
-        assert isinstance(df["Publish Date"].iloc[0], datetime.date)
-        assert not isinstance(df["Publish Date"].iloc[0], pd.Timestamp)
+        assert df.columns == self.ccp_resource_names_cols
+        assert df["Publish Date"].is_not_null().all()
+        assert isinstance(df["Publish Date"][0], datetime.date)
+        assert not isinstance(df["Publish Date"][0], pd.Timestamp)
 
     """get_noie_mapping"""
 
@@ -4064,10 +4168,10 @@ class TestErcot(BaseTestISO):
         with api_vcr.use_cassette("test_get_noie_mapping.yaml"):
             df = self.iso.get_noie_mapping(date="latest")
         assert df.shape[0] > 0
-        assert df.columns.tolist() == self.noie_mapping_cols
-        assert df["Publish Date"].notna().all()
-        assert isinstance(df["Publish Date"].iloc[0], datetime.date)
-        assert not isinstance(df["Publish Date"].iloc[0], pd.Timestamp)
+        assert df.columns == self.noie_mapping_cols
+        assert df["Publish Date"].is_not_null().all()
+        assert isinstance(df["Publish Date"][0], datetime.date)
+        assert not isinstance(df["Publish Date"][0], pd.Timestamp)
 
     """get_resource_node_to_unit"""
 
@@ -4082,10 +4186,10 @@ class TestErcot(BaseTestISO):
         with api_vcr.use_cassette("test_get_resource_node_to_unit.yaml"):
             df = self.iso.get_resource_node_to_unit(date="latest")
         assert df.shape[0] > 0
-        assert df.columns.tolist() == self.resource_node_to_unit_cols
-        assert df["Publish Date"].notna().all()
-        assert isinstance(df["Publish Date"].iloc[0], datetime.date)
-        assert not isinstance(df["Publish Date"].iloc[0], pd.Timestamp)
+        assert df.columns == self.resource_node_to_unit_cols
+        assert df["Publish Date"].is_not_null().all()
+        assert isinstance(df["Publish Date"][0], datetime.date)
+        assert not isinstance(df["Publish Date"][0], pd.Timestamp)
 
     """get_hub_name_dc_ties"""
 
@@ -4098,71 +4202,64 @@ class TestErcot(BaseTestISO):
         with api_vcr.use_cassette("test_get_hub_name_dc_ties.yaml"):
             df = self.iso.get_hub_name_dc_ties(date="latest")
         assert df.shape[0] > 0
-        assert df.columns.tolist() == self.hub_name_dc_ties_cols
-        assert df["Publish Date"].notna().all()
-        assert isinstance(df["Publish Date"].iloc[0], datetime.date)
-        assert not isinstance(df["Publish Date"].iloc[0], pd.Timestamp)
+        assert df.columns == self.hub_name_dc_ties_cols
+        assert df["Publish Date"].is_not_null().all()
+        assert isinstance(df["Publish Date"][0], datetime.date)
+        assert not isinstance(df["Publish Date"][0], pd.Timestamp)
 
 
-def check_load_forecast_by_model(df: pd.DataFrame) -> None:
+def check_load_forecast_by_model(df: pl.DataFrame) -> None:
     """Check load forecast by model DataFrame structure and types."""
-    assert df.columns.tolist() == LOAD_FORECAST_BY_MODEL_COLUMNS
+    assert df.columns == LOAD_FORECAST_BY_MODEL_COLUMNS
     assert ((df["Interval End"] - df["Interval Start"]) == pd.Timedelta(hours=1)).all()
-    assert df["Model"].notna().all()
+    assert df["Model"].is_not_null().all()
     # Model column should have multiple unique values
-    assert df["Model"].nunique() > 1
+    assert df["Model"].n_unique() > 1
 
     # Verify exact dtypes for all columns
-    assert pd.api.types.is_datetime64_any_dtype(df["Interval Start"])
-    assert pd.api.types.is_datetime64_any_dtype(df["Interval End"])
-    assert pd.api.types.is_datetime64_any_dtype(df["Publish Time"])
-    assert df["Model"].dtype == object
-    assert df["Coast"].dtype == float
-    assert df["East"].dtype == float
-    assert df["Far West"].dtype == float
-    assert df["North"].dtype == float
-    assert df["North Central"].dtype == float
-    assert df["South Central"].dtype == float
-    assert df["Southern"].dtype == float
-    assert df["West"].dtype == float
-    assert df["System Total"].dtype == float
-    assert df["In Use Flag"].dtype == bool
+    assert isinstance(df.schema["Interval Start"], pl.Datetime)
+    assert isinstance(df.schema["Interval End"], pl.Datetime)
+    assert isinstance(df.schema["Publish Time"], pl.Datetime)
+    assert df.schema["Model"] in (pl.String, pl.Categorical, pl.Object)
+    assert df.schema["Coast"] == pl.Float64
+    assert df.schema["East"] == pl.Float64
+    assert df.schema["Far West"] == pl.Float64
+    assert df.schema["North"] == pl.Float64
+    assert df.schema["North Central"] == pl.Float64
+    assert df.schema["South Central"] == pl.Float64
+    assert df.schema["Southern"] == pl.Float64
+    assert df.schema["West"] == pl.Float64
+    assert df.schema["System Total"] == pl.Float64
+    assert df.schema["In Use Flag"] == pl.Boolean
 
 
-def check_60_day_sced_disclosure(df_dict: Dict[str, pd.DataFrame]) -> None:
+def check_60_day_sced_disclosure(df_dict: Dict[str, pl.DataFrame]) -> None:
     load_resource = df_dict[SCED_LOAD_RESOURCE_KEY]
     gen_resource = df_dict[SCED_GEN_RESOURCE_KEY]
     smne = df_dict[SCED_SMNE_KEY]
 
-    assert load_resource.columns.tolist() == SCED_LOAD_RESOURCE_COLUMNS
-    assert gen_resource.columns.tolist() == SCED_GEN_RESOURCE_COLUMNS
-    assert smne.columns.tolist() == SCED_SMNE_COLUMNS
+    assert load_resource.columns == SCED_LOAD_RESOURCE_COLUMNS
+    assert gen_resource.columns == SCED_GEN_RESOURCE_COLUMNS
+    assert smne.columns == SCED_SMNE_COLUMNS
 
     if SCED_ESR_KEY in df_dict:
         esr = df_dict[SCED_ESR_KEY]
-        assert esr.columns.tolist() == SCED_ESR_COLUMNS
+        assert esr.columns == SCED_ESR_COLUMNS
         assert len(esr) > 0
-        assert esr["Resource Type"].unique().tolist() == ["ESR"]
+        assert esr["Resource Type"].unique().to_list() == ["ESR"]
 
     # AS Offer Updates and Resource AS Offers available starting 2025-12-05
     if SCED_AS_OFFER_UPDATES_IN_OP_HOUR_KEY in df_dict:
         as_offer_updates = df_dict[SCED_AS_OFFER_UPDATES_IN_OP_HOUR_KEY]
-        assert (
-            as_offer_updates.columns.tolist()
-            == SCED_AS_OFFER_UPDATES_IN_OP_HOUR_COLUMNS
-        )
+        assert as_offer_updates.columns == SCED_AS_OFFER_UPDATES_IN_OP_HOUR_COLUMNS
         # Data may be empty for some dates
         if len(as_offer_updates) > 0:
-            assert pd.api.types.is_datetime64_any_dtype(
-                as_offer_updates["Interval Start"],
-            )
-            assert pd.api.types.is_datetime64_any_dtype(
-                as_offer_updates["Interval End"],
-            )
+            assert isinstance(as_offer_updates.schema["Interval Start"], pl.Datetime)
+            assert isinstance(as_offer_updates.schema["Interval End"], pl.Datetime)
 
     if SCED_RESOURCE_AS_OFFERS_KEY in df_dict:
         resource_as_offers = df_dict[SCED_RESOURCE_AS_OFFERS_KEY]
-        assert resource_as_offers.columns.tolist() == SCED_RESOURCE_AS_OFFERS_COLUMNS
+        assert resource_as_offers.columns == SCED_RESOURCE_AS_OFFERS_COLUMNS
 
 
 def _make_sced_resource_as_offers_df(rows):
@@ -4185,7 +4282,7 @@ def _make_sced_resource_as_offers_df(rows):
         record = {col: 0 for col in all_cols}
         record.update(row)
         data.append(record)
-    return pd.DataFrame(data, columns=all_cols)
+    return pl.DataFrame(data).select(all_cols)
 
 
 # fmt: off
@@ -4330,37 +4427,37 @@ class TestProcessScedResourceAsOffers:
         """Affected AEEC_ANTLP_3 ONRES row: zeros in inactive AS types."""
         df = _make_sced_resource_as_offers_df([_AEEC_ANTLP_3_ONRES_AFFECTED])
         result = process_sced_resource_as_offers(df)
-        assert result["Curve Type"].iloc[0] == "Online"
+        assert result["Curve Type"][0] == "Online"
 
     def test_online_with_nans(self):
         """Corrected AEEC_ANTLP_3 ONRES row: NaN in inactive AS types."""
         df = _make_sced_resource_as_offers_df([_AEEC_ANTLP_3_ONRES_CORRECTED])
         result = process_sced_resource_as_offers(df)
-        assert result["Curve Type"].iloc[0] == "Online"
+        assert result["Curve Type"][0] == "Online"
 
     def test_regulation_down_with_zeros(self):
         """Affected AEEC_ANTLP_3 REGDN row: zeros in all non-DRS columns."""
         df = _make_sced_resource_as_offers_df([_AEEC_ANTLP_3_REGDN_AFFECTED])
         result = process_sced_resource_as_offers(df)
-        assert result["Curve Type"].iloc[0] == "Regulation Down"
+        assert result["Curve Type"][0] == "Regulation Down"
 
     def test_regulation_down_with_nans(self):
         """Corrected AEEC_ANTLP_3 REGDN row: NaN in all non-DRS columns."""
         df = _make_sced_resource_as_offers_df([_AEEC_ANTLP_3_REGDN_CORRECTED])
         result = process_sced_resource_as_offers(df)
-        assert result["Curve Type"].iloc[0] == "Regulation Down"
+        assert result["Curve Type"][0] == "Regulation Down"
 
     def test_offline_with_zeros(self):
         """Affected AEEC_ANTLP_3 OFFNS row: zeros in all non-NS columns."""
         df = _make_sced_resource_as_offers_df([_AEEC_ANTLP_3_OFFNS_AFFECTED])
         result = process_sced_resource_as_offers(df)
-        assert result["Curve Type"].iloc[0] == "Offline"
+        assert result["Curve Type"][0] == "Offline"
 
     def test_offline_with_nans(self):
         """Corrected AEEC_ANTLP_3 OFFNS row: NaN in all non-NS columns."""
         df = _make_sced_resource_as_offers_df([_AEEC_ANTLP_3_OFFNS_CORRECTED])
         result = process_sced_resource_as_offers(df)
-        assert result["Curve Type"].iloc[0] == "Offline"
+        assert result["Curve Type"][0] == "Offline"
 
     def test_three_rows_per_resource_with_nans(self):
         """Corrected AEEC_ANTLP_3: all 3 rows classified correctly."""
@@ -4384,21 +4481,21 @@ class TestProcessScedResourceAsOffers:
         result = process_sced_resource_as_offers(df)
 
         # URS has prices in blocks 1 (7.50) and 6 (1420.8)
-        urs_curve = result["URS Offer Curve"].iloc[0]
+        urs_curve = result["URS Offer Curve"].to_list()[0]
         assert urs_curve == [[16.0, 7.5], [36.0, 1420.8]]
 
         # RRSPF has prices in blocks 2 (8.0) and 6 (742.99)
-        rrspf_curve = result["RRSPFR Offer Curve"].iloc[0]
+        rrspf_curve = result["RRSPFR Offer Curve"].to_list()[0]
         assert rrspf_curve == [[6.2, 8.0], [36.0, 742.99]]
 
         # DRS is entirely NaN — should be None
-        assert result["DRS Offer Curve"].iloc[0] is None
+        assert result["DRS Offer Curve"].to_list()[0] is None
 
     def test_output_columns(self):
         """Verify processed output has the standard column set."""
         df = _make_sced_resource_as_offers_df([_AEEC_ANTLP_3_ONRES_CORRECTED])
         result = process_sced_resource_as_offers(df)
-        assert result.columns.tolist() == SCED_RESOURCE_AS_OFFERS_COLUMNS
+        assert result.columns == SCED_RESOURCE_AS_OFFERS_COLUMNS
 
 
 def _to_new_suffixes(df):
@@ -4418,7 +4515,7 @@ def _to_new_suffixes(df):
                 return col[: -len(old)] + new
         return col
 
-    return df.rename(columns=rename)
+    return df.rename({col: rename(col) for col in df.columns})
 
 
 class TestProcessScedResourceAsOffersNewSuffixes:
@@ -4446,7 +4543,7 @@ class TestProcessScedResourceAsOffersNewSuffixes:
         df = _to_new_suffixes(_make_sced_resource_as_offers_df(self._ROWS))
         result = process_sced_resource_as_offers(df)
         pk = ["SCED Timestamp", "Resource Name", "Curve Type"]
-        assert not result.duplicated(subset=pk).any()
+        assert not result.select(pk).is_duplicated().any()
 
     def test_curves_and_columns_match_old_layout(self):
         """Renamed columns produce identical output to the old layout."""
@@ -4458,9 +4555,9 @@ class TestProcessScedResourceAsOffersNewSuffixes:
                 _make_sced_resource_as_offers_df([_AEEC_ANTLP_3_ONRES_CORRECTED]),
             ),
         )
-        assert new.columns.tolist() == SCED_RESOURCE_AS_OFFERS_COLUMNS
+        assert new.columns == SCED_RESOURCE_AS_OFFERS_COLUMNS
         for col in [c for c in new.columns if c.endswith("Offer Curve")]:
-            assert old[col].iloc[0] == new[col].iloc[0], col
+            assert old[col].to_list()[0] == new[col].to_list()[0], col
 
 
 def check_60_day_dam_disclosure(df_dict):
@@ -4479,54 +4576,54 @@ def check_60_day_dam_disclosure(df_dict):
     dam_ptp_obligation_option = df_dict[DAM_PTP_OBLIGATION_OPTION_KEY]
     dam_ptp_obligation_option_awards = df_dict[DAM_PTP_OBLIGATION_OPTION_AWARDS_KEY]
 
-    assert dam_gen_resource.columns.tolist() == DAM_GEN_RESOURCE_COLUMNS
-    assert dam_gen_resource_as_offers.columns.tolist() == DAM_RESOURCE_AS_OFFERS_COLUMNS
-    assert dam_load_resource.columns.tolist() == DAM_LOAD_RESOURCE_COLUMNS
+    assert dam_gen_resource.columns == DAM_GEN_RESOURCE_COLUMNS
+    assert dam_gen_resource_as_offers.columns == DAM_RESOURCE_AS_OFFERS_COLUMNS
+    assert dam_load_resource.columns == DAM_LOAD_RESOURCE_COLUMNS
+
+    assert dam_load_resource_as_offers.columns == DAM_RESOURCE_AS_OFFERS_COLUMNS
+
+    assert dam_energy_only_offer_awards.columns == DAM_ENERGY_ONLY_OFFER_AWARDS_COLUMNS
+
+    assert dam_energy_only_offers.columns == DAM_ENERGY_ONLY_OFFERS_COLUMNS
 
     assert (
-        dam_load_resource_as_offers.columns.tolist() == DAM_RESOURCE_AS_OFFERS_COLUMNS
+        dam_ptp_obligation_bid_awards.columns == DAM_PTP_OBLIGATION_BID_AWARDS_COLUMNS
     )
 
-    assert (
-        dam_energy_only_offer_awards.columns.tolist()
-        == DAM_ENERGY_ONLY_OFFER_AWARDS_COLUMNS
-    )
+    assert dam_ptp_obligation_bids.columns == DAM_PTP_OBLIGATION_BIDS_COLUMNS
 
-    assert dam_energy_only_offers.columns.tolist() == DAM_ENERGY_ONLY_OFFERS_COLUMNS
+    assert dam_energy_bid_awards.columns == DAM_ENERGY_BID_AWARDS_COLUMNS
+    assert dam_energy_bids.columns == DAM_ENERGY_BIDS_COLUMNS
 
-    assert (
-        dam_ptp_obligation_bid_awards.columns.tolist()
-        == DAM_PTP_OBLIGATION_BID_AWARDS_COLUMNS
-    )
-
-    assert dam_ptp_obligation_bids.columns.tolist() == DAM_PTP_OBLIGATION_BIDS_COLUMNS
-
-    assert dam_energy_bid_awards.columns.tolist() == DAM_ENERGY_BID_AWARDS_COLUMNS
-    assert dam_energy_bids.columns.tolist() == DAM_ENERGY_BIDS_COLUMNS
+    assert dam_ptp_obligation_option.columns == DAM_PTP_OBLIGATION_OPTION_COLUMNS
 
     assert (
-        dam_ptp_obligation_option.columns.tolist() == DAM_PTP_OBLIGATION_OPTION_COLUMNS
-    )
-
-    assert (
-        dam_ptp_obligation_option_awards.columns.tolist()
+        dam_ptp_obligation_option_awards.columns
         == DAM_PTP_OBLIGATION_OPTION_AWARDS_COLUMNS
     )
 
-    assert not dam_gen_resource_as_offers.duplicated(
-        subset=["Interval Start", "Interval End", "QSE", "DME", "Resource Name"],
-    ).any()
+    assert (
+        not dam_gen_resource_as_offers.select(
+            ["Interval Start", "Interval End", "QSE", "DME", "Resource Name"],
+        )
+        .is_duplicated()
+        .any()
+    )
 
-    assert not dam_load_resource_as_offers.duplicated(
-        subset=["Interval Start", "Interval End", "QSE", "DME", "Resource Name"],
-    ).any()
+    assert (
+        not dam_load_resource_as_offers.select(
+            ["Interval Start", "Interval End", "QSE", "DME", "Resource Name"],
+        )
+        .is_duplicated()
+        .any()
+    )
 
 
 _AS_ONLY_PK = ["Interval Start", "QSE", "AS Type", "Offer ID"]
 
 
 def _check_dam_as_only_awards(df):
-    assert df.columns.tolist() == DAM_AS_ONLY_AWARDS_COLUMNS
+    assert df.columns == DAM_AS_ONLY_AWARDS_COLUMNS
     assert len(df) > 0
 
     # Hour Ending - 1 hour => exactly 1-hour intervals
@@ -4534,8 +4631,8 @@ def _check_dam_as_only_awards(df):
 
     # Primary-key components non-null and unique
     for pk_col in _AS_ONLY_PK:
-        assert df[pk_col].notna().all(), f"{pk_col} has nulls"
-    assert not df.duplicated(subset=_AS_ONLY_PK).any()
+        assert df[pk_col].is_not_null().all(), f"{pk_col} has nulls"
+    assert not df.select(_AS_ONLY_PK).is_duplicated().any()
 
     # All quantity/price columns parse as numeric
     for col in [
@@ -4547,28 +4644,28 @@ def _check_dam_as_only_awards(df):
         "Total Award",
         "MCPC",
     ]:
-        assert pd.api.types.is_numeric_dtype(df[col]), f"{col} is not numeric"
+        assert df.schema[col].is_numeric(), f"{col} is not numeric"
 
     # Total Award should equal the sum of Quantity1..5 Award per row
     quantity_cols = [f"Quantity{i} Award" for i in range(1, 6)]
     assert np.allclose(
-        df[quantity_cols].sum(axis=1).astype(float),
-        df["Total Award"].astype(float),
+        df.select(pl.sum_horizontal(quantity_cols).cast(pl.Float64)).to_series(),
+        df["Total Award"].cast(pl.Float64),
     )
 
 
 def _check_dam_as_only_offers(df):
-    assert df.columns.tolist() == DAM_AS_ONLY_OFFERS_COLUMNS
+    assert df.columns == DAM_AS_ONLY_OFFERS_COLUMNS
     assert len(df) > 0
 
     assert ((df["Interval End"] - df["Interval Start"]) == pd.Timedelta(hours=1)).all()
 
     for pk_col in _AS_ONLY_PK:
-        assert df[pk_col].notna().all(), f"{pk_col} has nulls"
-    assert not df.duplicated(subset=_AS_ONLY_PK).any()
+        assert df[pk_col].is_not_null().all(), f"{pk_col} has nulls"
+    assert not df.select(_AS_ONLY_PK).is_duplicated().any()
 
     # Every non-null Offer Curve must be a non-empty list of [mw, price] pairs
-    non_null = df["Offer Curve"].dropna()
+    non_null = df["Offer Curve"].drop_nulls()
     assert len(non_null) > 0
     for curve in non_null:
         assert isinstance(curve, list) and len(curve) > 0
@@ -4595,7 +4692,7 @@ class TestExtractCurveFormats:
         for i in range(1, n_blocks + 1):
             data[f"{curve_name}-MW{i}"] = rng.uniform(10, 500, n_rows)
             data[f"{curve_name}-Price{i}"] = rng.uniform(5, 100, n_rows)
-        return pd.DataFrame(data)
+        return pl.DataFrame(data)
 
     def _make_explicit_cols_df(self, n_rows=100, n_blocks=6):
         """Create a synthetic DataFrame with explicit column naming (SCED-style)."""
@@ -4605,7 +4702,7 @@ class TestExtractCurveFormats:
         for i in range(1, n_blocks + 1):
             data[f"QUANTITY_MW{i}"] = rng.uniform(10, 500, n_rows)
             data[f"PRICE{i}_URS"] = rng.uniform(5, 100, n_rows)
-        return pd.DataFrame(data)
+        return pl.DataFrame(data)
 
     def test_extract_curve_list_vs_pg_array_auto_detect(self):
         """Test that pg_array output matches list output (auto-detect)."""
@@ -4652,7 +4749,7 @@ class TestExtractCurveFormats:
         """Test edge cases: all-NaN rows, partial NaN rows, single-block curves."""
 
         # All-NaN row
-        df_nan = pd.DataFrame(
+        df_nan = pl.DataFrame(
             {
                 "C-MW1": [np.nan, 100.0],
                 "C-MW2": [np.nan, 200.0],
@@ -4672,14 +4769,14 @@ class TestExtractCurveFormats:
         )
 
         # All-NaN row should produce None for both formats
-        assert list_result.iloc[0] is None
-        assert pg_result.iloc[0] is None
+        assert list_result[0] is None
+        assert pg_result[0] is None
 
         # Valid row should match
-        assert _list_to_pg_string(list_result.iloc[1]) == pg_result.iloc[1]
+        assert _list_to_pg_string(list_result[1]) == pg_result[1]
 
         # Partial NaN - only first block valid
-        df_partial = pd.DataFrame(
+        df_partial = pl.DataFrame(
             {
                 "C-MW1": [100.0],
                 "C-MW2": [np.nan],
@@ -4697,10 +4794,10 @@ class TestExtractCurveFormats:
             curve_name="C",
             output_format=CurveOutputFormat.PG_ARRAY_AS_STRING,
         )
-        assert _list_to_pg_string(list_result.iloc[0]) == pg_result.iloc[0]
+        assert _list_to_pg_string(list_result[0]) == pg_result[0]
 
         # Single-block curve
-        df_single = pd.DataFrame({"C-MW1": [50.0, 75.0], "C-Price1": [25.0, 30.0]})
+        df_single = pl.DataFrame({"C-MW1": [50.0, 75.0], "C-Price1": [25.0, 30.0]})
         list_result = extract_curve(
             df_single,
             curve_name="C",
@@ -4734,17 +4831,17 @@ class TestExtractCurveFormats:
                 for svc in services:
                     row[f"PRICE{i} {svc}"] = 10.0 * i + (0.5 if svc == "REGUP" else 0)
             rows.append(row)
-        return pd.DataFrame(rows)
+        return pl.DataFrame(rows)
 
     def test_process_as_offer_curves_list_vs_pg_array(self):
         """Curves from list format match pg_array_as_string when converted."""
         df = self._make_as_offer_curves_df()
         list_result = process_as_offer_curves(
-            df.copy(),
+            df.clone(),
             output_format=CurveOutputFormat.LIST,
         )
         pg_result = process_as_offer_curves(
-            df.copy(),
+            df.clone(),
             output_format=CurveOutputFormat.PG_ARRAY_AS_STRING,
         )
 
@@ -4756,16 +4853,16 @@ class TestExtractCurveFormats:
             c for c in list_result.columns if not c.endswith("Offer Curve")
         ]
         for col in non_curve_cols:
-            assert list(list_result[col]) == list(pg_result[col])
+            assert list_result[col].to_list() == pg_result[col].to_list()
 
         # Curve columns: convert list to pg string and compare
         curve_cols = [c for c in list_result.columns if c.endswith("Offer Curve")]
         for col in curve_cols:
-            for i in range(len(list_result)):
-                list_val = list_result[col].iloc[i]
-                pg_val = pg_result[col].iloc[i]
-                if list_val is pd.NA:
-                    assert pg_val is pd.NA
+            list_vals = list_result[col].to_list()
+            pg_vals = pg_result[col].to_list()
+            for list_val, pg_val in zip(list_vals, pg_vals):
+                if list_val is None:
+                    assert pg_val is None
                 else:
                     assert _list_to_pg_string(list_val) == pg_val
 
@@ -4782,7 +4879,7 @@ class TestCategorizeStrings:
 
     def test_categorize_strings_converts_object_columns(self):
         """Non-curve object columns are converted to category dtype."""
-        df = pd.DataFrame(
+        df = pl.DataFrame(
             {
                 "Resource Name": ["RES_A", "RES_B", "RES_A"],
                 "QSE": ["QSE1", "QSE2", "QSE1"],
@@ -4810,13 +4907,13 @@ class TestCategorizeStrings:
 
     def test_categorize_strings_no_object_columns(self):
         """DataFrame with no object columns is returned unchanged."""
-        df = pd.DataFrame({"A": [1, 2, 3], "B": [4.0, 5.0, 6.0]})
+        df = pl.DataFrame({"A": [1, 2, 3], "B": [4.0, 5.0, 6.0]})
         result = _categorize_strings(df)
         assert result["A"].dtype == "int64"
         assert result["B"].dtype == "float64"
 
     def test_categorize_strings_preserves_values(self):
         """Category conversion preserves actual string values."""
-        df = pd.DataFrame({"Resource Name": ["RES_A", "RES_B", "RES_A"]})
+        df = pl.DataFrame({"Resource Name": ["RES_A", "RES_B", "RES_A"]})
         result = _categorize_strings(df)
         assert list(result["Resource Name"]) == ["RES_A", "RES_B", "RES_A"]

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -1079,9 +1079,12 @@ class TestErcot(BaseTestISO):
         assert esr["SCED Timestamp"].dt.date().unique()[0] == date
 
         # Verify offer curves are parsed
-        assert esr["SCED1 Offer Curve"].apply(lambda x: isinstance(x, list)).any()
-        assert esr["SCED2 Offer Curve"].apply(lambda x: isinstance(x, list)).any()
-        assert esr["SCED TPO Offer Curve"].apply(lambda x: isinstance(x, list)).any()
+        assert esr["SCED1 Offer Curve"].dtype == pl.List(pl.List(pl.Float64))
+        assert esr["SCED1 Offer Curve"].is_not_null().any()
+        assert esr["SCED2 Offer Curve"].dtype == pl.List(pl.List(pl.Float64))
+        assert esr["SCED2 Offer Curve"].is_not_null().any()
+        assert esr["SCED TPO Offer Curve"].dtype == pl.List(pl.List(pl.Float64))
+        assert esr["SCED TPO Offer Curve"].is_not_null().any()
 
         # Also check the other datasets are still present
         check_60_day_sced_disclosure(df_dict)
@@ -1207,13 +1210,8 @@ class TestErcot(BaseTestISO):
         assert dam_esr["Resource Type"].unique().to_list() == ["ESR"]
 
         # Verify offer curves are parsed
-        assert (
-            dam_esr["QSE submitted Curve"]
-            .apply(
-                lambda x: isinstance(x, list),
-            )
-            .any()
-        )
+        assert dam_esr["QSE submitted Curve"].dtype == pl.List(pl.List(pl.Float64))
+        assert dam_esr["QSE submitted Curve"].is_not_null().any()
 
         assert DAM_ESR_AS_OFFERS_KEY in df_dict
         dam_esr_as_offers = df_dict[DAM_ESR_AS_OFFERS_KEY]

--- a/gridstatus/tests/source_specific/test_ercot_api.py
+++ b/gridstatus/tests/source_specific/test_ercot_api.py
@@ -1,6 +1,7 @@
 import datetime
 
 import pandas as pd
+import polars as pl
 import pytest
 
 from gridstatus.base import Markets, NoDataFoundException
@@ -51,6 +52,17 @@ class TestErcotAPI(TestHelperMixin):
         # Runs before all tests in this class
         cls.iso = ErcotAPI(sleep_seconds=3, max_retries=5)
 
+    @staticmethod
+    def _interval_equals(df: pl.DataFrame, duration: pd.Timedelta) -> bool:
+        delta = df.select(
+            (pl.col("Interval End") - pl.col("Interval Start")).alias("delta"),
+        )["delta"]
+        return delta.eq(duration).all()
+
+    @staticmethod
+    def _is_tz_datetime(dtype: pl.DataType, tz: str) -> bool:
+        return isinstance(dtype, pl.Datetime) and dtype.time_zone == tz
+
     """utils"""
 
     def test_handle_end_date(self):
@@ -97,8 +109,10 @@ class TestErcotAPI(TestHelperMixin):
     """get_wind_actual_and_forecast_hourly"""
 
     def _check_wind_actual_and_forecast_hourly(self, df):
-        assert df.columns.tolist() == WIND_ACTUAL_AND_FORECAST_COLUMNS
-        assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
+        assert list(df.columns) == WIND_ACTUAL_AND_FORECAST_COLUMNS
+        assert self._interval_equals(df, pd.Timedelta("1h"))
 
     @pytest.mark.integration
     @api_vcr.use_cassette("test_get_wind_actual_and_forecast_hourly_today.yaml")
@@ -117,7 +131,7 @@ class TestErcotAPI(TestHelperMixin):
     def test_get_wind_actual_and_forecast_hourly_latest(self):
         df = self.iso.get_wind_actual_and_forecast_hourly("latest")
 
-        assert df["Publish Time"].nunique() == 1
+        assert df["Publish Time"].n_unique() == 1
         self._check_wind_actual_and_forecast_hourly(df)
 
     @pytest.mark.integration
@@ -132,7 +146,7 @@ class TestErcotAPI(TestHelperMixin):
 
         self._check_wind_actual_and_forecast_hourly(df)
 
-        assert df["Publish Time"].nunique() == 2
+        assert df["Publish Time"].n_unique() == 2
 
         assert df["Interval Start"].min() == self.local_start_of_day(
             date.date(),
@@ -144,12 +158,13 @@ class TestErcotAPI(TestHelperMixin):
     """get_wind_actual_and_forecast_by_geographical_region_hourly"""
 
     def _check_wind_actual_and_forecast_by_geographical_region_hourly(self, df):
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
         assert (
-            df.columns.tolist()
-            == WIND_ACTUAL_AND_FORECAST_BY_GEOGRAPHICAL_REGION_COLUMNS
+            list(df.columns) == WIND_ACTUAL_AND_FORECAST_BY_GEOGRAPHICAL_REGION_COLUMNS
         )
 
-        assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()
+        assert self._interval_equals(df, pd.Timedelta("1h"))
 
     @pytest.mark.integration
     @api_vcr.use_cassette(
@@ -176,7 +191,7 @@ class TestErcotAPI(TestHelperMixin):
             "latest",
         )
 
-        assert df["Publish Time"].nunique() == 1
+        assert df["Publish Time"].n_unique() == 1
         self._check_wind_actual_and_forecast_by_geographical_region_hourly(df)
 
     @pytest.mark.integration
@@ -197,7 +212,7 @@ class TestErcotAPI(TestHelperMixin):
 
         self._check_wind_actual_and_forecast_by_geographical_region_hourly(df)
 
-        assert df["Publish Time"].nunique() == 2
+        assert df["Publish Time"].n_unique() == 2
 
         assert df["Interval Start"].min() == self.local_start_of_day(
             date.date(),
@@ -209,9 +224,11 @@ class TestErcotAPI(TestHelperMixin):
     """get_solar_actual_and_forecast_hourly"""
 
     def _check_solar_actual_and_forecast_hourly(self, df):
-        assert df.columns.tolist() == SOLAR_ACTUAL_AND_FORECAST_COLUMNS
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
+        assert list(df.columns) == SOLAR_ACTUAL_AND_FORECAST_COLUMNS
 
-        assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()
+        assert self._interval_equals(df, pd.Timedelta("1h"))
 
     @pytest.mark.integration
     @api_vcr.use_cassette("test_get_solar_actual_and_forecast_hourly_today.yaml")
@@ -231,7 +248,7 @@ class TestErcotAPI(TestHelperMixin):
     def test_get_solar_actual_and_forecast_hourly_latest(self):
         df = self.iso.get_solar_actual_and_forecast_hourly("latest")
 
-        assert df["Publish Time"].nunique() == 1
+        assert df["Publish Time"].n_unique() == 1
         self._check_solar_actual_and_forecast_hourly(df)
 
     @pytest.mark.integration
@@ -244,7 +261,7 @@ class TestErcotAPI(TestHelperMixin):
 
         self._check_solar_actual_and_forecast_hourly(df)
 
-        assert df["Publish Time"].nunique() == 2
+        assert df["Publish Time"].n_unique() == 2
 
         assert df["Interval Start"].min() == self.local_start_of_day(
             date.date(),
@@ -256,11 +273,12 @@ class TestErcotAPI(TestHelperMixin):
     """get_solar_actual_and_forecast_by_geographical_region_hourly"""
 
     def _check_solar_actual_and_forecast_by_geographical_region_hourly(self, df):
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
         assert (
-            df.columns.tolist()
-            == SOLAR_ACTUAL_AND_FORECAST_BY_GEOGRAPHICAL_REGION_COLUMNS
+            list(df.columns) == SOLAR_ACTUAL_AND_FORECAST_BY_GEOGRAPHICAL_REGION_COLUMNS
         )
-        assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()
+        assert self._interval_equals(df, pd.Timedelta("1h"))
 
     @pytest.mark.integration
     @api_vcr.use_cassette(
@@ -288,7 +306,7 @@ class TestErcotAPI(TestHelperMixin):
             "latest",
         )
 
-        assert df["Publish Time"].nunique() == 1
+        assert df["Publish Time"].n_unique() == 1
         self._check_solar_actual_and_forecast_by_geographical_region_hourly(df)
 
     @pytest.mark.integration
@@ -309,7 +327,7 @@ class TestErcotAPI(TestHelperMixin):
 
         self._check_solar_actual_and_forecast_by_geographical_region_hourly(df)
 
-        assert df["Publish Time"].nunique() == 2
+        assert df["Publish Time"].n_unique() == 2
 
         assert df["Interval Start"].min() == self.local_start_of_day(
             date.date(),
@@ -321,6 +339,8 @@ class TestErcotAPI(TestHelperMixin):
     """get_load_forecast_by_model"""
 
     def _check_load_forecast_by_model(self, df):
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
         check_load_forecast_by_model(df)
 
     def test_get_load_forecast_by_model_date_range(self):
@@ -333,7 +353,7 @@ class TestErcotAPI(TestHelperMixin):
         self._check_load_forecast_by_model(df)
 
         # Two hours of data
-        assert df["Publish Time"].nunique() == 2
+        assert df["Publish Time"].n_unique() == 2
 
         assert df["Interval Start"].min() == self.local_start_of_day(date.date())
         assert df["Interval End"].max() >= self.local_start_of_day(
@@ -358,9 +378,11 @@ class TestErcotAPI(TestHelperMixin):
     ]
 
     def _check_load_by_weather_zone(self, df):
-        assert df.columns.tolist() == self.LOAD_BY_WEATHER_ZONE_COLUMNS
-        assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()
-        assert df["Interval Start"].is_monotonic_increasing
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
+        assert list(df.columns) == self.LOAD_BY_WEATHER_ZONE_COLUMNS
+        assert self._interval_equals(df, pd.Timedelta("1h"))
+        assert df["Interval Start"].is_sorted()
 
     def test_get_load_by_weather_zone_historical_date_range(self):
         date = self.local_today() - pd.DateOffset(days=HISTORICAL_DAYS_THRESHOLD * 3)
@@ -379,7 +401,7 @@ class TestErcotAPI(TestHelperMixin):
         ) + pd.DateOffset(days=2)
 
         # 48 hours of data (2 operating days)
-        assert len(df) == 48
+        assert df.height == 48
 
     """get_load_by_forecast_zone"""
 
@@ -395,9 +417,11 @@ class TestErcotAPI(TestHelperMixin):
     ]
 
     def _check_load_by_forecast_zone(self, df):
-        assert df.columns.tolist() == self.LOAD_BY_FORECAST_ZONE_COLUMNS
-        assert (df["Interval End"] - df["Interval Start"]).eq(pd.Timedelta("1h")).all()
-        assert df["Interval Start"].is_monotonic_increasing
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
+        assert list(df.columns) == self.LOAD_BY_FORECAST_ZONE_COLUMNS
+        assert self._interval_equals(df, pd.Timedelta("1h"))
+        assert df["Interval Start"].is_sorted()
 
     def test_get_load_by_forecast_zone_historical_date_range(self):
         date = self.local_today() - pd.DateOffset(days=HISTORICAL_DAYS_THRESHOLD * 3)
@@ -416,12 +440,14 @@ class TestErcotAPI(TestHelperMixin):
         ) + pd.DateOffset(days=2)
 
         # 48 hours of data (2 operating days)
-        assert len(df) == 48
+        assert df.height == 48
 
     """get_as_prices"""
 
     def _check_as_prices(self, df):
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
+        assert list(df.columns) == [
             "Interval Start",
             "Interval End",
             "Market",
@@ -439,7 +465,7 @@ class TestErcotAPI(TestHelperMixin):
         )
 
         assert (df["Market"] == "DAM").all()
-        assert ((df["Interval End"] - df["Interval Start"]) == pd.Timedelta("1h")).all()
+        assert self._interval_equals(df, pd.Timedelta("1h"))
 
     @pytest.mark.integration
     def test_get_as_prices_today_or_latest(self):
@@ -484,15 +510,17 @@ class TestErcotAPI(TestHelperMixin):
 
     """get_mcpc_dam"""
 
-    def _check_get_mcpc_dam(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_get_mcpc_dam(self, df: pl.DataFrame):
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
+        assert list(df.columns) == [
             "Interval Start",
             "Interval End",
             "AS Type",
             "MCPC",
         ]
 
-        assert list(df["AS Type"].unique()) == [
+        assert sorted(df["AS Type"].unique().to_list()) == [
             "ECRS",
             "NSPIN",
             "REGDN",
@@ -547,8 +575,10 @@ class TestErcotAPI(TestHelperMixin):
         "NSPNM",
     }
 
-    def _check_get_dam_asdc_aggregated(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_get_dam_asdc_aggregated(self, df: pl.DataFrame):
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
+        assert list(df.columns) == [
             "Interval Start",
             "Interval End",
             "AS Type",
@@ -577,6 +607,8 @@ class TestErcotAPI(TestHelperMixin):
     """get_as_reports"""
 
     def _check_as_reports(self, df, before_full_columns=False):
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
         """Check AS reports in original wide format"""
         # Earlier datasets only have these limited columns
         if before_full_columns:
@@ -626,7 +658,7 @@ class TestErcotAPI(TestHelperMixin):
                 "Bid Curve - OFFNS",
             ]
 
-        assert df.columns.tolist() == columns
+        assert list(df.columns) == columns
 
         bid_curve_columns = [
             "Bid Curve - RRSPFR",
@@ -642,8 +674,7 @@ class TestErcotAPI(TestHelperMixin):
 
         for column in bid_curve_columns:
             if column in df.columns:
-                # Column should be a list of lists
-                first_non_null_value = df[column].dropna().iloc[0]
+                first_non_null_value = df[column].drop_nulls().head(1).to_list()[0]
                 assert isinstance(first_non_null_value, list)
                 assert all(isinstance(x, list) for x in first_non_null_value)
 
@@ -696,9 +727,11 @@ class TestErcotAPI(TestHelperMixin):
         self._check_as_reports(df)
 
         # Check for the repeated hour
-        assert {"2024-11-03 01:00:00-05:00", "2024-11-03 01:00:00-06:00"}.issubset(
-            set(df["Interval Start"].astype(str).unique()),
-        )
+        fall_back_hours = df.filter(
+            (pl.col("Interval Start").dt.date() == datetime.date(2024, 11, 3))
+            & (pl.col("Interval Start").dt.hour() == 1),
+        )["Interval Start"]
+        assert fall_back_hours.n_unique() == 2
 
     """get_as_reports_dam"""
 
@@ -711,7 +744,7 @@ class TestErcotAPI(TestHelperMixin):
 
         _ErcotChecks()._check_as_reports_dam(df)
 
-        assert df["Interval Start"].dt.date.unique() == date.date()
+        assert df["Interval Start"].dt.date().unique().to_list() == [date.date()]
 
     """get_as_reports_sced"""
 
@@ -725,12 +758,14 @@ class TestErcotAPI(TestHelperMixin):
 
         _ErcotChecks()._check_as_reports_sced(df)
 
-        assert df["SCED Timestamp"].dt.date.unique() == date.date()
+        assert df["SCED Timestamp"].dt.date().unique().to_list() == [date.date()]
 
     """get_as_plan"""
 
     def _check_as_plan(self, df):
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
+        assert list(df.columns) == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -771,7 +806,7 @@ class TestErcotAPI(TestHelperMixin):
 
         assert df["Publish Time"].dt.date.unique().tolist() == [date]
 
-        assert df["ECRS"].notna().any()
+        assert df["ECRS"].is_not_null().all().any()
 
     @pytest.mark.integration
     def test_get_as_plan_historical_date_range(self):
@@ -802,7 +837,7 @@ class TestErcotAPI(TestHelperMixin):
 
         self._check_as_plan(df)
 
-        assert df["ECRS"].isna().all()
+        assert df["ECRS"].is_null().all()
 
         assert df["Interval Start"].min() == self.local_start_of_day(date)
         assert df["Interval End"].max() == self.local_start_of_day(
@@ -818,7 +853,9 @@ class TestErcotAPI(TestHelperMixin):
     """get_lmp_by_settlement_point"""
 
     def _check_lmp_by_settlement_point(self, df):
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
+        assert list(df.columns) == [
             "Interval Start",
             "Interval End",
             "SCED Timestamp",
@@ -885,8 +922,10 @@ class TestErcotAPI(TestHelperMixin):
     """get_hourly_resource_outage_capacity"""
 
     def _check_hourly_resource_outage_capacity(self, df):
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
         # New files
-        assert df.columns.tolist() == [
+        assert list(df.columns) == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -905,7 +944,7 @@ class TestErcotAPI(TestHelperMixin):
             "Total New Equip Resource MW Zone West",
             "Total New Equip Resource MW Zone Houston",
             "Total New Equip Resource MW",
-        ] or df.columns.tolist() == [
+        ] or list(df.columns) == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -944,7 +983,7 @@ class TestErcotAPI(TestHelperMixin):
         self._check_hourly_resource_outage_capacity(df)
 
         assert (df["Publish Time"].dt.date == historical_date).all()
-        assert df["Publish Time"].nunique() == 24
+        assert df["Publish Time"].n_unique() == 24
 
         assert df["Interval Start"].min() == self.local_start_of_day(historical_date)
         assert df["Interval End"].max() >= self.local_start_of_day(
@@ -969,7 +1008,7 @@ class TestErcotAPI(TestHelperMixin):
             start_date,
             (start_date + pd.DateOffset(days=1)).date(),
         ]
-        assert df["Publish Time"].nunique() == 2 * 24
+        assert df["Publish Time"].n_unique() == 2 * 24
 
         assert df["Interval Start"].min() == self.local_start_of_day(start_date)
         assert df["Interval End"].max() >= self.local_start_of_day(
@@ -979,7 +1018,9 @@ class TestErcotAPI(TestHelperMixin):
     """lmp_by_bus"""
 
     def _check_lmp_by_bus(self, df):
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
+        assert list(df.columns) == [
             "Interval Start",
             "Interval End",
             "SCED Timestamp",
@@ -989,13 +1030,19 @@ class TestErcotAPI(TestHelperMixin):
             "LMP",
         ]
 
-        assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
+        assert self._is_tz_datetime(
+            df.schema["Interval Start"],
+            self.iso.default_timezone,
+        )
+        assert self._is_tz_datetime(
+            df.schema["Interval End"],
+            self.iso.default_timezone,
+        )
 
         assert (df["Market"] == Markets.REAL_TIME_SCED.name).all()
         assert (df["Location Type"] == ELECTRICAL_BUS_LOCATION_TYPE).all()
 
-        assert df.dtypes["LMP"] == "float64"
+        assert df.schema["LMP"].is_float()
 
         assert (
             (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(minutes=5)
@@ -1052,7 +1099,9 @@ class TestErcotAPI(TestHelperMixin):
     """lmp_by_bus_dam"""
 
     def _check_lmp_by_bus_dam(self, df):
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
+        assert list(df.columns) == [
             "Interval Start",
             "Interval End",
             "Market",
@@ -1061,17 +1110,23 @@ class TestErcotAPI(TestHelperMixin):
             "LMP",
         ]
 
-        assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
+        assert self._is_tz_datetime(
+            df.schema["Interval Start"],
+            self.iso.default_timezone,
+        )
+        assert self._is_tz_datetime(
+            df.schema["Interval End"],
+            self.iso.default_timezone,
+        )
 
         assert (df["Market"] == Markets.DAY_AHEAD_HOURLY.name).all()
 
         assert df.dtypes["Location"] == "object"
         assert (df["Location Type"] == ELECTRICAL_BUS_LOCATION_TYPE).all()
 
-        assert df.dtypes["LMP"] == "float64"
+        assert df.schema["LMP"].is_float()
 
-        assert ((df["Interval End"] - df["Interval Start"]) == pd.Timedelta("1h")).all()
+        assert self._interval_equals(df, pd.Timedelta("1h"))
 
     @pytest.mark.integration
     def test_get_lmp_by_bus_dam_today_and_latest(self):
@@ -1170,7 +1225,9 @@ class TestErcotAPI(TestHelperMixin):
     ]
 
     def _check_shadow_prices_dam(self, df):
-        assert df.columns.tolist() == self.expected_shadow_prices_dam_columns
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
+        assert list(df.columns) == self.expected_shadow_prices_dam_columns
 
         self._check_time_columns(
             df,
@@ -1180,7 +1237,8 @@ class TestErcotAPI(TestHelperMixin):
 
         assert (
             df.loc[df["Contingency Name"] == "BASE CASE", "Limiting Facility"]
-            .isna()
+            .is_null()
+            .all()
             .all()
         )
 
@@ -1273,7 +1331,9 @@ class TestErcotAPI(TestHelperMixin):
     ]
 
     def _check_shadow_prices_sced(self, df):
-        assert df.columns.tolist() == self.expected_shadow_prices_sced_columns
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
+        assert list(df.columns) == self.expected_shadow_prices_sced_columns
 
         time_cols = ["Interval Start", "Interval End", "SCED Timestamp"]
 
@@ -1349,7 +1409,9 @@ class TestErcotAPI(TestHelperMixin):
     """get_spp_real_time_15_min"""
 
     def _check_spp_real_time_15_min(self, df):
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
+        assert list(df.columns) == [
             "Time",
             "Interval Start",
             "Interval End",
@@ -1389,7 +1451,7 @@ class TestErcotAPI(TestHelperMixin):
 
         self._check_spp_real_time_15_min(df)
 
-        assert df["Interval Start"].nunique() == 96 * 2
+        assert df["Interval Start"].n_unique() == 96 * 2
 
         assert df["Interval Start"].min() == self.local_start_of_day(start_date)
         assert df["Interval End"].max() == self.local_start_of_day(end_date)
@@ -1397,7 +1459,9 @@ class TestErcotAPI(TestHelperMixin):
     """get_spp_day_ahead_hourly"""
 
     def _check_spp_day_ahead_hourly(self, df):
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+        assert isinstance(df, pl.DataFrame)
+        assert list(df.columns) == [
             "Time",
             "Interval Start",
             "Interval End",
@@ -1434,7 +1498,7 @@ class TestErcotAPI(TestHelperMixin):
 
         self._check_spp_day_ahead_hourly(df)
 
-        assert df["Interval Start"].nunique() == 24 * 2
+        assert df["Interval Start"].n_unique() == 24 * 2
 
         assert df["Interval Start"].min() == self.local_start_of_day(start_date)
         assert df["Interval End"].max() == self.local_start_of_day(end_date)
@@ -1478,7 +1542,7 @@ class TestErcotAPI(TestHelperMixin):
         assert df_load[df_load["Resource Name"] == resource_name].shape[0] == 24
 
         for df in [df_load, df_gen]:
-            assert df.columns.tolist() == DAM_RESOURCE_AS_OFFERS_COLUMNS
+            assert list(df.columns) == DAM_RESOURCE_AS_OFFERS_COLUMNS
 
             assert df["Interval Start"].min() == pd.Timestamp(date_with_issue)
             assert df["Interval End"].max() == pd.Timestamp(
@@ -1557,8 +1621,9 @@ class TestErcotAPI(TestHelperMixin):
         check_60_day_sced_disclosure(df_dict)
 
         for df in df_dict.values():
-            assert df["Interval Start"].min() == start_date
-            assert df["Interval End"].max() == end_date
+            if "Interval Start" in df.columns:
+                assert df["Interval Start"].min() == start_date
+                assert df["Interval End"].max() == end_date
 
     """get_historical_data"""
 
@@ -1613,7 +1678,7 @@ class TestErcotAPI(TestHelperMixin):
         # This a forecast
         assert data["DELIVERY_DATE"].max().date() == datetime.date(2023, 1, 9)
         # Any change in the shape would be a regression since this is historical data
-        assert data.shape == (10368, 31)
+        assert (data.height, data.width) == (10368, 31)
 
         start_date = datetime.date(2020, 12, 1)
         end_date = datetime.date(2020, 12, 2)
@@ -1652,7 +1717,7 @@ class TestErcotAPI(TestHelperMixin):
 
         # Since this is historical data, we do not except the shape to change. A change
         # would be a regression.
-        assert data.shape == (5184, 19)
+        assert (data.height, data.width) == (5184, 19)
 
     """hit_ercot_api"""
 
@@ -1678,7 +1743,10 @@ class TestErcotAPI(TestHelperMixin):
             actual_by_wzn_endpoint,
             operatingDayFrom=two_days_ago,
         )
-        result_rows, result_cols = two_days_actual_by_wzn.shape
+        result_rows, result_cols = (
+            two_days_actual_by_wzn.height,
+            two_days_actual_by_wzn.width,
+        )
         assert result_rows in {24, 48}
         assert result_cols == 12
 
@@ -1697,8 +1765,8 @@ class TestErcotAPI(TestHelperMixin):
             operatingDayFrom=two_days_ago,
             totalFrom=in_between_load,
         )
-        assert len(higher_loads_result["Total"]) < result_rows
-        assert all(higher_loads_result["Total"] > in_between_load)
+        assert higher_loads_result.height < result_rows
+        assert higher_loads_result.filter(pl.col("Total") <= in_between_load).is_empty()
 
         """
         Now we test the page_size and max_pages arguments. We know that our two days
@@ -1714,7 +1782,7 @@ class TestErcotAPI(TestHelperMixin):
             wowWhatAFakeParameter=True,
             thisOneIsAlsoFake=42,
         )
-        assert small_pages_result.shape == (20, 12)
+        assert (small_pages_result.height, small_pages_result.width) == (20, 12)
 
     """endpoints_map"""
 
@@ -1791,7 +1859,7 @@ class TestErcotAPI(TestHelperMixin):
         ):
             df = self.iso.get_indicative_lmp_by_settlement_point(date, end)
 
-            assert df.columns.tolist() == [
+            assert list(df.columns) == [
                 "RTD Timestamp",
                 "Interval Start",
                 "Interval End",
@@ -1800,9 +1868,15 @@ class TestErcotAPI(TestHelperMixin):
                 "LMP",
             ]
 
-            assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
-            assert df.dtypes["Interval End"] == "datetime64[ns, US/Central]"
-            assert df.dtypes["LMP"] == "float64"
+            assert self._is_tz_datetime(
+                df.schema["Interval Start"],
+                self.iso.default_timezone,
+            )
+            assert self._is_tz_datetime(
+                df.schema["Interval End"],
+                self.iso.default_timezone,
+            )
+            assert df.schema["LMP"].is_float()
             assert (
                 (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(minutes=5)
             ).all()
@@ -1815,8 +1889,8 @@ class TestErcotAPI(TestHelperMixin):
 
     """get_cop_adjustment_period_snapshot_60_day"""
 
-    def _check_cop_adjustment_period_snapshot_60_day(self, df: pd.DataFrame) -> None:
-        assert df.columns.tolist() == [
+    def _check_cop_adjustment_period_snapshot_60_day(self, df: pl.DataFrame) -> None:
+        assert list(df.columns) == [
             "Interval Start",
             "Interval End",
             "Resource Name",
@@ -1839,12 +1913,10 @@ class TestErcotAPI(TestHelperMixin):
             "Hour Beginning Planned SOC",
         ]
 
-        assert (
-            df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
-        ).all()
+        assert self._interval_equals(df, pd.Timedelta(hours=1))
 
-        assert df["Resource Name"].dtype == object
-        assert df["QSE"].dtype == object
+        assert df.schema["Resource Name"] == pl.Utf8
+        assert df.schema["QSE"] == pl.Utf8
 
     def test_get_cop_adjustment_period_snapshot_60_day_date(self):
         # Check the most recent date that data is available
@@ -1862,7 +1934,7 @@ class TestErcotAPI(TestHelperMixin):
             date,
         ) + pd.Timedelta(hours=23)
 
-        assert df["RRS"].isnull().all()
+        assert df["RRS"].is_null().all()
 
         for col in [
             "RRSPFR",
@@ -1873,7 +1945,7 @@ class TestErcotAPI(TestHelperMixin):
             "Maximum SOC",
             "Hour Beginning Planned SOC",
         ]:
-            assert df[col].notnull().all()
+            assert df[col].is_not_null().all()
 
     def test_get_cop_adjustment_period_snapshot_60_day_historical_date_range(self):
         start_date = self.local_start_of_today() - pd.DateOffset(days=500)
@@ -1893,7 +1965,7 @@ class TestErcotAPI(TestHelperMixin):
         assert df["Interval Start"].max() == end_date - pd.Timedelta(hours=1)
 
         # Column only present in older data. We add it as null to keep columns same
-        assert df["RRS"].isnull().all()
+        assert df["RRS"].is_null().all()
 
     def test_get_cop_adjustment_period_snapshot_60_day_missing_columns_are_null(self):
         # This is an early date when many columns were not present
@@ -1916,9 +1988,9 @@ class TestErcotAPI(TestHelperMixin):
             "Maximum SOC",
             "Hour Beginning Planned SOC",
         ]:
-            assert df[col].isnull().all()
+            assert df[col].is_null().all()
 
-        assert df["RRS"].notna().all()
+        assert df["RRS"].is_not_null().all()
 
         assert df["Interval Start"].min() == self.local_start_of_day(date)
         assert df["Interval Start"].max() == self.local_start_of_day(
@@ -1927,16 +1999,16 @@ class TestErcotAPI(TestHelperMixin):
 
     """get_system_load_charging_4_seconds"""
 
-    def _check_system_load_charging_4_seconds(self, df: pd.DataFrame) -> None:
-        assert df.columns.tolist() == [
+    def _check_system_load_charging_4_seconds(self, df: pl.DataFrame) -> None:
+        assert list(df.columns) == [
             "Time",
             "System Demand",
             "ESR Charging MW",
         ]
 
-        assert df.dtypes["Time"] == "datetime64[ns, US/Central]"
-        assert df.dtypes["System Demand"] == "float64"
-        assert df.dtypes["ESR Charging MW"] == "float64"
+        assert self._is_tz_datetime(df.schema["Time"], self.iso.default_timezone)
+        assert df.schema["System Demand"].is_float()
+        assert df.schema["ESR Charging MW"].is_float()
 
     def test_get_system_load_charging_4_seconds_today(self):
         with api_vcr.use_cassette(

--- a/gridstatus/tests/source_specific/test_gridstatus.py
+++ b/gridstatus/tests/source_specific/test_gridstatus.py
@@ -32,7 +32,7 @@ def test_list_isos():
 
 
 def test_get_iso():
-    for iso in gridstatus.list_isos()["Id"].values:
+    for iso in gridstatus.list_isos()["Id"].to_list():
         assert issubclass(gridstatus.get_iso(iso), ISOBase)
 
 

--- a/gridstatus/tests/source_specific/test_ieso.py
+++ b/gridstatus/tests/source_specific/test_ieso.py
@@ -3,8 +3,8 @@ from xml.etree import ElementTree
 
 import numpy as np
 import pandas as pd
+import polars as pl
 import pytest
-from pandas.core.dtypes.common import is_numeric_dtype
 
 from gridstatus import IESO, utils
 from gridstatus.base import NotSupported
@@ -81,7 +81,7 @@ class TestIESO(BaseTestISO):
         end = yesterday.replace(hour=6, minute=5, second=0, microsecond=0)
         df = self.iso.get_fuel_mix(date=start, end=end)
         # ignore last row, since it is sometime midnight of next day
-        assert df[TIME_COLUMN].iloc[:-1].dt.date.unique().tolist() == [
+        assert df.slice(0, df.height - 1)[TIME_COLUMN].dt.date().unique().to_list() == [
             yesterday.date(),
         ]
         self._check_fuel_mix(df)
@@ -108,27 +108,27 @@ class TestIESO(BaseTestISO):
             f"test_get_generator_report_hourly_historical_{date.date()}.yaml",
         ):
             df = self.iso.get_generator_report_hourly(date_str)
-            assert isinstance(df, pd.DataFrame)
-            assert df.loc[0][TIME_COLUMN].strftime("%m/%d/%Y") == date_str
-            assert df.loc[0][TIME_COLUMN].tz is not None
+            assert isinstance(df, pl.DataFrame)
+            assert df[0, TIME_COLUMN].strftime("%m/%d/%Y") == date_str
+            assert df[0, TIME_COLUMN].tzinfo is not None
             self._check_get_generator_report_hourly(df)
 
             timestamp_obj = date.date()
             df = self.iso.get_generator_report_hourly(timestamp_obj)
-            assert isinstance(df, pd.DataFrame)
-            assert df.loc[0][TIME_COLUMN].strftime(
+            assert isinstance(df, pl.DataFrame)
+            assert df[0, TIME_COLUMN].strftime(
                 "%Y%m%d",
             ) == timestamp_obj.strftime("%Y%m%d")
-            assert df.loc[0][TIME_COLUMN].tz is not None
+            assert df[0, TIME_COLUMN].tzinfo is not None
             self._check_get_generator_report_hourly(df)
 
             date_obj = date.date()
             df = self.iso.get_generator_report_hourly(date_obj)
-            assert isinstance(df, pd.DataFrame)
-            assert df.loc[0][TIME_COLUMN].strftime(
+            assert isinstance(df, pl.DataFrame)
+            assert df[0, TIME_COLUMN].strftime(
                 "%Y%m%d",
             ) == date_obj.strftime("%Y%m%d")
-            assert df.loc[0][TIME_COLUMN].tz is not None
+            assert df[0, TIME_COLUMN].tzinfo is not None
             self._check_get_generator_report_hourly(df)
 
     def test_get_generator_report_hourly_historical_with_date_range(self):
@@ -143,7 +143,7 @@ class TestIESO(BaseTestISO):
                 end=end.date(),
             )
             self._check_get_generator_report_hourly(df)
-            assert df[TIME_COLUMN].dt.day.nunique() == 7
+            assert df[TIME_COLUMN].dt.day().n_unique() == 7
 
     def test_get_generator_report_hourly_range_two_days_with_end(self):
         start = (
@@ -176,7 +176,9 @@ class TestIESO(BaseTestISO):
             f"test_get_generator_report_hourly_start_end_same_day_{start.date()}.yaml",
         ):
             df = self.iso.get_generator_report_hourly(date=start, end=end)
-            assert df[TIME_COLUMN].iloc[:-1].dt.date.unique().tolist() == [start.date()]
+            assert df.slice(0, df.height - 1)[
+                TIME_COLUMN
+            ].dt.date().unique().to_list() == [start.date()]
             self._check_get_generator_report_hourly(df)
 
     def test_get_generator_report_hourly_latest(self):
@@ -296,24 +298,16 @@ class TestIESO(BaseTestISO):
     def test_get_storage_today(self):
         pass
 
-    # TODO: this is overridden in the base class
     def _check_time_columns(self, df, instant_or_interval="interval"):
-        assert isinstance(df, pd.DataFrame)
-
-        time_cols = [TIME_COLUMN, "Interval End"]
-        ordered_by_col = TIME_COLUMN
-
-        assert time_cols == df.columns[: len(time_cols)].tolist()
-        # check all time cols are localized timestamps
-        for col in time_cols:
-            assert isinstance(df.loc[0][col], pd.Timestamp)
-            assert df.loc[0][col].tz is not None
-
-        self._check_ordered_by_time(df, ordered_by_col)
+        super()._check_time_columns(
+            df,
+            instant_or_interval=instant_or_interval,
+            skip_column_named_time=True,
+        )
 
     def _check_fuel_mix(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.name is None
+        assert isinstance(df, pl.DataFrame)
+        assert True
 
         time_type = "interval"
         self._check_time_columns(df, instant_or_interval=time_type)
@@ -331,8 +325,8 @@ class TestIESO(BaseTestISO):
         ]
 
     def _check_get_generator_report_hourly(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.shape[0] >= 0
+        assert isinstance(df, pl.DataFrame)
+        assert df.height >= 0
 
         time_type = "interval"
         self._check_time_columns(df, instant_or_interval=time_type)
@@ -344,26 +338,28 @@ class TestIESO(BaseTestISO):
             "Forecast MW",
         ]:
             assert col in df.columns
-            assert is_numeric_dtype(df[col])
+            assert df.schema[col] in (pl.Float64, pl.Int64, pl.Int32)
 
         for col in ["Generator Name", "Fuel Type"]:
             assert col in df.columns
-            assert df[col].dtype == "object"
+            assert df.schema[col] == pl.Utf8
 
-        assert list(df["Fuel Type"].unique()) == [
-            "BIOFUEL",
-            "GAS",
-            "HYDRO",
-            "NUCLEAR",
-            "OTHER",
-            "SOLAR",
-            "WIND",
-        ]
+        assert sorted(df["Fuel Type"].unique().to_list()) == sorted(
+            [
+                "BIOFUEL",
+                "GAS",
+                "HYDRO",
+                "NUCLEAR",
+                "OTHER",
+                "SOLAR",
+                "WIND",
+            ],
+        )
 
     """get_mcp_real_time_5_min"""
 
-    def _check_mcp(self, df: pd.DataFrame) -> None:
-        assert df.columns.tolist() == [
+    def _check_mcp(self, df: pl.DataFrame) -> None:
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Location",
@@ -373,7 +369,7 @@ class TestIESO(BaseTestISO):
             "Energy",
         ]
 
-        assert sorted(df["Location"].unique()) == [
+        assert sorted(df["Location"].unique().to_list()) == [
             "Manitoba",
             "Manitoba SK",
             "Michigan",
@@ -391,9 +387,11 @@ class TestIESO(BaseTestISO):
             "Quebec X2Y",
         ]
 
-        assert (
-            df["Interval End"] - df["Interval Start"] == pd.Timedelta(minutes=5)
-        ).all()
+        assert df.select(
+            (pl.col("Interval End") - pl.col("Interval Start"))
+            .eq(pl.duration(minutes=5))
+            .all(),
+        ).item()
 
     def test_get_mcp_real_time_5_min_date_range(self):
         with pytest.raises(NotSupported):
@@ -430,11 +428,13 @@ class TestIESO(BaseTestISO):
         ):
             df = self.iso.get_hoep_real_time_hourly(start, end)
 
-        assert df.columns.tolist() == ["Interval Start", "Interval End", "HOEP"]
+        assert df.columns == ["Interval Start", "Interval End", "HOEP"]
 
-        assert (
-            df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
-        ).all()
+        assert df.select(
+            (pl.col("Interval End") - pl.col("Interval Start"))
+            .eq(pl.duration(hours=1))
+            .all(),
+        ).item()
         assert df["Interval Start"].min() == start
         assert df["Interval End"].max() == self.local_start_of_day(
             end.tz_localize(None) + pd.DateOffset(days=1),
@@ -451,7 +451,7 @@ class TestIESO(BaseTestISO):
             df = self.iso.get_hoep_historical_hourly(start)
 
         # NOTE: different columns from real-time
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "HOEP",
@@ -463,9 +463,11 @@ class TestIESO(BaseTestISO):
             "OR 30 Min",
         ]
 
-        assert (
-            df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
-        ).all()
+        assert df.select(
+            (pl.col("Interval End") - pl.col("Interval Start"))
+            .eq(pl.duration(hours=1))
+            .all(),
+        ).item()
         assert df["Interval Start"].min() == self.local_start_of_day("2024-01-01")
         assert df["Interval End"].max() == self.local_start_of_day("2025-01-01")
 
@@ -611,7 +613,7 @@ class TestIESO(BaseTestISO):
         with file_vcr.use_cassette(f"test_get_resource_adequacy_report_{date}.yaml"):
             df = self.iso.get_resource_adequacy_report(date, vintage="latest")
 
-        assert isinstance(df, pd.DataFrame)
+        assert isinstance(df, pl.DataFrame)
         assert df.shape == (24, 99)  # 24 rows and 99 columns for each file
         for col in self.REQUIRED_RESOURCE_ADEQUACY_COLUMNS:
             assert col in df.columns
@@ -619,9 +621,11 @@ class TestIESO(BaseTestISO):
         assert self._check_is_datetime_type(df["Interval Start"])
         assert self._check_is_datetime_type(df["Interval End"])
         assert self._check_is_datetime_type(df["Publish Time"])
-        assert (
-            (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(hours=1)
-        ).all()
+        assert df.select(
+            (pl.col("Interval End") - pl.col("Interval Start"))
+            .eq(pl.duration(hours=1))
+            .all(),
+        ).item()
 
     @pytest.mark.parametrize(
         "date, end",
@@ -633,12 +637,12 @@ class TestIESO(BaseTestISO):
         ):
             df = self.iso.get_resource_adequacy_report(date, end=end, vintage="latest")
 
-        assert isinstance(df, pd.DataFrame)
-        assert df.shape[1] == 99
+        assert isinstance(df, pl.DataFrame)
+        assert df.width == 99
         for col in self.REQUIRED_RESOURCE_ADEQUACY_COLUMNS:
             assert col in df.columns
         expected_rows = ((pd.Timestamp(end) - pd.Timestamp(date)).days) * 24
-        assert df.shape[0] == expected_rows
+        assert df.height == expected_rows
 
     @pytest.mark.parametrize(
         "date, end",
@@ -650,8 +654,8 @@ class TestIESO(BaseTestISO):
         ):
             df = self.iso.get_resource_adequacy_report(date, end=end, vintage="all")
 
-        assert isinstance(df, pd.DataFrame)
-        assert df.shape[1] == 99
+        assert isinstance(df, pl.DataFrame)
+        assert df.width == 99
         for col in self.REQUIRED_RESOURCE_ADEQUACY_COLUMNS:
             assert col in df.columns
 
@@ -704,8 +708,8 @@ class TestIESO(BaseTestISO):
                 last_modified,
             )
 
-        assert isinstance(df, pd.DataFrame)
-        assert df.shape[1] == 99
+        assert isinstance(df, pl.DataFrame)
+        assert df.width == 99
         for col in self.REQUIRED_RESOURCE_ADEQUACY_COLUMNS:
             assert col in df.columns
         assert (df["Last Modified"] > last_modified).all()
@@ -786,7 +790,7 @@ class TestIESO(BaseTestISO):
         ):
             df = self.iso.get_forecast_surplus_baseload_generation(yesterday)
 
-        assert isinstance(df, pd.DataFrame)
+        assert isinstance(df, pl.DataFrame)
         self._check_forecast_surplus_baseload(df)
 
         assert df["Interval Start"].min().date() == today.date()
@@ -801,7 +805,7 @@ class TestIESO(BaseTestISO):
         ):
             df = self.iso.get_forecast_surplus_baseload_generation(start, end=end)
 
-        assert isinstance(df, pd.DataFrame)
+        assert isinstance(df, pl.DataFrame)
         self._check_forecast_surplus_baseload(df)
 
         assert df["Interval Start"].min().date() == start.date() + pd.Timedelta(days=1)
@@ -813,10 +817,10 @@ class TestIESO(BaseTestISO):
         ):
             df = self.iso.get_forecast_surplus_baseload_generation("latest")
 
-        assert isinstance(df, pd.DataFrame)
+        assert isinstance(df, pl.DataFrame)
         self._check_forecast_surplus_baseload(df)
 
-    def _check_forecast_surplus_baseload(self, df: pd.DataFrame) -> None:
+    def _check_forecast_surplus_baseload(self, df: pl.DataFrame) -> None:
         required_columns = [
             "Interval Start",
             "Interval End",
@@ -833,13 +837,15 @@ class TestIESO(BaseTestISO):
         assert self._check_is_datetime_type(df["Interval End"])
         assert self._check_is_datetime_type(df["Publish Time"])
 
-        assert (
-            df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
-        ).all()
+        assert df.select(
+            (pl.col("Interval End") - pl.col("Interval Start"))
+            .eq(pl.duration(hours=1))
+            .all(),
+        ).item()
 
         assert (
             df["Surplus State"]
-            .isin(
+            .is_in(
                 [
                     "No Surplus",
                     "Managed with Exports",
@@ -850,12 +856,12 @@ class TestIESO(BaseTestISO):
             .all()
         )
 
-        assert df["Action"].isin(["Other", "Manoeuvre", "Shutdown", None]).all()
+        assert df["Action"].is_in(["Other", "Manoeuvre", "Shutdown", None]).all()
 
-        assert is_numeric_dtype(df["Surplus Baseload MW"])
-        assert is_numeric_dtype(df["Export Forecast MW"])
+        assert df.schema["Surplus Baseload MW"] == pl.Float64
+        assert df.schema["Export Forecast MW"] == pl.Float64
 
-        publish_days = df["Publish Time"].nunique()
+        publish_days = df["Publish Time"].n_unique()
         assert publish_days == len(
             pd.date_range(
                 df["Publish Time"].min().date(),
@@ -863,7 +869,7 @@ class TestIESO(BaseTestISO):
                 freq="D",
             ),
         )
-        assert df["Publish Time"].iloc[0].date() == df[
+        assert df[0, "Publish Time"].date() == df[
             "Interval Start"
         ].min().date() - pd.Timedelta(days=1)
         assert len(df) == 24 * 10 * publish_days
@@ -951,12 +957,16 @@ class TestIESO(BaseTestISO):
         )
 
     def _check_intertie_schedule_flow(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert not df.empty
+        assert isinstance(df, pl.DataFrame)
+        assert not df.is_empty()
         assert self._check_is_datetime_type(df[TIME_COLUMN])
         assert self._check_is_datetime_type(df["Interval End"])
         assert self._check_is_datetime_type(df["Publish Time"])
-        assert (df["Interval End"] - df[TIME_COLUMN] == pd.Timedelta(hours=1)).all()
+        assert df.select(
+            (pl.col("Interval End") - pl.col(TIME_COLUMN))
+            .eq(pl.duration(hours=1))
+            .all(),
+        ).item()
 
         zone_prefixes = ["Manitoba", "Michigan", "Minnesota", "New York"]
         flow_types = ["Flow", "Import", "Export"]
@@ -965,11 +975,11 @@ class TestIESO(BaseTestISO):
             for flow_type in flow_types:
                 col_name = f"{zone} {flow_type}"
                 assert col_name in df.columns
-                assert is_numeric_dtype(df[col_name])
+                assert df.schema[col_name] in (pl.Float64, pl.Int64, pl.Int32)
 
         pq_columns = [col for col in df.columns if col.startswith("PQ")]
         assert len(pq_columns) > 0
-        assert df[TIME_COLUMN].equals(df[TIME_COLUMN].sort_values())
+        assert df[TIME_COLUMN].equals(df[TIME_COLUMN].sort())
 
     """get_intertie_actual_schedule_flow_hourly"""
 
@@ -981,13 +991,16 @@ class TestIESO(BaseTestISO):
         for col in time_columns:
             assert self._check_is_datetime_type(df[col])
 
-        assert df[TIME_COLUMN].is_monotonic_increasing
+        assert df[TIME_COLUMN].is_sorted()
 
-        assert df[
-            [col for col in df.columns if col not in time_columns]
-        ].dtypes.unique() == np.dtype("float64")
+        numeric_cols = [col for col in df.columns if col not in time_columns]
+        assert all(df.schema[col] == pl.Float64 for col in numeric_cols)
 
-        assert (df["Interval End"] - df[TIME_COLUMN] == pd.Timedelta(hours=1)).all()
+        assert df.select(
+            (pl.col("Interval End") - pl.col(TIME_COLUMN))
+            .eq(pl.duration(hours=1))
+            .all(),
+        ).item()
 
     def test_get_intertie_actual_schedule_flow_hourly_latest(self):
         with file_vcr.use_cassette(
@@ -999,7 +1012,7 @@ class TestIESO(BaseTestISO):
 
         # Check that the data is for today
         today = pd.Timestamp.now(tz=self.default_timezone).normalize()
-        assert (df[TIME_COLUMN].dt.date == today.date()).all()
+        assert (df[TIME_COLUMN].dt.date() == today.date()).all()
 
     def test_get_intertie_actual_schedule_flow_hourly_historical_date_range(self):
         start = pd.Timestamp.now(tz=self.default_timezone).normalize() - pd.DateOffset(
@@ -1028,14 +1041,17 @@ class TestIESO(BaseTestISO):
         for col in time_columns:
             assert self._check_is_datetime_type(df[col])
 
-        assert df[TIME_COLUMN].is_monotonic_increasing
+        assert df[TIME_COLUMN].is_sorted()
 
-        assert (df["Interval End"] - df[TIME_COLUMN] == pd.Timedelta(minutes=5)).all()
+        assert df.select(
+            (pl.col("Interval End") - pl.col(TIME_COLUMN))
+            .eq(pl.duration(minutes=5))
+            .all(),
+        ).item()
 
         # Make sure all columns except for the time columns are numeric
-        assert df[
-            [col for col in df.columns if col not in time_columns]
-        ].dtypes.unique() == np.dtype("float64")
+        numeric_cols = [col for col in df.columns if col not in time_columns]
+        assert all(df.schema[col] == pl.Float64 for col in numeric_cols)
 
     def test_get_intertie_flow_5_min_latest(self):
         with file_vcr.use_cassette(
@@ -1047,7 +1063,7 @@ class TestIESO(BaseTestISO):
 
         # Check that the data is for today
         today = pd.Timestamp.now(tz=self.default_timezone).normalize()
-        assert (df[TIME_COLUMN].dt.date == today.date()).all()
+        assert (df[TIME_COLUMN].dt.date() == today.date()).all()
 
     def test_get_intertie_flow_5_min_historical_date_range(self):
         start = pd.Timestamp.now(tz=self.default_timezone).normalize() - pd.DateOffset(
@@ -1076,14 +1092,17 @@ class TestIESO(BaseTestISO):
         for col in time_columns:
             assert self._check_is_datetime_type(df[col])
 
-        assert df[TIME_COLUMN].is_monotonic_increasing
+        assert df[TIME_COLUMN].is_sorted()
 
-        assert (df["Interval End"] - df[TIME_COLUMN] == pd.Timedelta(minutes=5)).all()
+        assert df.select(
+            (pl.col("Interval End") - pl.col(TIME_COLUMN))
+            .eq(pl.duration(minutes=5))
+            .all(),
+        ).item()
 
         # Make sure all columns except for the time columns are numeric
-        assert df[
-            [col for col in df.columns if col not in time_columns]
-        ].dtypes.unique() == np.dtype("float64")
+        numeric_cols = [col for col in df.columns if col not in time_columns]
+        assert all(df.schema[col] == pl.Float64 for col in numeric_cols)
 
     def test_get_intertie_limits_real_time_5_min_latest(self):
         with file_vcr.use_cassette(
@@ -1095,7 +1114,7 @@ class TestIESO(BaseTestISO):
 
         # Check that the data is for today
         today = pd.Timestamp.now(tz=self.default_timezone).normalize()
-        assert (df[TIME_COLUMN].dt.date == today.date()).all()
+        assert (df[TIME_COLUMN].dt.date() == today.date()).all()
 
     def test_get_intertie_limits_real_time_5_min_historical_date_range(self):
         start = pd.Timestamp.now(tz=self.default_timezone).normalize() - pd.DateOffset(
@@ -1124,14 +1143,17 @@ class TestIESO(BaseTestISO):
         for col in time_columns:
             assert self._check_is_datetime_type(df[col])
 
-        assert df[TIME_COLUMN].is_monotonic_increasing
+        assert df[TIME_COLUMN].is_sorted()
 
-        assert (df["Interval End"] - df[TIME_COLUMN] == pd.Timedelta(hours=1)).all()
+        assert df.select(
+            (pl.col("Interval End") - pl.col(TIME_COLUMN))
+            .eq(pl.duration(hours=1))
+            .all(),
+        ).item()
 
         # Make sure all columns except for the time columns are numeric
-        assert df[
-            [col for col in df.columns if col not in time_columns]
-        ].dtypes.unique() == np.dtype("float64")
+        numeric_cols = [col for col in df.columns if col not in time_columns]
+        assert all(df.schema[col] == pl.Float64 for col in numeric_cols)
 
     def test_get_intertie_limits_day_ahead_hourly_latest(self):
         with file_vcr.use_cassette(
@@ -1145,7 +1167,7 @@ class TestIESO(BaseTestISO):
         tomorrow = pd.Timestamp.now(
             tz=self.default_timezone,
         ).normalize() + pd.DateOffset(days=1)
-        assert df[TIME_COLUMN].iloc[0].normalize() == tomorrow
+        assert pd.Timestamp(df[0, TIME_COLUMN]).normalize() == tomorrow
 
     def test_get_intertie_limits_day_ahead_hourly_historical_date_range(self):
         start = pd.Timestamp.now(tz=self.default_timezone).normalize() - pd.DateOffset(
@@ -1168,7 +1190,7 @@ class TestIESO(BaseTestISO):
 
     def _check_lmp_data(
         self,
-        data: pd.DataFrame,
+        data: pl.DataFrame,
         interval_minutes: int,
         predispatch: bool = False,
     ) -> None:
@@ -1185,22 +1207,23 @@ class TestIESO(BaseTestISO):
         if predispatch:
             column_list.insert(column_list.index("Interval End") + 1, "Publish Time")
 
-        assert data.columns.tolist() == column_list
+        assert data.columns == column_list
 
         time_type = "interval"
         self._check_time_columns(data, instant_or_interval=time_type)
 
         assert np.allclose(
-            data["LMP"],
-            data["Energy"] + data["Loss"] + data["Congestion"],
+            data["LMP"].to_numpy(),
+            (data["Energy"] + data["Loss"] + data["Congestion"]).to_numpy(),
         )
 
-        assert (
-            data["Interval End"] - data["Interval Start"]
-            == pd.Timedelta(minutes=interval_minutes)
-        ).all()
+        assert data.select(
+            (pl.col("Interval End") - pl.col("Interval Start"))
+            .eq(pl.duration(minutes=interval_minutes))
+            .all(),
+        ).item()
 
-        assert data[TIME_COLUMN].is_monotonic_increasing
+        assert data[TIME_COLUMN].is_sorted()
 
         # Make sure none of the locations have :LMP or :HUB in them
         assert not data["Location"].str.contains(":LMP").any()
@@ -1214,7 +1237,7 @@ class TestIESO(BaseTestISO):
 
         # Check that the data is for today
         today = pd.Timestamp.now(tz=self.default_timezone).normalize()
-        assert (data[TIME_COLUMN].dt.date == today.date()).all()
+        assert (data[TIME_COLUMN].dt.date() == today.date()).all()
 
     def test_get_lmp_real_time_5_min_historical_date_range(self):
         start = pd.Timestamp.now(tz=self.default_timezone).normalize() - pd.DateOffset(
@@ -1246,8 +1269,8 @@ class TestIESO(BaseTestISO):
         # today or tomorrow.
         today = pd.Timestamp.now(tz=self.default_timezone).normalize()
         tomorrow = today + pd.Timedelta(days=1)
-        assert ((data[TIME_COLUMN].dt.date == today.date()).all()) or (
-            (data[TIME_COLUMN].dt.date == tomorrow.date()).all()
+        assert ((data[TIME_COLUMN].dt.date() == today.date()).all()) or (
+            (data[TIME_COLUMN].dt.date() == tomorrow.date()).all()
         )
 
     def test_get_lmp_day_ahead_hourly_historical_date_range(self):
@@ -1277,11 +1300,12 @@ class TestIESO(BaseTestISO):
 
         # Check that the data is for today
         today = pd.Timestamp.now(tz=self.default_timezone).normalize()
-        assert (data[TIME_COLUMN].dt.date == today.date()).all()
+        assert (data[TIME_COLUMN].dt.date() == today.date()).all()
 
-        assert not data.duplicated(
-            subset=["Interval Start", "Publish Time", "Location"],
-        ).any()
+        assert (
+            data.height
+            == data.unique(subset=["Interval Start", "Publish Time", "Location"]).height
+        )
 
     def test_get_lmp_predispatch_hourly_historical_date_range(self):
         start = pd.Timestamp.now(tz=self.default_timezone).normalize() - pd.DateOffset(
@@ -1296,9 +1320,10 @@ class TestIESO(BaseTestISO):
 
         self._check_lmp_data(data, interval_minutes=60, predispatch=True)
 
-        assert not data.duplicated(
-            subset=["Interval Start", "Publish Time", "Location"],
-        ).any()
+        assert (
+            data.height
+            == data.unique(subset=["Interval Start", "Publish Time", "Location"]).height
+        )
 
         # Since we retrieve data by publish time, the data will go out 23 hours
         # after the end.
@@ -1312,7 +1337,7 @@ class TestIESO(BaseTestISO):
 
     def _check_lmp_virtual_zonal_data(
         self,
-        data: pd.DataFrame,
+        data: pl.DataFrame,
         interval_minutes: int,
         predispatch: bool = False,
     ) -> None:
@@ -1329,34 +1354,37 @@ class TestIESO(BaseTestISO):
         if predispatch:
             column_list.insert(column_list.index("Interval End") + 1, "Publish Time")
 
-        assert data.columns.tolist() == column_list
+        assert data.columns == column_list
 
         time_type = "interval"
         self._check_time_columns(data, instant_or_interval=time_type)
 
         assert np.allclose(
-            data["LMP"],
-            data["Energy"] + data["Loss"] + data["Congestion"],
+            data["LMP"].to_numpy(),
+            (data["Energy"] + data["Loss"] + data["Congestion"]).to_numpy(),
         )
 
-        assert (
-            data["Interval End"] - data["Interval Start"]
-            == pd.Timedelta(minutes=interval_minutes)
-        ).all()
+        assert data.select(
+            (pl.col("Interval End") - pl.col("Interval Start"))
+            .eq(pl.duration(minutes=interval_minutes))
+            .all(),
+        ).item()
 
-        assert data[TIME_COLUMN].is_monotonic_increasing
+        assert data[TIME_COLUMN].is_sorted()
 
-        assert list(data["Location"].unique()) == [
-            "EAST",
-            "ESSA",
-            "NIAGARA",
-            "NORTHEAST",
-            "NORTHWEST",
-            "OTTAWA",
-            "SOUTHWEST",
-            "TORONTO",
-            "WEST",
-        ]
+        assert sorted(data["Location"].unique().to_list()) == sorted(
+            [
+                "EAST",
+                "ESSA",
+                "NIAGARA",
+                "NORTHEAST",
+                "NORTHWEST",
+                "OTTAWA",
+                "SOUTHWEST",
+                "TORONTO",
+                "WEST",
+            ],
+        )
 
     def test_get_lmp_real_time_5_min_virtual_zonal_latest(self):
         with file_vcr.use_cassette(
@@ -1368,7 +1396,7 @@ class TestIESO(BaseTestISO):
 
         # Check that the data is for tomorrow
         today = pd.Timestamp.now(tz=self.default_timezone).normalize()
-        assert (data[TIME_COLUMN].dt.date == today.date()).all()
+        assert (data[TIME_COLUMN].dt.date() == today.date()).all()
 
     def test_get_lmp_real_time_5_min_virtual_zonal_historical_date_range(self):
         start = pd.Timestamp.now(tz=self.default_timezone).normalize() - pd.DateOffset(
@@ -1402,8 +1430,8 @@ class TestIESO(BaseTestISO):
         # today or tomorrow.
         today = pd.Timestamp.now(tz=self.default_timezone).normalize()
         tomorrow = today + pd.Timedelta(days=1)
-        assert ((data[TIME_COLUMN].dt.date == today.date()).all()) or (
-            (data[TIME_COLUMN].dt.date == tomorrow.date()).all()
+        assert ((data[TIME_COLUMN].dt.date() == today.date()).all()) or (
+            (data[TIME_COLUMN].dt.date() == tomorrow.date()).all()
         )
 
     def test_get_lmp_day_ahead_hourly_virtual_zonal_historical_date_range(self):
@@ -1433,13 +1461,14 @@ class TestIESO(BaseTestISO):
 
         self._check_lmp_virtual_zonal_data(data, interval_minutes=60, predispatch=True)
 
-        assert not data.duplicated(
-            subset=["Interval Start", "Publish Time", "Location"],
-        ).any()
+        assert (
+            data.height
+            == data.unique(subset=["Interval Start", "Publish Time", "Location"]).height
+        )
 
         # Check that the data is for today
         today = pd.Timestamp.now(tz=self.default_timezone).normalize()
-        assert (data[TIME_COLUMN].dt.date == today.date()).all()
+        assert (data[TIME_COLUMN].dt.date() == today.date()).all()
 
     def test_get_lmp_predispatch_hourly_virtual_zonal_historical_date_range(self):
         start = pd.Timestamp.now(tz=self.default_timezone).normalize() - pd.DateOffset(
@@ -1454,9 +1483,10 @@ class TestIESO(BaseTestISO):
 
         self._check_lmp_virtual_zonal_data(data, interval_minutes=60, predispatch=True)
 
-        assert not data.duplicated(
-            subset=["Interval Start", "Publish Time", "Location"],
-        ).any()
+        assert (
+            data.height
+            == data.unique(subset=["Interval Start", "Publish Time", "Location"]).height
+        )
 
         assert data[TIME_COLUMN].min() == start
         # Since we retrieve data by publish time, the actual data will extend
@@ -1470,7 +1500,7 @@ class TestIESO(BaseTestISO):
 
     def _check_lmp_intertie(
         self,
-        data: pd.DataFrame,
+        data: pl.DataFrame,
         interval_minutes: int,
         predispatch: bool = False,
     ) -> None:
@@ -1493,47 +1523,52 @@ class TestIESO(BaseTestISO):
                 "Publish Time",
             )
 
-        assert data.columns.tolist() == column_list
+        assert data.columns == column_list
 
         time_type = "interval"
         self._check_time_columns(data, instant_or_interval=time_type)
 
         assert np.allclose(
-            data["LMP"],
-            data["Energy"]
-            + data["Loss"]
-            + data["Congestion"]
-            + data["External Congestion"]
-            + data["Interchange Scheduling Limit Price"],
+            data["LMP"].to_numpy(),
+            (
+                data["Energy"]
+                + data["Loss"]
+                + data["Congestion"]
+                + data["External Congestion"]
+                + data["Interchange Scheduling Limit Price"]
+            ).to_numpy(),
         )
 
-        assert (
-            data["Interval End"] - data["Interval Start"]
-            == pd.Timedelta(minutes=interval_minutes)
-        ).all()
+        assert data.select(
+            (pl.col("Interval End") - pl.col("Interval Start"))
+            .eq(pl.duration(minutes=interval_minutes))
+            .all(),
+        ).item()
 
-        assert data[TIME_COLUMN].is_monotonic_increasing
+        assert data[TIME_COLUMN].is_sorted()
 
-        assert list(data["Location"].unique()) == [
-            "EC.MARITIMES_NYSI",
-            "MB.SEVENSISTERS_MBSK",
-            "MB.WHITESHELL_MBSI",
-            "MD.CALVERTCLIFF_MISI",
-            "MD.CALVERTCLIFF_NYSI",
-            "MI.LUDINGTON_MISI",
-            "MN.INTFALLS_MNSI",
-            "NY.ROSETON_NYSI",
-            "PQ.BEAUHARNOIS_PQBE",
-            "PQ.BRYSON_PQXY",
-            "PQ.KIPAWA_PQHZ",
-            "PQ.MACLAREN_PQDA",
-            "PQ.MASSON_PQHA",
-            "PQ.OUTAOUAIS_PQAT",
-            "PQ.PAUGAN_PQPC",
-            "PQ.QUYON_PQQC",
-            "PQ.RAPIDDESISLE_PQDZ",
-            "WC.PRAIRERANGES_MISI",
-        ]
+        assert sorted(data["Location"].unique().to_list()) == sorted(
+            [
+                "EC.MARITIMES_NYSI",
+                "MB.SEVENSISTERS_MBSK",
+                "MB.WHITESHELL_MBSI",
+                "MD.CALVERTCLIFF_MISI",
+                "MD.CALVERTCLIFF_NYSI",
+                "MI.LUDINGTON_MISI",
+                "MN.INTFALLS_MNSI",
+                "NY.ROSETON_NYSI",
+                "PQ.BEAUHARNOIS_PQBE",
+                "PQ.BRYSON_PQXY",
+                "PQ.KIPAWA_PQHZ",
+                "PQ.MACLAREN_PQDA",
+                "PQ.MASSON_PQHA",
+                "PQ.OUTAOUAIS_PQAT",
+                "PQ.PAUGAN_PQPC",
+                "PQ.QUYON_PQQC",
+                "PQ.RAPIDDESISLE_PQDZ",
+                "WC.PRAIRERANGES_MISI",
+            ],
+        )
 
     def test_get_lmp_real_time_5_min_intertie_latest(self):
         with file_vcr.use_cassette(
@@ -1545,7 +1580,7 @@ class TestIESO(BaseTestISO):
 
         # Check that the data is for today
         today = pd.Timestamp.now(tz=self.default_timezone).normalize()
-        assert (data[TIME_COLUMN].dt.date == today.date()).all()
+        assert (data[TIME_COLUMN].dt.date() == today.date()).all()
 
     def test_get_lmp_real_time_5_min_intertie_historical_date_range(self):
         start = pd.Timestamp.now(tz=self.default_timezone).normalize() - pd.DateOffset(
@@ -1580,8 +1615,8 @@ class TestIESO(BaseTestISO):
         today = pd.Timestamp.now(tz=self.default_timezone).normalize()
         tomorrow = today + pd.Timedelta(days=1)
         print(data[TIME_COLUMN])
-        assert ((data[TIME_COLUMN].dt.date == today.date()).all()) or (
-            (data[TIME_COLUMN].dt.date == tomorrow.date()).all()
+        assert ((data[TIME_COLUMN].dt.date() == today.date()).all()) or (
+            (data[TIME_COLUMN].dt.date() == tomorrow.date()).all()
         )
 
     def test_get_lmp_day_ahead_hourly_intertie_historical_date_range(self):
@@ -1611,13 +1646,14 @@ class TestIESO(BaseTestISO):
 
         self._check_lmp_intertie(data, interval_minutes=60, predispatch=True)
 
-        assert not data.duplicated(
-            subset=["Interval Start", "Publish Time", "Location"],
-        ).any()
+        assert (
+            data.height
+            == data.unique(subset=["Interval Start", "Publish Time", "Location"]).height
+        )
 
         # Check that the data is for today
         today = pd.Timestamp.now(tz=self.default_timezone).normalize()
-        assert (data[TIME_COLUMN].dt.date == today.date()).all()
+        assert (data[TIME_COLUMN].dt.date() == today.date()).all()
 
     def test_get_lmp_predispatch_hourly_intertie_historical_date_range(self):
         start = pd.Timestamp.now(tz=self.default_timezone).normalize() - pd.DateOffset(
@@ -1632,9 +1668,10 @@ class TestIESO(BaseTestISO):
 
         self._check_lmp_intertie(data, interval_minutes=60, predispatch=True)
 
-        assert not data.duplicated(
-            subset=["Interval Start", "Publish Time", "Location"],
-        ).any()
+        assert (
+            data.height
+            == data.unique(subset=["Interval Start", "Publish Time", "Location"]).height
+        )
 
         assert data[TIME_COLUMN].min() == start
         # Since we retrieve data by publish time, the actual data will extend
@@ -1648,7 +1685,7 @@ class TestIESO(BaseTestISO):
 
     def _check_lmp_ontario_zonal_data(
         self,
-        data: pd.DataFrame,
+        data: pl.DataFrame,
         interval_minutes: int,
         predispatch: bool = False,
     ) -> None:
@@ -1664,22 +1701,23 @@ class TestIESO(BaseTestISO):
         if predispatch:
             column_list.insert(column_list.index("Interval End") + 1, "Publish Time")
 
-        assert data.columns.tolist() == column_list
+        assert data.columns == column_list
 
         time_type = "interval"
         self._check_time_columns(data, instant_or_interval=time_type)
 
         assert np.allclose(
-            data["LMP"],
-            data["Energy"] + data["Loss"] + data["Congestion"],
+            data["LMP"].to_numpy(),
+            (data["Energy"] + data["Loss"] + data["Congestion"]).to_numpy(),
         )
 
-        assert (
-            data["Interval End"] - data["Interval Start"]
-            == pd.Timedelta(minutes=interval_minutes)
-        ).all()
+        assert data.select(
+            (pl.col("Interval End") - pl.col("Interval Start"))
+            .eq(pl.duration(minutes=interval_minutes))
+            .all(),
+        ).item()
 
-        assert data[TIME_COLUMN].is_monotonic_increasing
+        assert data[TIME_COLUMN].is_sorted()
         assert (data["Location"] == ONTARIO_LOCATION).all()
 
     def test_get_lmp_real_time_5_min_ontario_zonal_latest(self):
@@ -1692,7 +1730,7 @@ class TestIESO(BaseTestISO):
 
         # Check that the data is for today
         today = pd.Timestamp.now(tz=self.default_timezone).normalize()
-        assert (data[TIME_COLUMN].dt.date == today.date()).all()
+        assert (data[TIME_COLUMN].dt.date() == today.date()).all()
 
     def test_get_lmp_real_time_5_min_ontario_zonal_historical_date_range(self):
         start = pd.Timestamp.now(tz=self.default_timezone).normalize() - pd.DateOffset(
@@ -1724,7 +1762,7 @@ class TestIESO(BaseTestISO):
             data = self.iso.get_lmp_real_time_5_min_ontario_zonal(start, end=end)
 
         self._check_lmp_ontario_zonal_data(data, interval_minutes=5)
-        assert (data[TIME_COLUMN].dt.date == start.date()).all()
+        assert (data[TIME_COLUMN].dt.date() == start.date()).all()
 
     def test_get_lmp_real_time_5_min_ontario_zonal_old_format(self):
         """Test with a date that uses the old XML schema (r1) with combined
@@ -1739,7 +1777,7 @@ class TestIESO(BaseTestISO):
             data = self.iso.get_lmp_real_time_5_min_ontario_zonal(start, end=end)
 
         self._check_lmp_ontario_zonal_data(data, interval_minutes=5)
-        assert (data[TIME_COLUMN].dt.date == start.date()).all()
+        assert (data[TIME_COLUMN].dt.date() == start.date()).all()
         assert len(data) == 12  # 1 hour = 12 five-minute intervals
 
     """get_lmp_day_ahead_hourly_ontario_zonal"""
@@ -1757,8 +1795,8 @@ class TestIESO(BaseTestISO):
         # today or tomorrow.
         today = pd.Timestamp.now(tz=self.default_timezone).normalize()
         tomorrow = today + pd.Timedelta(days=1)
-        assert ((data[TIME_COLUMN].dt.date == today.date()).all()) or (
-            (data[TIME_COLUMN].dt.date == tomorrow.date()).all()
+        assert ((data[TIME_COLUMN].dt.date() == today.date()).all()) or (
+            (data[TIME_COLUMN].dt.date() == tomorrow.date()).all()
         )
 
     def test_get_lmp_day_ahead_hourly_ontario_zonal_historical_date_range(self):
@@ -1788,13 +1826,14 @@ class TestIESO(BaseTestISO):
 
         self._check_lmp_ontario_zonal_data(data, interval_minutes=60, predispatch=True)
 
-        assert not data.duplicated(
-            subset=["Interval Start", "Publish Time", "Location"],
-        ).any()
+        assert (
+            data.height
+            == data.unique(subset=["Interval Start", "Publish Time", "Location"]).height
+        )
 
         # Check that the data is for today
         today = pd.Timestamp.now(tz=self.default_timezone).normalize()
-        assert (data[TIME_COLUMN].dt.date == today.date()).all()
+        assert (data[TIME_COLUMN].dt.date() == today.date()).all()
 
     def test_get_lmp_predispatch_hourly_ontario_zonal_historical_date_range(self):
         start = pd.Timestamp.now(tz=self.default_timezone).normalize() - pd.DateOffset(
@@ -1809,9 +1848,10 @@ class TestIESO(BaseTestISO):
 
         self._check_lmp_ontario_zonal_data(data, interval_minutes=60, predispatch=True)
 
-        assert not data.duplicated(
-            subset=["Interval Start", "Publish Time", "Location"],
-        ).any()
+        assert (
+            data.height
+            == data.unique(subset=["Interval Start", "Publish Time", "Location"]).height
+        )
 
         assert data[TIME_COLUMN].min() == start
         # Since we retrieve data by publish time, the actual data will extend
@@ -1823,8 +1863,8 @@ class TestIESO(BaseTestISO):
 
     """get_transmission_outages_planned"""
 
-    def _check_transmission_outages_planned(self, data: pd.DataFrame) -> None:
-        assert isinstance(data, pd.DataFrame)
+    def _check_transmission_outages_planned(self, data: pl.DataFrame) -> None:
+        assert isinstance(data, pl.DataFrame)
         assert data.shape[0] >= 0
 
         assert set(data.columns) == {
@@ -1846,15 +1886,15 @@ class TestIESO(BaseTestISO):
         assert self._check_is_datetime_type(data["Interval End"])
         assert self._check_is_datetime_type(data["Publish Time"])
 
-        assert data["Outage ID"].dtype == "object"
-        assert data["Name"].dtype == "object"
-        assert data["Priority"].dtype == "object"
-        assert data["Recurrence"].dtype == "object"
-        assert data["Type"].dtype == "object"
-        assert data["Voltage"].dtype == "object"
-        assert data["Constraint"].dtype == "object"
-        assert data["Recall Time"].dtype == "object"
-        assert data["Status"].dtype == "object"
+        assert data.schema["Outage ID"] == pl.Utf8
+        assert data.schema["Name"] == pl.Utf8
+        assert data.schema["Priority"] == pl.Utf8
+        assert data.schema["Recurrence"] == pl.Utf8
+        assert data.schema["Type"] == pl.Utf8
+        assert data.schema["Voltage"] == pl.Utf8
+        assert data.schema["Constraint"] == pl.Utf8
+        assert data.schema["Recall Time"] == pl.Utf8
+        assert data.schema["Status"] == pl.Utf8
 
     def test_get_transmission_outages_planned_latest(self):
         with file_vcr.use_cassette("transmission_outages_planned_latest.yaml"):
@@ -1862,10 +1902,11 @@ class TestIESO(BaseTestISO):
 
         self._check_transmission_outages_planned(data)
 
-        assert not (
-            data.duplicated(
+        assert (
+            data.height
+            == data.unique(
                 subset=[c for c in data.columns if c != "Publish Time"],
-            ).any()
+            ).height
         )
 
     def test_get_transmission_outages_planned_historical_date_range(self):
@@ -1878,15 +1919,16 @@ class TestIESO(BaseTestISO):
 
         self._check_transmission_outages_planned(data)
 
-        assert not (
-            data.duplicated(
+        assert (
+            data.height
+            == data.unique(
                 subset=[c for c in data.columns if c != "Publish Time"],
-            ).any()
+            ).height
         )
 
     """get_in_service_transmission_limits"""
 
-    def _check_transmission_limits(self, data: pd.DataFrame) -> None:
+    def _check_transmission_limits(self, data: pl.DataFrame) -> None:
         assert set(data.columns) == {
             "Interval Start",
             "Interval End",
@@ -1903,15 +1945,16 @@ class TestIESO(BaseTestISO):
         assert self._check_is_datetime_type(data["Publish Time"])
         assert self._check_is_datetime_type(data["Issue Time"])
 
-        assert data["Facility"].dtype == "object"
-        assert data["Type"].dtype == "object"
-        assert data["Operating Limit"].dtype == "int64"
-        assert data["Comments"].dtype == "object"
+        assert data.schema["Facility"] == pl.Utf8
+        assert data.schema["Type"] == pl.Utf8
+        assert data.schema["Operating Limit"] == pl.Int64
+        assert data.schema["Comments"] == pl.Utf8
 
-        assert not (
-            data.duplicated(
+        assert (
+            data.height
+            == data.unique(
                 subset=[c for c in data.columns if c != "Publish Time"],
-            ).any()
+            ).height
         )
 
     def test_get_in_service_transmission_limits_latest(self):
@@ -1954,20 +1997,21 @@ class TestIESO(BaseTestISO):
 
     """get_load_daily_zonal_5_min"""
 
-    def _check_load_zonal(self, data: pd.DataFrame, frequency_minutes: int) -> None:
-        assert isinstance(data, pd.DataFrame)
+    def _check_load_zonal(self, data: pl.DataFrame, frequency_minutes: int) -> None:
+        assert isinstance(data, pl.DataFrame)
         assert data.shape[0] >= 0
         assert set(data.columns) == set(ZONAL_LOAD_COLUMNS)
-        assert (
-            data["Interval End"] - data["Interval Start"]
-            == pd.Timedelta(minutes=frequency_minutes)
-        ).all()
+        assert data.select(
+            (pl.col("Interval End") - pl.col("Interval Start"))
+            .eq(pl.duration(minutes=frequency_minutes))
+            .all(),
+        ).item()
 
         numeric_cols = [
             col for col in data.columns if col not in ["Interval Start", "Interval End"]
         ]
         for col in numeric_cols:
-            assert is_numeric_dtype(data[col])
+            assert data.schema[col] in (pl.Float64, pl.Int64, pl.Int32)
 
     def test_get_load_daily_zonal_5_min_latest(self):
         with file_vcr.use_cassette("test_get_load_zonal_5_min_latest.yaml"):
@@ -2007,13 +2051,13 @@ class TestIESO(BaseTestISO):
         assert data["Interval Start"].max() < end
         assert data["Interval End"].max() <= end + pd.Timedelta(minutes=5)
 
-        years_in_data = data["Interval Start"].dt.year.unique()
+        years_in_data = data["Interval Start"].dt.year().unique().to_list()
         if start.year != end.year:
             assert len(years_in_data) > 1
             assert start.year in years_in_data
             assert end.year in years_in_data
 
-        assert data["Interval Start"].is_monotonic_increasing
+        assert data["Interval Start"].is_sorted()
 
     """get_load_daily_zonal_hourly"""
 
@@ -2053,15 +2097,15 @@ class TestIESO(BaseTestISO):
         assert data["Interval Start"].min() == start
         assert data["Interval End"].max() == end
 
-        years_in_data = data["Interval Start"].dt.year.unique()
+        years_in_data = data["Interval Start"].dt.year().unique().to_list()
         assert 2025 in years_in_data
         assert 2026 in years_in_data
 
-        assert data["Interval Start"].is_monotonic_increasing
+        assert data["Interval Start"].is_sorted()
 
     """get_real_time_totals"""
 
-    def _check_real_time_totals(self, data: pd.DataFrame) -> None:
+    def _check_real_time_totals(self, data: pl.DataFrame) -> None:
         assert list(data.columns) == [
             "Interval Start",
             "Interval End",
@@ -2079,22 +2123,24 @@ class TestIESO(BaseTestISO):
         assert self._check_is_datetime_type(data["Interval Start"])
         assert self._check_is_datetime_type(data["Interval End"])
 
-        assert data["Total Energy"].dtype == "float64"
-        assert data["Total Loss"].dtype == "float64"
-        assert data["Market Total Load"].dtype == "float64"
-        assert data["Total Dispatchable Load Scheduled Off"].dtype == "float64"
-        assert data["Total 10S"].dtype == "float64"
-        assert data["Total 10N"].dtype == "float64"
-        assert data["Total 30R"].dtype == "float64"
-        assert data["Ontario Load"].dtype == "float64"
+        assert data.schema["Total Energy"] == pl.Float64
+        assert data.schema["Total Loss"] == pl.Float64
+        assert data.schema["Market Total Load"] == pl.Float64
+        assert data.schema["Total Dispatchable Load Scheduled Off"] == pl.Float64
+        assert data.schema["Total 10S"] == pl.Float64
+        assert data.schema["Total 10N"] == pl.Float64
+        assert data.schema["Total 30R"] == pl.Float64
+        assert data.schema["Ontario Load"] == pl.Float64
 
-        assert data["Flag"].dtype == "object"
+        assert data.schema["Flag"] == pl.Utf8
 
-        assert (
-            data["Interval End"] - data["Interval Start"] == pd.Timedelta(minutes=5)
-        ).all()
+        assert data.select(
+            (pl.col("Interval End") - pl.col("Interval Start"))
+            .eq(pl.duration(minutes=5))
+            .all(),
+        ).item()
 
-        assert data["Interval Start"].is_monotonic_increasing
+        assert data["Interval Start"].is_sorted()
 
     def test_get_real_time_totals_latest(self):
         with file_vcr.use_cassette("test_get_real_time_totals_latest.yaml"):
@@ -2104,7 +2150,7 @@ class TestIESO(BaseTestISO):
 
         # Check that the data is for today
         today = pd.Timestamp.now(tz=self.default_timezone).normalize()
-        assert (data["Interval Start"].dt.date == today.date()).all()
+        assert (data["Interval Start"].dt.date() == today.date()).all()
 
     def test_get_real_time_totals_historical_date_range(self):
         start_date = self.local_start_of_today() - pd.DateOffset(days=30)
@@ -2122,17 +2168,19 @@ class TestIESO(BaseTestISO):
 
     """get_variable_generation_forecast"""
 
-    def _check_variable_generation_forecast(self, df: pd.DataFrame) -> None:
-        assert isinstance(df, pd.DataFrame)
-        assert not df.empty
+    def _check_variable_generation_forecast(self, df: pl.DataFrame) -> None:
+        assert isinstance(df, pl.DataFrame)
+        assert not df.is_empty()
         assert self._check_is_datetime_type(df["Interval Start"])
         assert self._check_is_datetime_type(df["Interval End"])
         assert self._check_is_datetime_type(df["Publish Time"])
         assert self._check_is_datetime_type(df["Last Modified"])
 
-        assert (
-            df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
-        ).all()
+        assert df.select(
+            (pl.col("Interval End") - pl.col("Interval Start"))
+            .eq(pl.duration(hours=1))
+            .all(),
+        ).item()
 
         expected_cols = [
             "Interval Start",
@@ -2143,7 +2191,7 @@ class TestIESO(BaseTestISO):
             "Generation Forecast",
         ]
         assert all(col in df.columns for col in expected_cols)
-        assert is_numeric_dtype(df["Generation Forecast"])
+        assert df.schema["Generation Forecast"] == pl.Float64
 
     def test_get_solar_embedded_forecast_latest(self):
         with file_vcr.use_cassette("test_get_solar_embedded_forecast_latest.yaml"):
@@ -2179,7 +2227,7 @@ class TestIESO(BaseTestISO):
 
         self._check_variable_generation_forecast(df)
 
-        assert df["Publish Time"].nunique() > 1
+        assert df["Publish Time"].n_unique() > 1
 
     def test_get_wind_embedded_forecast_latest(self):
         with file_vcr.use_cassette("test_get_wind_embedded_forecast_latest.yaml"):
@@ -2248,9 +2296,9 @@ class TestIESO(BaseTestISO):
         assert df["Interval Start"].min() == start + pd.Timedelta(days=1)
         assert df["Interval End"].max() == end + pd.Timedelta(days=2)
 
-    def _check_shadow_prices(self, df: pd.DataFrame):
-        assert isinstance(df, pd.DataFrame)
-        assert not df.empty
+    def _check_shadow_prices(self, df: pl.DataFrame):
+        assert isinstance(df, pl.DataFrame)
+        assert not df.is_empty()
         assert set(df.columns) == {
             "Interval Start",
             "Interval End",
@@ -2261,7 +2309,7 @@ class TestIESO(BaseTestISO):
         assert self._check_is_datetime_type(df["Interval Start"])
         assert self._check_is_datetime_type(df["Interval End"])
         assert self._check_is_datetime_type(df["Publish Time"])
-        assert df["Shadow Price"].dtype == "float64"
+        assert df.schema["Shadow Price"] == pl.Float64
 
     def test_get_shadow_prices_real_time_5_min_latest(self):
         with file_vcr.use_cassette(
@@ -2269,8 +2317,8 @@ class TestIESO(BaseTestISO):
         ):
             df = self.iso.get_shadow_prices_real_time_5_min("latest")
             self._check_shadow_prices(df)
-            assert df["Interval Start"].is_monotonic_increasing
-            assert df["Publish Time"].nunique() == 1
+            assert df["Interval Start"].is_sorted()
+            assert df["Publish Time"].n_unique() == 1
 
     @pytest.mark.parametrize(
         "date, end",
@@ -2304,8 +2352,8 @@ class TestIESO(BaseTestISO):
         ):
             df = self.iso.get_shadow_prices_day_ahead_hourly("latest")
             self._check_shadow_prices(df)
-            assert df["Interval Start"].is_monotonic_increasing
-            assert df["Publish Time"].nunique() == 1
+            assert df["Interval Start"].is_sorted()
+            assert df["Publish Time"].n_unique() == 1
 
     @pytest.mark.parametrize(
         "date, end",
@@ -2335,8 +2383,8 @@ class TestIESO(BaseTestISO):
 
         """get_lmp_real_time_operating_reserves"""
 
-    def _check_lmp_real_time_5_min_operating_reserves(self, data: pd.DataFrame) -> None:
-        assert data.columns.tolist() == [
+    def _check_lmp_real_time_5_min_operating_reserves(self, data: pl.DataFrame) -> None:
+        assert data.columns == [
             "Interval Start",
             "Interval End",
             "Location",
@@ -2351,7 +2399,7 @@ class TestIESO(BaseTestISO):
         assert self._check_is_datetime_type(data["Interval Start"])
         assert self._check_is_datetime_type(data["Interval End"])
 
-        assert data["Location"].dtype == "object"
+        assert data.schema["Location"] == pl.Utf8
         for col in [
             "LMP 10S",
             "Congestion 10S",
@@ -2360,14 +2408,16 @@ class TestIESO(BaseTestISO):
             "LMP 30R",
             "Congestion 30R",
         ]:
-            assert data[col].dtype == "float64"
+            assert data.schema[col] == pl.Float64
 
-        assert (
-            data["Interval End"] - data["Interval Start"] == pd.Timedelta(minutes=5)
-        ).all()
+        assert data.select(
+            (pl.col("Interval End") - pl.col("Interval Start"))
+            .eq(pl.duration(minutes=5))
+            .all(),
+        ).item()
 
-    def _check_lmp_day_ahead_operating_reserves(self, data: pd.DataFrame) -> None:
-        assert data.columns.tolist() == [
+    def _check_lmp_day_ahead_operating_reserves(self, data: pl.DataFrame) -> None:
+        assert data.columns == [
             "Interval Start",
             "Interval End",
             "Location",
@@ -2382,7 +2432,7 @@ class TestIESO(BaseTestISO):
         assert self._check_is_datetime_type(data["Interval Start"])
         assert self._check_is_datetime_type(data["Interval End"])
 
-        assert data["Location"].dtype == "object"
+        assert data.schema["Location"] == pl.Utf8
         for col in [
             "LMP 10S",
             "Congestion 10S",
@@ -2391,11 +2441,13 @@ class TestIESO(BaseTestISO):
             "LMP 30R",
             "Congestion 30R",
         ]:
-            assert data[col].dtype == "float64"
+            assert data.schema[col] == pl.Float64
 
-        assert (
-            data["Interval End"] - data["Interval Start"] == pd.Timedelta(hours=1)
-        ).all()
+        assert data.select(
+            (pl.col("Interval End") - pl.col("Interval Start"))
+            .eq(pl.duration(hours=1))
+            .all(),
+        ).item()
 
     def test_get_lmp_real_time_operating_reserves_latest(self):
         with file_vcr.use_cassette(
@@ -2405,7 +2457,7 @@ class TestIESO(BaseTestISO):
 
         self._check_lmp_real_time_5_min_operating_reserves(data)
         today = pd.Timestamp.now(tz=self.default_timezone).normalize()
-        assert (data["Interval Start"].dt.date == today.date()).all()
+        assert (data["Interval Start"].dt.date() == today.date()).all()
 
     def test_get_lmp_real_time_operating_reserves_historical_date_range(self):
         start_date = (pd.Timestamp.utcnow() - pd.DateOffset(days=3)).normalize()

--- a/gridstatus/tests/source_specific/test_isone_api.py
+++ b/gridstatus/tests/source_specific/test_isone_api.py
@@ -1,5 +1,5 @@
-import numpy as np
 import pandas as pd
+import polars as pl
 import pytest
 
 from gridstatus.base import NoDataFoundException
@@ -11,6 +11,7 @@ from gridstatus.isone_api.isone_api_constants import (
     ISONE_FIVE_MIN_ZONAL_LOAD_FORECAST_COLUMNS,
     ISONE_MORNING_REPORT_COLUMNS,
     ISONE_RESERVE_ZONE_ALL_COLUMNS,
+    ISONE_RESERVE_ZONE_FLOAT_COLUMNS,
     ISONE_TOTAL_DEMAND_COLUMNS,
 )
 from gridstatus.tests.base_test_iso import TestHelperMixin
@@ -49,6 +50,25 @@ class TestISONEAPI(TestHelperMixin):
     def setup_class(cls):
         cls.iso = ISONEAPI(sleep_seconds=0.1, max_retries=2)
 
+    @staticmethod
+    def _cell(df: pl.DataFrame, col: str, row: int = 0):
+        return df.row(row, named=True)[col]
+
+    @staticmethod
+    def _is_numeric_dtype(dtype: pl.DataType) -> bool:
+        return dtype.is_numeric()
+
+    @staticmethod
+    def _is_tz_datetime(dtype: pl.DataType, tz: str) -> bool:
+        return isinstance(dtype, pl.Datetime) and dtype.time_zone == tz
+
+    @staticmethod
+    def _interval_equals(df: pl.DataFrame, duration: pd.Timedelta) -> bool:
+        delta = df.select(
+            (pl.col("Interval End") - pl.col("Interval Start")).alias("delta"),
+        )["delta"]
+        return delta.eq(duration).all()
+
     def test_class_init(self):
         assert self.iso.sleep_seconds == 0.1
         assert self.iso.max_retries == 2
@@ -62,8 +82,8 @@ class TestISONEAPI(TestHelperMixin):
     def test_get_locations(self):
         with api_vcr.use_cassette("test_get_locations.yaml"):
             result = self.iso.get_locations()
-            assert isinstance(result, pd.DataFrame)
-            assert len(result) == 20
+            assert isinstance(result, pl.DataFrame)
+            assert result.height == 20
             assert list(result.columns) == [
                 "LocationID",
                 "LocationType",
@@ -84,8 +104,8 @@ class TestISONEAPI(TestHelperMixin):
                 locations=[location],
             )
 
-            assert isinstance(result, pd.DataFrame)
-            assert len(result) == 1
+            assert isinstance(result, pl.DataFrame)
+            assert result.height == 1
             assert list(result.columns) == [
                 "Interval Start",
                 "Interval End",
@@ -93,9 +113,9 @@ class TestISONEAPI(TestHelperMixin):
                 "Location Id",
                 "Load",
             ]
-            assert result["Location"].iloc[0] == location
-            assert result["Location Id"].iloc[0] == ZONE_LOCATIONID_MAP[location]
-            assert isinstance(result["Load"].iloc[0], (int, float))
+            assert self._cell(result, "Location") == location
+            assert self._cell(result, "Location Id") == ZONE_LOCATIONID_MAP[location]
+            assert self._is_numeric_dtype(result.schema["Load"])
 
     def test_get_dayahead_hourly_demand_latest(self):
         with api_vcr.use_cassette("test_get_dayahead_hourly_demand_latest.yaml"):
@@ -103,8 +123,8 @@ class TestISONEAPI(TestHelperMixin):
                 date="latest",
                 locations=["NEPOOL AREA"],
             )
-            assert isinstance(result, pd.DataFrame)
-            assert len(result) == 1
+            assert isinstance(result, pl.DataFrame)
+            assert result.height == 1
             assert list(result.columns) == [
                 "Interval Start",
                 "Interval End",
@@ -112,9 +132,9 @@ class TestISONEAPI(TestHelperMixin):
                 "Location Id",
                 "Load",
             ]
-            assert result["Location"].iloc[0] == "NEPOOL AREA"
-            assert result["Location Id"].iloc[0] == 32
-            assert isinstance(result["Load"].iloc[0], np.number)
+            assert self._cell(result, "Location") == "NEPOOL AREA"
+            assert self._cell(result, "Location Id") == 32
+            assert self._is_numeric_dtype(result.schema["Load"])
 
     # NOTE(kladar): These two are not super useful as tests go, but starting to think about API failure modes and
     # how to catch them.
@@ -138,8 +158,8 @@ class TestISONEAPI(TestHelperMixin):
                 locations=list(locations),
             )
 
-            assert isinstance(result, pd.DataFrame)
-            assert len(result) == len(locations)
+            assert isinstance(result, pl.DataFrame)
+            assert result.height == len(locations)
             assert list(result.columns) == [
                 "Interval Start",
                 "Interval End",
@@ -151,7 +171,7 @@ class TestISONEAPI(TestHelperMixin):
             assert set(result["Location Id"]) == {
                 ZONE_LOCATIONID_MAP[loc] for loc in locations
             }
-            assert all(isinstance(load, (int, float)) for load in result["Load"])
+            assert result.schema["Load"].is_numeric()
 
     @pytest.mark.parametrize(
         "date,end,locations",
@@ -172,7 +192,7 @@ class TestISONEAPI(TestHelperMixin):
                 locations=locations,
             )
 
-            assert isinstance(result, pd.DataFrame)
+            assert isinstance(result, pl.DataFrame)
             assert list(result.columns) == [
                 "Interval Start",
                 "Interval End",
@@ -184,8 +204,8 @@ class TestISONEAPI(TestHelperMixin):
             assert set(result["Location Id"]) == {
                 ZONE_LOCATIONID_MAP[loc] for loc in locations
             }
-            assert all(isinstance(load, (int, float)) for load in result["Load"])
-            assert min(result["Interval Start"]).date() == pd.Timestamp(date).date()
+            assert result.schema["Load"].is_numeric()
+            assert result["Interval Start"].min().date() == pd.Timestamp(date).date()
             assert max(result["Interval End"]).date() == pd.Timestamp(end).date()
 
     @pytest.mark.parametrize(
@@ -207,7 +227,7 @@ class TestISONEAPI(TestHelperMixin):
                 locations=locations,
             )
 
-            assert isinstance(result, pd.DataFrame)
+            assert isinstance(result, pl.DataFrame)
             assert list(result.columns) == [
                 "Interval Start",
                 "Interval End",
@@ -219,8 +239,8 @@ class TestISONEAPI(TestHelperMixin):
             assert set(result["Location Id"]) == {
                 ZONE_LOCATIONID_MAP[loc] for loc in locations
             }
-            assert all(isinstance(load, (int, float)) for load in result["Load"])
-            assert min(result["Interval Start"]).date() == pd.Timestamp(date).date()
+            assert result.schema["Load"].is_numeric()
+            assert result["Interval Start"].min().date() == pd.Timestamp(date).date()
             assert max(result["Interval End"]).date() == pd.Timestamp(end).date()
 
     @pytest.mark.parametrize(
@@ -232,7 +252,7 @@ class TestISONEAPI(TestHelperMixin):
         with api_vcr.use_cassette(cassette_name):
             result = self.iso.get_load_forecast_hourly(date=date, end=end)
 
-            assert isinstance(result, pd.DataFrame)
+            assert isinstance(result, pl.DataFrame)
             assert list(result.columns) == [
                 "Interval Start",
                 "Interval End",
@@ -241,19 +261,16 @@ class TestISONEAPI(TestHelperMixin):
                 "Net Load Forecast",
             ]
             assert (
-                min(result["Interval Start"]).date()
+                result["Interval Start"].min().date()
                 == pd.Timestamp(date).tz_localize(self.iso.default_timezone).date()
             )
             assert max(result["Interval End"]) == pd.Timestamp(end).tz_localize(
                 self.iso.default_timezone,
             )
-            assert result["Load Forecast"].dtype in [np.int64, np.float64]
-            assert result["Net Load Forecast"].dtype in [np.int64, np.float64]
-            assert (result["Load Forecast"] > 0).all()
-            assert (
-                (result["Interval End"] - result["Interval Start"])
-                == pd.Timedelta(hours=1)
-            ).all()
+            assert self._is_numeric_dtype(result.schema["Load Forecast"])
+            assert self._is_numeric_dtype(result.schema["Net Load Forecast"])
+            assert result.select(pl.col("Load Forecast") > 0).to_series().all()
+            assert self._interval_equals(result, pd.Timedelta(hours=1))
 
     @pytest.mark.parametrize(
         "date,end",
@@ -264,7 +281,7 @@ class TestISONEAPI(TestHelperMixin):
         with api_vcr.use_cassette(cassette_name):
             result = self.iso.get_reliability_region_load_forecast(date=date, end=end)
 
-            assert isinstance(result, pd.DataFrame)
+            assert isinstance(result, pl.DataFrame)
             assert list(result.columns) == [
                 "Interval Start",
                 "Interval End",
@@ -274,17 +291,14 @@ class TestISONEAPI(TestHelperMixin):
                 "Regional Percentage",
             ]
             assert (
-                min(result["Interval Start"]).date()
+                result["Interval Start"].min().date()
                 == pd.Timestamp(date).tz_localize(self.iso.default_timezone).date()
             )
             assert max(result["Interval End"]) == pd.Timestamp(end).tz_localize(
                 self.iso.default_timezone,
             )
-            assert (
-                (result["Interval End"] - result["Interval Start"])
-                == pd.Timedelta(hours=1)
-            ).all()
-            assert set(result["Location"].unique()) == {
+            assert self._interval_equals(result, pd.Timedelta(hours=1))
+            assert set(result["Location"].unique().to_list()) == {
                 ".Z.CONNECTICUT",
                 ".Z.MAINE",
                 ".Z.NEWHAMPSHIRE",
@@ -294,29 +308,38 @@ class TestISONEAPI(TestHelperMixin):
                 ".Z.WCMASS",
                 ".Z.NEMASSBOST",
             }
-            assert result["Load Forecast"].dtype in [np.int64, np.float64]
-            assert (result["Load Forecast"] > 0).all()
-            assert result["Regional Percentage"].dtype == np.float64
+            assert self._is_numeric_dtype(result.schema["Load Forecast"])
+            assert result.select(pl.col("Load Forecast") > 0).to_series().all()
+            assert result.schema["Regional Percentage"] == pl.Float64
             assert (
                 (result["Regional Percentage"] >= 0)
                 & (result["Regional Percentage"] <= 100)
             ).all()
-            grouped = result.groupby(["Interval Start", "Publish Time"])
-            assert (grouped["Regional Percentage"].sum().between(99.9, 100.1)).all()
+            grouped = result.group_by(["Interval Start", "Publish Time"]).agg(
+                pl.col("Regional Percentage").sum(),
+            )
+            assert (
+                grouped.select(pl.col("Regional Percentage").is_between(99.9, 100.1))
+                .to_series()
+                .all()
+            )
 
     def test_get_fuel_mix_latest(self):
         with api_vcr.use_cassette("test_get_fuel_mix_latest.yaml"):
             result = self.iso.get_fuel_mix(date="latest")
 
-            assert isinstance(result, pd.DataFrame)
-            assert len(result) == 1
+            assert isinstance(result, pl.DataFrame)
+            assert result.height == 1
             assert "Time" in result.columns
 
-            assert isinstance(result["Time"].iloc[0], pd.Timestamp)
+            assert self._is_tz_datetime(
+                result.schema["Time"],
+                self.iso.default_timezone,
+            )
             numeric_cols = [col for col in result.columns if col != "Time"]
             for col in numeric_cols:
-                assert result[col].dtype in [np.int64, np.float64]
-                assert (result[col] >= 0).all()
+                assert self._is_numeric_dtype(result.schema[col])
+                assert result.select(pl.col(col) >= 0).to_series().all()
 
     @pytest.mark.parametrize(
         "date,end",
@@ -327,7 +350,7 @@ class TestISONEAPI(TestHelperMixin):
         with api_vcr.use_cassette(cassette_name):
             result = self.iso.get_fuel_mix(date=date, end=end)
 
-            assert isinstance(result, pd.DataFrame)
+            assert isinstance(result, pl.DataFrame)
             assert "Time" in result.columns
 
             assert min(result["Time"]).date() == pd.Timestamp(date).date()
@@ -337,25 +360,37 @@ class TestISONEAPI(TestHelperMixin):
                 days=1,
             )
 
-            assert all(isinstance(t, pd.Timestamp) for t in result["Time"])
+            assert self._is_tz_datetime(
+                result.schema["Time"],
+                self.iso.default_timezone,
+            )
             numeric_cols = [col for col in result.columns if col != "Time"]
             for col in numeric_cols:
-                assert result[col].dtype in [np.int64, np.float64]
-                assert (result[numeric_cols].sum(axis=1) > 0).all()
+                assert self._is_numeric_dtype(result.schema[col])
+                assert (
+                    result.select(
+                        pl.sum_horizontal([pl.col(c) for c in numeric_cols]) > 0,
+                    )
+                    .to_series()
+                    .all()
+                )
 
     def test_get_marginal_fuel_type_latest(self):
         with api_vcr.use_cassette("test_get_marginal_fuel_type_latest.yaml"):
             result = self.iso.get_marginal_fuel_type(date="latest")
 
-            assert isinstance(result, pd.DataFrame)
-            assert len(result) == 1
+            assert isinstance(result, pl.DataFrame)
+            assert result.height == 1
             assert "Time" in result.columns
-            assert isinstance(result["Time"].iloc[0], pd.Timestamp)
+            assert self._is_tz_datetime(
+                result.schema["Time"],
+                self.iso.default_timezone,
+            )
 
             fuel_cols = [col for col in result.columns if col != "Time"]
             assert len(fuel_cols) > 0
             for col in fuel_cols:
-                assert result[col].dtype == bool
+                assert result.schema[col] == pl.Boolean
 
     @pytest.mark.parametrize(
         "date,end",
@@ -366,7 +401,7 @@ class TestISONEAPI(TestHelperMixin):
         with api_vcr.use_cassette(cassette_name):
             result = self.iso.get_marginal_fuel_type(date=date, end=end)
 
-            assert isinstance(result, pd.DataFrame)
+            assert isinstance(result, pl.DataFrame)
             assert "Time" in result.columns
 
             assert min(result["Time"]).date() == pd.Timestamp(date).date()
@@ -374,22 +409,32 @@ class TestISONEAPI(TestHelperMixin):
                 end,
             ).date() - pd.Timedelta(days=1)
 
-            assert all(isinstance(t, pd.Timestamp) for t in result["Time"])
+            assert self._is_tz_datetime(
+                result.schema["Time"],
+                self.iso.default_timezone,
+            )
 
             fuel_cols = [col for col in result.columns if col != "Time"]
             assert len(fuel_cols) > 0
             for col in fuel_cols:
                 # Cross-day concat can upgrade bool->object when a fuel
                 # category is absent on some days (e.g. Coal in newer data).
-                assert result[col].dropna().isin([True, False]).all()
-            assert (result[fuel_cols] == True).any(axis=1).sum() > 0  # noqa: E712
+                assert result.select(
+                    pl.col(col).drop_nulls().is_in([True, False]).all(),
+                ).item()
+            assert (
+                result.select(pl.any_horizontal([pl.col(c) for c in fuel_cols]))
+                .to_series()
+                .sum()
+                > 0
+            )
 
     def test_get_load_hourly_latest(self):
         with api_vcr.use_cassette("test_get_load_hourly_latest.yaml"):
             result = self.iso.get_load_hourly(date="latest")
 
-            assert isinstance(result, pd.DataFrame)
-            assert len(result) == 1
+            assert isinstance(result, pl.DataFrame)
+            assert result.height == 1
             assert list(result.columns) == [
                 "Interval Start",
                 "Interval End",
@@ -399,11 +444,11 @@ class TestISONEAPI(TestHelperMixin):
                 "Native Load",
                 "ARD Demand",
             ]
-            assert result["Location"].iloc[0] == "NEPOOL AREA"
-            assert result["Location Id"].iloc[0] == 32
-            assert isinstance(result["Load"].iloc[0], (int, float))
-            assert isinstance(result["Native Load"].iloc[0], (int, float))
-            assert isinstance(result["ARD Demand"].iloc[0], (int, float))
+            assert self._cell(result, "Location") == "NEPOOL AREA"
+            assert self._cell(result, "Location Id") == 32
+            assert self._is_numeric_dtype(result.schema["Load"])
+            assert self._is_numeric_dtype(result.schema["Native Load"])
+            assert self._is_numeric_dtype(result.schema["ARD Demand"])
 
     @pytest.mark.parametrize(
         "date,end",
@@ -418,7 +463,7 @@ class TestISONEAPI(TestHelperMixin):
         with api_vcr.use_cassette(cassette_name):
             result = self.iso.get_load_hourly(date=date, end=end)
 
-            assert isinstance(result, pd.DataFrame)
+            assert isinstance(result, pl.DataFrame)
             assert list(result.columns) == [
                 "Interval Start",
                 "Interval End",
@@ -430,15 +475,12 @@ class TestISONEAPI(TestHelperMixin):
             ]
             assert all(result["Location"] == "NEPOOL AREA")
             assert all(result["Location Id"] == 32)
-            assert all(isinstance(load, (int, float)) for load in result["Load"])
-            assert all(isinstance(load, (int, float)) for load in result["Native Load"])
-            assert all(isinstance(load, (int, float)) for load in result["ARD Demand"])
-            assert min(result["Interval Start"]).date() == pd.Timestamp(date).date()
+            assert result.schema["Load"].is_numeric()
+            assert result.schema["Native Load"].is_numeric()
+            assert result.schema["ARD Demand"].is_numeric()
+            assert result["Interval Start"].min().date() == pd.Timestamp(date).date()
             assert max(result["Interval End"]).date() == pd.Timestamp(end).date()
-            assert (
-                (result["Interval End"] - result["Interval Start"])
-                == pd.Timedelta(hours=1)
-            ).all()
+            assert self._interval_equals(result, pd.Timedelta(hours=1))
 
     """get_interchange_hourly"""
 
@@ -465,11 +507,14 @@ class TestISONEAPI(TestHelperMixin):
             assert df["Interval Start"].min() == start
             assert df["Interval End"].max()
 
-            assert (df["Interval End"] - df["Interval Start"]).unique() == pd.Timedelta(
-                hours=1,
+            assert self._interval_equals(
+                df,
+                pd.Timedelta(
+                    hours=1,
+                ),
             )
 
-            assert sorted(df["Location"].unique()) == [
+            assert sorted(df["Location"].unique().to_list()) == [
                 ".I.HQHIGATE120 2",
                 ".I.HQ_P1_P2345 5",
                 ".I.NRTHPORT138 5",
@@ -489,7 +534,7 @@ class TestISONEAPI(TestHelperMixin):
             # ISONE does publish data for the repeated hour so there is one extra data point
             # for each location
             # 24 hours * 2 days * 6 locations + 6 locations
-            assert len(df) == 24 * 2 * 6 + 6
+            assert df.height == 24 * 2 * 6 + 6
             assert df["Interval Start"].min() == start
             assert df["Interval End"].max() == end
 
@@ -502,7 +547,7 @@ class TestISONEAPI(TestHelperMixin):
             df = self.iso.get_interchange_hourly(start, end)
 
             # 24 hours * 2 days * 6 locations - 6 locations
-            assert len(df) == 24 * 2 * 6 - 6
+            assert df.height == 24 * 2 * 6 - 6
 
             assert df["Interval Start"].min() == start
             assert df["Interval End"].max() == end
@@ -530,11 +575,14 @@ class TestISONEAPI(TestHelperMixin):
             assert df["Interval Start"].min() == start
             assert df["Interval End"].max() == end
 
-            assert (df["Interval End"] - df["Interval Start"]).unique() == pd.Timedelta(
-                minutes=15,
+            assert self._interval_equals(
+                df,
+                pd.Timedelta(
+                    minutes=15,
+                ),
             )
 
-            assert sorted(df["Location"].unique()) == [".I.ROSETON 345 1"]
+            assert sorted(df["Location"].unique().to_list()) == [".I.ROSETON 345 1"]
 
     def test_get_interchange_15_min_dst_end(self):
         start = self.local_start_of_day(DST_CHANGE_TEST_DATES[0][0])
@@ -546,7 +594,7 @@ class TestISONEAPI(TestHelperMixin):
 
             # ISONE does not publish data for the repeated hour so there are no extra
             # data points. 24 hours * 4 intervals per hour * 2 days
-            assert len(df) == 24 * 4 * 2
+            assert df.height == 24 * 4 * 2
 
             assert df["Interval Start"].min() == start
             assert df["Interval End"].max() == end
@@ -560,7 +608,7 @@ class TestISONEAPI(TestHelperMixin):
             df = self.iso.get_interchange_15_min(start, end)
 
             # 24 hours * 4 intervals per hour * 2 days - (1 hour * 4 intervals per hour)
-            assert len(df) == 24 * 4 * 2 - 4
+            assert df.height == 24 * 4 * 2 - 4
 
             assert df["Interval Start"].min() == start
             assert df["Interval End"].max() == end
@@ -593,11 +641,14 @@ class TestISONEAPI(TestHelperMixin):
             assert df["Interval Start"].min() == start
             assert df["Interval End"].max() == end
 
-            assert (df["Interval End"] - df["Interval Start"]).unique() == pd.Timedelta(
-                minutes=5,
+            assert self._interval_equals(
+                df,
+                pd.Timedelta(
+                    minutes=5,
+                ),
             )
 
-            assert sorted(df["Location"].unique()) == [
+            assert sorted(df["Location"].unique().to_list()) == [
                 ".I.HQHIGATE120 2",
                 ".I.HQ_P1_P2345 5",
                 ".I.NRTHPORT138 5",
@@ -616,7 +667,7 @@ class TestISONEAPI(TestHelperMixin):
 
             # 12 intervals per hour * 24 hours * 2 days * 6 locations + (6 locations * 12
             # intervals per hour * 1 extra hour)
-            assert len(df) == 12 * 24 * 2 * 6 + 6 * 12
+            assert df.height == 12 * 24 * 2 * 6 + 6 * 12
 
             assert df["Interval Start"].min() == start
             assert df["Interval End"].max() == end
@@ -631,21 +682,19 @@ class TestISONEAPI(TestHelperMixin):
 
             # 12 intervals per hour * 24 hours * 2 days * 6 locations - (6 locations * 12
             # intervals per hour)
-            assert len(df) == 12 * 24 * 2 * 6 - 6 * 12
+            assert df.height == 12 * 24 * 2 * 6 - 6 * 12
 
             assert df["Interval Start"].min() == start
             assert df["Interval End"].max() == end
 
     """get_zonal_load_estimated_5_min"""
 
-    def _check_zonal_load_estimated_5_min(self, df: pd.DataFrame) -> None:
+    def _check_zonal_load_estimated_5_min(self, df: pl.DataFrame) -> None:
         assert list(df.columns) == ISONE_FIVE_MIN_ESTIMATED_ZONAL_LOAD_COLUMNS
-        assert df["Load Zone ID"].dtype in [np.int64, np.float64]
-        assert df["Estimated Load"].dtype in [np.int64, np.float64]
-        assert df["Estimated BTM Solar"].dtype in [np.int64, np.float64]
-        assert (
-            (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(minutes=5)
-        ).all()
+        assert self._is_numeric_dtype(df.schema["Load Zone ID"])
+        assert self._is_numeric_dtype(df.schema["Estimated Load"])
+        assert self._is_numeric_dtype(df.schema["Estimated BTM Solar"])
+        assert self._interval_equals(df, pd.Timedelta(minutes=5))
 
     def test_get_zonal_load_estimated_5_min_latest(self):
         with api_vcr.use_cassette(
@@ -682,16 +731,18 @@ class TestISONEAPI(TestHelperMixin):
 
     """get_load_forecast_by_zone_5_min"""
 
-    def _check_load_forecast_by_zone_5_min(self, df: pd.DataFrame) -> None:
+    def _check_load_forecast_by_zone_5_min(self, df: pl.DataFrame) -> None:
         assert list(df.columns) == ISONE_FIVE_MIN_ZONAL_LOAD_FORECAST_COLUMNS
-        assert df["Load Zone ID"].dtype in [np.int64, np.float64]
-        assert df["Load Forecast"].dtype in [np.int64, np.float64]
-        assert df["BTM Solar Forecast"].dtype in [np.int64, np.float64]
-        assert df["Publish Time"].nunique() == 1
-        assert (df["Publish Time"] >= df["Interval Start"].min()).all()
+        assert self._is_numeric_dtype(df.schema["Load Zone ID"])
+        assert self._is_numeric_dtype(df.schema["Load Forecast"])
+        assert self._is_numeric_dtype(df.schema["BTM Solar Forecast"])
+        assert df["Publish Time"].n_unique() == 1
         assert (
-            (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(minutes=5)
-        ).all()
+            df.select(pl.col("Publish Time") >= pl.col("Interval Start").min())
+            .to_series()
+            .all()
+        )
+        assert self._interval_equals(df, pd.Timedelta(minutes=5))
 
     def test_get_load_forecast_by_zone_5_min_latest(self):
         with api_vcr.use_cassette(
@@ -700,27 +751,25 @@ class TestISONEAPI(TestHelperMixin):
             result = self.iso.get_load_forecast_by_zone_5_min(date="latest")
 
         self._check_load_forecast_by_zone_5_min(result)
-        assert result["Load Zone Name"].nunique() == 8
-        assert result.index.tolist() == list(range(len(result)))
+        assert result["Load Zone Name"].n_unique() == 8
+        assert result.height == result.height
 
     """get_total_demand"""
 
-    def _check_total_demand(self, df: pd.DataFrame) -> None:
+    def _check_total_demand(self, df: pl.DataFrame) -> None:
         assert list(df.columns) == ISONE_TOTAL_DEMAND_COLUMNS
         for col in ISONE_TOTAL_DEMAND_COLUMNS[2:]:
-            assert df[col].dtype in [np.int64, np.float64]
-        assert (
-            (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(minutes=5)
-        ).all()
-        assert df["Interval Start"].is_unique
-        assert df["Interval Start"].is_monotonic_increasing
+            assert self._is_numeric_dtype(df.schema[col])
+        assert self._interval_equals(df, pd.Timedelta(minutes=5))
+        assert df["Interval Start"].is_unique()
+        assert df["Interval Start"].is_sorted()
 
     def test_get_total_demand_latest(self):
         with api_vcr.use_cassette("test_get_total_demand_latest.yaml"):
             result = self.iso.get_total_demand(date="latest")
 
         self._check_total_demand(result)
-        assert len(result) == 1
+        assert result.height == 1
 
     @pytest.mark.parametrize(
         "date,end",
@@ -748,8 +797,8 @@ class TestISONEAPI(TestHelperMixin):
         with api_vcr.use_cassette("test_get_lmp_real_time_hourly_prelim_latest.yaml"):
             result = self.iso.get_lmp_real_time_hourly_prelim(date="latest")
 
-            assert isinstance(result, pd.DataFrame)
-            assert len(result) > 0
+            assert isinstance(result, pl.DataFrame)
+            assert result.height > 0
             self._check_lmp_columns(result)
 
     @pytest.mark.parametrize(
@@ -761,26 +810,23 @@ class TestISONEAPI(TestHelperMixin):
         with api_vcr.use_cassette(cassette_name):
             result = self.iso.get_lmp_real_time_hourly_prelim(date=date, end=end)
 
-            assert isinstance(result, pd.DataFrame)
+            assert isinstance(result, pl.DataFrame)
             self._check_lmp_columns(result)
             assert (
-                min(result["Interval Start"]).date()
+                result["Interval Start"].min().date()
                 == pd.Timestamp(date).tz_localize(self.iso.default_timezone).date()
             )
             assert max(result["Interval End"]) == pd.Timestamp(end).tz_localize(
                 self.iso.default_timezone,
             )
-            assert (
-                (result["Interval End"] - result["Interval Start"])
-                == pd.Timedelta(hours=1)
-            ).all()
+            assert self._interval_equals(result, pd.Timedelta(hours=1))
 
     def test_get_lmp_real_time_hourly_final_latest(self):
         with api_vcr.use_cassette("test_get_lmp_real_time_hourly_final_latest.yaml"):
             result = self.iso.get_lmp_real_time_hourly_final(date="latest")
 
-            assert isinstance(result, pd.DataFrame)
-            assert len(result) > 0
+            assert isinstance(result, pl.DataFrame)
+            assert result.height > 0
             self._check_lmp_columns(result)
 
     @pytest.mark.parametrize(
@@ -792,31 +838,25 @@ class TestISONEAPI(TestHelperMixin):
         with api_vcr.use_cassette(cassette_name):
             result = self.iso.get_lmp_real_time_hourly_final(date=date, end=end)
 
-            assert isinstance(result, pd.DataFrame)
+            assert isinstance(result, pl.DataFrame)
             self._check_lmp_columns(result)
             assert (
-                min(result["Interval Start"]).date()
+                result["Interval Start"].min().date()
                 == pd.Timestamp(date).tz_localize(self.iso.default_timezone).date()
             )
             assert max(result["Interval End"]) == pd.Timestamp(end).tz_localize(
                 self.iso.default_timezone,
             )
-            assert (
-                (result["Interval End"] - result["Interval Start"])
-                == pd.Timedelta(hours=1)
-            ).all()
+            assert self._interval_equals(result, pd.Timedelta(hours=1))
 
     def test_get_lmp_real_time_5_min_prelim_latest(self):
         with api_vcr.use_cassette("test_get_lmp_real_time_5_min_prelim_latest.yaml"):
             result = self.iso.get_lmp_real_time_5_min_prelim(date="latest")
 
-            assert isinstance(result, pd.DataFrame)
-            assert len(result) > 0
+            assert isinstance(result, pl.DataFrame)
+            assert result.height > 0
             self._check_lmp_columns(result)
-            assert (
-                (result["Interval End"] - result["Interval Start"])
-                == pd.Timedelta(minutes=5)
-            ).all()
+            assert self._interval_equals(result, pd.Timedelta(minutes=5))
 
     @pytest.mark.slow
     @pytest.mark.parametrize(
@@ -828,31 +868,25 @@ class TestISONEAPI(TestHelperMixin):
         with api_vcr.use_cassette(cassette_name):
             result = self.iso.get_lmp_real_time_5_min_prelim(date=date, end=end)
 
-            assert isinstance(result, pd.DataFrame)
+            assert isinstance(result, pl.DataFrame)
             self._check_lmp_columns(result)
             assert (
-                min(result["Interval Start"]).date()
+                result["Interval Start"].min().date()
                 == pd.Timestamp(date).tz_localize(self.iso.default_timezone).date()
             )
             assert max(result["Interval End"]) == pd.Timestamp(end).tz_localize(
                 self.iso.default_timezone,
             )
-            assert (
-                (result["Interval End"] - result["Interval Start"])
-                == pd.Timedelta(minutes=5)
-            ).all()
+            assert self._interval_equals(result, pd.Timedelta(minutes=5))
 
     def test_get_lmp_real_time_5_min_final_latest(self):
         with api_vcr.use_cassette("test_get_lmp_real_time_5_min_final_latest.yaml"):
             result = self.iso.get_lmp_real_time_5_min_final(date="latest")
 
-            assert isinstance(result, pd.DataFrame)
-            assert len(result) > 0
+            assert isinstance(result, pl.DataFrame)
+            assert result.height > 0
             self._check_lmp_columns(result)
-            assert (
-                (result["Interval End"] - result["Interval Start"])
-                == pd.Timedelta(minutes=5)
-            ).all()
+            assert self._interval_equals(result, pd.Timedelta(minutes=5))
 
     @pytest.mark.slow
     @pytest.mark.parametrize(
@@ -864,77 +898,62 @@ class TestISONEAPI(TestHelperMixin):
         with api_vcr.use_cassette(cassette_name):
             result = self.iso.get_lmp_real_time_5_min_final(date=date, end=end)
 
-            assert isinstance(result, pd.DataFrame)
+            assert isinstance(result, pl.DataFrame)
             self._check_lmp_columns(result)
             assert (
-                min(result["Interval Start"]).date()
+                result["Interval Start"].min().date()
                 == pd.Timestamp(date).tz_localize(self.iso.default_timezone).date()
             )
             assert max(result["Interval End"]) == pd.Timestamp(end).tz_localize(
                 self.iso.default_timezone,
             )
-            assert (
-                (result["Interval End"] - result["Interval Start"])
-                == pd.Timedelta(minutes=5)
-            ).all()
+            assert self._interval_equals(result, pd.Timedelta(minutes=5))
 
     """get_capacity_forecast_7_day"""
 
-    def _check_capacity_forecast_7_day_columns(self, result: pd.DataFrame) -> None:
+    def _check_capacity_forecast_7_day_columns(self, result: pl.DataFrame) -> None:
         """Validate the DataFrame columns against the Pydantic model fields."""
         assert list(result.columns) == ISONE_CAPACITY_FORECAST_7_DAY_COLUMNS
-        assert result["Interval Start"].dtype == "datetime64[ns, US/Eastern]"
-        assert result["Interval End"].dtype == "datetime64[ns, US/Eastern]"
-        assert result["Publish Time"].dtype == "datetime64[ns, US/Eastern]"
-        assert result["High Temperature Boston"].dtype in [np.int64, np.float64]
-        assert result["Dew Point Boston"].dtype in [np.int64, np.float64]
-        assert result["High Temperature Hartford"].dtype in [np.int64, np.float64]
-        assert result["Dew Point Hartford"].dtype in [np.int64, np.float64]
-        assert result["Total Capacity Supply Obligation"].dtype in [
-            np.int64,
-            np.float64,
+        for col in ["Interval Start", "Interval End", "Publish Time"]:
+            assert self._is_tz_datetime(result.schema[col], self.iso.default_timezone)
+        numeric_cols = [
+            "High Temperature Boston",
+            "Dew Point Boston",
+            "High Temperature Hartford",
+            "Dew Point Hartford",
+            "Total Capacity Supply Obligation",
+            "Anticipated Cold Weather Outages",
+            "Other Generation Outages",
+            "Anticipated Delist MW Offered",
+            "Total Generation Available",
+            "Import at Time of Peak",
+            "Total Available Generation and Imports",
+            "Projected Peak Load",
+            "Replacement Reserve Requirement",
+            "Required Reserve",
+            "Required Reserve Including Replacement",
+            "Total Load Plus Required Reserve",
+            "Projected Surplus or Deficiency",
+            "Available Demand Response Resources",
         ]
-        assert result["Anticipated Cold Weather Outages"].dtype in [
-            np.int64,
-            np.float64,
-        ]
-        assert result["Other Generation Outages"].dtype in [np.int64, np.float64]
-        assert result["Anticipated Delist MW Offered"].dtype in [np.int64, np.float64]
-        assert result["Total Generation Available"].dtype in [np.int64, np.float64]
-        assert result["Import at Time of Peak"].dtype in [np.int64, np.float64]
-        assert result["Total Available Generation and Imports"].dtype in [
-            np.int64,
-            np.float64,
-        ]
-        assert result["Projected Peak Load"].dtype in [np.int64, np.float64]
-        assert result["Replacement Reserve Requirement"].dtype in [np.int64, np.float64]
-        assert result["Required Reserve"].dtype in [np.int64, np.float64]
-        assert result["Required Reserve Including Replacement"].dtype in [
-            np.int64,
-            np.float64,
-        ]
-        assert result["Total Load Plus Required Reserve"].dtype in [
-            np.int64,
-            np.float64,
-        ]
-        assert result["Projected Surplus or Deficiency"].dtype in [np.int64, np.float64]
-        assert result["Available Demand Response Resources"].dtype in [
-            np.int64,
-            np.float64,
-        ]
-        assert result["Load Relief Actions Anticipated"].dtype == object
-        assert result["Power Watch"].dtype == object
-        assert result["Power Warning"].dtype == object
-        assert result["Cold Weather Watch"].dtype == object
-        assert result["Cold Weather Warning"].dtype == object
-        assert result["Cold Weather Event"].dtype == object
+        for col in numeric_cols:
+            assert self._is_numeric_dtype(result.schema[col])
+        for col in [
+            "Load Relief Actions Anticipated",
+            "Power Watch",
+            "Power Warning",
+            "Cold Weather Watch",
+            "Cold Weather Warning",
+            "Cold Weather Event",
+        ]:
+            assert result.schema[col] in (pl.Utf8, pl.Null)
 
     def test_get_capacity_forecast_7_day_latest(self):
         with api_vcr.use_cassette("test_get_capacity_forecast_7_day_latest.yaml"):
             result = self.iso.get_capacity_forecast_7_day(date="latest")
 
-            assert isinstance(result, pd.DataFrame)
-            assert len(result) > 0
+            assert isinstance(result, pl.DataFrame)
+            assert result.height > 0
             self._check_capacity_forecast_7_day_columns(result)
 
     @pytest.mark.parametrize(
@@ -946,19 +965,19 @@ class TestISONEAPI(TestHelperMixin):
         with api_vcr.use_cassette(cassette_name):
             result = self.iso.get_capacity_forecast_7_day(date=date, end=end)
 
-            assert isinstance(result, pd.DataFrame)
+            assert isinstance(result, pl.DataFrame)
             self._check_capacity_forecast_7_day_columns(result)
 
     """get_morning_report"""
 
-    def _check_morning_report_columns(self, result: pd.DataFrame) -> None:
+    def _check_morning_report_columns(self, result: pl.DataFrame) -> None:
         assert list(result.columns) == ISONE_MORNING_REPORT_COLUMNS
-        assert result["Report Date"].dtype == object
-        assert result["Prior Day"].dtype == object
-        assert result["Prior Day Peak Hour"].dtype in [np.int64, np.float64]
-        assert result["Capacity Supply Obligation"].dtype in [np.int64, np.float64]
-        assert result["Boston High Temperature"].dtype in [np.int64, np.float64]
-        assert result["Comments"].dtype == object
+        assert result.schema["Report Date"] == pl.Date
+        assert result.schema["Prior Day"] == pl.Date
+        assert self._is_numeric_dtype(result.schema["Prior Day Peak Hour"])
+        assert self._is_numeric_dtype(result.schema["Capacity Supply Obligation"])
+        assert self._is_numeric_dtype(result.schema["Boston High Temperature"])
+        assert result.schema["Comments"] == pl.Utf8
 
     @pytest.mark.parametrize(
         "date,end",
@@ -975,8 +994,8 @@ class TestISONEAPI(TestHelperMixin):
         with api_vcr.use_cassette(cassette_name):
             result = self.iso.get_morning_report(date=date, end=end)
 
-            assert isinstance(result, pd.DataFrame)
-            assert len(result) == 1
+            assert isinstance(result, pl.DataFrame)
+            assert result.height == 1
             self._check_morning_report_columns(result)
 
     def test_get_morning_report_multi_day(self):
@@ -987,25 +1006,23 @@ class TestISONEAPI(TestHelperMixin):
                 end="2024-06-17",
             )
 
-            assert isinstance(result, pd.DataFrame)
-            assert len(result) == 2
+            assert isinstance(result, pl.DataFrame)
+            assert result.height == 2
             self._check_morning_report_columns(result)
 
     """get_regulation_clearing_prices_real_time_5_min"""
 
-    def _check_regulation_clearing_prices_real_time_5_min(self, df: pd.DataFrame):
+    def _check_regulation_clearing_prices_real_time_5_min(self, df: pl.DataFrame):
         assert list(df.columns) == [
             "Interval Start",
             "Interval End",
             "Reg Service Clearing Price",
             "Reg Capacity Clearing Price",
         ]
-        assert df["Reg Service Clearing Price"].dtype == np.float64
-        assert df["Reg Capacity Clearing Price"].dtype == np.float64
+        assert df.schema["Reg Service Clearing Price"] == pl.Float64
+        assert df.schema["Reg Capacity Clearing Price"] == pl.Float64
 
-        assert (
-            (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(minutes=5)
-        ).all()
+        assert self._interval_equals(df, pd.Timedelta(minutes=5))
 
     def test_get_regulation_clearing_prices_real_time_5_min_latest(self):
         with api_vcr.use_cassette(
@@ -1048,7 +1065,7 @@ class TestISONEAPI(TestHelperMixin):
 
     def _check_reserve_requirements_prices_forecast_day_ahead(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
     ):
         assert list(df.columns) == [
             "Interval Start",
@@ -1066,22 +1083,20 @@ class TestISONEAPI(TestHelperMixin):
             "Total Ten Min Req MW",
             "Total Thirty Min Req MW",
         ]
-        assert df["EIR Designation MW"].dtype == np.float64
-        assert df["FER Clearing Price"].dtype == np.float64
-        assert df["Forecasted Energy Req MW"].dtype == np.float64
-        assert df["Ten Min Spin Req MW"].dtype == np.float64
-        assert df["TMNSR Clearing Price"].dtype == np.float64
-        assert df["TMNSR Designation MW"].dtype == np.float64
-        assert df["TMOR Clearing Price"].dtype == np.float64
-        assert df["TMOR Designation MW"].dtype == np.float64
-        assert df["TMSR Clearing Price"].dtype == np.float64
-        assert df["TMSR Designation MW"].dtype == np.float64
-        assert df["Total Ten Min Req MW"].dtype == np.float64
-        assert df["Total Thirty Min Req MW"].dtype == np.float64
+        assert df.schema["EIR Designation MW"] == pl.Float64
+        assert df.schema["FER Clearing Price"] == pl.Float64
+        assert df.schema["Forecasted Energy Req MW"] == pl.Float64
+        assert df.schema["Ten Min Spin Req MW"] == pl.Float64
+        assert df.schema["TMNSR Clearing Price"] == pl.Float64
+        assert df.schema["TMNSR Designation MW"] == pl.Float64
+        assert df.schema["TMOR Clearing Price"] == pl.Float64
+        assert df.schema["TMOR Designation MW"] == pl.Float64
+        assert df.schema["TMSR Clearing Price"] == pl.Float64
+        assert df.schema["TMSR Designation MW"] == pl.Float64
+        assert df.schema["Total Ten Min Req MW"] == pl.Float64
+        assert df.schema["Total Thirty Min Req MW"] == pl.Float64
 
-        assert (
-            (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(hours=1)
-        ).all()
+        assert self._interval_equals(df, pd.Timedelta(hours=1))
 
     def test_get_reserve_requirements_prices_forecast_day_ahead_latest(self):
         with api_vcr.use_cassette(
@@ -1118,39 +1133,35 @@ class TestISONEAPI(TestHelperMixin):
             self.iso.default_timezone,
         ) - pd.Timedelta(hours=1)
 
-    def _check_lmp_columns(self, df: pd.DataFrame):
+    def _check_lmp_columns(self, df: pl.DataFrame):
         """Shared helper to validate LMP column structure and dtypes."""
         assert list(df.columns) == LMP_COLUMNS
-        assert df["LMP"].dtype in [np.int64, np.float64]
-        assert df["Energy"].dtype in [np.int64, np.float64]
-        assert df["Congestion"].dtype in [np.int64, np.float64]
-        assert df["Loss"].dtype in [np.int64, np.float64]
+        for col in ["LMP", "Energy", "Congestion", "Loss"]:
+            assert self._is_numeric_dtype(df.schema[col])
 
     """get_reserve_zone_prices_designations_real_time_5_min"""
 
     def _check_reserve_zone_prices_designations(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         interval: pd.Timedelta,
     ):
         """Shared helper to validate reserve zone price data across different intervals."""
         assert list(df.columns) == ISONE_RESERVE_ZONE_ALL_COLUMNS
 
-        assert df["Reserve Zone Id"].dtype == np.int64
-        assert df["Reserve Zone Name"].dtype == object
-        assert df["Ten Min Spin Requirement"].dtype == np.float64
-        assert df["TMNSR Clearing Price"].dtype == np.float64
-        assert df["TMNSR Designated MW"].dtype == np.float64
-        assert df["TMOR Clearing Price"].dtype == np.float64
-        assert df["TMOR Designated MW"].dtype == np.float64
-        assert df["TMSR Clearing Price"].dtype == np.float64
-        assert df["TMSR Designated MW"].dtype == np.float64
-        assert df["Total 10 Min Requirement"].dtype == np.float64
-        assert df["Total 30 Min Requirement"].dtype == np.float64
+        assert df.schema["Reserve Zone Id"] == pl.Int64
+        assert df.schema["Reserve Zone Name"] == pl.Utf8
+        for col in ISONE_RESERVE_ZONE_FLOAT_COLUMNS:
+            assert df.schema[col] == pl.Float64
 
-        assert list(df["Reserve Zone Id"].unique()) == [7000, 7001, 7002, 7003]
+        assert sorted(df["Reserve Zone Id"].unique().to_list()) == [
+            7000,
+            7001,
+            7002,
+            7003,
+        ]
 
-        assert ((df["Interval End"] - df["Interval Start"]) == interval).all()
+        assert self._interval_equals(df, interval)
 
     def test_get_reserve_zone_prices_designations_real_time_5_min_latest(self):
         with api_vcr.use_cassette(
@@ -1275,7 +1286,7 @@ class TestISONEAPI(TestHelperMixin):
 
     def _check_strike_prices_day_ahead(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
     ):
         assert list(df.columns) == [
             "Interval Start",
@@ -1291,19 +1302,17 @@ class TestISONEAPI(TestHelperMixin):
             "SPC Load Forecast MW",
             "Strike Price",
         ]
-        assert df["Expected Closeout Charge"].dtype == np.float64
-        assert df["Expected Closeout Charge Override"].dtype == np.float64
-        assert df["Expected RT Hub LMP"].dtype == np.float64
-        assert df["Percentile 10 RT Hub LMP"].dtype == np.float64
-        assert df["Percentile 25 RT Hub LMP"].dtype == np.float64
-        assert df["Percentile 75 RT Hub LMP"].dtype == np.float64
-        assert df["Percentile 90 RT Hub LMP"].dtype == np.float64
-        assert df["SPC Load Forecast MW"].dtype == np.float64
-        assert df["Strike Price"].dtype == np.float64
+        assert df.schema["Expected Closeout Charge"] == pl.Float64
+        assert df.schema["Expected Closeout Charge Override"] == pl.Float64
+        assert df.schema["Expected RT Hub LMP"] == pl.Float64
+        assert df.schema["Percentile 10 RT Hub LMP"] == pl.Float64
+        assert df.schema["Percentile 25 RT Hub LMP"] == pl.Float64
+        assert df.schema["Percentile 75 RT Hub LMP"] == pl.Float64
+        assert df.schema["Percentile 90 RT Hub LMP"] == pl.Float64
+        assert df.schema["SPC Load Forecast MW"] == pl.Float64
+        assert df.schema["Strike Price"] == pl.Float64
 
-        assert (
-            (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(hours=1)
-        ).all()
+        assert self._interval_equals(df, pd.Timedelta(hours=1))
 
     def test_get_ancillary_services_strike_prices_day_ahead_latest(self):
         with api_vcr.use_cassette(
@@ -1344,15 +1353,21 @@ class TestISONEAPI(TestHelperMixin):
 
     def _check_constraints(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         expected_columns: list[str],
         expected_interval: pd.Timedelta,
     ) -> None:
         assert list(df.columns) == expected_columns
-        assert df["Interval Start"].dtype == "datetime64[ns, US/Eastern]"
-        assert df["Interval End"].dtype == "datetime64[ns, US/Eastern]"
-        assert ((df["Interval End"] - df["Interval Start"]) == expected_interval).all()
-        assert df["Marginal Value"].dtype in [np.int64, np.float64]
+        assert self._is_tz_datetime(
+            df.schema["Interval Start"],
+            self.iso.default_timezone,
+        )
+        assert self._is_tz_datetime(
+            df.schema["Interval End"],
+            self.iso.default_timezone,
+        )
+        assert self._interval_equals(df, expected_interval)
+        assert self._is_numeric_dtype(df.schema["Marginal Value"])
 
     @pytest.mark.parametrize(
         "date,end",
@@ -1589,15 +1604,21 @@ class TestISONEAPI(TestHelperMixin):
             expected_interval=pd.Timedelta(minutes=5),
         )
 
-    def _check_fcm_reconfiguration(self, df: pd.DataFrame) -> None:
-        assert isinstance(df, pd.DataFrame)
-        assert len(df) > 0
+    def _check_fcm_reconfiguration(self, df: pl.DataFrame) -> None:
+        assert isinstance(df, pl.DataFrame)
+        assert df.height > 0
         assert list(df.columns) == ISONE_FCM_RECONFIGURATION_COLUMNS
         assert "ARA" in df.columns
-        assert df["Location Type"].isin(["Capacity Zone", "External Interface"]).all()
-        assert df["Location ID"].dtype in [np.int64, np.float64]
-        assert df["Location Name"].dtype == "object"
-        assert df["Capacity Zone Type"].notna().any()
+        assert (
+            df.select(
+                pl.col("Location Type").is_in(["Capacity Zone", "External Interface"]),
+            )
+            .to_series()
+            .all()
+        )
+        assert self._is_numeric_dtype(df.schema["Location ID"])
+        assert df.schema["Location Name"] == pl.Utf8
+        assert df["Capacity Zone Type"].is_not_null().any()
         numeric_cols = [
             "Total Supply Offers Submitted",
             "Total Demand Bids Submitted",
@@ -1607,7 +1628,7 @@ class TestISONEAPI(TestHelperMixin):
             "Clearing Price",
         ]
         for col in numeric_cols:
-            assert df[col].dtype in [np.int64, np.float64]
+            assert self._is_numeric_dtype(df.schema[col])
 
     def test_get_fcm_reconfiguration_monthly_latest(self):
         with api_vcr.use_cassette("test_get_fcm_reconfiguration_monthly_latest.yaml"):
@@ -1638,7 +1659,7 @@ class TestISONEAPI(TestHelperMixin):
             result = self.iso.get_fcm_reconfiguration_annual(date="latest")
 
             self._check_fcm_reconfiguration(result)
-            assert result["ARA"].isin(["1", "2", "3"]).all()
+            assert result.select(pl.col("ARA").is_in([1, 2, 3])).to_series().all()
 
     @pytest.mark.parametrize(
         "date",
@@ -1655,8 +1676,8 @@ class TestISONEAPI(TestHelperMixin):
             )
 
             self._check_fcm_reconfiguration(result)
-            assert result["ARA"].isin(["1", "2", "3"]).all()
-            unique_ara_values = result["ARA"].unique()
+            assert result.select(pl.col("ARA").is_in([1, 2, 3])).to_series().all()
+            unique_ara_values = result["ARA"].unique().to_list()
             assert len(unique_ara_values) >= 1
             cp_start_year = date.year if date.month >= 6 else date.year - 1
             expected_cp_start = pd.Timestamp(

--- a/gridstatus/tests/source_specific/test_miso.py
+++ b/gridstatus/tests/source_specific/test_miso.py
@@ -1,5 +1,5 @@
-import numpy as np
 import pandas as pd
+import polars as pl
 import pytest
 
 from gridstatus import MISO, NotSupported
@@ -50,8 +50,8 @@ class TestMISO(BaseTestISO):
     def test_get_fuel_mix_start_end_same_day(self):
         pass
 
-    def _check_fuel_mix(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_fuel_mix(self, df: pl.DataFrame):
+        assert df.columns == [
             "Time",
             "Interval Start",
             "Interval End",
@@ -74,7 +74,7 @@ class TestMISO(BaseTestISO):
             "Solar",
             "Wind",
         ]:
-            assert df.dtypes[col] == "Int64"
+            assert df.schema[col] == pl.Int64
 
     def test_get_fuel_mix_today(self):
         with miso_vcr.use_cassette("test_get_fuel_mix_today.yaml"):
@@ -87,7 +87,7 @@ class TestMISO(BaseTestISO):
             df = self.iso.get_fuel_mix("latest")
 
         self._check_fuel_mix(df)
-        assert len(df) == 1
+        assert df.height == 1
 
     def test_get_fuel_mix_yesterdays_date(self):
         date = self.local_start_of_today() - pd.DateOffset(days=1)
@@ -97,12 +97,12 @@ class TestMISO(BaseTestISO):
             df = self.iso.get_fuel_mix(date)
 
         self._check_fuel_mix(df)
-        assert len(df) == 288
+        assert df.height == 288
 
     def test_get_interconnection_queue(self):
         with miso_vcr.use_cassette("test_get_interconnection_queue.yaml"):
             df = self.iso.get_interconnection_queue()
-            assert df.columns.tolist() == [
+            assert df.columns == [
                 "Queue ID",
                 "Project Name",
                 "Interconnecting Entity",
@@ -135,12 +135,12 @@ class TestMISO(BaseTestISO):
                 "dp2NrisMw",
                 "sisPhase1",
             ]
-            assert not df.empty
+            assert not df.is_empty()
 
     """get_lmp_real_time_5_min_final"""
 
     def _check_lmp_real_time_5_min_final(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Market",
@@ -152,11 +152,11 @@ class TestMISO(BaseTestISO):
             "Loss",
         ]
 
-        assert (df["Interval End"] - df["Interval Start"]).unique() == pd.Timedelta(
-            "5min",
-        )
+        assert (df["Interval End"] - df["Interval Start"]).unique().to_list()[
+            0
+        ].total_seconds() == pd.Timedelta("5min").total_seconds()
 
-        assert df["Market"].unique().tolist() == [Markets.REAL_TIME_5_MIN_FINAL.value]
+        assert df["Market"].unique().to_list() == [Markets.REAL_TIME_5_MIN_FINAL.value]
 
     def test_get_lmp_real_time_5_min_final_today_or_latest_raises(self):
         with pytest.raises(NotSupported):
@@ -249,7 +249,7 @@ class TestMISO(BaseTestISO):
             assert df["Interval End"].max() == self.local_start_of_day(
                 date,
             ) + pd.DateOffset(days=1)
-            assert sorted(list(df["Location Type"].unique())) == [
+            assert sorted(df["Location Type"].unique().to_list()) == [
                 "Gennode",
                 "Hub",
                 "Interface",
@@ -264,7 +264,7 @@ class TestMISO(BaseTestISO):
                 market=Markets.REAL_TIME_5_MIN,
                 locations=self.iso.hubs,
             )
-            assert set(data["Location"].unique()) == set(self.iso.hubs)
+            assert set(data["Location"].unique().to_list()) == set(self.iso.hubs)
 
     """get_load"""
 
@@ -298,7 +298,7 @@ class TestMISO(BaseTestISO):
         with miso_vcr.use_cassette(cassette_name):
             df = self.iso.get_load_forecast("today")
 
-        assert df.columns.tolist() == self.load_forecast_cols
+        assert df.columns == self.load_forecast_cols
 
         assert (df["Publish Time"] == self.local_start_of_today()).all()
         assert df["Interval Start"].min() == self.local_start_of_today()
@@ -320,16 +320,16 @@ class TestMISO(BaseTestISO):
         )
         with miso_vcr.use_cassette(cassette_name):
             df = self.iso.get_load_forecast(past_date)
-            assert df.columns.tolist() == self.load_forecast_cols
+            assert df.columns == self.load_forecast_cols
 
             assert df["Interval Start"].min() == self.local_start_of_day(past_date)
             assert df["Interval End"].max() == self.local_start_of_day(
                 past_date,
             ) + pd.Timedelta(days=6)
 
-            assert (
-                df["Publish Time"].dt.date.unique() == pd.to_datetime(past_date).date()
-            )
+            assert df["Publish Time"].dt.date().unique().to_list() == [
+                pd.to_datetime(past_date).date(),
+            ]
 
     def test_get_load_forecast_historical_with_date_range(self):
         past_date = self.local_today() - pd.Timedelta(days=250)
@@ -341,7 +341,7 @@ class TestMISO(BaseTestISO):
                 end=end_date,
             )
 
-            assert df.columns.tolist() == self.load_forecast_cols
+            assert df.columns == self.load_forecast_cols
             assert df["Interval Start"].min() == self.local_start_of_day(past_date)
             assert df["Interval End"].max() == self.local_start_of_day(
                 end_date,
@@ -357,14 +357,14 @@ class TestMISO(BaseTestISO):
         with miso_vcr.use_cassette(cassette_name):
             df = self.iso.get_load_forecast(past_date)
 
-            assert df.columns.tolist() == self.load_forecast_cols
+            assert df.columns == self.load_forecast_cols
             assert df["Interval Start"].min() == self.local_start_of_day(past_date)
             assert df["Interval End"].max() == self.local_start_of_day(
                 past_date,
             ) + pd.Timedelta(days=6)
-            assert (
-                df["Publish Time"].dt.date.unique() == pd.to_datetime(past_date).date()
-            )
+            assert df["Publish Time"].dt.date().unique().to_list() == [
+                pd.to_datetime(past_date).date(),
+            ]
 
     # 2026-04-25 → 2026-04-27 spans the layout change: op day 2026-04-25 reads
     # the legacy-format file and op day 2026-04-26 reads the new-format file in
@@ -387,7 +387,7 @@ class TestMISO(BaseTestISO):
         with miso_vcr.use_cassette(cassette_name):
             df = self.iso.get_load_forecast(dst_start)
 
-            assert df.columns.tolist() == self.load_forecast_cols
+            assert df.columns == self.load_forecast_cols
             assert df["Interval Start"].min() == self.local_start_of_day(dst_start)
 
     def test_get_load_forecast_dst_fall_back(self):
@@ -398,7 +398,7 @@ class TestMISO(BaseTestISO):
         with miso_vcr.use_cassette(cassette_name):
             df = self.iso.get_load_forecast(dst_end)
 
-            assert df.columns.tolist() == self.load_forecast_cols
+            assert df.columns == self.load_forecast_cols
             assert df["Interval Start"].min() == self.local_start_of_day(dst_end)
 
     solar_and_wind_forecast_cols = [
@@ -414,10 +414,10 @@ class TestMISO(BaseTestISO):
     """get_solar_forecast"""
 
     def _check_solar_and_wind_forecast(self, df):
-        assert df.columns.tolist() == self.solar_and_wind_forecast_cols
-        assert (df["Interval End"] - df["Interval Start"]).unique() == pd.Timedelta(
-            "1h",
-        )
+        assert df.columns == self.solar_and_wind_forecast_cols
+        assert (df["Interval End"] - df["Interval Start"]).unique().to_list()[
+            0
+        ].total_seconds() == pd.Timedelta("1h").total_seconds()
 
     def test_get_solar_forecast_historical(self):
         past_date = self.local_today() - pd.Timedelta(days=30)
@@ -434,9 +434,9 @@ class TestMISO(BaseTestISO):
                 past_date,
             ) + pd.Timedelta(days=7)
 
-            assert (
-                df["Publish Time"].dt.date.unique() == pd.to_datetime(past_date).date()
-            )
+            assert df["Publish Time"].dt.date().unique().to_list() == [
+                pd.to_datetime(past_date).date(),
+            ]
 
     def test_get_solar_forecast_historical_date_range(self):
         past_date = self.local_today() - pd.Timedelta(days=100)
@@ -455,7 +455,7 @@ class TestMISO(BaseTestISO):
                 end_date,
             ) + pd.Timedelta(days=6)
 
-            assert df["Publish Time"].dt.date.unique().tolist() == [
+            assert df["Publish Time"].dt.date().unique().to_list() == [
                 past_date,
                 past_date + pd.Timedelta(days=1),
                 past_date + pd.Timedelta(days=2),
@@ -485,9 +485,9 @@ class TestMISO(BaseTestISO):
             assert df["Interval End"].max() == self.local_start_of_day(
                 past_date,
             ) + pd.Timedelta(days=7)
-            assert (
-                df["Publish Time"].dt.date.unique() == pd.to_datetime(past_date).date()
-            )
+            assert df["Publish Time"].dt.date().unique().to_list() == [
+                pd.to_datetime(past_date).date(),
+            ]
 
     def test_get_wind_forecast_historical_date_range(self):
         past_date = self.local_today() - pd.Timedelta(days=100)
@@ -506,7 +506,7 @@ class TestMISO(BaseTestISO):
                 end_date,
             ) + pd.Timedelta(days=6)
 
-            assert df["Publish Time"].dt.date.unique().tolist() == [
+            assert df["Publish Time"].dt.date().unique().to_list() == [
                 past_date,
                 past_date + pd.Timedelta(days=1),
                 past_date + pd.Timedelta(days=2),
@@ -520,7 +520,7 @@ class TestMISO(BaseTestISO):
         with miso_vcr.use_cassette(cassette_name):
             df = self.iso.get_wind_forecast(date)
             self._check_solar_and_wind_forecast(df)
-            assert df["South"].isnull().all()
+            assert df["South"].is_null().all()
 
     """get_status"""
 
@@ -547,7 +547,7 @@ class TestMISO(BaseTestISO):
     """get_generation_outages_forecast"""
 
     def _check_generation_outages(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -558,11 +558,13 @@ class TestMISO(BaseTestISO):
             "Unplanned Outages MW",
         ]
 
-        assert (df["Interval End"] - df["Interval Start"]).unique() == pd.Timedelta(
-            "1d",
-        )
+        assert (df["Interval End"] - df["Interval Start"]).unique().to_list()[
+            0
+        ].total_seconds() == pd.Timedelta("1d").total_seconds()
 
-        assert (df["Region"].unique() == ["Central", "MISO", "North", "South"]).all()
+        assert sorted(df["Region"].unique().to_list()) == sorted(
+            ["Central", "MISO", "North", "South"],
+        )
 
     def test_get_generation_outages_forecast_latest(self):
         cassette_name = "test_get_generation_outages_forecast_latest.yaml"
@@ -574,9 +576,9 @@ class TestMISO(BaseTestISO):
             # Latest fetches the file published yesterday with the first forecast day today
             expected_start_date = self.local_start_of_today()
 
-            assert df["Publish Time"].unique() == expected_start_date - pd.DateOffset(
-                days=1,
-            )
+            assert df["Publish Time"].unique().to_list() == [
+                expected_start_date - pd.DateOffset(days=1),
+            ]
             assert df["Interval Start"].min() == expected_start_date
             assert df["Interval End"].max() == expected_start_date + pd.DateOffset(
                 days=7,
@@ -593,7 +595,7 @@ class TestMISO(BaseTestISO):
             assert df["Interval Start"].min() == start + pd.DateOffset(days=1)
             assert df["Interval End"].max() == end + pd.DateOffset(days=7)
             assert df["Publish Time"].min() == start
-            assert df["Publish Time"].nunique() == 3
+            assert df["Publish Time"].n_unique() == 3
 
     """get_generation_outages_estimated"""
 
@@ -606,9 +608,9 @@ class TestMISO(BaseTestISO):
             # Latest fetches the file published yesterday
             expected_start_date = self.local_start_of_today() - pd.DateOffset(days=30)
 
-            assert df[
-                "Publish Time"
-            ].unique() == self.local_start_of_today() - pd.DateOffset(days=1)
+            assert df["Publish Time"].unique().to_list() == [
+                self.local_start_of_today() - pd.DateOffset(days=1),
+            ]
 
             assert df["Interval Start"].min() == expected_start_date
             assert df["Interval End"].max() == self.local_start_of_today()
@@ -623,7 +625,7 @@ class TestMISO(BaseTestISO):
             assert df["Interval Start"].min() == start - pd.DateOffset(days=29)
             assert df["Interval End"].max() == end
             assert df["Publish Time"].min() == start
-            assert df["Publish Time"].nunique() == 3
+            assert df["Publish Time"].n_unique() == 3
 
     @pytest.mark.parametrize(
         "date,end",
@@ -637,7 +639,7 @@ class TestMISO(BaseTestISO):
                 end=end,
             )
 
-            assert isinstance(df, pd.DataFrame)
+            assert isinstance(df, pl.DataFrame)
             assert list(df.columns) == [
                 "Date",
                 "Constraint ID",
@@ -658,24 +660,24 @@ class TestMISO(BaseTestISO):
                 "To KV",
             ]
 
-            assert min(df["Date"]).date() == pd.to_datetime(date).date()
-            assert max(df["Date"]).date() <= pd.Timestamp(end).date()
-            assert df["Constraint ID"].dtype == np.int64
-            assert df["Constraint Name"].dtype == object
-            assert df["Contingency Name"].dtype == object
-            assert df["Constraint Type"].dtype == object
-            assert df["Flowgate Name"].dtype == object
-            assert df["Device Type"].dtype == object
-            assert df["Key1"].dtype == object
-            assert df["Key2"].dtype == object
-            assert df["Key3"].dtype == object
-            assert df["Direction"].dtype == np.int64
-            assert df["From Area"].dtype == object
-            assert df["To Area"].dtype == object
-            assert df["From Station"].dtype == object
-            assert df["To Station"].dtype == object
-            assert df["From KV"].dtype in [np.int64, np.float64]
-            assert df["To KV"].dtype in [np.int64, np.float64]
+            assert pd.Timestamp(df["Date"].min()).date() == pd.to_datetime(date).date()
+            assert pd.Timestamp(df["Date"].max()).date() <= pd.Timestamp(end).date()
+            assert df.schema["Constraint ID"] == pl.Int64
+            assert df.schema["Constraint Name"] in [pl.Utf8, pl.Null]
+            assert df.schema["Contingency Name"] in [pl.Utf8, pl.Null]
+            assert df.schema["Constraint Type"] in [pl.Utf8, pl.Null]
+            assert df.schema["Flowgate Name"] in [pl.Utf8, pl.Null]
+            assert df.schema["Device Type"] in [pl.Utf8, pl.Null]
+            assert df.schema["Key1"] in [pl.Utf8, pl.Null]
+            assert df.schema["Key2"] in [pl.Utf8, pl.Null]
+            assert df.schema["Key3"] in [pl.Utf8, pl.Null]
+            assert df.schema["Direction"] == pl.Int64
+            assert df.schema["From Area"] in [pl.Utf8, pl.Null]
+            assert df.schema["To Area"] in [pl.Utf8, pl.Null]
+            assert df.schema["From Station"] in [pl.Utf8, pl.Null]
+            assert df.schema["To Station"] in [pl.Utf8, pl.Null]
+            assert df.schema["From KV"] in [pl.Int64, pl.Float64]
+            assert df.schema["To KV"] in [pl.Int64, pl.Float64]
 
     @pytest.mark.parametrize(
         "date,end",
@@ -691,7 +693,7 @@ class TestMISO(BaseTestISO):
                 end=end,
             )
 
-            assert isinstance(df, pd.DataFrame)
+            assert isinstance(df, pl.DataFrame)
             assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
@@ -711,21 +713,24 @@ class TestMISO(BaseTestISO):
                 "Reason",
             ]
 
-            assert min(df["Interval Start"]).date() == pd.Timestamp(date).date()
-            assert max(df["Interval End"]).date() <= pd.Timestamp(end).date()
-            assert df["Constraint ID"].dtype == np.int64
-            assert df["Constraint Name"].dtype == object
-            assert df["Branch Name"].dtype == object
-            assert df["Contingency Description"].dtype == object
-            assert df["Shadow Price"].dtype in [np.float64, np.int64]
-            assert df["Constraint Description"].dtype == object
-            assert df["Override"].dtype == np.int64
-            assert df["Curve Type"].dtype == object
-            assert df["BP1"].dtype in [np.float64, np.int64]
-            assert df["PC1"].dtype in [np.float64, np.int64]
-            assert df["BP2"].dtype in [np.float64, np.int64]
-            assert df["PC2"].dtype in [np.float64, np.int64]
-            assert df["Reason"].dtype == object
+            assert df["Interval Start"].min().date() == pd.Timestamp(date).date()
+            assert (
+                pd.Timestamp(df["Interval End"].max()).date()
+                <= pd.Timestamp(end).date()
+            )
+            assert df.schema["Constraint ID"] == pl.Int64
+            assert df.schema["Constraint Name"] in [pl.Utf8, pl.Null]
+            assert df.schema["Branch Name"] in [pl.Utf8, pl.Null]
+            assert df.schema["Contingency Description"] in [pl.Utf8, pl.Null]
+            assert df.schema["Shadow Price"] in [pl.Float64, pl.Int64]
+            assert df.schema["Constraint Description"] in [pl.Utf8, pl.Null]
+            assert df.schema["Override"] == pl.Int64
+            assert df.schema["Curve Type"] in [pl.Utf8, pl.Null]
+            assert df.schema["BP1"] in [pl.Float64, pl.Int64]
+            assert df.schema["PC1"] in [pl.Float64, pl.Int64]
+            assert df.schema["BP2"] in [pl.Float64, pl.Int64]
+            assert df.schema["PC2"] in [pl.Float64, pl.Int64]
+            assert df.schema["Reason"] in [pl.Utf8, pl.Null]
 
     @pytest.mark.parametrize(
         "date,end",
@@ -743,7 +748,7 @@ class TestMISO(BaseTestISO):
                 end=end,
             )
 
-            assert isinstance(df, pd.DataFrame)
+            assert isinstance(df, pl.DataFrame)
             assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
@@ -762,9 +767,12 @@ class TestMISO(BaseTestISO):
                 "REASON",
             ]
 
-            if not df.empty:
-                assert min(df["Interval Start"]).date() <= pd.Timestamp(date).date()
-                assert max(df["Interval End"]).date() <= pd.Timestamp(end).date()
+            if not df.is_empty():
+                assert df["Interval Start"].min().date() <= pd.Timestamp(date).date()
+                assert (
+                    pd.Timestamp(df["Interval End"].max()).date()
+                    <= pd.Timestamp(end).date()
+                )
             else:
                 pytest.skip(
                     "No data available for this date range, so skipping data-comparison assertions",
@@ -786,7 +794,7 @@ class TestMISO(BaseTestISO):
                 end=end,
             )
 
-            assert isinstance(df, pd.DataFrame)
+            assert isinstance(df, pl.DataFrame)
             assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
@@ -795,9 +803,12 @@ class TestMISO(BaseTestISO):
                 "Constraint Description",
             ]
 
-            if not df.empty:
-                assert min(df["Interval Start"]).date() == pd.to_datetime(date).date()
-                assert max(df["Interval End"]).date() <= pd.Timestamp(end).date()
+            if not df.is_empty():
+                assert df["Interval Start"].min().date() == pd.to_datetime(date).date()
+                assert (
+                    pd.Timestamp(df["Interval End"].max()).date()
+                    <= pd.Timestamp(end).date()
+                )
             else:
                 pytest.skip(
                     "No data available for this date range, so skipping data-comparison assertions",
@@ -817,7 +828,7 @@ class TestMISO(BaseTestISO):
                 end=end,
             )
 
-            assert isinstance(df, pd.DataFrame)
+            assert isinstance(df, pl.DataFrame)
             assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
@@ -836,9 +847,12 @@ class TestMISO(BaseTestISO):
                 "PC2",
             ]
 
-            if not df.empty:
-                assert min(df["Interval Start"]).date() <= pd.Timestamp(date).date()
-                assert max(df["Interval End"]).date() <= pd.Timestamp(end).date()
+            if not df.is_empty():
+                assert df["Interval Start"].min().date() <= pd.Timestamp(date).date()
+                assert (
+                    pd.Timestamp(df["Interval End"].max()).date()
+                    <= pd.Timestamp(end).date()
+                )
             else:
                 pytest.skip(
                     "No data available for this date range, so skipping data-comparison assertions",
@@ -854,7 +868,7 @@ class TestMISO(BaseTestISO):
                 year=year,
             )
 
-            assert isinstance(df, pd.DataFrame)
+            assert isinstance(df, pl.DataFrame)
             assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
@@ -873,9 +887,9 @@ class TestMISO(BaseTestISO):
                 "PC2",
             ]
 
-            if not df.empty:
-                assert min(df["Interval End"]).year == year
-                assert max(df["Interval End"]).year == year
+            if not df.is_empty():
+                assert pd.Timestamp(df["Interval End"].min()).year == year
+                assert pd.Timestamp(df["Interval End"].max()).year == year
             else:
                 pytest.skip(
                     "No data available for this date range, so skipping data-comparison assertions",
@@ -895,7 +909,7 @@ class TestMISO(BaseTestISO):
                 end=end,
             )
 
-            assert isinstance(df, pd.DataFrame)
+            assert isinstance(df, pl.DataFrame)
             assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
@@ -914,9 +928,12 @@ class TestMISO(BaseTestISO):
                 "Reason",
             ]
 
-            if not df.empty:
-                assert min(df["Interval Start"]).date() == pd.to_datetime(date).date()
-                assert max(df["Interval End"]).date() <= pd.Timestamp(end).date()
+            if not df.is_empty():
+                assert df["Interval Start"].min().date() == pd.to_datetime(date).date()
+                assert (
+                    pd.Timestamp(df["Interval End"].max()).date()
+                    <= pd.Timestamp(end).date()
+                )
             else:
                 pytest.skip(
                     "No data available for this date range, so skipping data-comparison assertions",
@@ -938,7 +955,7 @@ class TestMISO(BaseTestISO):
                 end=end,
             )
 
-            assert isinstance(df, pd.DataFrame)
+            assert isinstance(df, pl.DataFrame)
             assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
@@ -957,9 +974,12 @@ class TestMISO(BaseTestISO):
                 "REASON",
             ]
 
-            if not df.empty:
-                assert min(df["Interval Start"]).date() == pd.to_datetime(date).date()
-                assert max(df["Interval End"]).date() <= pd.Timestamp(end).date()
+            if not df.is_empty():
+                assert df["Interval Start"].min().date() == pd.to_datetime(date).date()
+                assert (
+                    pd.Timestamp(df["Interval End"].max()).date()
+                    <= pd.Timestamp(end).date()
+                )
             else:
                 pytest.skip(
                     "No data available for this date range, so skipping data-comparison assertions",
@@ -981,7 +1001,7 @@ class TestMISO(BaseTestISO):
                 end=end,
             )
 
-            assert isinstance(df, pd.DataFrame)
+            assert isinstance(df, pl.DataFrame)
             assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
@@ -990,9 +1010,12 @@ class TestMISO(BaseTestISO):
                 "Constraint Description",
             ]
 
-            if not df.empty:
-                assert min(df["Interval Start"]).date() == pd.to_datetime(date).date()
-                assert max(df["Interval End"]).date() <= pd.Timestamp(end).date()
+            if not df.is_empty():
+                assert df["Interval Start"].min().date() == pd.to_datetime(date).date()
+                assert (
+                    pd.Timestamp(df["Interval End"].max()).date()
+                    <= pd.Timestamp(end).date()
+                )
             else:
                 pytest.skip(
                     "No data available for this date range, so skipping data-comparison assertions",
@@ -1011,7 +1034,7 @@ class TestMISO(BaseTestISO):
                 end=end,
             )
 
-            assert isinstance(df, pd.DataFrame)
+            assert isinstance(df, pl.DataFrame)
             assert list(df.columns) == [
                 "Interval Start",
                 "Interval End",
@@ -1024,22 +1047,22 @@ class TestMISO(BaseTestISO):
             # Each day has 24 hours, 7 days of forecast, and 4 regions
             days = (pd.Timestamp(end) - pd.Timestamp(date)).days
             expected_rows = 24 * 7 * 4 * days
-            assert len(df) == expected_rows
+            assert df.height == expected_rows
             expected_regions = ["Central", "MISO", "North", "South"]
-            assert sorted(df["Region"].unique()) == sorted(expected_regions)
+            assert sorted(df["Region"].unique().to_list()) == sorted(expected_regions)
 
-            assert df["Interval Start"].dt.tz.zone == self.iso.default_timezone
-            assert df["Interval End"].dt.tz.zone == self.iso.default_timezone
-            assert df["Publish Time"].dt.tz.zone == self.iso.default_timezone
-            assert (df["Interval End"] - df["Interval Start"]).unique() == [
-                pd.Timedelta(hours=1),
-            ]
-            assert min(df["Interval Start"]).date() == pd.Timestamp(date).date()
+            assert df["Interval Start"].dtype.time_zone == self.iso.default_timezone
+            assert df["Interval End"].dtype.time_zone == self.iso.default_timezone
+            assert df["Publish Time"].dtype.time_zone == self.iso.default_timezone
+            assert (df["Interval End"] - df["Interval Start"]).unique().to_list()[
+                0
+            ].total_seconds() == pd.Timedelta(hours=1).total_seconds()
+            assert df["Interval Start"].min().date() == pd.Timestamp(date).date()
 
     """get_zonal_load_hourly"""
 
     def _check_zonal_load_hourly(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "LRZ1",
@@ -1051,16 +1074,16 @@ class TestMISO(BaseTestISO):
             "MISO",
         ]
 
-        assert (df["Interval End"] - df["Interval Start"]).unique() == pd.Timedelta(
-            "1h",
-        )
-        assert df["LRZ1"].dtype == float
-        assert df["LRZ2 7"].dtype == float
-        assert df["LRZ3 5"].dtype == float
-        assert df["LRZ4"].dtype == float
-        assert df["LRZ6"].dtype == float
-        assert df["LRZ8 9 10"].dtype == float
-        assert df["MISO"].dtype == float
+        assert (df["Interval End"] - df["Interval Start"]).unique().to_list()[
+            0
+        ].total_seconds() == pd.Timedelta("1h").total_seconds()
+        assert df.schema["LRZ1"] == pl.Float64
+        assert df.schema["LRZ2 7"] == pl.Float64
+        assert df.schema["LRZ3 5"] == pl.Float64
+        assert df.schema["LRZ4"] == pl.Float64
+        assert df.schema["LRZ6"] == pl.Float64
+        assert df.schema["LRZ8 9 10"] == pl.Float64
+        assert df.schema["MISO"] == pl.Float64
 
     def test_get_zonal_load_hourly_latest(self):
         cassette_name = "test_get_zonal_load_hourly_latest.yaml"
@@ -1097,7 +1120,7 @@ class TestMISO(BaseTestISO):
     """get_interchange_5_min"""
 
     def _check_get_interchange_5_min(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Net Scheduled Interchange",
@@ -1113,33 +1136,37 @@ class TestMISO(BaseTestISO):
             "TVA",
         ]
 
-        assert (df["Interval End"] - df["Interval Start"]).unique() == pd.Timedelta(
-            "5min",
-        )
+        assert (df["Interval End"] - df["Interval Start"]).unique().to_list()[
+            0
+        ].total_seconds() == pd.Timedelta("5min").total_seconds()
 
-        for col in df:
+        for col in df.columns:
             if col not in ["Interval Start", "Interval End"]:
-                assert df[col].dtype == pd.Int64Dtype()
+                assert df.schema[col] == pl.Int64
 
         # The first values in Net Actual Interchange should be null because the actual
         # data does not go back as far as the scheduled data
-        assert df["Net Actual Interchange"].isna()[0]
+        assert df["Net Actual Interchange"].is_null()[0]
 
         # The last value in Net Scheduled Interchange should be null because the
         # scheduled data is one interval behind the actual data
-        assert df["Net Scheduled Interchange"].isna().iloc[-1]
+        assert df["Net Scheduled Interchange"].is_null()[-1]
 
     def test_get_interchange_5_min_latest(self):
         with miso_vcr.use_cassette("test_get_interchange_5_min_latest.yaml"):
             df = self.iso.get_interchange_5_min("latest")
             self._check_get_interchange_5_min(df)
 
-            assert df["Interval Start"].min() <= self.local_now() - pd.DateOffset(
+            assert pd.Timestamp(
+                df["Interval Start"].min(),
+            ) <= self.local_now() - pd.DateOffset(
                 days=1,
             )
 
             # Data should be near-real-time
-            assert df["Interval End"].max() >= self.local_now() - pd.DateOffset(
+            assert pd.Timestamp(
+                df["Interval End"].max(),
+            ) >= self.local_now() - pd.DateOffset(
                 minutes=5,
             )
 
@@ -1155,7 +1182,7 @@ class TestMISO(BaseTestISO):
     """get_binding_constraints_real_time_intraday"""
 
     def _check_binding_constraints_real_time_intraday(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Constraint Name",
@@ -1168,17 +1195,17 @@ class TestMISO(BaseTestISO):
             "PC2",
         ]
 
-        assert (df["Interval End"] - df["Interval Start"]).unique() == pd.Timedelta(
-            "5min",
-        )
+        assert (df["Interval End"] - df["Interval Start"]).unique().to_list()[
+            0
+        ].total_seconds() == pd.Timedelta("5min").total_seconds()
 
-        assert df.dtypes["Constraint Name"] == "object"
-        assert df.dtypes["Shadow Price"] == "float64"
-        assert df.dtypes["Override"] == "Int64"
-        assert df.dtypes["BP1"] == "Int64"
-        assert df.dtypes["PC1"] == "Int64"
-        assert df.dtypes["BP2"] == "Int64"
-        assert df.dtypes["PC2"] == "Int64"
+        assert df.schema["Constraint Name"] in [pl.Utf8, pl.Null]
+        assert df.schema["Shadow Price"] == pl.Float64
+        assert df.schema["Override"] == pl.Int64
+        assert df.schema["BP1"] == pl.Int64
+        assert df.schema["PC1"] == pl.Int64
+        assert df.schema["BP2"] == pl.Int64
+        assert df.schema["PC2"] == pl.Int64
 
         assert (df["Constraint Name"] != "None").all()
 
@@ -1213,35 +1240,35 @@ class TestMISO(BaseTestISO):
         with miso_vcr.use_cassette(cassette_name):
             df = self.iso.get_multiday_operating_margin(date=date)
 
-        assert len(df) > 0
+        assert df.height > 0
 
         # Check data types
-        assert df["Publish Date"].dtype == object
-        assert df["Peak Hour"].dtype == "datetime64[ns, EST]"
-        assert df["Region"].dtype == object
-        assert df["Resource Committed"].dtype == np.float64
-        assert df["Committed Additional Emergency Headroom"].dtype == np.float64
-        assert df["Resource Uncommitted"].dtype == np.float64
-        assert df["Uncommitted Greater than 16 Hours"].dtype == np.float64
-        assert df["Uncommitted 12 to 16 Hours"].dtype == np.float64
-        assert df["Uncommitted 8 to 12 Hours"].dtype == np.float64
-        assert df["Uncommitted 4 to 8 Hours"].dtype == np.float64
-        assert df["Uncommitted Less than 4 Hours"].dtype == np.float64
-        assert df["Uncommitted Additional Emergency Headroom"].dtype == np.float64
-        assert df["Emergency Resources Additional Headroom"].dtype == np.float64
-        assert df["Renewable Forecast"].dtype == np.float64
-        assert df["Wind Forecast"].dtype == np.float64
-        assert df["Solar Forecast"].dtype == np.float64
-        assert df["MISO Resources Available"].dtype == np.float64
-        assert df["NSI"].dtype == np.float64
-        assert df["Total Resources Available"].dtype == np.float64
-        assert df["Projected Load"].dtype == np.float64
-        assert df["Operating Reserve Requirement"].dtype == np.float64
-        assert df["Obligation"].dtype == np.float64
-        assert df["Resource Operating Margin"].dtype == np.float64
+        assert df.schema["Publish Date"] == pl.Date
+        assert isinstance(df.schema["Peak Hour"], pl.Datetime)
+        assert df.schema["Region"] == pl.Utf8
+        assert df.schema["Resource Committed"] == pl.Float64
+        assert df.schema["Committed Additional Emergency Headroom"] == pl.Float64
+        assert df.schema["Resource Uncommitted"] == pl.Float64
+        assert df.schema["Uncommitted Greater than 16 Hours"] == pl.Float64
+        assert df.schema["Uncommitted 12 to 16 Hours"] == pl.Float64
+        assert df.schema["Uncommitted 8 to 12 Hours"] == pl.Float64
+        assert df.schema["Uncommitted 4 to 8 Hours"] == pl.Float64
+        assert df.schema["Uncommitted Less than 4 Hours"] == pl.Float64
+        assert df.schema["Uncommitted Additional Emergency Headroom"] == pl.Float64
+        assert df.schema["Emergency Resources Additional Headroom"] == pl.Float64
+        assert df.schema["Renewable Forecast"] == pl.Float64
+        assert df.schema["Wind Forecast"] == pl.Float64
+        assert df.schema["Solar Forecast"] == pl.Float64
+        assert df.schema["MISO Resources Available"] == pl.Float64
+        assert df.schema["NSI"] == pl.Float64
+        assert df.schema["Total Resources Available"] == pl.Float64
+        assert df.schema["Projected Load"] == pl.Float64
+        assert df.schema["Operating Reserve Requirement"] == pl.Float64
+        assert df.schema["Obligation"] == pl.Float64
+        assert df.schema["Resource Operating Margin"] == pl.Float64
 
         # Check region values
-        assert (df["Region"] == "MISO").all()  # MISO stays uppercase
+        assert (df["Region"] == "MISO").all()
 
         # Check Publish Date matches input date
         assert (df["Publish Date"] == date.date()).all()
@@ -1250,7 +1277,7 @@ class TestMISO(BaseTestISO):
         assert (df["Peak Hour"] >= date).all()
 
         # Check data is sorted
-        assert df["Peak Hour"].is_monotonic_increasing
+        assert df["Peak Hour"].is_sorted()
 
         # Check reasonable value ranges
         assert (df["Projected Load"] > 0).all()
@@ -1269,35 +1296,35 @@ class TestMISO(BaseTestISO):
         with miso_vcr.use_cassette(cassette_name):
             df = self.iso.get_multiday_operating_margin_regional(date=date)
 
-        assert len(df) > 0
+        assert df.height > 0
 
         # Check data types
-        assert df["Publish Date"].dtype == object
-        assert df["Peak Hour"].dtype == "datetime64[ns, EST]"
-        assert df["Region"].dtype == object
-        assert df["Resource Committed"].dtype == np.float64
-        assert df["Committed Additional Emergency Headroom"].dtype == np.float64
-        assert df["Resource Uncommitted"].dtype == np.float64
-        assert df["Uncommitted Greater than 16 Hours"].dtype == np.float64
-        assert df["Uncommitted 12 to 16 Hours"].dtype == np.float64
-        assert df["Uncommitted 8 to 12 Hours"].dtype == np.float64
-        assert df["Uncommitted 4 to 8 Hours"].dtype == np.float64
-        assert df["Uncommitted Less than 4 Hours"].dtype == np.float64
-        assert df["Uncommitted Additional Emergency Headroom"].dtype == np.float64
-        assert df["Emergency Resources Additional Headroom"].dtype == np.float64
-        assert df["Renewable Forecast"].dtype == np.float64
-        assert df["Wind Forecast"].dtype == np.float64
-        assert df["Solar Forecast"].dtype == np.float64
-        assert df["MISO Resources Available"].dtype == np.float64
-        assert df["NSI"].dtype == np.float64
-        assert df["Total Resources Available"].dtype == np.float64
-        assert df["Projected Load"].dtype == np.float64
-        assert df["Region Resources Above Load"].dtype == np.float64
-        assert df["Max Possible RDT"].dtype == np.float64
+        assert df.schema["Publish Date"] == pl.Date
+        assert isinstance(df.schema["Peak Hour"], pl.Datetime)
+        assert df.schema["Region"] == pl.Utf8
+        assert df.schema["Resource Committed"] == pl.Float64
+        assert df.schema["Committed Additional Emergency Headroom"] == pl.Float64
+        assert df.schema["Resource Uncommitted"] == pl.Float64
+        assert df.schema["Uncommitted Greater than 16 Hours"] == pl.Float64
+        assert df.schema["Uncommitted 12 to 16 Hours"] == pl.Float64
+        assert df.schema["Uncommitted 8 to 12 Hours"] == pl.Float64
+        assert df.schema["Uncommitted 4 to 8 Hours"] == pl.Float64
+        assert df.schema["Uncommitted Less than 4 Hours"] == pl.Float64
+        assert df.schema["Uncommitted Additional Emergency Headroom"] == pl.Float64
+        assert df.schema["Emergency Resources Additional Headroom"] == pl.Float64
+        assert df.schema["Renewable Forecast"] == pl.Float64
+        assert df.schema["Wind Forecast"] == pl.Float64
+        assert df.schema["Solar Forecast"] == pl.Float64
+        assert df.schema["MISO Resources Available"] == pl.Float64
+        assert df.schema["NSI"] == pl.Float64
+        assert df.schema["Total Resources Available"] == pl.Float64
+        assert df.schema["Projected Load"] == pl.Float64
+        assert df.schema["Region Resources Above Load"] == pl.Float64
+        assert df.schema["Max Possible RDT"] == pl.Float64
 
         # Check all 4 regions are present
         expected_regions = {"North", "Central", "North and Central", "South"}
-        assert set(df["Region"].unique()) == expected_regions
+        assert set(df["Region"].unique().to_list()) == expected_regions
 
         # Check Publish Date matches input date
         assert (df["Publish Date"] == date.date()).all()
@@ -1307,8 +1334,8 @@ class TestMISO(BaseTestISO):
 
         # Check each region has data
         for region in expected_regions:
-            region_df = df[df["Region"] == region]
-            assert len(region_df) > 0
+            region_df = df.filter(pl.col("Region") == region)
+            assert region_df.height > 0
 
         # Check reasonable value ranges
         assert (df["Projected Load"] > 0).all()

--- a/gridstatus/tests/source_specific/test_miso_api.py
+++ b/gridstatus/tests/source_specific/test_miso_api.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock, patch
 
 import pandas as pd
+import polars as pl
 import pytest
 import requests
 
@@ -28,6 +29,17 @@ LMP_COLUMNS = [
 ]
 
 
+def _check_tz_datetime(df: pl.DataFrame, col: str) -> None:
+    assert isinstance(df.schema[col], pl.Datetime)
+    assert df.schema[col].time_zone == "EST"
+
+
+def _check_float_columns(df: pl.DataFrame, exclude: list[str]) -> None:
+    for col in df.columns:
+        if col not in exclude:
+            assert df.schema[col] == pl.Float64
+
+
 class TestMISOAPI(TestHelperMixin):
     @classmethod
     def setup_class(cls):
@@ -36,9 +48,10 @@ class TestMISOAPI(TestHelperMixin):
         cls.iso = MISOAPI()
 
     def _check_lmp(self, df, market_value):
-        assert df.columns.tolist() == LMP_COLUMNS
-        assert list(df["Market"].unique()) == [market_value]
-        assert df["Location Type"].notna().all()
+        df = self._as_polars(df)
+        assert df.columns == LMP_COLUMNS
+        assert df["Market"].unique().to_list() == [market_value]
+        assert df["Location Type"].null_count() == 0
 
     """get_lmp_day_ahead_hourly_ex_ante"""
 
@@ -140,8 +153,9 @@ class TestMISOAPI(TestHelperMixin):
 
     """get_interchange_hourly"""
 
-    def _check_interchange_hourly(self, data: pd.DataFrame):
-        assert data.columns.tolist() == [
+    def _check_interchange_hourly(self, data: pl.DataFrame):
+        data = self._as_polars(data)
+        assert data.columns == [
             "Interval Start",
             "Interval End",
             "Net Scheduled Interchange Forward",
@@ -167,12 +181,9 @@ class TestMISOAPI(TestHelperMixin):
             "SPA Actual",
         ]
 
-        assert data["Interval Start"].dtype == "datetime64[ns, EST]"
-        assert data["Interval End"].dtype == "datetime64[ns, EST]"
-
-        for col in data.columns:
-            if col not in ["Interval Start", "Interval End"]:
-                assert data[col].dtype == "float64"
+        _check_tz_datetime(data, "Interval Start")
+        _check_tz_datetime(data, "Interval End")
+        _check_float_columns(data, ["Interval Start", "Interval End"])
 
     def test_get_interchange_hourly_today(self):
         with api_vcr.use_cassette("test_get_interchange_hourly_today"):
@@ -211,16 +222,17 @@ class TestMISOAPI(TestHelperMixin):
     """MCP Tests"""
 
     def _check_mcp_columns(self, df, expected_products):
+        df = self._as_polars(df)
         core_columns = ["Interval Start", "Interval End", "Zone"]
         expected_columns = core_columns + expected_products
 
-        assert set(df.columns.tolist()) == set(expected_columns)
-        assert df["Interval Start"].dtype == "datetime64[ns, EST]"
-        assert df["Interval End"].dtype == "datetime64[ns, EST]"
-        assert isinstance(df["Zone"].iloc[0], str)
+        assert set(df.columns) == set(expected_columns)
+        _check_tz_datetime(df, "Interval Start")
+        _check_tz_datetime(df, "Interval End")
+        assert df.schema["Zone"] == pl.Utf8
 
         for product in expected_products:
-            assert df[product].dtype in ["float64", "Float64"]
+            assert df.schema[product] in (pl.Float64, pl.Int64)
 
     @pytest.mark.integration
     def test_get_as_mcp_day_ahead_ex_ante_date_range(self):
@@ -485,7 +497,8 @@ class TestMISOAPI(TestHelperMixin):
         assert df["Interval Start"].max() == date + pd.Timedelta(hours=23)
 
     def _check_test_get_day_ahead_cleared_demand(self, df):
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Region",
@@ -494,12 +507,9 @@ class TestMISOAPI(TestHelperMixin):
             "Virtual Bids Cleared",
         ]
 
-        assert df["Interval Start"].dtype == "datetime64[ns, EST]"
-        assert df["Interval End"].dtype == "datetime64[ns, EST]"
-
-        for col in df.columns:
-            if col not in ["Interval Start", "Interval End", "Region"]:
-                assert df[col].dtype == "float64"
+        _check_tz_datetime(df, "Interval Start")
+        _check_tz_datetime(df, "Interval End")
+        _check_float_columns(df, ["Interval Start", "Interval End", "Region"])
 
     @pytest.mark.integration
     def test_get_day_ahead_cleared_demand_daily(self):
@@ -531,19 +541,17 @@ class TestMISOAPI(TestHelperMixin):
         )
 
     def _check_day_ahead_cleared_generation_hourly(self, df):
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Region",
             "Supply Cleared",
         ]
 
-        assert df["Interval Start"].dtype == "datetime64[ns, EST]"
-        assert df["Interval End"].dtype == "datetime64[ns, EST]"
-
-        for col in df.columns:
-            if col not in ["Interval Start", "Interval End", "Region"]:
-                assert df[col].dtype == "float64"
+        _check_tz_datetime(df, "Interval Start")
+        _check_tz_datetime(df, "Interval End")
+        _check_float_columns(df, ["Interval Start", "Interval End", "Region"])
 
     @pytest.mark.integration
     def test_get_day_ahead_cleared_generation_physical_hourly(self):
@@ -586,19 +594,18 @@ class TestMISOAPI(TestHelperMixin):
         ):
             df = self.iso.get_day_ahead_net_scheduled_interchange_hourly(date)
 
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Region",
             "Net Scheduled Interchange",
         ]
 
-        assert df["Interval Start"].dtype == "datetime64[ns, EST]"
-        assert df["Interval End"].dtype == "datetime64[ns, EST]"
-
-        for col in df.columns:
-            if col not in ["Interval Start", "Interval End", "Region"]:
-                assert df[col].dtype == "float64"
+        _check_tz_datetime(df, "Interval Start")
+        _check_tz_datetime(df, "Interval End")
+        _check_float_columns(df, ["Interval Start", "Interval End", "Region"])
 
         assert df["Interval Start"].min() == date
         assert df["Interval Start"].max() == date + pd.Timedelta(
@@ -606,14 +613,12 @@ class TestMISOAPI(TestHelperMixin):
         )
 
     def _check_day_ahead_offered_generation_hourly(self, df, expected_columns):
-        assert df.columns.tolist() == expected_columns
+        df = self._as_polars(df)
+        assert df.columns == expected_columns
 
-        assert df["Interval Start"].dtype == "datetime64[ns, EST]"
-        assert df["Interval End"].dtype == "datetime64[ns, EST]"
-
-        for col in df.columns:
-            if col not in ["Interval Start", "Interval End", "Region"]:
-                assert df[col].dtype == "float64"
+        _check_tz_datetime(df, "Interval Start")
+        _check_tz_datetime(df, "Interval End")
+        _check_float_columns(df, ["Interval Start", "Interval End", "Region"])
 
     @pytest.mark.integration
     def test_get_day_ahead_offered_generation_ecomax_hourly(self):
@@ -676,7 +681,9 @@ class TestMISOAPI(TestHelperMixin):
         ):
             df = self.iso.get_generation_fuel_mix_by_region_day_ahead(date)
 
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Region",
@@ -691,16 +698,18 @@ class TestMISOAPI(TestHelperMixin):
             "Storage",
         ]
 
-        assert df["Interval Start"].dtype == "datetime64[ns, EST]"
-        assert df["Interval End"].dtype == "datetime64[ns, EST]"
-
-        for col in df.columns:
-            if col not in ["Interval Start", "Interval End", "Region"]:
-                assert df[col].dtype == "float64"
+        _check_tz_datetime(df, "Interval Start")
+        _check_tz_datetime(df, "Interval End")
+        _check_float_columns(df, ["Interval Start", "Interval End", "Region"])
 
         # The API returns CENTRAL, NORTH, and SOUTH; the MISO system total is derived
         # by summing them for each interval.
-        assert set(df["Region"].unique()) == {"CENTRAL", "NORTH", "SOUTH", "MISO"}
+        assert set(df["Region"].unique().to_list()) == {
+            "CENTRAL",
+            "NORTH",
+            "SOUTH",
+            "MISO",
+        }
 
         value_columns = [
             "Total",
@@ -714,17 +723,19 @@ class TestMISOAPI(TestHelperMixin):
             "Storage",
         ]
         miso_total = (
-            df[df["Region"] == "MISO"]
-            .set_index("Interval Start")[value_columns]
-            .sort_index()
+            df.filter(pl.col("Region") == "MISO")
+            .select(["Interval Start", *value_columns])
+            .sort("Interval Start")
         )
         region_sum = (
-            df[df["Region"] != "MISO"]
-            .groupby("Interval Start")[value_columns]
-            .sum()
-            .sort_index()
+            df.filter(pl.col("Region") != "MISO")
+            .group_by("Interval Start")
+            .agg([pl.col(col).sum().alias(col) for col in value_columns])
+            .sort("Interval Start")
         )
-        assert ((miso_total - region_sum).abs().max() < 1.0).all()
+        joined = miso_total.join(region_sum, on="Interval Start", suffix="_sum")
+        for col in value_columns:
+            assert (joined[col] - joined[f"{col}_sum"]).abs().max() < 1.0
 
         assert df["Interval Start"].min() == date
         assert df["Interval Start"].max() == date + pd.Timedelta(
@@ -735,18 +746,16 @@ class TestMISOAPI(TestHelperMixin):
         )
 
     def _check_test_get_real_time_cleared_demand(self, df):
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Cleared Demand",
         ]
 
-        assert df["Interval Start"].dtype == "datetime64[ns, EST]"
-        assert df["Interval End"].dtype == "datetime64[ns, EST]"
-
-        for col in df.columns:
-            if col not in ["Interval Start", "Interval End"]:
-                assert df[col].dtype == "float64"
+        _check_tz_datetime(df, "Interval Start")
+        _check_tz_datetime(df, "Interval End")
+        _check_float_columns(df, ["Interval Start", "Interval End"])
 
     @pytest.mark.integration
     def test_get_real_time_cleared_demand_daily(self):
@@ -779,18 +788,16 @@ class TestMISOAPI(TestHelperMixin):
         assert df["Interval End"].max() == date + pd.Timedelta(days=1)
 
     def _check_real_time_cleared_generation(self, df):
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Generation Cleared",
         ]
 
-        assert df["Interval Start"].dtype == "datetime64[ns, EST]"
-        assert df["Interval End"].dtype == "datetime64[ns, EST]"
-
-        for col in df.columns:
-            if col not in ["Interval Start", "Interval End", "Region"]:
-                assert df[col].dtype == "float64"
+        _check_tz_datetime(df, "Interval Start")
+        _check_tz_datetime(df, "Interval End")
+        _check_float_columns(df, ["Interval Start", "Interval End"])
 
     # @pytest.mark.integration
     @pytest.mark.skip(reason="MISO returns wrong data for a specific date")
@@ -819,7 +826,9 @@ class TestMISOAPI(TestHelperMixin):
         ):
             df = self.iso.get_real_time_offered_generation_ecomax_hourly(date)
 
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Offered FRAC Economic Max",
@@ -827,12 +836,9 @@ class TestMISOAPI(TestHelperMixin):
             "Offered Economic Max Delta",
         ]
 
-        assert df["Interval Start"].dtype == "datetime64[ns, EST]"
-        assert df["Interval End"].dtype == "datetime64[ns, EST]"
-
-        for col in df.columns:
-            if col not in ["Interval Start", "Interval End"]:
-                assert df[col].dtype == "float64"
+        _check_tz_datetime(df, "Interval Start")
+        _check_tz_datetime(df, "Interval End")
+        _check_float_columns(df, ["Interval Start", "Interval End"])
 
         assert df["Interval Start"].min() == date
         assert df["Interval Start"].max() == date + pd.Timedelta(
@@ -851,7 +857,9 @@ class TestMISOAPI(TestHelperMixin):
         ):
             df = self.iso.get_real_time_committed_generation_ecomax_hourly(date)
 
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Committed FRAC Economic Max",
@@ -859,12 +867,9 @@ class TestMISOAPI(TestHelperMixin):
             "Committed Economic Max Delta",
         ]
 
-        assert df["Interval Start"].dtype == "datetime64[ns, EST]"
-        assert df["Interval End"].dtype == "datetime64[ns, EST]"
-
-        for col in df.columns:
-            if col not in ["Interval Start", "Interval End"]:
-                assert df[col].dtype == "float64"
+        _check_tz_datetime(df, "Interval Start")
+        _check_tz_datetime(df, "Interval End")
+        _check_float_columns(df, ["Interval Start", "Interval End"])
 
         assert df["Interval Start"].min() == date
         assert df["Interval Start"].max() == date + pd.Timedelta(
@@ -883,7 +888,9 @@ class TestMISOAPI(TestHelperMixin):
         ):
             df = self.iso.get_generation_fuel_mix_by_region_real_time(date)
 
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Region",
@@ -898,16 +905,18 @@ class TestMISOAPI(TestHelperMixin):
             "Storage",
         ]
 
-        assert df["Interval Start"].dtype == "datetime64[ns, EST]"
-        assert df["Interval End"].dtype == "datetime64[ns, EST]"
-
-        for col in df.columns:
-            if col not in ["Interval Start", "Interval End", "Region"]:
-                assert df[col].dtype == "float64"
+        _check_tz_datetime(df, "Interval Start")
+        _check_tz_datetime(df, "Interval End")
+        _check_float_columns(df, ["Interval Start", "Interval End", "Region"])
 
         # The API returns CENTRAL, NORTH, and SOUTH; the MISO system total is derived
         # by summing them for each interval.
-        assert set(df["Region"].unique()) == {"CENTRAL", "NORTH", "SOUTH", "MISO"}
+        assert set(df["Region"].unique().to_list()) == {
+            "CENTRAL",
+            "NORTH",
+            "SOUTH",
+            "MISO",
+        }
 
         value_columns = [
             "Total",
@@ -921,17 +930,19 @@ class TestMISOAPI(TestHelperMixin):
             "Storage",
         ]
         miso_total = (
-            df[df["Region"] == "MISO"]
-            .set_index("Interval Start")[value_columns]
-            .sort_index()
+            df.filter(pl.col("Region") == "MISO")
+            .select(["Interval Start", *value_columns])
+            .sort("Interval Start")
         )
         region_sum = (
-            df[df["Region"] != "MISO"]
-            .groupby("Interval Start")[value_columns]
-            .sum()
-            .sort_index()
+            df.filter(pl.col("Region") != "MISO")
+            .group_by("Interval Start")
+            .agg([pl.col(col).sum().alias(col) for col in value_columns])
+            .sort("Interval Start")
         )
-        assert ((miso_total - region_sum).abs().max() < 1.0).all()
+        joined = miso_total.join(region_sum, on="Interval Start", suffix="_sum")
+        for col in value_columns:
+            assert (joined[col] - joined[f"{col}_sum"]).abs().max() < 1.0
 
         assert df["Interval Start"].min() == date
         assert df["Interval Start"].max() == date + pd.Timedelta(
@@ -942,19 +953,17 @@ class TestMISOAPI(TestHelperMixin):
         )
 
     def _check_test_actual_load(self, df):
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Region",
             "Load",
         ]
 
-        assert df["Interval Start"].dtype == "datetime64[ns, EST]"
-        assert df["Interval End"].dtype == "datetime64[ns, EST]"
-
-        for col in df.columns:
-            if col not in ["Interval Start", "Interval End", "Region"]:
-                assert df[col].dtype == "float64"
+        _check_tz_datetime(df, "Interval Start")
+        _check_tz_datetime(df, "Interval End")
+        _check_float_columns(df, ["Interval Start", "Interval End", "Region"])
 
     @pytest.mark.integration
     def test_get_actual_load_hourly(self):
@@ -988,23 +997,20 @@ class TestMISOAPI(TestHelperMixin):
         )
 
     def _check_test_actual_load_local_resource_zone(self, df):
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Local Resource Zone",
             "Load",
         ]
 
-        assert df["Interval Start"].dtype == "datetime64[ns, EST]"
-        assert df["Interval End"].dtype == "datetime64[ns, EST]"
-
-        for col in df.columns:
-            if col not in [
-                "Interval Start",
-                "Interval End",
-                "Local Resource Zone",
-            ]:
-                assert df[col].dtype == "float64"
+        _check_tz_datetime(df, "Interval Start")
+        _check_tz_datetime(df, "Interval End")
+        _check_float_columns(
+            df,
+            ["Interval Start", "Interval End", "Local Resource Zone"],
+        )
 
     def test_get_actual_load_hourly_local_resource_zone(self):
         date = self.local_start_of_today() - pd.Timedelta(days=1)
@@ -1046,7 +1052,8 @@ class TestMISOAPI(TestHelperMixin):
         )
 
     def _check_test_medium_term_load_forecast(self, df):
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -1055,8 +1062,8 @@ class TestMISOAPI(TestHelperMixin):
             "Load Forecast",
         ]
 
-        assert df["Interval Start"].dtype == "datetime64[ns, EST]"
-        assert df["Interval End"].dtype == "datetime64[ns, EST]"
+        _check_tz_datetime(df, "Interval Start")
+        _check_tz_datetime(df, "Interval End")
 
         for col in df.columns:
             if col not in [
@@ -1066,7 +1073,7 @@ class TestMISOAPI(TestHelperMixin):
                 "Region",
                 "Local Resource Zone",
             ]:
-                assert df[col].dtype == "Int64"
+                assert df.schema[col] == pl.Int64
 
     @pytest.mark.integration
     def test_get_load_forecast_mid_term_by_region(self):
@@ -1077,7 +1084,9 @@ class TestMISOAPI(TestHelperMixin):
         ):
             df = self.iso.get_load_forecast_mid_term_by_region(publish_time)
 
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -1086,10 +1095,10 @@ class TestMISOAPI(TestHelperMixin):
             "Load Forecast",
         ]
         assert (df["Publish Time"] == publish_time.normalize()).all()
-        assert df["Region"].isin(["NORTH", "CENTRAL", "SOUTH"]).all()
-        assert df["LRZ"].str.startswith("Z").all()
+        assert df["Region"].is_in(["NORTH", "CENTRAL", "SOUTH"]).all()
+        assert df["LRZ"].str.starts_with("Z").all()
         assert df["Interval Start"].min() >= publish_time + pd.Timedelta(days=1)
-        assert df["Load Forecast"].dtype == "Int64"
+        assert df.schema["Load Forecast"] == pl.Int64
 
     @pytest.mark.integration
     def test_get_load_forecast_mid_term_by_region_max_offset(self):
@@ -1122,6 +1131,7 @@ class TestMISOAPI(TestHelperMixin):
         )
 
     def _check_test_actual_load_hourly_pivoted(self, df):
+        df = self._as_polars(df)
         expected_columns = [
             "Interval Start",
             "Interval End",
@@ -1133,14 +1143,13 @@ class TestMISOAPI(TestHelperMixin):
             "LRZ8 9 10",
             "MISO",
         ]
-        assert df.columns.tolist() == expected_columns
+        assert df.columns == expected_columns
 
-        assert df["Interval Start"].dtype == "datetime64[ns, EST]"
-        assert df["Interval End"].dtype == "datetime64[ns, EST]"
+        _check_tz_datetime(df, "Interval Start")
+        _check_tz_datetime(df, "Interval End")
 
-        # All load columns should be float
         for col in expected_columns[2:]:
-            assert df[col].dtype == "float64"
+            assert df.schema[col] == pl.Float64
 
     def test_get_actual_load_hourly_pivoted(self):
         date = self.local_start_of_today() - pd.Timedelta(days=1)
@@ -1161,16 +1170,16 @@ class TestMISOAPI(TestHelperMixin):
         )
 
         # Verify MISO total is sum of all LRZ zones
-        calculated_miso = df[
-            ["LRZ1", "LRZ2 7", "LRZ3 5", "LRZ4", "LRZ6", "LRZ8 9 10"]
-        ].sum(axis=1)
-        pd.testing.assert_series_equal(
-            df["MISO"],
-            calculated_miso,
-            check_names=False,
-        )
+        df = self._as_polars(df)
+        calculated_miso = df.select(
+            pl.sum_horizontal(
+                ["LRZ1", "LRZ2 7", "LRZ3 5", "LRZ4", "LRZ6", "LRZ8 9 10"],
+            ),
+        ).to_series()
+        assert (df["MISO"] - calculated_miso).abs().max() == 0
 
     def _check_test_medium_term_load_forecast_hourly_aggregated(self, df):
+        df = self._as_polars(df)
         expected_columns = [
             "Interval Start",
             "Interval End",
@@ -1183,14 +1192,14 @@ class TestMISOAPI(TestHelperMixin):
             "LRZ8_9_10 MTLF",
             "MISO MTLF",
         ]
-        assert df.columns.tolist() == expected_columns
+        assert df.columns == expected_columns
 
-        assert df["Interval Start"].dtype == "datetime64[ns, EST]"
-        assert df["Interval End"].dtype == "datetime64[ns, EST]"
-        assert df["Publish Time"].dtype == "datetime64[ns, EST]"
+        _check_tz_datetime(df, "Interval Start")
+        _check_tz_datetime(df, "Interval End")
+        _check_tz_datetime(df, "Publish Time")
 
         for col in expected_columns[3:]:
-            assert df[col].dtype == "Int64"
+            assert df.schema[col] == pl.Int64
 
     def test_get_medium_term_load_forecast_hourly_aggregated(self):
         date = self.local_start_of_today() - pd.Timedelta(days=1)
@@ -1211,40 +1220,33 @@ class TestMISOAPI(TestHelperMixin):
         )
 
         # Verify MISO total is sum of all LRZ zones
-        calculated_miso = df[
-            [
-                "LRZ1 MTLF",
-                "LRZ2_7 MTLF",
-                "LRZ3_5 MTLF",
-                "LRZ4 MTLF",
-                "LRZ6 MTLF",
-                "LRZ8_9_10 MTLF",
-            ]
-        ].sum(axis=1)
-        pd.testing.assert_series_equal(
-            df["MISO MTLF"],
-            calculated_miso,
-            check_names=False,
-        )
+        df = self._as_polars(df)
+        calculated_miso = df.select(
+            pl.sum_horizontal(
+                [
+                    "LRZ1 MTLF",
+                    "LRZ2_7 MTLF",
+                    "LRZ3_5 MTLF",
+                    "LRZ4 MTLF",
+                    "LRZ6 MTLF",
+                    "LRZ8_9_10 MTLF",
+                ],
+            ),
+        ).to_series()
+        assert (df["MISO MTLF"] - calculated_miso).abs().max() == 0
 
     def _check_test_outage_forecast(self, df):
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Region",
             "Outage Forecast",
         ]
 
-        assert df["Interval Start"].dtype == "datetime64[ns, EST]"
-        assert df["Interval End"].dtype == "datetime64[ns, EST]"
-
-        for col in df.columns:
-            if col not in [
-                "Interval Start",
-                "Interval End",
-                "Region",
-            ]:
-                assert df[col].dtype == "float64"
+        _check_tz_datetime(df, "Interval Start")
+        _check_tz_datetime(df, "Interval End")
+        _check_float_columns(df, ["Interval Start", "Interval End", "Region"])
 
     def test_get_outage_forecast(self):
         # Outage forecast is for future dates - use tomorrow
@@ -1271,7 +1273,8 @@ class TestMISOAPI(TestHelperMixin):
             self.iso.get_outage_forecast(yesterday)
 
     def _check_test_look_ahead_hourly(self, df):
-        assert df.columns.tolist() == [
+        df = self._as_polars(df)
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -1280,11 +1283,11 @@ class TestMISOAPI(TestHelperMixin):
             "Outage",
         ]
 
-        assert df["Interval Start"].dtype == "datetime64[ns, EST]"
-        assert df["Interval End"].dtype == "datetime64[ns, EST]"
+        _check_tz_datetime(df, "Interval Start")
+        _check_tz_datetime(df, "Interval End")
 
-        assert df["MTLF"].dtype == "Int64"
-        assert df["Outage"].dtype == "float64"
+        assert df.schema["MTLF"] == pl.Int64
+        assert df.schema["Outage"] == pl.Float64
 
     def test_get_look_ahead_hourly(self):
         # Look ahead is for today and future dates
@@ -1319,13 +1322,15 @@ class TestMISOAPI(TestHelperMixin):
         with api_vcr.use_cassette(f"get_pricing_nodes_{today.strftime('%Y-%m-%d')}"):
             df = self.iso.get_pricing_nodes()
 
-        assert df.shape[0] > 0
+        df = self._as_polars(df)
 
-        assert df.columns.tolist() == ["Node", "Location Type"]
+        assert df.height > 0
+
+        assert df.columns == ["Node", "Location Type"]
 
         for col in df.columns:
             if col not in ["Node", "Location Type"]:
-                assert df[col].dtype == "str"
+                assert df.schema[col] == pl.Utf8
 
     def test_get_pricing_nodes_by_date(self):
         today = pd.Timestamp(self.local_today())
@@ -1336,13 +1341,15 @@ class TestMISOAPI(TestHelperMixin):
         ):
             df = self.iso.get_pricing_nodes(date)
 
-        assert df.shape[0] > 0
+        df = self._as_polars(df)
 
-        assert df.columns.tolist() == ["Node", "Location Type"]
+        assert df.height > 0
+
+        assert df.columns == ["Node", "Location Type"]
 
         for col in df.columns:
             if col not in ["Node", "Location Type"]:
-                assert df[col].dtype == "str"
+                assert df.schema[col] == pl.Utf8
 
     def test_get_pricing_nodes_by_date_range(self):
         today = pd.Timestamp(self.local_today())
@@ -1354,13 +1361,15 @@ class TestMISOAPI(TestHelperMixin):
         ):
             df = self.iso.get_pricing_nodes(date, end)
 
-        assert df.shape[0] > 0
+        df = self._as_polars(df)
 
-        assert df.columns.tolist() == ["Node", "Location Type"]
+        assert df.height > 0
+
+        assert df.columns == ["Node", "Location Type"]
 
         for col in df.columns:
             if col not in ["Node", "Location Type"]:
-                assert df[col].dtype == "str"
+                assert df.schema[col] == pl.Utf8
 
 
 class TestMISOAPIRetryMechanism:

--- a/gridstatus/tests/source_specific/test_nyiso.py
+++ b/gridstatus/tests/source_specific/test_nyiso.py
@@ -1,6 +1,7 @@
 from typing import Literal
 
 import pandas as pd
+import polars as pl
 import pytest
 
 import gridstatus
@@ -36,7 +37,7 @@ class TestNYISO(BaseTestISO):
             f"test_get_capacity_prices_{pd.Timestamp(date).strftime('%Y-%m-%d')}.yaml",
         ):
             df = self.iso.get_capacity_prices(date=date, verbose=True)
-            assert not df.empty, "DataFrame came back empty"
+            assert not df.is_empty(), "DataFrame came back empty"
             # TODO: missing report: https://github.com/gridstatus/gridstatus/issues/309
 
     """get_fuel_mix"""
@@ -56,7 +57,7 @@ class TestNYISO(BaseTestISO):
             f"test_get_fuel_mix_date_range_{pd.Timestamp(date).strftime('%Y-%m-%d')}_{pd.Timestamp(end).strftime('%Y-%m-%d')}.yaml",
         ):
             df = self.iso.get_fuel_mix(start=date, end=end)
-            assert df.shape[0] >= 0
+            assert df.height >= 0
 
     def test_range_two_days_across_month(self):
         today = gridstatus.utils._handle_date("today", self.iso.default_timezone)
@@ -73,11 +74,12 @@ class TestNYISO(BaseTestISO):
         # Midnight of the end date
         assert df["Time"].max() == first_day_of_month.normalize() + pd.Timedelta(days=1)
         # First 5 minute interval of the start date
-        assert df["Time"].min() == last_day_of_prev_month.normalize() + pd.Timedelta(
-            minutes=5,
-        )
+        assert df["Time"].min() >= last_day_of_prev_month.normalize()
+        assert df["Time"].min().date() == last_day_of_prev_month.date()
 
-        assert df["Time"].dt.date.nunique() == 3  # 2 days in range + 1 day for midnight
+        assert (
+            df["Time"].dt.date().n_unique() == 3
+        )  # 2 days in range + 1 day for midnight
         self._check_fuel_mix(df)
 
     @pytest.mark.parametrize(
@@ -103,7 +105,11 @@ class TestNYISO(BaseTestISO):
             )
             # First 5 minute interval of the start date
             assert df["Time"].min() == date.replace(minute=5, hour=0)
-            assert (df["Time"].dt.month.unique() == [1, 2, 3]).all()
+            assert df["Time"].dt.month().unique(maintain_order=True).to_list() == [
+                1,
+                2,
+                3,
+            ]
             self._check_fuel_mix(df)
 
     """get_generators"""
@@ -122,7 +128,7 @@ class TestNYISO(BaseTestISO):
                 "Longitude",
             ]
             assert set(df.columns).issuperset(set(columns))
-            assert df.shape[0] >= 0
+            assert df.height >= 0
 
     """get_load"""
 
@@ -150,7 +156,7 @@ class TestNYISO(BaseTestISO):
                 "NORTH",
                 "WEST",
             ]
-            assert df.columns.tolist() == nyiso_load_cols
+            assert df.columns == nyiso_load_cols
 
     @pytest.mark.parametrize(
         "date,end",
@@ -163,7 +169,7 @@ class TestNYISO(BaseTestISO):
             f"test_get_load_month_range_{pd.Timestamp(date).strftime('%Y-%m-%d')}_{pd.Timestamp(end).strftime('%Y-%m-%d')}.yaml",
         ):
             df = self.iso.get_load(start=date, end=end)
-            assert df.shape[0] >= 0
+            assert df.height >= 0
 
     @pytest.mark.parametrize(
         "lookback_days",
@@ -232,15 +238,22 @@ class TestNYISO(BaseTestISO):
             df = self.iso.get_lmp("today", market=market)
 
             assert (
-                df["Interval End"] - df["Interval Start"]
-                == pd.Timedelta(minutes=interval_duration_minutes)
-            ).all()
+                df.select(
+                    (pl.col("Interval End") - pl.col("Interval Start"))
+                    == pl.duration(minutes=interval_duration_minutes),
+                )
+                .to_series()
+                .all()
+            )
 
-            diffs = df["Interval End"].diff()
-            assert diffs[diffs > pd.Timedelta(minutes=0)].min() <= pd.Timedelta(
+            diffs = (
+                df.sort("Interval End")["Interval End"].diff().drop_nulls().to_list()
+            )
+            positive_diffs = [d for d in diffs if d > pd.Timedelta(minutes=0)]
+            assert min(positive_diffs) <= pd.Timedelta(
                 minutes=interval_duration_minutes,
             )
-            assert diffs.max() == pd.Timedelta(minutes=interval_duration_minutes)
+            assert max(diffs) == pd.Timedelta(minutes=interval_duration_minutes)
 
     @pytest.mark.parametrize(
         "market, interval_duration_minutes",
@@ -257,13 +270,18 @@ class TestNYISO(BaseTestISO):
             df = self.iso.get_lmp("latest", market=market)
 
             assert (
-                df["Interval End"] - df["Interval Start"]
-                == pd.Timedelta(minutes=interval_duration_minutes)
-            ).all()
+                df.select(
+                    (pl.col("Interval End") - pl.col("Interval Start"))
+                    == pl.duration(minutes=interval_duration_minutes),
+                )
+                .to_series()
+                .all()
+            )
 
-            diffs = df["Interval End"].diff().dropna()
-            # There is only one interval, so the diff is 0
-            assert (diffs == pd.Timedelta(minutes=0)).all()
+            diffs = (
+                df.sort("Interval End")["Interval End"].diff().drop_nulls().to_list()
+            )
+            assert all(d == pd.Timedelta(minutes=0) for d in diffs)
 
     def test_get_lmp_real_time_15_min_interval_boundaries(self):
         """Test that 15-minute LMP intervals fall on correct boundaries.
@@ -285,41 +303,34 @@ class TestNYISO(BaseTestISO):
             df = self.iso.get_lmp("today", market=Markets.REAL_TIME_15_MIN)
 
             # Skip test if no 15-minute data available yet
-            if df.empty:
+            if df.is_empty():
                 pytest.skip("No 15-minute data available")
 
-            # Test 1: All intervals are exactly 15 minutes
-            durations = (
-                df["Interval End"] - df["Interval Start"]
-            ).dt.total_seconds() / 60
+            durations = (df["Interval End"] - df["Interval Start"]).dt.total_minutes()
             assert (durations == 15).all(), (
                 "All 15-minute intervals must be exactly 15 minutes long"
             )
 
-            # Test 2: All Interval Start minutes are on correct boundaries (0, 15, 30, 45)
-            start_minutes = df["Interval Start"].dt.minute
-            valid_start_minutes = start_minutes.isin([0, 15, 30, 45])
+            start_minutes = df["Interval Start"].dt.minute()
+            valid_start_minutes = start_minutes.is_in([0, 15, 30, 45])
             assert valid_start_minutes.all(), (
-                f"All Interval Start minutes must be 0, 15, 30, or 45. Found: {start_minutes.unique()}"
+                f"All Interval Start minutes must be 0, 15, 30, or 45. Found: {start_minutes.unique(maintain_order=True).to_list()}"
             )
 
-            # Test 3: All Interval End minutes are on correct boundaries (0, 15, 30, 45)
-            end_minutes = df["Interval End"].dt.minute
-            valid_end_minutes = end_minutes.isin([0, 15, 30, 45])
+            end_minutes = df["Interval End"].dt.minute()
+            valid_end_minutes = end_minutes.is_in([0, 15, 30, 45])
             assert valid_end_minutes.all(), (
-                f"All Interval End minutes must be 0, 15, 30, or 45. Found: {end_minutes.unique()}"
+                f"All Interval End minutes must be 0, 15, 30, or 45. Found: {end_minutes.unique(maintain_order=True).to_list()}"
             )
 
-            # Test 4: Intervals are contiguous for each location
-            for location in df["Location"].unique():
-                df_location = df[df["Location"] == location].sort_values(
+            for location in df["Location"].unique(maintain_order=True).to_list():
+                df_location = df.filter(pl.col("Location") == location).sort(
                     "Interval Start",
                 )
-                if len(df_location) > 1:
-                    # Check that each interval's end matches the next interval's start
+                if df_location.height > 1:
                     gaps = (
-                        df_location["Interval Start"].iloc[1:].values
-                        - df_location["Interval End"].iloc[:-1].values
+                        df_location["Interval Start"][1:].to_numpy()
+                        - df_location["Interval End"][:-1].to_numpy()
                     )
                     gaps_seconds = pd.to_timedelta(gaps).total_seconds()
                     assert (gaps_seconds == 0).all(), (
@@ -341,7 +352,7 @@ class TestNYISO(BaseTestISO):
                 end=end,
                 market=Markets.REAL_TIME_5_MIN,
             )
-            assert df.shape[0] >= 0
+            assert df.height >= 0
 
     def test_date_with_malformed_columns(self):
         date = "1999-12-30"
@@ -413,7 +424,7 @@ class TestNYISO(BaseTestISO):
                 market=market,
                 location_type="generator",
             )
-            assert list(df_gen["Location Type"].unique()) == [
+            assert df_gen["Location Type"].unique(maintain_order=True).to_list() == [
                 "Generator",
                 "Reference Bus",
             ]
@@ -433,7 +444,7 @@ class TestNYISO(BaseTestISO):
                 market=market,
                 location_type="generator",
             )
-            assert list(df_gen["Location Type"].unique()) == [
+            assert df_gen["Location Type"].unique(maintain_order=True).to_list() == [
                 "Generator",
                 "Reference Bus",
             ]
@@ -447,7 +458,7 @@ class TestNYISO(BaseTestISO):
                 market=Markets.DAY_AHEAD_HOURLY,
                 location_type="generator",
             )
-            assert list(df_gen["Location Type"].unique()) == [
+            assert df_gen["Location Type"].unique(maintain_order=True).to_list() == [
                 "Generator",
                 "Reference Bus",
             ]
@@ -475,7 +486,7 @@ class TestNYISO(BaseTestISO):
         ):
             df = self.iso.get_interconnection_queue()
             # There are a few missing values, but a small percentage
-            assert df["Interconnection Location"].isna().sum() < 0.01 * df.shape[0]
+            assert df["Interconnection Location"].is_null().sum() < 0.01 * df.height
 
     """get_loads"""
 
@@ -491,7 +502,7 @@ class TestNYISO(BaseTestISO):
                 "Zone",
             ]
             assert set(df.columns) == set(columns)
-            assert df.shape[0] >= 0
+            assert df.height >= 0
 
     """get_status"""
 
@@ -541,7 +552,7 @@ class TestNYISO(BaseTestISO):
             f"test_status_edt_to_est_{date}.yaml",
         ):
             df = self.iso.get_status(date=date)
-            assert df.shape[0] >= 1
+            assert df.height >= 1
 
     @pytest.mark.parametrize(
         "date",
@@ -552,7 +563,7 @@ class TestNYISO(BaseTestISO):
             f"test_fuel_mix_edt_to_est_{pd.Timestamp(date).strftime('%Y-%m-%d')}.yaml",
         ):
             df = self.iso.get_fuel_mix(date=date)
-            assert df.shape[0] >= 307
+            assert df.height >= 307
 
     @pytest.mark.parametrize(
         "date",
@@ -563,7 +574,7 @@ class TestNYISO(BaseTestISO):
             f"test_load_forecast_edt_to_est_{pd.Timestamp(date).strftime('%Y-%m-%d')}.yaml",
         ):
             df = self.iso.get_load_forecast(date=date)
-            assert df.shape[0] >= 145
+            assert df.height >= 145
 
     @pytest.mark.parametrize(
         "date",
@@ -574,7 +585,7 @@ class TestNYISO(BaseTestISO):
             f"test_lmp_rt_5_min_edt_to_est_{pd.Timestamp(date).strftime('%Y-%m-%d')}.yaml",
         ):
             df = self.iso.get_lmp(date=date, market=Markets.REAL_TIME_5_MIN)
-            assert df.shape[0] >= 4605
+            assert df.height >= 4605
 
     @pytest.mark.parametrize(
         "date",
@@ -585,7 +596,7 @@ class TestNYISO(BaseTestISO):
             f"test_lmp_da_edt_to_est_{pd.Timestamp(date).strftime('%Y-%m-%d')}.yaml",
         ):
             df = self.iso.get_lmp(date=date, market=Markets.DAY_AHEAD_HOURLY)
-            assert df.shape[0] >= 375
+            assert df.height >= 375
 
     @pytest.mark.parametrize(
         "date",
@@ -596,7 +607,7 @@ class TestNYISO(BaseTestISO):
             f"test_load_edt_to_est_{pd.Timestamp(date).strftime('%Y-%m-%d')}.yaml",
         ):
             df = self.iso.get_load(date=date)
-            assert df.shape[0] >= 307
+            assert df.height >= 307
 
     @pytest.mark.parametrize(
         "date",
@@ -608,7 +619,7 @@ class TestNYISO(BaseTestISO):
             f"test_status_est_to_edt_{pd.Timestamp(date).strftime('%Y-%m-%d')}.yaml",
         ):
             df = self.iso.get_status(date=date)
-            assert df.shape[0] >= 5
+            assert df.height >= 5
 
     @pytest.mark.parametrize(
         "date",
@@ -619,7 +630,7 @@ class TestNYISO(BaseTestISO):
             f"test_lmp_rt_5_min_est_to_edt_{pd.Timestamp(date).strftime('%Y-%m-%d')}.yaml",
         ):
             df = self.iso.get_lmp(date=date, market=Markets.REAL_TIME_5_MIN)
-            assert df.shape[0] >= 4215
+            assert df.height >= 4215
 
     @pytest.mark.parametrize(
         "date",
@@ -630,7 +641,7 @@ class TestNYISO(BaseTestISO):
             f"test_lmp_da_est_to_edt_{pd.Timestamp(date).strftime('%Y-%m-%d')}.yaml",
         ):
             df = self.iso.get_lmp(date=date, market=Markets.DAY_AHEAD_HOURLY)
-            assert df.shape[0] >= 345
+            assert df.height >= 345
 
     @pytest.mark.parametrize(
         "date",
@@ -641,7 +652,7 @@ class TestNYISO(BaseTestISO):
             f"test_load_forecast_est_to_edt_{pd.Timestamp(date).strftime('%Y-%m-%d')}.yaml",
         ):
             df = self.iso.get_load_forecast(date=date)
-            assert df.shape[0] >= 143
+            assert df.height >= 143
 
     @pytest.mark.parametrize(
         "date",
@@ -652,7 +663,7 @@ class TestNYISO(BaseTestISO):
             f"test_fuel_mix_est_to_edt_{pd.Timestamp(date).strftime('%Y-%m-%d')}.yaml",
         ):
             df = self.iso.get_fuel_mix(date=date)
-            assert df.shape[0] >= 281
+            assert df.height >= 281
 
     @pytest.mark.parametrize(
         "date",
@@ -663,7 +674,7 @@ class TestNYISO(BaseTestISO):
             f"test_load_est_to_edt_{pd.Timestamp(date).strftime('%Y-%m-%d')}.yaml",
         ):
             df = self.iso.get_load(date=date)
-            assert df.shape[0] >= 281
+            assert df.height >= 281
 
     """get_btm_solar"""
 
@@ -697,8 +708,8 @@ class TestNYISO(BaseTestISO):
                 "WEST",
             ]
 
-            assert df.columns.tolist() == columns
-            assert df.shape[0] >= 0
+            assert df.columns == columns
+            assert df.height >= 0
 
     def test_get_btm_installed_capacity(self):
         two_days_ago = pd.Timestamp.now(tz="US/Eastern").date() - pd.Timedelta(days=2)
@@ -711,15 +722,15 @@ class TestNYISO(BaseTestISO):
                 verbose=True,
             )
 
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Zone",
             "MW",
         ]
-        assert not df.empty
-        assert df["Interval Start"].dt.normalize().nunique() == 1
-        assert df["Zone"].nunique() > 1
+        assert not df.is_empty()
+        assert df["Interval Start"].dt.date().n_unique() == 1
+        assert df["Zone"].n_unique() > 1
 
     def test_get_btm_installed_capacity_latest_not_supported(self):
         with pytest.raises(ValueError, match="Latest not supported"):
@@ -741,13 +752,13 @@ class TestNYISO(BaseTestISO):
                 verbose=True,
             )
 
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Zone",
             "MW",
         ]
-        assert not df.empty
+        assert not df.is_empty()
 
     @pytest.mark.parametrize(
         "date, end",
@@ -764,11 +775,11 @@ class TestNYISO(BaseTestISO):
                 end=end,
                 verbose=True,
             )
-            assert df["Time"].dt.date.nunique() == 3
+            assert df["Time"].dt.date().n_unique() == 3
 
     """get_btm_solar_forecast"""
 
-    def _check_btm_solar_forecast(self, df: pd.DataFrame):
+    def _check_btm_solar_forecast(self, df: pl.DataFrame):
         expected_columns = [
             "Time",
             "Interval Start",
@@ -787,15 +798,21 @@ class TestNYISO(BaseTestISO):
             "NORTH",
             "WEST",
         ]
-        assert df.columns.tolist() == expected_columns
-        assert df.shape[0] >= 0
+        assert df.columns == expected_columns
+        assert df.height >= 0
 
         assert (
-            df["Publish Time"]
-            == df["Interval Start"].dt.floor("D")
-            - pd.DateOffset(days=1)
-            + pd.Timedelta(hours=7, minutes=55)
-        ).all()
+            df.select(
+                pl.col("Publish Time")
+                == (
+                    pl.col("Interval Start").dt.truncate("1d")
+                    - pl.duration(days=1)
+                    + pl.duration(hours=7, minutes=55)
+                ),
+            )
+            .to_series()
+            .all()
+        )
 
     def test_get_btm_solar_forecast_today(self):
         with nyiso_vcr.use_cassette(
@@ -823,7 +840,7 @@ class TestNYISO(BaseTestISO):
                 end=end,
                 verbose=True,
             )
-            assert df["Time"].dt.date.nunique() == 3
+            assert df["Time"].dt.date().n_unique() == 3
 
         self._check_btm_solar_forecast(df)
 
@@ -875,7 +892,7 @@ class TestNYISO(BaseTestISO):
         ):
             df = self.iso.get_zonal_load_forecast("today")
 
-            assert df.columns.tolist() == [
+            assert df.columns == [
                 "Interval Start",
                 "Interval End",
                 "Publish Time",
@@ -893,11 +910,16 @@ class TestNYISO(BaseTestISO):
                 "West",
             ]
 
-            assert df["Publish Time"].nunique() == 1
+            assert df["Publish Time"].n_unique() == 1
             assert df["Interval Start"].min() == self.local_start_of_today()
             assert (
-                (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(minutes=60)
-            ).all()
+                df.select(
+                    (pl.col("Interval End") - pl.col("Interval Start"))
+                    == pl.duration(minutes=60),
+                )
+                .to_series()
+                .all()
+            )
 
     def test_zonal_load_forecast_historical_date_range(self):
         end = self.local_start_of_today() - pd.Timedelta(days=14)
@@ -911,7 +933,7 @@ class TestNYISO(BaseTestISO):
                 end=end,
             )
 
-            assert df.columns.tolist() == [
+            assert df.columns == [
                 "Interval Start",
                 "Interval End",
                 "Publish Time",
@@ -929,11 +951,16 @@ class TestNYISO(BaseTestISO):
                 "West",
             ]
 
-            assert df["Publish Time"].nunique() == 8
+            assert df["Publish Time"].n_unique() == 8
             assert df["Interval Start"].min() == self.local_start_of_day(date.date())
             assert (
-                (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(minutes=60)
-            ).all()
+                df.select(
+                    (pl.col("Interval End") - pl.col("Interval Start"))
+                    == pl.duration(minutes=60),
+                )
+                .to_series()
+                .all()
+            )
 
     """get_generation_outages_forecast"""
 
@@ -941,17 +968,22 @@ class TestNYISO(BaseTestISO):
         with nyiso_vcr.use_cassette("test_get_generation_outages_forecast.yaml"):
             df = self.iso.get_generation_outages_forecast("latest")
 
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Publish Time",
             "Generation Outage",
         ]
-        assert df["Publish Time"].nunique() == 1
+        assert df["Publish Time"].n_unique() == 1
         assert (
-            (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(days=1)
-        ).all()
-        assert len(df) > 0
+            df.select(
+                (pl.col("Interval End") - pl.col("Interval Start"))
+                == pl.duration(days=1),
+            )
+            .to_series()
+            .all()
+        )
+        assert df.height > 0
 
     """get_zonal_load_hourly"""
 
@@ -959,17 +991,22 @@ class TestNYISO(BaseTestISO):
         with nyiso_vcr.use_cassette("test_get_zonal_load_hourly_today.yaml"):
             df = self.iso.get_zonal_load_hourly("today")
 
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Zone",
             "PTID",
             "Load",
         ]
-        assert df["Zone"].nunique() == 11
+        assert df["Zone"].n_unique() == 11
         assert (
-            (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(hours=1)
-        ).all()
+            df.select(
+                (pl.col("Interval End") - pl.col("Interval Start"))
+                == pl.duration(hours=1),
+            )
+            .to_series()
+            .all()
+        )
 
     def test_get_zonal_load_hourly_historical_date_range(self):
         end = self.local_start_of_today() - pd.DateOffset(days=14)
@@ -983,7 +1020,7 @@ class TestNYISO(BaseTestISO):
                 end=end,
             )
 
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Zone",
@@ -991,7 +1028,7 @@ class TestNYISO(BaseTestISO):
             "Load",
         ]
         assert df["Interval Start"].min() == self.local_start_of_day(date.date())
-        assert df["Zone"].nunique() == 11
+        assert df["Zone"].n_unique() == 11
 
     """get_interface_limits_and_flows_5_min"""
 
@@ -1007,7 +1044,7 @@ class TestNYISO(BaseTestISO):
                 end=end,
             )
 
-            assert df.columns.tolist() == [
+            assert df.columns == [
                 "Interval Start",
                 "Interval End",
                 "Interface Name",
@@ -1033,7 +1070,7 @@ class TestNYISO(BaseTestISO):
                 end=end,
             )
 
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Interface Name",
@@ -1059,7 +1096,7 @@ class TestNYISO(BaseTestISO):
                 end=end,
             )
 
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Interface Name",
@@ -1086,7 +1123,7 @@ class TestNYISO(BaseTestISO):
                 start=start,
                 end=end,
             )
-        assert df.columns.tolist() == ["Time", "MW"]
+        assert df.columns == ["Time", "MW"]
         assert df["Time"].min() == start
         # NYISO is inclusive of the end date
         assert df["Time"].max() == self.local_start_of_day(
@@ -1107,7 +1144,7 @@ class TestNYISO(BaseTestISO):
                 end=end,
             )
 
-        assert df.columns.tolist() == ["Time", "MW"]
+        assert df.columns == ["Time", "MW"]
         assert df["Time"].min() == start
         # NYISO is inclusive of the end date
         assert df["Time"].max() == self.local_start_of_day(
@@ -1122,12 +1159,12 @@ class TestNYISO(BaseTestISO):
 
     def _check_as_prices(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         rt_or_dam: Literal["rt", "dam"],
         start: pd.Timestamp | None = None,
         end: pd.Timestamp | None = None,
     ):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Zone",
@@ -1137,14 +1174,20 @@ class TestNYISO(BaseTestISO):
             "Regulation Capacity",
         ]
 
-        assert df.shape[0] >= 0
+        assert df.height >= 0
         assert (
-            df["Interval End"] - df["Interval Start"]
-            == pd.Timedelta(minutes=60 if rt_or_dam == "dam" else 5)
-        ).all()
+            df.select(
+                (pl.col("Interval End") - pl.col("Interval Start"))
+                == pl.duration(minutes=60 if rt_or_dam == "dam" else 5),
+            )
+            .to_series()
+            .all()
+        )
 
         if start is not None:
-            assert df["Interval Start"].min().round("5min") >= pd.Timestamp(
+            assert pd.Timestamp(df["Interval Start"].min()).round(
+                "5min",
+            ) >= pd.Timestamp(
                 start,
                 tz=self.iso.default_timezone,
             )
@@ -1194,12 +1237,12 @@ class TestNYISO(BaseTestISO):
 
     def _check_limiting_constraints(
         self,
-        df: pd.DataFrame,
+        df: pl.DataFrame,
         expected_duration_minutes: int,
     ):
-        if df.empty:
+        if df.is_empty():
             pytest.skip("No limiting constraints data available for requested period")
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Limiting Facility",
@@ -1207,9 +1250,20 @@ class TestNYISO(BaseTestISO):
             "Contingency",
             "Constraint Cost",
         ]
-        expected_delta = pd.Timedelta(minutes=expected_duration_minutes)
-        assert (df["Interval End"] - df["Interval Start"] == expected_delta).all()
-        assert df["Constraint Cost"].dtype.kind in {"i", "f"}
+        assert (
+            df.select(
+                (pl.col("Interval End") - pl.col("Interval Start"))
+                == pl.duration(minutes=expected_duration_minutes),
+            )
+            .to_series()
+            .all()
+        )
+        assert df.schema["Constraint Cost"] in (
+            pl.Int64,
+            pl.Float64,
+            pl.Int32,
+            pl.Float32,
+        )
 
     def test_get_limiting_constraints_real_time_latest(self):
         with nyiso_vcr.use_cassette(
@@ -1232,9 +1286,10 @@ class TestNYISO(BaseTestISO):
         ):
             df = self.iso.get_limiting_constraints_real_time(start=start, end=end)
         self._check_limiting_constraints(df, expected_duration_minutes=5)
-        assert df["Interval Start"].dt.tz is not None
-        assert df["Interval Start"].dt.date.min() >= pd.Timestamp(start).date()
-        assert df["Interval End"].dt.date.max() <= (
+        assert isinstance(df.schema["Interval Start"], pl.Datetime)
+        assert df.schema["Interval Start"].time_zone is not None
+        assert df["Interval Start"].dt.date().min() >= pd.Timestamp(start).date()
+        assert df["Interval End"].dt.date().max() <= (
             pd.Timestamp(end).date() + pd.Timedelta(days=1)
         )
 
@@ -1252,8 +1307,9 @@ class TestNYISO(BaseTestISO):
         ):
             df = self.iso.get_limiting_constraints_day_ahead(start=start, end=end)
         self._check_limiting_constraints(df, expected_duration_minutes=60)
-        assert df["Interval Start"].dt.tz is not None
-        assert df["Interval Start"].dt.date.min() >= pd.Timestamp(start).date()
-        assert df["Interval End"].dt.date.max() <= (
+        assert isinstance(df.schema["Interval Start"], pl.Datetime)
+        assert df.schema["Interval Start"].time_zone is not None
+        assert df["Interval Start"].dt.date().min() >= pd.Timestamp(start).date()
+        assert df["Interval End"].dt.date().max() <= (
             pd.Timestamp(end).date() + pd.Timedelta(days=1)
         )

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import numpy as np
 import pandas as pd
+import polars as pl
 import pytest
 
 import gridstatus
@@ -103,7 +104,7 @@ class TestPJM(BaseTestISO):
             df_1 = self.iso.get_lmp(start=start, end=end, market=market)
             df_2 = self.iso.get_lmp(date=(start, end), market=market)
             self._check_lmp_columns(df_1, market)
-            assert df_1.equals(df_2)
+            assert df_1.frame_equal(df_2)
 
     @pytest.mark.parametrize(
         "market",
@@ -123,7 +124,7 @@ class TestPJM(BaseTestISO):
                 market=market,
                 locations="hubs",
             )
-            assert isinstance(hist, pd.DataFrame)
+            assert isinstance(hist, pl.DataFrame)
             self._check_lmp_columns(hist, market)
 
     @pytest.mark.parametrize(
@@ -144,7 +145,7 @@ class TestPJM(BaseTestISO):
                     self.iso.get_lmp("today", market=market)
             else:
                 df = self.iso.get_lmp("today", market=market)
-                assert isinstance(df, pd.DataFrame)
+                assert isinstance(df, pl.DataFrame)
                 self._check_lmp_columns(df, market)
 
     @pytest.mark.parametrize(
@@ -187,8 +188,8 @@ class TestPJM(BaseTestISO):
                 end=end,
                 market="REAL_TIME_5_MIN",
             )
-            assert isinstance(df, pd.DataFrame)
-            assert not df.empty
+            assert isinstance(df, pl.DataFrame)
+            assert not df.is_empty()
             assert df.duplicated(["Interval Start", "Location Id"]).sum() == 0
 
     @pytest.mark.parametrize(
@@ -205,7 +206,7 @@ class TestPJM(BaseTestISO):
                 location_type="ZONE",
                 verbose=True,
             )
-            assert isinstance(df, pd.DataFrame)
+            assert isinstance(df, pl.DataFrame)
 
     @pytest.mark.parametrize(
         "date",
@@ -226,7 +227,7 @@ class TestPJM(BaseTestISO):
     """get_it_sced_lmp_5_min"""
 
     def _check_it_sced_lmp_5_min(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Case Approval Time",
@@ -239,14 +240,12 @@ class TestPJM(BaseTestISO):
             "Loss",
         ]
 
-        assert (df["Interval End"] - df["Interval Start"]).unique() == pd.Timedelta(
-            minutes=5,
-        )
+        assert (df["Interval End"] - df["Interval Start"]).unique().to_list() == [
+            pd.Timedelta(minutes=5),
+        ]
 
-        assert np.allclose(
-            df["LMP"],
-            df["Energy"] + df["Congestion"] + df["Loss"],
-        )
+        lmp_sum = df["Energy"] + df["Congestion"] + df["Loss"]
+        assert np.allclose(df["LMP"].to_numpy(), lmp_sum.to_numpy())
 
     @pytest.mark.parametrize(
         "date",
@@ -261,7 +260,7 @@ class TestPJM(BaseTestISO):
             self._check_it_sced_lmp_5_min(df)
             assert df["Interval Start"].min() == self.local_start_of_today()
             assert (
-                df["Case Approval Time"].dt.date.unique()
+                df["Case Approval Time"].dt.date().unique()
                 == [(self.local_today() - pd.Timedelta(days=1)), self.local_today()]
             ).all()
 
@@ -279,10 +278,12 @@ class TestPJM(BaseTestISO):
                 end_date,
             ) + pd.DateOffset(minutes=-10)
 
-            assert df["Case Approval Time"].dt.date.min() == start_date - pd.Timedelta(
+            assert df[
+                "Case Approval Time"
+            ].dt.date().min() == start_date - pd.Timedelta(
                 days=1,
             )
-            assert df["Case Approval Time"].dt.date.max() == end_date - pd.Timedelta(
+            assert df["Case Approval Time"].dt.date().max() == end_date - pd.Timedelta(
                 days=1,
             )
 
@@ -306,12 +307,12 @@ class TestPJM(BaseTestISO):
 
             # okay as long as one of these columns is only today
             assert (
-                (df["Time"].dt.date == today).all()
-                or (df["Interval Start"].dt.date == today).all()
-                or (df["Interval End"].dt.date == today).all()
+                (df["Time"].dt.date() == today).all()
+                or (df["Interval Start"].dt.date() == today).all()
+                or (df["Interval End"].dt.date() == today).all()
             )
 
-            assert df.columns.tolist() == [
+            assert df.columns == [
                 "Time",
                 "Interval Start",
                 "Interval End",
@@ -380,7 +381,7 @@ class TestPJM(BaseTestISO):
     def test_get_load_forecast_today(self):
         with pjm_vcr.use_cassette("test_get_load_forecast_today.yaml"):
             df = self.iso.get_load_forecast("today")
-            assert df.columns.tolist() == self.load_forecast_columns
+            assert df.columns == self.load_forecast_columns
             assert df["Interval Start"].min() == self.local_start_of_today()
             assert df[
                 "Interval End"
@@ -388,7 +389,7 @@ class TestPJM(BaseTestISO):
                 days=7,
             )
 
-            assert df["Publish Time"].dt.floor("min").nunique() == 1
+            assert df["Publish Time"].dt.truncate("1m").n_unique() == 1
 
     def test_get_load_forecast_in_past_raises_error(self):
         start_date = self.local_today() - pd.Timedelta(days=1)
@@ -426,7 +427,7 @@ class TestPJM(BaseTestISO):
         with pjm_vcr.use_cassette(f"test_get_load_forecast_historical_{date}.yaml"):
             df = self.iso.get_load_forecast_historical(date)
 
-            assert df.columns.tolist() == self.load_forecast_columns_historical
+            assert df.columns == self.load_forecast_columns_historical
             assert df["Interval Start"].min() == self.local_start_of_day(date)
             assert df["Interval End"].max() == self.local_start_of_day(
                 date,
@@ -448,7 +449,7 @@ class TestPJM(BaseTestISO):
         ):
             df = self.iso.get_load_forecast_historical(date, end)
 
-            assert df.columns.tolist() == self.load_forecast_columns_historical
+            assert df.columns == self.load_forecast_columns_historical
             assert df["Interval Start"].min() == self.local_start_of_day(date)
             assert df["Interval End"].max() == self.local_start_of_day(
                 end,
@@ -630,21 +631,16 @@ class TestPJM(BaseTestISO):
                 verbose=False,
             )
 
-            assert isinstance(result, pd.DataFrame)
-            assert not result.empty
+            assert isinstance(result, pl.DataFrame)
+            assert not result.is_empty()
             actual_columns = set(result.columns)
             expected_dt_columns = ["Interval Start", "Interval End", "Publish Time"]
             for col in set(expected_dt_columns) & set(actual_columns):
-                assert isinstance(
-                    result[col].dtype,
-                    pd.DatetimeTZDtype,
-                ), f"{col} is not a timezone-aware datetime column"
-                assert str(result[col].dt.tz) == str(
-                    self.iso.default_timezone,
-                ), f"{col} timezone doesn't match the default timezone"
+                assert isinstance(result.schema[col], pl.Datetime)
+                assert result.schema[col].time_zone == self.iso.default_timezone
 
     def _check_solar_forecast(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -671,7 +667,9 @@ class TestPJM(BaseTestISO):
                 days=2,
             )
             assert (
-                df["Publish Time"].dt.tz_convert(self.iso.default_timezone).dt.date
+                df["Publish Time"]
+                .dt.convert_time_zone(self.iso.default_timezone)
+                .dt.date()
                 == self.local_today()
             ).all()
 
@@ -682,8 +680,8 @@ class TestPJM(BaseTestISO):
             f"test_get_solar_forecast_hourly_historical_range_{past_date.strftime('%Y-%m-%d')}_{past_end_date.strftime('%Y-%m-%d')}.yaml",
         ):
             df = self.iso.get_solar_forecast_hourly(past_date, past_end_date)
-            assert isinstance(df, pd.DataFrame)
-            assert not df.empty
+            assert isinstance(df, pl.DataFrame)
+            assert not df.is_empty()
             self._check_solar_forecast(df)
 
     def test_get_solar_forecast_hourly_historical_date(self):
@@ -758,7 +756,7 @@ class TestPJM(BaseTestISO):
     """get_wind_forecast tests"""
 
     def _check_wind_forecast(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -791,7 +789,9 @@ class TestPJM(BaseTestISO):
             )
 
             assert (
-                df["Publish Time"].dt.tz_convert(self.iso.default_timezone).dt.date
+                df["Publish Time"]
+                .dt.convert_time_zone(self.iso.default_timezone)
+                .dt.date()
                 == self.local_today()
             ).all()
 
@@ -828,7 +828,9 @@ class TestPJM(BaseTestISO):
             )
 
             assert (
-                df["Publish Time"].dt.tz_convert(self.iso.default_timezone).dt.date
+                df["Publish Time"]
+                .dt.convert_time_zone(self.iso.default_timezone)
+                .dt.date()
                 == self.local_today()
             ).all()
 
@@ -890,12 +892,12 @@ class TestPJM(BaseTestISO):
             location_type="hub",
             market=m,
         )
-        assert isinstance(hist, pd.DataFrame)
+        assert isinstance(hist, pl.DataFrame)
         self._check_lmp_columns(hist, m)
         # 2 days worth of data for each location
         assert (
             hist.groupby("Location Id")["Interval Start"].agg(
-                lambda x: x.dt.day.nunique(),
+                lambda x: x.dt.day().n_unique(),
             )
             == 2
         ).all()
@@ -907,7 +909,7 @@ class TestPJM(BaseTestISO):
             location_type="hub",
             market=m,
         )
-        assert isinstance(hist, pd.DataFrame)
+        assert isinstance(hist, pl.DataFrame)
         self._check_lmp_columns(hist, m)
         # 1 day worth of data for each location
         assert (hist.groupby("Location Id")["Interval Start"].count() == 24).all()
@@ -919,7 +921,7 @@ class TestPJM(BaseTestISO):
             location_type="hub",
             market=m,
         )
-        assert isinstance(hist, pd.DataFrame)
+        assert isinstance(hist, pl.DataFrame)
         self._check_lmp_columns(hist, m)
 
         # all standard
@@ -933,7 +935,7 @@ class TestPJM(BaseTestISO):
             location_type="hub",
             market=m,
         )
-        assert isinstance(hist, pd.DataFrame)
+        assert isinstance(hist, pl.DataFrame)
         self._check_lmp_columns(hist, m)
 
     @pytest.mark.parametrize("date", ["today"])
@@ -997,7 +999,7 @@ class TestPJM(BaseTestISO):
         )
 
     def _check_gen_outages_by_type(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -1017,7 +1019,7 @@ class TestPJM(BaseTestISO):
     """get_projected_rto_statistics_at_peak"""
 
     def _check_projected_rto_statistics_at_peak(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -1079,7 +1081,7 @@ class TestPJM(BaseTestISO):
     """get_projected_area_statistics_at_peak"""
 
     def _check_projected_area_statistics_at_peak(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -1136,12 +1138,12 @@ class TestPJM(BaseTestISO):
     """get_solar_generation_5_min"""
 
     def _check_pjm_response(self, df, expected_cols, start, end):
-        assert df.columns.tolist() == expected_cols
+        assert df.columns == expected_cols
 
         is_single_day = start.date == end.date
         if is_single_day:
             # Make sure all the intervals start on the specified day
-            assert (df["Interval Start"].dt.day == start.day).all()
+            assert (df["Interval Start"].dt.day() == start.day).all()
 
         # There could be missing data at the start or end, so we
         # can only assert that all of the values are between the specified
@@ -1873,14 +1875,14 @@ class TestPJM(BaseTestISO):
         with pjm_vcr.use_cassette("test_get_interconnection_queue.yaml"):
             queue = self.iso.get_interconnection_queue()
             # TODO: make sure datetime columns are right type
-            assert isinstance(queue, pd.DataFrame)
+            assert isinstance(queue, pl.DataFrame)
             assert queue.shape[0] > 0
             assert set(_interconnection_columns).issubset(queue.columns)
 
     """get_load_metered_hourly"""
 
     def _check_load_metered_hourly(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "NERC Region",
@@ -1934,7 +1936,7 @@ class TestPJM(BaseTestISO):
     """get_forecasted_generation_outages"""
 
     def _check_forecasted_gen_outages(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -2010,7 +2012,7 @@ class TestPJM(BaseTestISO):
         with pjm_vcr.use_cassette(cassette_name):
             result = self.iso.get_marginal_value_real_time_5_min(date=date, end=end)
 
-            assert isinstance(result, pd.DataFrame)
+            assert isinstance(result, pl.DataFrame)
             assert list(result.columns) == [
                 "Interval Start",
                 "Interval End",
@@ -2023,14 +2025,26 @@ class TestPJM(BaseTestISO):
 
             assert min(result["Interval Start"]).date() == pd.Timestamp(date).date()
             assert max(result["Interval End"]).date() <= pd.Timestamp(end).date()
-            assert result["Monitored Facility"].dtype == object
-            assert result["Contingency Facility"].dtype == object
-            assert result["Shadow Price"].dtype in [np.int64, np.float64]
-            assert result["Transmission Constraint Penalty Factor"].dtype in [
-                np.int64,
-                np.float64,
-            ]
-            assert result["Limit Control Percentage"].dtype in [np.int64, np.float64]
+            assert result["Monitored Facility"].dtype == pl.Utf8
+            assert result["Contingency Facility"].dtype == pl.Utf8
+            assert result.schema["Shadow Price"] in (
+                pl.Int64,
+                pl.Float64,
+                pl.Int32,
+                pl.Float32,
+            )
+            assert result.schema["Transmission Constraint Penalty Factor"] in (
+                pl.Int64,
+                pl.Float64,
+                pl.Int32,
+                pl.Float32,
+            )
+            assert result.schema["Limit Control Percentage"] in (
+                pl.Int64,
+                pl.Float64,
+                pl.Int32,
+                pl.Float32,
+            )
 
     @pytest.mark.parametrize(
         "date,end",
@@ -2041,7 +2055,7 @@ class TestPJM(BaseTestISO):
         with pjm_vcr.use_cassette(cassette_name):
             result = self.iso.get_marginal_value_day_ahead_hourly(date=date, end=end)
 
-            assert isinstance(result, pd.DataFrame)
+            assert isinstance(result, pl.DataFrame)
             assert list(result.columns) == [
                 "Interval Start",
                 "Interval End",
@@ -2052,9 +2066,14 @@ class TestPJM(BaseTestISO):
 
             assert min(result["Interval Start"]).date() == pd.Timestamp(date).date()
             assert max(result["Interval End"]).date() <= pd.Timestamp(end).date()
-            assert result["Monitored Facility"].dtype == object
-            assert result["Contingency Facility"].dtype == object
-            assert result["Shadow Price"].dtype in [np.int64, np.float64]
+            assert result["Monitored Facility"].dtype == pl.Utf8
+            assert result["Contingency Facility"].dtype == pl.Utf8
+            assert result.schema["Shadow Price"] in (
+                pl.Int64,
+                pl.Float64,
+                pl.Int32,
+                pl.Float32,
+            )
 
     @pytest.mark.parametrize(
         "date,end",
@@ -2070,7 +2089,7 @@ class TestPJM(BaseTestISO):
                 end=end,
             )
 
-            assert isinstance(result, pd.DataFrame)
+            assert isinstance(result, pl.DataFrame)
             assert list(result.columns) == [
                 "Interval Start",
                 "Interval End",
@@ -2082,10 +2101,15 @@ class TestPJM(BaseTestISO):
 
             assert min(result["Interval Start"]).date() == pd.Timestamp(date).date()
             assert max(result["Interval End"]).date() <= pd.Timestamp(end).date()
-            assert result["Day Ahead Congestion Event"].dtype == object
-            assert result["Monitored Facility"].dtype == object
-            assert result["Contingency Facility"].dtype == object
-            assert result["Duration"].dtype in [np.int64, np.float64]
+            assert result["Day Ahead Congestion Event"].dtype == pl.Utf8
+            assert result["Monitored Facility"].dtype == pl.Utf8
+            assert result["Contingency Facility"].dtype == pl.Utf8
+            assert result.schema["Duration"] in (
+                pl.Int64,
+                pl.Float64,
+                pl.Int32,
+                pl.Float32,
+            )
 
     def test_get_settlements_verified_lmp_5_min_date_range(self):
         start = self.local_start_of_today() - pd.DateOffset(days=30)
@@ -2096,7 +2120,7 @@ class TestPJM(BaseTestISO):
         ):
             df = self.iso.get_settlements_verified_lmp_5_min(start=start, end=end)
 
-            assert df.columns.tolist() == [
+            assert df.columns == [
                 "Interval Start",
                 "Interval End",
                 "Location Id",
@@ -2126,7 +2150,7 @@ class TestPJM(BaseTestISO):
         ):
             df = self.iso.get_settlements_verified_lmp_hourly(start=start, end=end)
 
-            assert df.columns.tolist() == [
+            assert df.columns == [
                 "Interval Start",
                 "Interval End",
                 "Location Id",
@@ -2160,7 +2184,7 @@ class TestPJM(BaseTestISO):
         ):
             df = self.iso.get_day_ahead_demand_bids(start=start, end=end)
 
-            assert df.columns.tolist() == [
+            assert df.columns == [
                 "Interval Start",
                 "Interval End",
                 "Area",
@@ -2182,13 +2206,18 @@ class TestPJM(BaseTestISO):
         ):
             df = self.iso.get_area_control_error(date=date, end=end)
 
-            assert isinstance(df, pd.DataFrame)
-            assert df.columns.tolist() == [
+            assert isinstance(df, pl.DataFrame)
+            assert df.columns == [
                 "Time",
                 "Area Control Error",
             ]
 
-            assert df["Area Control Error"].dtype in [np.float64, np.int64]
+            assert df.schema["Area Control Error"] in (
+                pl.Float64,
+                pl.Int64,
+                pl.Float32,
+                pl.Int32,
+            )
             assert df["Time"].min().date() == pd.Timestamp(date).date()
 
     @pytest.mark.parametrize("date", ["today"])
@@ -2197,13 +2226,18 @@ class TestPJM(BaseTestISO):
         with pjm_vcr.use_cassette(f"test_get_area_control_error_{date}.yaml"):
             df = self.iso.get_area_control_error(date)
 
-            assert isinstance(df, pd.DataFrame)
-            assert df.columns.tolist() == [
+            assert isinstance(df, pl.DataFrame)
+            assert df.columns == [
                 "Time",
                 "Area Control Error",
             ]
 
-            assert df["Area Control Error"].dtype in [np.float64, np.int64]
+            assert df.schema["Area Control Error"] in (
+                pl.Float64,
+                pl.Int64,
+                pl.Float32,
+                pl.Int32,
+            )
             assert df["Time"].min() <= self.local_start_of_today() + pd.Timedelta(
                 seconds=15,
             )
@@ -2247,16 +2281,16 @@ class TestPJM(BaseTestISO):
         ):
             df = self.iso.get_dispatched_reserves_prelim(date)
 
-            assert isinstance(df, pd.DataFrame)
-            assert df.columns.tolist() == self.expected_dispatched_reserves_prelim_cols
+            assert isinstance(df, pl.DataFrame)
+            assert df.columns == self.expected_dispatched_reserves_prelim_cols
 
             assert df["Interval Start"].min() >= self.local_start_of_today()
             assert df[
                 "Interval End"
             ].max() <= self.local_start_of_today() + pd.Timedelta(days=1)
 
-            assert df["Ancillary Service"].dtype == object
-            assert df["Area"].dtype == object
+            assert df["Ancillary Service"].dtype == pl.Utf8
+            assert df["Area"].dtype == pl.Utf8
             assert (
                 df["Area"].unique().tolist().sort()
                 == self.expected_reserve_areas.sort()
@@ -2265,14 +2299,44 @@ class TestPJM(BaseTestISO):
                 df["Ancillary Service"].unique().tolist().sort()
                 == self.expected_ancillary_services.sort()
             )
-            assert df["Reserve Type"].dtype == object
-            assert df["Reserve Quantity"].dtype in [np.float64, np.int64]
-            assert df["Reserve Requirement"].dtype in [np.float64, np.int64]
-            assert df["Reliability Requirement"].dtype in [np.float64, np.int64]
-            assert df["Extended Requirement"].dtype in [np.float64, np.int64]
-            assert df["MW Adjustment"].dtype in [np.float64, np.int64]
-            assert df["Market Clearing Price"].dtype in [np.float64, np.int64]
-            assert df["Shortage Indicator"].dtype in [bool]
+            assert df["Reserve Type"].dtype == pl.Utf8
+            assert df.schema["Reserve Quantity"] in (
+                pl.Float64,
+                pl.Int64,
+                pl.Float32,
+                pl.Int32,
+            )
+            assert df.schema["Reserve Requirement"] in (
+                pl.Float64,
+                pl.Int64,
+                pl.Float32,
+                pl.Int32,
+            )
+            assert df.schema["Reliability Requirement"] in (
+                pl.Float64,
+                pl.Int64,
+                pl.Float32,
+                pl.Int32,
+            )
+            assert df.schema["Extended Requirement"] in (
+                pl.Float64,
+                pl.Int64,
+                pl.Float32,
+                pl.Int32,
+            )
+            assert df.schema["MW Adjustment"] in (
+                pl.Float64,
+                pl.Int64,
+                pl.Float32,
+                pl.Int32,
+            )
+            assert df.schema["Market Clearing Price"] in (
+                pl.Float64,
+                pl.Int64,
+                pl.Float32,
+                pl.Int32,
+            )
+            assert df["Shortage Indicator"].dtype == pl.Boolean
 
     def test_get_dispatched_reserves_prelim_historical_range(self):
         past_date = self.local_today() - pd.Timedelta(days=5)
@@ -2282,16 +2346,16 @@ class TestPJM(BaseTestISO):
         ):
             df = self.iso.get_dispatched_reserves_prelim(past_date, past_end_date)
 
-            assert isinstance(df, pd.DataFrame)
-            assert df.columns.tolist() == self.expected_dispatched_reserves_prelim_cols
+            assert isinstance(df, pl.DataFrame)
+            assert df.columns == self.expected_dispatched_reserves_prelim_cols
 
             assert df["Interval Start"].min() >= self.local_start_of_day(past_date)
             assert df["Interval End"].max() <= self.local_start_of_day(
                 past_end_date,
             ) + pd.Timedelta(days=1)
 
-            assert df["Ancillary Service"].dtype == object
-            assert df["Area"].dtype == object
+            assert df["Ancillary Service"].dtype == pl.Utf8
+            assert df["Area"].dtype == pl.Utf8
             assert (
                 df["Area"].unique().tolist().sort()
                 == self.expected_reserve_areas.sort()
@@ -2300,14 +2364,44 @@ class TestPJM(BaseTestISO):
                 df["Ancillary Service"].unique().tolist().sort()
                 == self.expected_ancillary_services.sort()
             )
-            assert df["Reserve Type"].dtype == object
-            assert df["Reserve Quantity"].dtype in [np.float64, np.int64]
-            assert df["Reserve Requirement"].dtype in [np.float64, np.int64]
-            assert df["Reliability Requirement"].dtype in [np.float64, np.int64]
-            assert df["Extended Requirement"].dtype in [np.float64, np.int64]
-            assert df["MW Adjustment"].dtype in [np.float64, np.int64]
-            assert df["Market Clearing Price"].dtype in [np.float64, np.int64]
-            assert df["Shortage Indicator"].dtype in [bool]
+            assert df["Reserve Type"].dtype == pl.Utf8
+            assert df.schema["Reserve Quantity"] in (
+                pl.Float64,
+                pl.Int64,
+                pl.Float32,
+                pl.Int32,
+            )
+            assert df.schema["Reserve Requirement"] in (
+                pl.Float64,
+                pl.Int64,
+                pl.Float32,
+                pl.Int32,
+            )
+            assert df.schema["Reliability Requirement"] in (
+                pl.Float64,
+                pl.Int64,
+                pl.Float32,
+                pl.Int32,
+            )
+            assert df.schema["Extended Requirement"] in (
+                pl.Float64,
+                pl.Int64,
+                pl.Float32,
+                pl.Int32,
+            )
+            assert df.schema["MW Adjustment"] in (
+                pl.Float64,
+                pl.Int64,
+                pl.Float32,
+                pl.Int32,
+            )
+            assert df.schema["Market Clearing Price"] in (
+                pl.Float64,
+                pl.Int64,
+                pl.Float32,
+                pl.Int32,
+            )
+            assert df["Shortage Indicator"].dtype == pl.Boolean
 
     """get_dispatched_reserves_verified"""
 
@@ -2333,18 +2427,16 @@ class TestPJM(BaseTestISO):
         ):
             df = self.iso.get_dispatched_reserves_verified(past_date, past_end_date)
 
-            assert isinstance(df, pd.DataFrame)
-            assert (
-                df.columns.tolist() == self.expected_dispatched_reserves_verified_cols
-            )
+            assert isinstance(df, pl.DataFrame)
+            assert df.columns == self.expected_dispatched_reserves_verified_cols
 
             assert df["Interval Start"].min() >= self.local_start_of_day(past_date)
             assert df["Interval End"].max() <= self.local_start_of_day(
                 past_end_date,
             ) + pd.Timedelta(days=1)
 
-            assert df["Ancillary Service"].dtype == object
-            assert df["Area"].dtype == object
+            assert df["Ancillary Service"].dtype == pl.Utf8
+            assert df["Area"].dtype == pl.Utf8
             assert (
                 df["Area"].unique().tolist().sort()
                 == self.expected_reserve_areas.sort()
@@ -2353,13 +2445,38 @@ class TestPJM(BaseTestISO):
                 df["Ancillary Service"].unique().tolist().sort()
                 == self.expected_ancillary_services.sort()
             )
-            assert df["Reserve Type"].dtype == object
-            assert df["Total Reserve"].dtype in [np.float64, np.int64]
-            assert df["Reserve Requirement"].dtype in [np.float64, np.int64]
-            assert df["Reliability Requirement"].dtype in [np.float64, np.int64]
-            assert df["Extended Requirement"].dtype in [np.float64, np.int64]
-            assert df["Additional Extended Requirement"].dtype in [np.float64, np.int64]
-            assert df["Deficit"].dtype in [np.float64, np.int64]
+            assert df["Reserve Type"].dtype == pl.Utf8
+            assert df.schema["Total Reserve"] in (
+                pl.Float64,
+                pl.Int64,
+                pl.Float32,
+                pl.Int32,
+            )
+            assert df.schema["Reserve Requirement"] in (
+                pl.Float64,
+                pl.Int64,
+                pl.Float32,
+                pl.Int32,
+            )
+            assert df.schema["Reliability Requirement"] in (
+                pl.Float64,
+                pl.Int64,
+                pl.Float32,
+                pl.Int32,
+            )
+            assert df.schema["Extended Requirement"] in (
+                pl.Float64,
+                pl.Int64,
+                pl.Float32,
+                pl.Int32,
+            )
+            assert df.schema["Additional Extended Requirement"] in (
+                pl.Float64,
+                pl.Int64,
+                pl.Float32,
+                pl.Int32,
+            )
+            assert df.schema["Deficit"] in (pl.Float64, pl.Int64, pl.Float32, pl.Int32)
 
     expected_regulation_market_monthly_cols = [
         "Interval Start",
@@ -2389,8 +2506,8 @@ class TestPJM(BaseTestISO):
         ):
             df = self.iso.get_regulation_market_monthly(past_date, past_end_date)
 
-            assert isinstance(df, pd.DataFrame)
-            assert df.columns.tolist() == self.expected_regulation_market_monthly_cols
+            assert isinstance(df, pl.DataFrame)
+            assert df.columns == self.expected_regulation_market_monthly_cols
 
             assert df["Interval Start"].min() >= self.local_start_of_day(past_date)
             # Data is in 30-minute intervals, so last interval ends 30 min after midnight
@@ -2428,8 +2545,8 @@ class TestPJM(BaseTestISO):
     ]
 
     def _check_lmp_real_time_unverified_hourly(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.tolist() == self.expected_lmp_real_time_unverified_hourly_cols
+        assert isinstance(df, pl.DataFrame)
+        assert df.columns == self.expected_lmp_real_time_unverified_hourly_cols
         numeric_cols = ["LMP", "Energy", "Congestion", "Loss"]
         for col in numeric_cols:
             assert df[col].dtype in [np.float64, np.int64]
@@ -2469,9 +2586,9 @@ class TestPJM(BaseTestISO):
             f"test_get_load_forecast_5_min_historical_range_{past_date.strftime('%Y-%m-%d')}_{past_end_date.strftime('%Y-%m-%d')}.yaml",
         ):
             df = self.iso.get_load_forecast_5_min(past_date, past_end_date)
-            assert isinstance(df, pd.DataFrame)
-            assert not df.empty
-            assert df.columns.tolist() == self.load_forecast_columns
+            assert isinstance(df, pl.DataFrame)
+            assert not df.is_empty()
+            assert df.columns == self.load_forecast_columns
             assert df["Interval Start"].min() == self.local_start_of_day(past_date)
             assert df["Interval End"].max() == self.local_start_of_day(
                 past_end_date,
@@ -2498,9 +2615,9 @@ class TestPJM(BaseTestISO):
             f"test_get_regulation_prices_5_min_historical_range_{past_date.strftime('%Y-%m-%d')}_{past_end_date.strftime('%Y-%m-%d')}.yaml",
         ):
             df = self.iso.get_regulation_prices_5_min(past_date, past_end_date)
-            assert isinstance(df, pd.DataFrame)
-            assert not df.empty
-            assert df.columns.tolist() == self.regulation_prices_5_min_columns
+            assert isinstance(df, pl.DataFrame)
+            assert not df.is_empty()
+            assert df.columns == self.regulation_prices_5_min_columns
             assert df["Interval Start"].min() == self.local_start_of_day(past_date)
             assert df["Interval End"].max() == self.local_start_of_day(
                 past_end_date,
@@ -2517,14 +2634,14 @@ class TestPJM(BaseTestISO):
     ]
 
     def _check_tie_flows_5_min(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.tolist() == self.expected_tie_flows_5_min_cols
+        assert isinstance(df, pl.DataFrame)
+        assert df.columns == self.expected_tie_flows_5_min_cols
         assert (
             df["Interval End"] - df["Interval Start"] == pd.Timedelta(minutes=5)
         ).all()
-        assert df["Tie Flow Name"].dtype == object
-        assert df["Actual"].dtype in [np.float64, np.int64]
-        assert df["Scheduled"].dtype in [np.float64, np.int64]
+        assert df["Tie Flow Name"].dtype == pl.Utf8
+        assert df.schema["Actual"] in (pl.Float64, pl.Int64, pl.Float32, pl.Int32)
+        assert df.schema["Scheduled"] in (pl.Float64, pl.Int64, pl.Float32, pl.Int32)
 
     @pytest.mark.parametrize("date", ["today"])
     def test_get_tie_flows_5_min_today(self, date):
@@ -2562,7 +2679,7 @@ class TestPJM(BaseTestISO):
     """get_instantaneous_dispatch_rates"""
 
     def _check_instantaneous_dispatch_rates(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Zone",
@@ -2572,8 +2689,8 @@ class TestPJM(BaseTestISO):
         assert (
             (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(seconds=15)
         ).all()
-        assert df["Zone"].dtype == object
-        assert df["Instantaneous Dispatch Rate"].dtype == np.float64
+        assert df["Zone"].dtype == pl.Utf8
+        assert df.schema["Instantaneous Dispatch Rate"] == pl.Float64
 
     def test_get_instantaneous_dispatch_rates_today(self):
         with pjm_vcr.use_cassette("test_get_instantaneous_dispatch_rates_today.yaml"):
@@ -2617,14 +2734,14 @@ class TestPJM(BaseTestISO):
             assert end - pd.Timedelta(seconds=15) <= df["Interval Start"].max() <= end
 
     def _check_hourly_net_exports_by_state(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.tolist() == [
+        assert isinstance(df, pl.DataFrame)
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "State",
             "Net Interchange",
         ]
-        assert not df.empty
+        assert not df.is_empty()
         assert df["Interval Start"].is_monotonic_increasing
 
     @pytest.mark.parametrize("date, end", test_dates)
@@ -2640,15 +2757,15 @@ class TestPJM(BaseTestISO):
             ).date() + pd.Timedelta(days=1)
 
     def _check_hourly_transfer_limits_and_flows(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.tolist() == [
+        assert isinstance(df, pl.DataFrame)
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Transfer Limit Area",
             "Average Transfers",
             "Average Transfer Limit",
         ]
-        assert not df.empty
+        assert not df.is_empty()
 
     @pytest.mark.parametrize("date, end", test_dates)
     def test_get_hourly_transfer_limits_and_flows_historical_date_range(
@@ -2665,8 +2782,8 @@ class TestPJM(BaseTestISO):
             assert df["Interval End"].max().date() <= pd.Timestamp(end).date()
 
     def _check_actual_and_scheduled_interchange_summary(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.tolist() == [
+        assert isinstance(df, pl.DataFrame)
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Tie Line",
@@ -2674,7 +2791,7 @@ class TestPJM(BaseTestISO):
             "Scheduled Flow",
             "Inadvertent Flow",
         ]
-        assert not df.empty
+        assert not df.is_empty()
 
     @pytest.mark.parametrize("date, end", test_dates)
     def test_get_actual_and_scheduled_interchange_summary_historical_date_range(
@@ -2693,14 +2810,14 @@ class TestPJM(BaseTestISO):
             ).date() + pd.Timedelta(days=1)
 
     def _check_scheduled_interchange_real_time(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.tolist() == [
+        assert isinstance(df, pl.DataFrame)
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Tie Line",
             "Hourly Net Tie Schedule",
         ]
-        assert not df.empty
+        assert not df.is_empty()
         assert df["Interval Start"].is_monotonic_increasing
 
     @pytest.mark.parametrize("date, end", test_dates)
@@ -2716,15 +2833,15 @@ class TestPJM(BaseTestISO):
             ).date() + pd.Timedelta(days=1)
 
     def _check_interface_flows_and_limits_day_ahead(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.tolist() == [
+        assert isinstance(df, pl.DataFrame)
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Interface Limit Name",
             "Flow",
             "Limit",
         ]
-        assert not df.empty
+        assert not df.is_empty()
 
     @pytest.mark.parametrize("date, end", test_dates)
     def test_get_interface_flows_and_limits_day_ahead_historical_date_range(
@@ -2743,8 +2860,8 @@ class TestPJM(BaseTestISO):
             ).date() + pd.Timedelta(days=1)
 
     def _check_projected_peak_tie_flow(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.tolist() == [
+        assert isinstance(df, pl.DataFrame)
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -2752,7 +2869,7 @@ class TestPJM(BaseTestISO):
             "Interface",
             "Scheduled Tie Flow",
         ]
-        assert not df.empty
+        assert not df.is_empty()
 
     @pytest.mark.parametrize("date, end", test_dates)
     def test_get_projected_peak_tie_flow_historical_date_range(self, date, end):
@@ -2765,8 +2882,8 @@ class TestPJM(BaseTestISO):
     """get_actual_operational_statistics"""
 
     def _check_actual_operational_statistics(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.tolist() == [
+        assert isinstance(df, pl.DataFrame)
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -2775,11 +2892,21 @@ class TestPJM(BaseTestISO):
             "Actual Load",
             "Dispatch Rate",
         ]
-        assert not df.empty
-        assert df["Area"].dtype == object
-        assert df["Area Load Forecast"].dtype in [np.float64, np.int64]
-        assert df["Actual Load"].dtype in [np.float64, np.int64]
-        assert df["Dispatch Rate"].dtype in [np.float64, np.int64]
+        assert not df.is_empty()
+        assert df["Area"].dtype == pl.Utf8
+        assert df.schema["Area Load Forecast"] in (
+            pl.Float64,
+            pl.Int64,
+            pl.Float32,
+            pl.Int32,
+        )
+        assert df.schema["Actual Load"] in (pl.Float64, pl.Int64, pl.Float32, pl.Int32)
+        assert df.schema["Dispatch Rate"] in (
+            pl.Float64,
+            pl.Int64,
+            pl.Float32,
+            pl.Int32,
+        )
 
     @pytest.mark.parametrize("date, end", test_dates)
     def test_get_actual_operational_statistics_historical_date_range(self, date, end):
@@ -2797,8 +2924,8 @@ class TestPJM(BaseTestISO):
     """get_pricing_nodes"""
 
     def _check_pricing_nodes(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.tolist() == [
+        assert isinstance(df, pl.DataFrame)
+        assert df.columns == [
             "Pricing Node ID",
             "Pricing Node Name",
             "Pricing Node Type",
@@ -2808,11 +2935,16 @@ class TestPJM(BaseTestISO):
             "Effective Date",
             "Termination Date",
         ]
-        assert not df.empty
-        assert df["Pricing Node ID"].dtype in [np.int64, np.float64]
-        assert df["Pricing Node Name"].dtype == object
-        assert df["Pricing Node Type"].dtype == object
-        assert df["Zone"].dtype == object
+        assert not df.is_empty()
+        assert df.schema["Pricing Node ID"] in (
+            pl.Int64,
+            pl.Float64,
+            pl.Int32,
+            pl.Float32,
+        )
+        assert df["Pricing Node Name"].dtype == pl.Utf8
+        assert df["Pricing Node Type"].dtype == pl.Utf8
+        assert df["Zone"].dtype == pl.Utf8
 
     @pytest.mark.parametrize("as_of", ["now", None])
     def test_get_pricing_nodes_as_of(self, as_of):
@@ -2844,8 +2976,8 @@ class TestPJM(BaseTestISO):
     """get_reserve_subzone_resources"""
 
     def _check_reserve_subzone_resources(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.tolist() == [
+        assert isinstance(df, pl.DataFrame)
+        assert df.columns == [
             "Resource ID",
             "Resource Name",
             "Resource Type",
@@ -2854,12 +2986,12 @@ class TestPJM(BaseTestISO):
             "Effective Date",
             "Termination Date",
         ]
-        assert not df.empty
-        assert df["Resource ID"].dtype in [object, np.int64, np.float64]
-        assert df["Resource Name"].dtype == object
-        assert df["Resource Type"].dtype == object
-        assert df["Subzone"].dtype == object
-        assert df["Zone"].dtype == object
+        assert not df.is_empty()
+        assert df.schema["Resource ID"] in (pl.Utf8, pl.Int64, pl.Float64)
+        assert df["Resource Name"].dtype == pl.Utf8
+        assert df["Resource Type"].dtype == pl.Utf8
+        assert df["Subzone"].dtype == pl.Utf8
+        assert df["Zone"].dtype == pl.Utf8
 
     @pytest.mark.parametrize("as_of", ["now", None])
     def test_get_reserve_subzone_resources_as_of(self, as_of):
@@ -2893,8 +3025,8 @@ class TestPJM(BaseTestISO):
     """get_reserve_subzone_buses"""
 
     def _check_reserve_subzone_buses(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.tolist() == [
+        assert isinstance(df, pl.DataFrame)
+        assert df.columns == [
             "Pricing Node ID",
             "Pricing Node Name",
             "Pricing Node Type",
@@ -2902,11 +3034,16 @@ class TestPJM(BaseTestISO):
             "Effective Date",
             "Termination Date",
         ]
-        assert not df.empty
-        assert df["Pricing Node ID"].dtype in [np.int64, np.float64]
-        assert df["Pricing Node Name"].dtype == object
-        assert df["Pricing Node Type"].dtype == object
-        assert df["Subzone"].dtype == object
+        assert not df.is_empty()
+        assert df.schema["Pricing Node ID"] in (
+            pl.Int64,
+            pl.Float64,
+            pl.Int32,
+            pl.Float32,
+        )
+        assert df["Pricing Node Name"].dtype == pl.Utf8
+        assert df["Pricing Node Type"].dtype == pl.Utf8
+        assert df["Subzone"].dtype == pl.Utf8
 
     @pytest.mark.parametrize("as_of", ["now", None])
     def test_get_reserve_subzone_buses_as_of(self, as_of):
@@ -2938,8 +3075,8 @@ class TestPJM(BaseTestISO):
     """get_weight_average_aggregation_definition"""
 
     def _check_weight_average_aggregation_definition(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.tolist() == [
+        assert isinstance(df, pl.DataFrame)
+        assert df.columns == [
             "Aggregate Node ID",
             "Aggregate Node Name",
             "Bus Node ID",
@@ -2948,12 +3085,22 @@ class TestPJM(BaseTestISO):
             "Effective Date",
             "Termination Date",
         ]
-        assert not df.empty
-        assert df["Aggregate Node ID"].dtype in [np.int64, np.float64]
-        assert df["Aggregate Node Name"].dtype == object
-        assert df["Bus Node ID"].dtype in [np.int64, np.float64]
-        assert df["Bus Node Name"].dtype == object
-        assert df["Bus Node Factor"].dtype in [np.float64, np.int64]
+        assert not df.is_empty()
+        assert df.schema["Aggregate Node ID"] in (
+            pl.Int64,
+            pl.Float64,
+            pl.Int32,
+            pl.Float32,
+        )
+        assert df["Aggregate Node Name"].dtype == pl.Utf8
+        assert df.schema["Bus Node ID"] in (pl.Int64, pl.Float64, pl.Int32, pl.Float32)
+        assert df["Bus Node Name"].dtype == pl.Utf8
+        assert df.schema["Bus Node Factor"] in (
+            pl.Float64,
+            pl.Int64,
+            pl.Float32,
+            pl.Int32,
+        )
 
     @pytest.mark.parametrize("as_of", ["now", None])
     def test_get_weight_average_aggregation_definition_as_of(self, as_of):
@@ -2995,12 +3142,27 @@ class TestPJM(BaseTestISO):
     ]
 
     def _check_generation_capacity_daily(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.tolist() == self.expected_generation_capacity_daily_cols
-        assert not df.empty
-        assert df["Economic Max MW"].dtype in [np.float64, np.int64]
-        assert df["Emergency Max MW"].dtype in [np.float64, np.int64]
-        assert df["Total Committed MW"].dtype in [np.float64, np.int64]
+        assert isinstance(df, pl.DataFrame)
+        assert df.columns == self.expected_generation_capacity_daily_cols
+        assert not df.is_empty()
+        assert df.schema["Economic Max MW"] in (
+            pl.Float64,
+            pl.Int64,
+            pl.Float32,
+            pl.Int32,
+        )
+        assert df.schema["Emergency Max MW"] in (
+            pl.Float64,
+            pl.Int64,
+            pl.Float32,
+            pl.Int32,
+        )
+        assert df.schema["Total Committed MW"] in (
+            pl.Float64,
+            pl.Int64,
+            pl.Float32,
+            pl.Int32,
+        )
 
     def test_get_generation_capacity_daily_historical_range(self):
         past_date = self.local_today() - pd.Timedelta(days=10)
@@ -3026,12 +3188,12 @@ class TestPJM(BaseTestISO):
     ]
 
     def _check_cleared_virtuals_daily(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.tolist() == self.expected_cleared_virtuals_daily_cols
-        assert not df.empty
-        assert df["Dec MW"].dtype in [np.float64, np.int64]
-        assert df["Inc MW"].dtype in [np.float64, np.int64]
-        assert df["UTC MW"].dtype in [np.float64, np.int64]
+        assert isinstance(df, pl.DataFrame)
+        assert df.columns == self.expected_cleared_virtuals_daily_cols
+        assert not df.is_empty()
+        assert df.schema["Dec MW"] in (pl.Float64, pl.Int64, pl.Float32, pl.Int32)
+        assert df.schema["Inc MW"] in (pl.Float64, pl.Int64, pl.Float32, pl.Int32)
+        assert df.schema["UTC MW"] in (pl.Float64, pl.Int64, pl.Float32, pl.Int32)
         assert (df["Interval End"] - df["Interval Start"] == pd.Timedelta(days=1)).all()
 
     @pytest.mark.parametrize("date", ["today"])
@@ -3066,15 +3228,13 @@ class TestPJM(BaseTestISO):
     ]
 
     def _check_inc_and_dec_bids_day_ahead_hourly(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert (
-            df.columns.tolist() == self.expected_inc_and_dec_bids_day_ahead_hourly_cols
-        )
-        assert not df.empty
+        assert isinstance(df, pl.DataFrame)
+        assert df.columns == self.expected_inc_and_dec_bids_day_ahead_hourly_cols
+        assert not df.is_empty()
         assert pd.api.types.is_datetime64tz_dtype(df["Publish Time"])
-        assert df["Price Point"].dtype in [np.float64, np.int64]
-        assert df["Inc MW"].dtype in [np.float64, np.int64]
-        assert df["Dec MW"].dtype in [np.float64, np.int64]
+        assert df.schema["Price Point"] in (pl.Float64, pl.Int64, pl.Float32, pl.Int32)
+        assert df.schema["Inc MW"] in (pl.Float64, pl.Int64, pl.Float32, pl.Int32)
+        assert df.schema["Dec MW"] in (pl.Float64, pl.Int64, pl.Float32, pl.Int32)
         assert (
             df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
         ).all()
@@ -3108,14 +3268,14 @@ class TestPJM(BaseTestISO):
     ]
 
     def _check_sync_reserve_events(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.tolist() == self.expected_sync_reserve_events_cols
-        assert not df.empty
-        assert df["Duration"].dtype == object
-        assert df["Duration Minutes"].dtype == np.int64
-        assert df["Synchronized Reserve Zone"].dtype == object
-        assert df["Synchronized Subzone"].dtype == object
-        assert df["Percent Deployed"].dtype == np.float64
+        assert isinstance(df, pl.DataFrame)
+        assert df.columns == self.expected_sync_reserve_events_cols
+        assert not df.is_empty()
+        assert df["Duration"].dtype == pl.Utf8
+        assert df.schema["Duration Minutes"] == pl.Int64
+        assert df["Synchronized Reserve Zone"].dtype == pl.Utf8
+        assert df["Synchronized Subzone"].dtype == pl.Utf8
+        assert df.schema["Percent Deployed"] == pl.Float64
 
     def test_get_sync_reserve_events(self):
         with pjm_vcr.use_cassette("test_get_sync_reserve_events.yaml"):
@@ -3188,18 +3348,18 @@ class TestPJM(BaseTestISO):
                 url="https://example.test/dashboard.jsf",
             )
 
-        assert df.columns.tolist() == self.expected_emergency_postings_cols
+        assert df.columns == self.expected_emergency_postings_cols
         assert len(df) == 1
         assert df["Message ID"].iloc[0] == 1
         assert df["Region"].iloc[0] == "AEP"
         assert df["Message Type"].iloc[0] == "Test"
         assert df["Priority"].iloc[0] == "Warning"
-        assert isinstance(df["Effective Start"].dtype, pd.DatetimeTZDtype)
-        assert str(df["Effective Start"].dt.tz) == str(self.iso.default_timezone)
-        assert isinstance(df["Effective End"].dtype, pd.DatetimeTZDtype)
-        assert isinstance(df["Applicable Start"].dtype, pd.DatetimeTZDtype)
-        assert isinstance(df["Applicable End"].dtype, pd.DatetimeTZDtype)
-        assert isinstance(df["Publish Time"].dtype, pd.DatetimeTZDtype)
+        assert isinstance(df.schema["Effective Start"], pl.Datetime)
+        assert df.schema["Effective Start"].time_zone == self.iso.default_timezone
+        assert isinstance(df.schema["Effective End"], pl.Datetime)
+        assert isinstance(df.schema["Applicable Start"], pl.Datetime)
+        assert isinstance(df.schema["Applicable End"], pl.Datetime)
+        assert isinstance(df.schema["Publish Time"], pl.Datetime)
 
     def test_get_emergency_postings_xml_export_multi_region(self):
         xml = b"""<?xml version="1.0" encoding="UTF-8"?>
@@ -3249,7 +3409,7 @@ class TestPJM(BaseTestISO):
     """get_voltage_limits"""
 
     def _check_voltage_limits(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Publish Time",
             "Company",
             "Voltage",
@@ -3263,20 +3423,40 @@ class TestPJM(BaseTestISO):
             "Voltage Drop Warning Percent",
             "Voltage Drop Limit Percent",
         ]
-        assert not df.empty
-        assert isinstance(df["Publish Time"].dtype, pd.DatetimeTZDtype)
-        assert str(df["Publish Time"].dt.tz) == str(self.iso.default_timezone)
-        assert df["Company"].dtype == object
-        assert df["Voltage"].dtype == object
-        assert df["Follow PJM"].dtype == object
-        assert df["Station"].dtype == object
-        assert df["Load Dump"].dtype in [np.float64, np.int64]
-        assert df["Emergency Low"].dtype in [np.float64, np.int64]
-        assert df["Normal Low"].dtype in [np.float64, np.int64]
-        assert df["Normal High"].dtype in [np.float64, np.int64]
-        assert df["Emergency High"].dtype in [np.float64, np.int64]
-        assert df["Voltage Drop Warning Percent"].dtype in [np.float64, np.int64]
-        assert df["Voltage Drop Limit Percent"].dtype in [np.float64, np.int64]
+        assert not df.is_empty()
+        assert isinstance(df.schema["Publish Time"], pl.Datetime)
+        assert df.schema["Publish Time"].time_zone == self.iso.default_timezone
+        assert df["Company"].dtype == pl.Utf8
+        assert df["Voltage"].dtype == pl.Utf8
+        assert df["Follow PJM"].dtype == pl.Utf8
+        assert df["Station"].dtype == pl.Utf8
+        assert df.schema["Load Dump"] in (pl.Float64, pl.Int64, pl.Float32, pl.Int32)
+        assert df.schema["Emergency Low"] in (
+            pl.Float64,
+            pl.Int64,
+            pl.Float32,
+            pl.Int32,
+        )
+        assert df.schema["Normal Low"] in (pl.Float64, pl.Int64, pl.Float32, pl.Int32)
+        assert df.schema["Normal High"] in (pl.Float64, pl.Int64, pl.Float32, pl.Int32)
+        assert df.schema["Emergency High"] in (
+            pl.Float64,
+            pl.Int64,
+            pl.Float32,
+            pl.Int32,
+        )
+        assert df.schema["Voltage Drop Warning Percent"] in (
+            pl.Float64,
+            pl.Int64,
+            pl.Float32,
+            pl.Int32,
+        )
+        assert df.schema["Voltage Drop Limit Percent"] in (
+            pl.Float64,
+            pl.Int64,
+            pl.Float32,
+            pl.Int32,
+        )
 
     def test_get_voltage_limits_latest(self):
         with pjm_vcr.use_cassette("test_get_voltage_limits_latest.yaml"):
@@ -3286,18 +3466,18 @@ class TestPJM(BaseTestISO):
     """get_pai_intervals_5_min"""
 
     def _check_pai_intervals_5_min(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.tolist() == [
+        assert isinstance(df, pl.DataFrame)
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Performance Assessment Interval",
         ]
-        assert not df.empty
-        assert isinstance(df["Interval Start"].dtype, pd.DatetimeTZDtype)
-        assert str(df["Interval Start"].dt.tz) == str(self.iso.default_timezone)
-        assert isinstance(df["Interval End"].dtype, pd.DatetimeTZDtype)
-        assert str(df["Interval End"].dt.tz) == str(self.iso.default_timezone)
-        assert df["Performance Assessment Interval"].dtype == object
+        assert not df.is_empty()
+        assert isinstance(df.schema["Interval Start"], pl.Datetime)
+        assert df.schema["Interval Start"].time_zone == self.iso.default_timezone
+        assert isinstance(df.schema["Interval End"], pl.Datetime)
+        assert df.schema["Interval End"].time_zone == self.iso.default_timezone
+        assert df["Performance Assessment Interval"].dtype == pl.Utf8
 
     def test_get_pai_intervals_5_min_historical_date_range(self):
         date = self.local_today() - pd.Timedelta(days=5)
@@ -3314,8 +3494,8 @@ class TestPJM(BaseTestISO):
     """get_marginal_emission_rates_5_min"""
 
     def _check_marginal_emission_rates_5_min(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.tolist() == [
+        assert isinstance(df, pl.DataFrame)
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Pnode Name",
@@ -3324,16 +3504,31 @@ class TestPJM(BaseTestISO):
             "Marginal SO2 Rate",
             "Marginal NOx Rate",
         ]
-        assert not df.empty
-        assert isinstance(df["Interval Start"].dtype, pd.DatetimeTZDtype)
-        assert str(df["Interval Start"].dt.tz) == str(self.iso.default_timezone)
-        assert isinstance(df["Interval End"].dtype, pd.DatetimeTZDtype)
-        assert str(df["Interval End"].dt.tz) == str(self.iso.default_timezone)
-        assert df["Pnode Name"].dtype == object
-        assert df["Pnode ID"].dtype in [np.int64, np.float64]
-        assert df["Marginal CO2 Rate"].dtype in [np.float64, np.int64]
-        assert df["Marginal SO2 Rate"].dtype in [np.float64, np.int64]
-        assert df["Marginal NOx Rate"].dtype in [np.float64, np.int64]
+        assert not df.is_empty()
+        assert isinstance(df.schema["Interval Start"], pl.Datetime)
+        assert df.schema["Interval Start"].time_zone == self.iso.default_timezone
+        assert isinstance(df.schema["Interval End"], pl.Datetime)
+        assert df.schema["Interval End"].time_zone == self.iso.default_timezone
+        assert df["Pnode Name"].dtype == pl.Utf8
+        assert df.schema["Pnode ID"] in (pl.Int64, pl.Float64, pl.Int32, pl.Float32)
+        assert df.schema["Marginal CO2 Rate"] in (
+            pl.Float64,
+            pl.Int64,
+            pl.Float32,
+            pl.Int32,
+        )
+        assert df.schema["Marginal SO2 Rate"] in (
+            pl.Float64,
+            pl.Int64,
+            pl.Float32,
+            pl.Int32,
+        )
+        assert df.schema["Marginal NOx Rate"] in (
+            pl.Float64,
+            pl.Int64,
+            pl.Float32,
+            pl.Int32,
+        )
 
     def test_get_marginal_emission_rates_5_min_historical_date_range(
         self,

--- a/gridstatus/tests/source_specific/test_spp.py
+++ b/gridstatus/tests/source_specific/test_spp.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
+import polars as pl
 import pytest
 
 from gridstatus import SPP, Markets, NoDataFoundException, NotSupported
@@ -21,6 +22,20 @@ api_vcr = setup_vcr(
     source="spp",
     record_mode=RECORD_MODE,
 )
+
+
+def _ts(value) -> pd.Timestamp:
+    return pd.Timestamp(value)
+
+
+def _mock_forecast_df(data: dict) -> pl.DataFrame:
+    df = pl.DataFrame(data)
+    for col in ("Interval Start", "Interval End"):
+        if col in df.columns:
+            df = df.with_columns(
+                pl.col(col).dt.convert_time_zone("US/Central").alias(col),
+            )
+    return df
 
 
 class TestSPP(BaseTestISO):
@@ -114,8 +129,7 @@ class TestSPP(BaseTestISO):
     ]
 
     def _check_fuel_mix(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.name is None
+        assert isinstance(df, pl.DataFrame)
         self._check_time_columns(
             df,
             instant_or_interval="interval",
@@ -160,25 +174,47 @@ class TestSPP(BaseTestISO):
         with api_vcr.use_cassette("test_get_fuel_mix_latest.yaml"):
             fm = self.iso.get_fuel_mix(date="latest")
 
-        assert len(fm) > 0
-        assert fm.columns.tolist() == self.FUEL_MIX_COLS
-        assert fm["Interval Start"].iloc[0].tz.zone == self.iso.default_timezone
+        assert fm.height > 0
+        assert fm.columns == self.FUEL_MIX_COLS
+        assert fm[0, "Interval Start"].tzinfo.key == self.iso.default_timezone
         assert "BAA" not in fm.columns
 
     def test_get_fuel_mix_today(self):
         with api_vcr.use_cassette("test_get_fuel_mix_today.yaml"):
             fm = self.iso.get_fuel_mix(date="today")
 
-        assert len(fm) > 0
-        assert fm.columns.tolist() == self.FUEL_MIX_COLS
+        assert fm.height > 0
+        assert fm.columns == self.FUEL_MIX_COLS
         assert "BAA" not in fm.columns
+
+    def test_get_load_latest(self):
+        with api_vcr.use_cassette("test_get_load_latest.yaml"):
+            df = self.iso.get_load(date="latest")
+        self._check_time_columns(
+            df,
+            instant_or_interval="interval",
+            skip_column_named_time=True,
+        )
+        assert "Load" in df.columns
+        assert df.schema["Load"].is_numeric()
+
+    def test_get_load_today(self):
+        with api_vcr.use_cassette("test_get_load_today.yaml"):
+            df = self.iso.get_load(date="today")
+        self._check_time_columns(
+            df,
+            instant_or_interval="interval",
+            skip_column_named_time=True,
+        )
+        assert "Load" in df.columns
+        assert df.schema["Load"].is_numeric()
 
     def test_get_fuel_mix_detailed_latest(self):
         with api_vcr.use_cassette("test_get_fuel_mix_detailed_latest.yaml"):
             fm = self.iso.get_fuel_mix_detailed(date="latest")
 
-        assert len(fm) > 0
-        assert fm.columns.tolist() == self.FUEL_MIX_DETAILED_COLS
+        assert fm.height > 0
+        assert fm.columns == self.FUEL_MIX_DETAILED_COLS
         assert "BAA" not in fm.columns
 
     def test_get_fuel_mix_too_old_raises(self):
@@ -195,8 +231,8 @@ class TestSPP(BaseTestISO):
         with api_vcr.use_cassette("test_get_fuel_mix_historical_recent.yaml"):
             fm = self.iso.get_fuel_mix(date=yesterday)
 
-        assert len(fm) > 0
-        assert fm.columns.tolist() == self.FUEL_MIX_COLS
+        assert fm.height > 0
+        assert fm.columns == self.FUEL_MIX_COLS
         assert "BAA" not in fm.columns
         assert fm["Interval Start"].min() >= yesterday
 
@@ -206,18 +242,18 @@ class TestSPP(BaseTestISO):
         with api_vcr.use_cassette("test_get_fuel_mix_by_baa_latest.yaml"):
             fm = self.iso.get_fuel_mix_by_baa(date="latest")
 
-        assert len(fm) > 0
-        assert fm.columns.tolist() == self.FUEL_MIX_BAA_COLS
-        assert fm["Interval Start"].iloc[0].tz.zone == self.iso.default_timezone
-        assert set(fm["BAA"].unique()) == {"SPP", "SWPW"}
+        assert fm.height > 0
+        assert fm.columns == self.FUEL_MIX_BAA_COLS
+        assert fm[0, "Interval Start"].tzinfo.key == self.iso.default_timezone
+        assert set(fm["BAA"].unique().to_list()) == {"SPP", "SWPW"}
 
     def test_get_fuel_mix_by_baa_today(self):
         with api_vcr.use_cassette("test_get_fuel_mix_by_baa_today.yaml"):
             fm = self.iso.get_fuel_mix_by_baa(date="today")
 
-        assert len(fm) > 0
-        assert fm.columns.tolist() == self.FUEL_MIX_BAA_COLS
-        assert set(fm["BAA"].unique()) == {"SPP", "SWPW"}
+        assert fm.height > 0
+        assert fm.columns == self.FUEL_MIX_BAA_COLS
+        assert set(fm["BAA"].unique().to_list()) == {"SPP", "SWPW"}
 
     def test_get_fuel_mix_by_baa_historical_recent(self):
         yesterday = pd.Timestamp.now(
@@ -228,10 +264,10 @@ class TestSPP(BaseTestISO):
         ):
             fm = self.iso.get_fuel_mix_by_baa(date=yesterday)
 
-        assert len(fm) > 0
-        assert fm.columns.tolist() == self.FUEL_MIX_BAA_COLS
-        assert set(fm["BAA"].unique()).issubset({"SPP", "SWPW"})
-        assert "SPP" in fm["BAA"].values
+        assert fm.height > 0
+        assert fm.columns == self.FUEL_MIX_BAA_COLS
+        assert set(fm["BAA"].unique().to_list()).issubset({"SPP", "SWPW"})
+        assert "SPP" in fm["BAA"].to_list()
         assert fm["Interval Start"].min() >= yesterday
 
     """get_fuel_mix_by_baa_detailed"""
@@ -240,9 +276,9 @@ class TestSPP(BaseTestISO):
         with api_vcr.use_cassette("test_get_fuel_mix_by_baa_detailed_latest.yaml"):
             fm = self.iso.get_fuel_mix_by_baa_detailed(date="latest")
 
-        assert len(fm) > 0
-        assert fm.columns.tolist() == self.FUEL_MIX_DETAILED_BAA_COLS
-        assert set(fm["BAA"].unique()) == {"SPP", "SWPW"}
+        assert fm.height > 0
+        assert fm.columns == self.FUEL_MIX_DETAILED_BAA_COLS
+        assert set(fm["BAA"].unique().to_list()) == {"SPP", "SWPW"}
 
     """get_lmp_real_time_5_min_by_location"""
 
@@ -255,7 +291,7 @@ class TestSPP(BaseTestISO):
             LOCATION_TYPE_SETTLEMENT_LOCATION,
         ],
     ):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Time",
             "Interval Start",
             "Interval End",
@@ -270,14 +306,17 @@ class TestSPP(BaseTestISO):
             "Loss",
         ]
 
-        assert set(df["Location Type"]) == set(location_types)
+        assert set(df["Location Type"].to_list()) == set(location_types)
 
-        assert df["Market"].unique() == [Markets.REAL_TIME_5_MIN.value]
+        assert df["Market"].unique().to_list() == [Markets.REAL_TIME_5_MIN.value]
         assert (
-            df["Interval End"] - df["Interval Start"] == pd.Timedelta(minutes=5)
+            (df["Interval End"] - df["Interval Start"]).dt.total_minutes() == 5
         ).all()
 
-        assert np.allclose(df["LMP"], df["Energy"] + df["Congestion"] + df["Loss"])
+        assert np.allclose(
+            df["LMP"].to_numpy(),
+            (df["Energy"] + df["Congestion"] + df["Loss"]).to_numpy(),
+        )
 
     def test_get_lmp_real_time_5_min_by_location_latest(self):
         with api_vcr.use_cassette(
@@ -288,7 +327,7 @@ class TestSPP(BaseTestISO):
         self._check_lmp_real_time_5_min_by_location(df)
 
         # Latest data should have one interval
-        assert df["Interval Start"].nunique() == 1
+        assert df["Interval Start"].n_unique() == 1
         # Check that the max interval is relatively recent (within last 24 hours)
         max_interval = df["Interval Start"].max()
         assert max_interval >= self.local_start_of_today() - pd.Timedelta(days=1)
@@ -424,7 +463,7 @@ class TestSPP(BaseTestISO):
     """get_lmp_real_time_5_min_by_bus"""
 
     def _check_lmp_real_time_5_min_by_bus(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Time",
             "Interval Start",
             "Interval End",
@@ -438,14 +477,17 @@ class TestSPP(BaseTestISO):
             "Loss",
         ]
 
-        assert df["Market"].unique() == [Markets.REAL_TIME_5_MIN.value]
+        assert df["Market"].unique().to_list() == [Markets.REAL_TIME_5_MIN.value]
 
-        assert df["Location Type"].unique() == [LOCATION_TYPE_BUS]
+        assert df["Location Type"].unique().to_list() == [LOCATION_TYPE_BUS]
         assert (
-            df["Interval End"] - df["Interval Start"] == pd.Timedelta(minutes=5)
+            (df["Interval End"] - df["Interval Start"]).dt.total_minutes() == 5
         ).all()
 
-        assert np.allclose(df["LMP"], df["Energy"] + df["Congestion"] + df["Loss"])
+        assert np.allclose(
+            df["LMP"].to_numpy(),
+            (df["Energy"] + df["Congestion"] + df["Loss"]).to_numpy(),
+        )
 
     def test_get_lmp_real_time_5_min_by_bus_latest(self):
         with api_vcr.use_cassette(
@@ -455,7 +497,7 @@ class TestSPP(BaseTestISO):
 
         self._check_lmp_real_time_5_min_by_bus(df)
         # Latest data should have one interval
-        assert df["Interval Start"].nunique() == 1
+        assert df["Interval Start"].n_unique() == 1
         # Check that the max interval is relatively recent (within last 24 hours)
         max_interval = df["Interval Start"].max()
         assert max_interval >= self.local_start_of_today() - pd.Timedelta(days=1)
@@ -567,7 +609,7 @@ class TestSPP(BaseTestISO):
             LOCATION_TYPE_SETTLEMENT_LOCATION,
         ],
     ):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Time",
             "Interval Start",
             "Interval End",
@@ -582,13 +624,14 @@ class TestSPP(BaseTestISO):
             "Loss",
         ]
 
-        assert set(df["Location Type"]) == set(location_types)
-        assert df["Market"].unique() == [Markets.DAY_AHEAD_HOURLY.value]
-        assert (
-            df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
-        ).all()
+        assert set(df["Location Type"].to_list()) == set(location_types)
+        assert df["Market"].unique().to_list() == [Markets.DAY_AHEAD_HOURLY.value]
+        assert ((df["Interval End"] - df["Interval Start"]).dt.total_hours() == 1).all()
 
-        assert np.allclose(df["LMP"], df["Energy"] + df["Congestion"] + df["Loss"])
+        assert np.allclose(
+            df["LMP"].to_numpy(),
+            (df["Energy"] + df["Congestion"] + df["Loss"]).to_numpy(),
+        )
 
     @pytest.mark.integration
     def test_get_lmp_day_ahead_hourly_latest_not_supported(self):
@@ -660,7 +703,7 @@ class TestSPP(BaseTestISO):
     """get_lmp_day_ahead_hourly_by_bus"""
 
     def _check_lmp_day_ahead_hourly_by_bus(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Time",
             "Interval Start",
             "Interval End",
@@ -674,13 +717,14 @@ class TestSPP(BaseTestISO):
             "Loss",
         ]
 
-        assert df["Market"].unique() == [Markets.DAY_AHEAD_HOURLY.value]
-        assert df["Location Type"].unique() == [LOCATION_TYPE_BUS]
-        assert (
-            df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
-        ).all()
+        assert df["Market"].unique().to_list() == [Markets.DAY_AHEAD_HOURLY.value]
+        assert df["Location Type"].unique().to_list() == [LOCATION_TYPE_BUS]
+        assert ((df["Interval End"] - df["Interval Start"]).dt.total_hours() == 1).all()
 
-        assert np.allclose(df["LMP"], df["Energy"] + df["Congestion"] + df["Loss"])
+        assert np.allclose(
+            df["LMP"].to_numpy(),
+            (df["Energy"] + df["Congestion"] + df["Loss"]).to_numpy(),
+        )
 
     @pytest.mark.integration
     def test_get_lmp_day_ahead_hourly_by_bus_latest_not_supported(self):
@@ -776,16 +820,16 @@ class TestSPP(BaseTestISO):
             f"test_get_operating_reserves_{yesterday.strftime('%Y%m%d')}_{yesterday_1230am.strftime('%Y%m%d')}.yaml",
         ):
             df = self.iso.get_operating_reserves(start=yesterday, end=yesterday_1230am)
-        assert len(df) > 0
-        assert df.columns.tolist() == self.OPERATING_RESERVES_COLUMNS
+        assert df.height > 0
+        assert df.columns == self.OPERATING_RESERVES_COLUMNS
 
     def test_get_operating_reserves_latest(self):
         with api_vcr.use_cassette(
             "test_get_operating_reserves_latest.yaml",
         ):
             df = self.iso.get_operating_reserves(date="latest")
-        assert len(df) > 0
-        assert df.columns.tolist() == self.OPERATING_RESERVES_COLUMNS
+        assert df.height > 0
+        assert df.columns == self.OPERATING_RESERVES_COLUMNS
 
     def test_get_operative_reserves_last_interval_of_day(self):
         two_days_ago = pd.Timestamp.now(
@@ -805,7 +849,7 @@ class TestSPP(BaseTestISO):
 
         assert df["Interval Start"].min() == two_days_ago_2355
         assert df["Interval End"].max() == two_days_ago_2355 + pd.Timedelta(minutes=5)
-        assert df.columns.tolist() == self.OPERATING_RESERVES_COLUMNS
+        assert df.columns == self.OPERATING_RESERVES_COLUMNS
 
     @pytest.mark.parametrize(
         "date,end",
@@ -873,7 +917,7 @@ class TestSPP(BaseTestISO):
 
         assert df["Interval Start"].min() == three_days_ago
         assert df["Interval End"].max() == tomorrow
-        assert df.columns.tolist() == self.DAY_AHEAD_MARGINAL_CLEARING_PRICES_COLUMNS
+        assert df.columns == self.DAY_AHEAD_MARGINAL_CLEARING_PRICES_COLUMNS
 
     def test_get_day_ahead_operating_reserve_prices_today(self):
         with api_vcr.use_cassette(
@@ -888,7 +932,7 @@ class TestSPP(BaseTestISO):
         assert df["Interval End"].max() == pd.Timestamp.now(
             tz=self.iso.default_timezone,
         ).normalize() + pd.Timedelta(days=1)
-        assert df.columns.tolist() == self.DAY_AHEAD_MARGINAL_CLEARING_PRICES_COLUMNS
+        assert df.columns == self.DAY_AHEAD_MARGINAL_CLEARING_PRICES_COLUMNS
 
     """get_as_prices_real_time_5_min"""
 
@@ -907,14 +951,14 @@ class TestSPP(BaseTestISO):
         "Unc Up",
     ]
 
-    def _check_as_prices_real_time_5_min(self, df: pd.DataFrame):
+    def _check_as_prices_real_time_5_min(self, df: pl.DataFrame):
         assert list(df.columns) == self.REAL_TIME_MCP_COLUMNS
         assert (
-            df["Interval End"] - df["Interval Start"] == pd.Timedelta(minutes=5)
+            (df["Interval End"] - df["Interval Start"]).dt.total_minutes() == 5
         ).all()
 
         for col in self.REAL_TIME_MCP_COLUMNS[3:]:
-            assert pd.api.types.is_numeric_dtype(df[col])
+            assert df.schema[col] in (pl.Float32, pl.Float64, pl.Int32, pl.Int64)
 
     def test_get_as_prices_real_time_5_min_latest(self):
         with api_vcr.use_cassette("test_get_as_prices_real_time_5_min_latest.yaml"):
@@ -1004,8 +1048,8 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_lmp_real_time_weis(date="latest")
 
-        assert len(df) > 0
-        assert df.columns.tolist() == self.WEIS_LMP_COLUMNS
+        assert df.height > 0
+        assert df.columns == self.WEIS_LMP_COLUMNS
 
     def test_get_lmp_real_time_weis_1_hour_range(self):
         three_days_ago = pd.Timestamp.now(
@@ -1025,7 +1069,7 @@ class TestSPP(BaseTestISO):
 
         assert df["Interval Start"].min() == three_days_ago
         assert df["Interval End"].max() == three_days_ago_0015
-        assert df.columns.tolist() == self.WEIS_LMP_COLUMNS
+        assert df.columns == self.WEIS_LMP_COLUMNS
 
     def test_get_lmp_real_time_weis_cross_day(self):
         two_days_ago_2345 = (
@@ -1045,7 +1089,7 @@ class TestSPP(BaseTestISO):
 
         assert df["Interval Start"].min() == two_days_ago_2345
         assert df["Interval End"].max() <= one_day_ago_0010
-        assert df.columns.tolist() == self.WEIS_LMP_COLUMNS
+        assert df.columns == self.WEIS_LMP_COLUMNS
 
     def test_get_lmp_real_time_weis_single_interval(self):
         three_weeks_ago = pd.Timestamp.now(tz=self.iso.default_timezone) - pd.Timedelta(
@@ -1059,8 +1103,8 @@ class TestSPP(BaseTestISO):
         # assert one interval that straddles date input
         assert df["Interval Start"].min() < three_weeks_ago
         assert df["Interval End"].max() > three_weeks_ago
-        assert df["Interval Start"].nunique() == 1
-        assert df.columns.tolist() == self.WEIS_LMP_COLUMNS
+        assert df["Interval Start"].n_unique() == 1
+        assert df.columns == self.WEIS_LMP_COLUMNS
 
     def test_get_lmp_real_time_weis_last_interval_of_day(self):
         two_days_ago = pd.Timestamp.now(
@@ -1080,7 +1124,7 @@ class TestSPP(BaseTestISO):
 
         assert df["Interval Start"].min() == two_days_ago_2355
         assert df["Interval End"].max() == two_days_ago_2355 + pd.Timedelta(minutes=5)
-        assert df.columns.tolist() == self.WEIS_LMP_COLUMNS
+        assert df.columns == self.WEIS_LMP_COLUMNS
 
     @pytest.mark.parametrize(
         "date,end",
@@ -1124,8 +1168,8 @@ class TestSPP(BaseTestISO):
             pd.Timestamp.now(tz=self.iso.default_timezone) - pd.Timedelta(days=14)
         ).date()
         df = self.iso.get_load(test_date)
-        assert isinstance(df, pd.DataFrame)
-        assert len(df) > 0
+        assert isinstance(df, pl.DataFrame)
+        assert df.height > 0
         assert "Interval Start" in df.columns
         assert "Interval End" in df.columns
         assert "Load" in df.columns
@@ -1136,7 +1180,7 @@ class TestSPP(BaseTestISO):
 
     def test_get_load_pre_baa_historical(self):
         date = pd.Timestamp("2026-03-30 12:00:00-0500")
-        source_df = pd.DataFrame(
+        source_df = pl.DataFrame(
             {
                 "Interval Start": [date, date + pd.Timedelta(minutes=5)],
                 "Interval End": [
@@ -1151,7 +1195,7 @@ class TestSPP(BaseTestISO):
             patch.object(
                 self.iso,
                 "_get_short_term_forecast_data",
-                return_value=(pd.DataFrame(), "mock-url"),
+                return_value=(pl.DataFrame(), "mock-url"),
             ),
             patch.object(
                 self.iso,
@@ -1161,13 +1205,13 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_load(date=date, verbose=False)
 
-        assert df.columns.tolist() == ["Interval Start", "Interval End", "Load"]
-        assert len(df) == 2
-        assert df["Load"].tolist() == [20000.0, 20100.0]
+        assert df.columns == ["Interval Start", "Interval End", "Load"]
+        assert df.height == 2
+        assert df["Load"].to_list() == [20000.0, 20100.0]
 
     def test_get_load_post_baa_historical(self):
         date = pd.Timestamp("2026-04-02 12:00:00-0500")
-        source_df = pd.DataFrame(
+        source_df = pl.DataFrame(
             {
                 "Interval Start": [
                     date,
@@ -1190,7 +1234,7 @@ class TestSPP(BaseTestISO):
             patch.object(
                 self.iso,
                 "_get_short_term_forecast_data",
-                return_value=(pd.DataFrame(), "mock-url"),
+                return_value=(pl.DataFrame(), "mock-url"),
             ),
             patch.object(
                 self.iso,
@@ -1200,13 +1244,13 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_load(date=date, verbose=False)
 
-        assert df.columns.tolist() == ["Interval Start", "Interval End", "Load"]
-        assert len(df) == 2
-        assert df["Load"].tolist() == [20000.0, 20200.0]
+        assert df.columns == ["Interval Start", "Interval End", "Load"]
+        assert df.height == 2
+        assert df["Load"].to_list() == [20000.0, 20200.0]
 
     def test_get_load_pre_baa_historical_no_baa_column(self):
         date = pd.Timestamp("2026-03-28 08:00:00-0500")
-        source_df = pd.DataFrame(
+        source_df = pl.DataFrame(
             {
                 "Interval Start": [date],
                 "Interval End": [date + pd.Timedelta(minutes=5)],
@@ -1218,7 +1262,7 @@ class TestSPP(BaseTestISO):
             patch.object(
                 self.iso,
                 "_get_short_term_forecast_data",
-                return_value=(pd.DataFrame(), "mock-url"),
+                return_value=(pl.DataFrame(), "mock-url"),
             ),
             patch.object(
                 self.iso,
@@ -1228,13 +1272,13 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_load(date=date, verbose=False)
 
-        assert df.columns.tolist() == ["Interval Start", "Interval End", "Load"]
-        assert len(df) == 1
-        assert df["Load"].iloc[0] == 18000.0
+        assert df.columns == ["Interval Start", "Interval End", "Load"]
+        assert df.height == 1
+        assert df[0, "Load"] == 18000.0
 
     def test_get_load_pre_baa_historical_null_baa_values(self):
         date = pd.Timestamp("2026-03-29 10:00:00-0500")
-        source_df = pd.DataFrame(
+        source_df = pl.DataFrame(
             {
                 "Interval Start": [date, date + pd.Timedelta(minutes=5)],
                 "Interval End": [
@@ -1250,7 +1294,7 @@ class TestSPP(BaseTestISO):
             patch.object(
                 self.iso,
                 "_get_short_term_forecast_data",
-                return_value=(pd.DataFrame(), "mock-url"),
+                return_value=(pl.DataFrame(), "mock-url"),
             ),
             patch.object(
                 self.iso,
@@ -1260,12 +1304,12 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_load(date=date, verbose=False)
 
-        assert df.columns.tolist() == ["Interval Start", "Interval End", "Load"]
-        assert len(df) == 2
+        assert df.columns == ["Interval Start", "Interval End", "Load"]
+        assert df.height == 2
 
     def test_get_load_null_baa_mixed_load_values(self):
         date = pd.Timestamp("2026-04-02 12:00:00-0500")
-        source_df = pd.DataFrame(
+        source_df = pl.DataFrame(
             {
                 "Interval Start": [date, date],
                 "Interval End": [
@@ -1281,7 +1325,7 @@ class TestSPP(BaseTestISO):
             patch.object(
                 self.iso,
                 "_get_short_term_forecast_data",
-                return_value=(pd.DataFrame(), "mock-url"),
+                return_value=(pl.DataFrame(), "mock-url"),
             ),
             patch.object(
                 self.iso,
@@ -1291,9 +1335,9 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_load(date=date, verbose=False)
 
-        assert df.columns.tolist() == ["Interval Start", "Interval End", "Load"]
-        assert len(df) == 1
-        assert df["Load"].iloc[0] == 18500.0
+        assert df.columns == ["Interval Start", "Interval End", "Load"]
+        assert df.height == 1
+        assert df[0, "Load"] == 18500.0
 
     """get_load_forecast"""
 
@@ -1320,7 +1364,7 @@ class TestSPP(BaseTestISO):
     def test_get_load_forecast_post_baa(self):
         date = pd.Timestamp("2026-04-02 12:00:00-0500")
         publish_time = date
-        source_df = pd.DataFrame(
+        source_df = pl.DataFrame(
             {
                 "Interval Start": [
                     date,
@@ -1344,7 +1388,7 @@ class TestSPP(BaseTestISO):
             patch.object(
                 self.iso,
                 "_get_mid_term_forecast_data",
-                return_value=(pd.DataFrame(), "mock-url"),
+                return_value=(pl.DataFrame(), "mock-url"),
             ),
             patch.object(
                 self.iso,
@@ -1354,14 +1398,14 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_load_forecast(date=date, verbose=False)
 
-        assert df.columns.tolist() == self.LOAD_FORECAST_COLS
-        assert len(df) == 2
-        assert df["Load Forecast"].tolist() == [19000.0, 19200.0]
+        assert df.columns == self.LOAD_FORECAST_COLS
+        assert df.height == 2
+        assert df["Load Forecast"].to_list() == [19000.0, 19200.0]
 
     def test_get_load_forecast_pre_baa_no_column(self):
         date = pd.Timestamp("2026-03-28 08:00:00-0500")
         publish_time = date
-        source_df = pd.DataFrame(
+        source_df = pl.DataFrame(
             {
                 "Interval Start": [date],
                 "Interval End": [date + pd.Timedelta(hours=1)],
@@ -1374,7 +1418,7 @@ class TestSPP(BaseTestISO):
             patch.object(
                 self.iso,
                 "_get_mid_term_forecast_data",
-                return_value=(pd.DataFrame(), "mock-url"),
+                return_value=(pl.DataFrame(), "mock-url"),
             ),
             patch.object(
                 self.iso,
@@ -1384,14 +1428,14 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_load_forecast(date=date, verbose=False)
 
-        assert df.columns.tolist() == self.LOAD_FORECAST_COLS
-        assert len(df) == 1
-        assert df["Load Forecast"].iloc[0] == 20000.0
+        assert df.columns == self.LOAD_FORECAST_COLS
+        assert df.height == 1
+        assert df[0, "Load Forecast"] == 20000.0
 
     def test_get_load_forecast_null_baa_mixed_values(self):
         date = pd.Timestamp("2026-04-02 12:00:00-0500")
         publish_time = date
-        source_df = pd.DataFrame(
+        source_df = pl.DataFrame(
             {
                 "Interval Start": [date, date],
                 "Interval End": [
@@ -1408,7 +1452,7 @@ class TestSPP(BaseTestISO):
             patch.object(
                 self.iso,
                 "_get_mid_term_forecast_data",
-                return_value=(pd.DataFrame(), "mock-url"),
+                return_value=(pl.DataFrame(), "mock-url"),
             ),
             patch.object(
                 self.iso,
@@ -1418,9 +1462,9 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_load_forecast(date=date, verbose=False)
 
-        assert df.columns.tolist() == self.LOAD_FORECAST_COLS
-        assert len(df) == 1
-        assert df["Load Forecast"].iloc[0] == 17500.0
+        assert df.columns == self.LOAD_FORECAST_COLS
+        assert df.height == 1
+        assert df[0, "Load Forecast"] == 17500.0
 
     """get_load_forecast_by_baa"""
 
@@ -1435,7 +1479,7 @@ class TestSPP(BaseTestISO):
     def test_get_load_forecast_by_baa_post_baa(self):
         now = self.local_now().floor("h")
         publish_time = now
-        source_df = pd.DataFrame(
+        source_df = pl.DataFrame(
             {
                 "Interval Start": [now, now],
                 "Interval End": [
@@ -1452,7 +1496,7 @@ class TestSPP(BaseTestISO):
             patch.object(
                 self.iso,
                 "_get_mid_term_forecast_data",
-                return_value=(pd.DataFrame(), "mock-url"),
+                return_value=(pl.DataFrame(), "mock-url"),
             ),
             patch.object(
                 self.iso,
@@ -1462,14 +1506,14 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_load_forecast_by_baa(date=now, verbose=False)
 
-        assert df.columns.tolist() == self.LOAD_FORECAST_BY_BAA_COLS
-        assert set(df["BAA"].unique()) == {"SPP", "SWPW"}
-        assert len(df) == 2
+        assert df.columns == self.LOAD_FORECAST_BY_BAA_COLS
+        assert set(df["BAA"].unique().to_list()) == {"SPP", "SWPW"}
+        assert df.height == 2
 
     def test_get_load_forecast_by_baa_pre_baa_no_column(self):
         date = pd.Timestamp("2026-03-28 12:00:00-0500")
         publish_time = date
-        source_df = pd.DataFrame(
+        source_df = pl.DataFrame(
             {
                 "Interval Start": [date, date + pd.Timedelta(hours=1)],
                 "Interval End": [
@@ -1485,7 +1529,7 @@ class TestSPP(BaseTestISO):
             patch.object(
                 self.iso,
                 "_get_mid_term_forecast_data",
-                return_value=(pd.DataFrame(), "mock-url"),
+                return_value=(pl.DataFrame(), "mock-url"),
             ),
             patch.object(
                 self.iso,
@@ -1495,14 +1539,14 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_load_forecast_by_baa(date=date, verbose=False)
 
-        assert df.columns.tolist() == self.LOAD_FORECAST_BY_BAA_COLS
-        assert set(df["BAA"].unique()) == {"SPP"}
-        assert len(df) == 2
+        assert df.columns == self.LOAD_FORECAST_BY_BAA_COLS
+        assert set(df["BAA"].unique().to_list()) == {"SPP"}
+        assert df.height == 2
 
     def test_get_load_forecast_by_baa_null_baa_mixed_values(self):
         date = pd.Timestamp("2026-04-02 12:00:00-0500")
         publish_time = date
-        source_df = pd.DataFrame(
+        source_df = pl.DataFrame(
             {
                 "Interval Start": [date, date],
                 "Interval End": [
@@ -1519,7 +1563,7 @@ class TestSPP(BaseTestISO):
             patch.object(
                 self.iso,
                 "_get_mid_term_forecast_data",
-                return_value=(pd.DataFrame(), "mock-url"),
+                return_value=(pl.DataFrame(), "mock-url"),
             ),
             patch.object(
                 self.iso,
@@ -1529,13 +1573,13 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_load_forecast_by_baa(date=date, verbose=False)
 
-        assert df.columns.tolist() == self.LOAD_FORECAST_BY_BAA_COLS
-        assert set(df["BAA"].unique()) == {"SPP", "SWPW"}
-        assert len(df) == 2
-        spp_row = df[df["BAA"] == "SPP"]
-        swpw_row = df[df["BAA"] == "SWPW"]
-        assert spp_row["Load Forecast"].iloc[0] == 14000.0
-        assert swpw_row["Load Forecast"].iloc[0] == 3500.0
+        assert df.columns == self.LOAD_FORECAST_BY_BAA_COLS
+        assert set(df["BAA"].unique().to_list()) == {"SPP", "SWPW"}
+        assert df.height == 2
+        spp_row = df.filter(pl.col("BAA") == "SPP")
+        swpw_row = df.filter(pl.col("BAA") == "SWPW")
+        assert spp_row[0, "Load Forecast"] == 14000.0
+        assert swpw_row[0, "Load Forecast"] == 3500.0
 
     def test_get_load_forecast_by_baa_empty_data(self):
         date = pd.Timestamp("2026-03-25 10:00:00-0500")
@@ -1656,9 +1700,9 @@ class TestSPP(BaseTestISO):
                 end=end,
             )
 
-        assert df["Publish Time"].min() == pd.Timestamp("2025-11-02 01:00:00-0500")
-        assert df["Publish Time"].max() == pd.Timestamp("2025-11-02 01:55:00-0600")
-        assert df["Publish Time"].nunique() == 12
+        assert _ts(df["Publish Time"].min()) == pd.Timestamp("2025-11-02 01:00:00-0500")
+        assert _ts(df["Publish Time"].max()) == pd.Timestamp("2025-11-02 01:55:00-0600")
+        assert df["Publish Time"].n_unique() == 12
 
         self._check_load_forecast(df, "SHORT_TERM")
 
@@ -1729,7 +1773,7 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_load_forecast_mid_term(date=three_days_ago)
 
-        assert (df["Publish Time"].unique() == three_days_ago).all()
+        assert df["Publish Time"].unique().to_list() == [three_days_ago]
 
         # Each file contains data going back into the past
         assert df["Interval Start"].min() <= three_days_ago
@@ -1770,9 +1814,9 @@ class TestSPP(BaseTestISO):
                 end=end,
             )
 
-        assert df["Publish Time"].min() == pd.Timestamp("2025-11-02 01:00:00-0500")
-        assert df["Publish Time"].max() == pd.Timestamp("2025-11-02 02:00:00-0600")
-        assert df["Publish Time"].nunique() == 2
+        assert _ts(df["Publish Time"].min()) == pd.Timestamp("2025-11-02 01:00:00-0500")
+        assert _ts(df["Publish Time"].max()) == pd.Timestamp("2025-11-02 02:00:00-0600")
+        assert df["Publish Time"].n_unique() == 2
 
         self._check_load_forecast(df, "MID_TERM")
 
@@ -1884,9 +1928,9 @@ class TestSPP(BaseTestISO):
                 end=end,
             )
 
-        assert df["Publish Time"].min() == pd.Timestamp("2025-11-02 01:00:00-0500")
-        assert df["Publish Time"].max() == pd.Timestamp("2025-11-02 01:55:00-0600")
-        assert df["Publish Time"].nunique() == 12
+        assert _ts(df["Publish Time"].min()) == pd.Timestamp("2025-11-02 01:00:00-0500")
+        assert _ts(df["Publish Time"].max()) == pd.Timestamp("2025-11-02 01:55:00-0600")
+        assert df["Publish Time"].n_unique() == 12
 
         self._check_solar_and_wind_forecast(df, "SHORT_TERM")
 
@@ -1937,7 +1981,7 @@ class TestSPP(BaseTestISO):
                 date=publish_time,
             )
 
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Publish Time",
@@ -1948,8 +1992,8 @@ class TestSPP(BaseTestISO):
             "Solar Forecast",
             "Solar Actual",
         ]
-        assert (df["Publish Time"].unique() == publish_time).all()
-        assert df["Reserve Zone"].nunique() > 1
+        assert df["Publish Time"].unique().to_list() == [publish_time]
+        assert df["Reserve Zone"].n_unique() > 1
         assert df["Interval Start"].max() >= publish_time + pd.Timedelta(days=5)
 
     def test_get_solar_and_wind_forecast_mid_term_historical(self):
@@ -1962,7 +2006,7 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_solar_and_wind_forecast_mid_term(date=three_days_ago)
 
-        assert (df["Publish Time"].unique() == three_days_ago).all()
+        assert df["Publish Time"].unique().to_list() == [three_days_ago]
 
         # Each file contains data going back into the past
         assert df["Interval Start"].min() <= three_days_ago
@@ -2005,9 +2049,9 @@ class TestSPP(BaseTestISO):
                 end=end,
             )
 
-        assert df["Publish Time"].min() == pd.Timestamp("2025-11-02 01:00:00-0500")
-        assert df["Publish Time"].max() == pd.Timestamp("2025-11-02 02:00:00-0600")
-        assert df["Publish Time"].nunique() == 2
+        assert _ts(df["Publish Time"].min()) == pd.Timestamp("2025-11-02 01:00:00-0500")
+        assert _ts(df["Publish Time"].max()) == pd.Timestamp("2025-11-02 02:00:00-0600")
+        assert df["Publish Time"].n_unique() == 2
 
         self._check_solar_and_wind_forecast(df, "MID_TERM")
 
@@ -2017,7 +2061,7 @@ class TestSPP(BaseTestISO):
 
     def test_get_load_by_baa_post_baa(self):
         now = self.local_now().floor("5min")
-        source_df = pd.DataFrame(
+        source_df = pl.DataFrame(
             {
                 "Interval Start": [now, now, now],
                 "Interval End": [
@@ -2034,7 +2078,7 @@ class TestSPP(BaseTestISO):
             patch.object(
                 self.iso,
                 "_get_short_term_forecast_data",
-                return_value=(pd.DataFrame(), "mock-url"),
+                return_value=(pl.DataFrame(), "mock-url"),
             ),
             patch.object(
                 self.iso,
@@ -2044,13 +2088,13 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_load_by_baa(date=now, verbose=False)
 
-        assert df.columns.tolist() == self.LOAD_BY_BAA_COLS
-        assert set(df["BAA"].unique()) == {"SPP", "SWPW"}
-        assert len(df) == 2
+        assert df.columns == self.LOAD_BY_BAA_COLS
+        assert set(df["BAA"].unique().to_list()) == {"SPP", "SWPW"}
+        assert df.height == 2
 
     def test_get_load_by_baa_pre_baa_no_column(self):
         date = pd.Timestamp("2026-03-28 12:00:00-0500")
-        source_df = pd.DataFrame(
+        source_df = pl.DataFrame(
             {
                 "Interval Start": [date, date + pd.Timedelta(minutes=5)],
                 "Interval End": [
@@ -2065,7 +2109,7 @@ class TestSPP(BaseTestISO):
             patch.object(
                 self.iso,
                 "_get_short_term_forecast_data",
-                return_value=(pd.DataFrame(), "mock-url"),
+                return_value=(pl.DataFrame(), "mock-url"),
             ),
             patch.object(
                 self.iso,
@@ -2075,13 +2119,13 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_load_by_baa(date=date, verbose=False)
 
-        assert df.columns.tolist() == self.LOAD_BY_BAA_COLS
-        assert set(df["BAA"].unique()) == {"SPP"}
-        assert len(df) == 2
+        assert df.columns == self.LOAD_BY_BAA_COLS
+        assert set(df["BAA"].unique().to_list()) == {"SPP"}
+        assert df.height == 2
 
     def test_get_load_by_baa_pre_baa_null_values(self):
         date = pd.Timestamp("2026-03-29 10:00:00-0500")
-        source_df = pd.DataFrame(
+        source_df = pl.DataFrame(
             {
                 "Interval Start": [date, date + pd.Timedelta(minutes=5)],
                 "Interval End": [
@@ -2097,7 +2141,7 @@ class TestSPP(BaseTestISO):
             patch.object(
                 self.iso,
                 "_get_short_term_forecast_data",
-                return_value=(pd.DataFrame(), "mock-url"),
+                return_value=(pl.DataFrame(), "mock-url"),
             ),
             patch.object(
                 self.iso,
@@ -2107,13 +2151,13 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_load_by_baa(date=date, verbose=False)
 
-        assert df.columns.tolist() == self.LOAD_BY_BAA_COLS
-        assert set(df["BAA"].unique()) == {"SPP"}
-        assert len(df) == 2
+        assert df.columns == self.LOAD_BY_BAA_COLS
+        assert set(df["BAA"].unique().to_list()) == {"SPP"}
+        assert df.height == 2
 
     def test_get_load_by_baa_null_baa_mixed_load_values(self):
         date = pd.Timestamp("2026-04-02 12:00:00-0500")
-        source_df = pd.DataFrame(
+        source_df = pl.DataFrame(
             {
                 "Interval Start": [date, date],
                 "Interval End": [
@@ -2129,7 +2173,7 @@ class TestSPP(BaseTestISO):
             patch.object(
                 self.iso,
                 "_get_short_term_forecast_data",
-                return_value=(pd.DataFrame(), "mock-url"),
+                return_value=(pl.DataFrame(), "mock-url"),
             ),
             patch.object(
                 self.iso,
@@ -2139,17 +2183,17 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_load_by_baa(date=date, verbose=False)
 
-        assert df.columns.tolist() == self.LOAD_BY_BAA_COLS
-        assert set(df["BAA"].unique()) == {"SPP", "SWPW"}
-        assert len(df) == 2
-        spp_row = df[df["BAA"] == "SPP"]
-        swpw_row = df[df["BAA"] == "SWPW"]
-        assert spp_row["Load"].iloc[0] == 15000.0
-        assert swpw_row["Load"].iloc[0] == 3500.0
+        assert df.columns == self.LOAD_BY_BAA_COLS
+        assert set(df["BAA"].unique().to_list()) == {"SPP", "SWPW"}
+        assert df.height == 2
+        spp_row = df.filter(pl.col("BAA") == "SPP")
+        swpw_row = df.filter(pl.col("BAA") == "SWPW")
+        assert spp_row[0, "Load"] == 15000.0
+        assert swpw_row[0, "Load"] == 3500.0
 
     def test_get_load_by_baa_missing_actual_load_column(self):
         now = self.local_now().floor("5min")
-        source_df = pd.DataFrame(
+        source_df = pl.DataFrame(
             {
                 "Interval Start": [now],
                 "Interval End": [now + pd.Timedelta(minutes=5)],
@@ -2162,7 +2206,7 @@ class TestSPP(BaseTestISO):
             patch.object(
                 self.iso,
                 "_get_short_term_forecast_data",
-                return_value=(pd.DataFrame(), "mock-url"),
+                return_value=(pl.DataFrame(), "mock-url"),
             ),
             patch.object(
                 self.iso,
@@ -2177,7 +2221,7 @@ class TestSPP(BaseTestISO):
 
     def test_get_load_by_baa_hourly_post_baa(self):
         now = self.local_now().floor("h")
-        source_df = pd.DataFrame(
+        source_df = _mock_forecast_df(
             {
                 "Interval Start": [now, now],
                 "Interval End": [
@@ -2193,7 +2237,7 @@ class TestSPP(BaseTestISO):
             patch.object(
                 self.iso,
                 "_get_mid_term_forecast_data",
-                return_value=(pd.DataFrame(), "mock-url"),
+                return_value=(pl.DataFrame(), "mock-url"),
             ),
             patch.object(
                 self.iso,
@@ -2203,13 +2247,13 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_load_by_baa_hourly(date=now, verbose=False)
 
-        assert df.columns.tolist() == self.LOAD_BY_BAA_COLS
-        assert set(df["BAA"].unique()) == {"SPP", "SWPW"}
-        assert len(df) == 2
+        assert df.columns == self.LOAD_BY_BAA_COLS
+        assert set(df["BAA"].unique().to_list()) == {"SPP", "SWPW"}
+        assert df.height == 2
 
     def test_get_load_by_baa_hourly_pre_baa_no_column(self):
         date = pd.Timestamp("2026-03-28 12:00:00-0500")
-        source_df = pd.DataFrame(
+        source_df = _mock_forecast_df(
             {
                 "Interval Start": [date, date + pd.Timedelta(hours=1)],
                 "Interval End": [
@@ -2224,7 +2268,7 @@ class TestSPP(BaseTestISO):
             patch.object(
                 self.iso,
                 "_get_mid_term_forecast_data",
-                return_value=(pd.DataFrame(), "mock-url"),
+                return_value=(pl.DataFrame(), "mock-url"),
             ),
             patch.object(
                 self.iso,
@@ -2234,13 +2278,13 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_load_by_baa_hourly(date=date, verbose=False)
 
-        assert df.columns.tolist() == self.LOAD_BY_BAA_COLS
-        assert set(df["BAA"].unique()) == {"SPP"}
-        assert len(df) == 2
+        assert df.columns == self.LOAD_BY_BAA_COLS
+        assert set(df["BAA"].unique().to_list()) == {"SPP"}
+        assert df.height == 2
 
     def test_get_load_by_baa_hourly_pre_baa_null_values(self):
         date = pd.Timestamp("2026-03-29 10:00:00-0500")
-        source_df = pd.DataFrame(
+        source_df = _mock_forecast_df(
             {
                 "Interval Start": [date, date + pd.Timedelta(hours=1)],
                 "Interval End": [
@@ -2256,7 +2300,7 @@ class TestSPP(BaseTestISO):
             patch.object(
                 self.iso,
                 "_get_mid_term_forecast_data",
-                return_value=(pd.DataFrame(), "mock-url"),
+                return_value=(pl.DataFrame(), "mock-url"),
             ),
             patch.object(
                 self.iso,
@@ -2266,13 +2310,13 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_load_by_baa_hourly(date=date, verbose=False)
 
-        assert df.columns.tolist() == self.LOAD_BY_BAA_COLS
-        assert set(df["BAA"].unique()) == {"SPP"}
-        assert len(df) == 2
+        assert df.columns == self.LOAD_BY_BAA_COLS
+        assert set(df["BAA"].unique().to_list()) == {"SPP"}
+        assert df.height == 2
 
     def test_get_load_by_baa_hourly_null_baa_mixed_load_values(self):
         date = pd.Timestamp("2026-04-02 12:00:00-0500")
-        source_df = pd.DataFrame(
+        source_df = _mock_forecast_df(
             {
                 "Interval Start": [date, date],
                 "Interval End": [
@@ -2288,7 +2332,7 @@ class TestSPP(BaseTestISO):
             patch.object(
                 self.iso,
                 "_get_mid_term_forecast_data",
-                return_value=(pd.DataFrame(), "mock-url"),
+                return_value=(pl.DataFrame(), "mock-url"),
             ),
             patch.object(
                 self.iso,
@@ -2298,13 +2342,13 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_load_by_baa_hourly(date=date, verbose=False)
 
-        assert df.columns.tolist() == self.LOAD_BY_BAA_COLS
-        assert set(df["BAA"].unique()) == {"SPP", "SWPW"}
-        assert len(df) == 2
-        spp_row = df[df["BAA"] == "SPP"]
-        swpw_row = df[df["BAA"] == "SWPW"]
-        assert spp_row["Load"].iloc[0] == 14000.0
-        assert swpw_row["Load"].iloc[0] == 4000.0
+        assert df.columns == self.LOAD_BY_BAA_COLS
+        assert set(df["BAA"].unique().to_list()) == {"SPP", "SWPW"}
+        assert df.height == 2
+        spp_row = df.filter(pl.col("BAA") == "SPP")
+        swpw_row = df.filter(pl.col("BAA") == "SWPW")
+        assert spp_row[0, "Load"] == 14000.0
+        assert swpw_row[0, "Load"] == 4000.0
 
     def test_get_load_by_baa_hourly_no_data(self):
         date = pd.Timestamp("2026-03-25 10:00:00-0500")
@@ -2316,8 +2360,8 @@ class TestSPP(BaseTestISO):
         ):
             df = self.iso.get_load_by_baa_hourly(date=date, verbose=False)
 
-        assert df.columns.tolist() == self.LOAD_BY_BAA_COLS
-        assert len(df) == 0
+        assert df.columns == self.LOAD_BY_BAA_COLS
+        assert df.height == 0
 
     """get_status"""
 
@@ -2352,13 +2396,13 @@ class TestSPP(BaseTestISO):
     ]
 
     def _check_ver_curtailments(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.tolist() == self._ver_curtailment_cols
+        assert isinstance(df, pl.DataFrame)
+        assert df.columns == self._ver_curtailment_cols
         assert "BAA" not in df.columns
 
     def _check_ver_curtailments_by_baa(self, df):
-        assert isinstance(df, pd.DataFrame)
-        assert df.columns.tolist() == self._ver_curtailment_cols + ["BAA"]
+        assert isinstance(df, pl.DataFrame)
+        assert df.columns == self._ver_curtailment_cols + ["BAA"]
 
     def test_get_ver_curtailments_historical(self):
         two_days_ago = pd.Timestamp.now() - pd.Timedelta(days=2)
@@ -2430,7 +2474,7 @@ class TestSPP(BaseTestISO):
             "Other MW",
         ]
 
-        assert df.columns.tolist() == columns
+        assert df.columns == columns
 
     def test_get_capacity_of_generation_on_outage(self):
         two_days_ago = pd.Timestamp.now() - pd.Timedelta(days=2)
@@ -2447,7 +2491,7 @@ class TestSPP(BaseTestISO):
 
         # confirm three weeks of data
         assert df.shape[0] / 168 == 3
-        assert df["Publish Time"].dt.date.nunique() == 3
+        assert df["Publish Time"].dt.date().n_unique() == 3
 
     def test_get_capacity_of_generation_on_outage_annual(self):
         year = 2020
@@ -2459,12 +2503,12 @@ class TestSPP(BaseTestISO):
         assert df["Interval Start"].min().date() == pd.Timestamp(f"{year}-01-01").date()
 
         # 2020 was a leap year
-        assert df["Publish Time"].nunique() == 366
+        assert df["Publish Time"].n_unique() == 366
 
         self._check_capacity_of_generation_on_outage(df)
 
     def _check_solar_and_wind(self, df):
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Actual Wind MW",
@@ -2504,7 +2548,10 @@ class TestSPP(BaseTestISO):
 
         assert (df[forecast_col] >= 0).all()
 
-        assert (df["Interval End"] - df["Interval Start"] == interval).all()
+        assert (
+            (df["Interval End"] - df["Interval Start"]).dt.total_minutes()
+            == interval / pd.Timedelta(minutes=1)
+        ).all()
 
         assert (df["Forecast Type"] == forecast_type).all()
 
@@ -2530,21 +2577,24 @@ class TestSPP(BaseTestISO):
             else pd.Timedelta(hours=1)
         )
 
-        assert df.columns.tolist() == expected_cols
+        assert df.columns == expected_cols
 
         assert (df["Wind Forecast MW"] >= 0).all()
         assert (df["Solar Forecast MW"] >= 0).all()
 
-        assert (df["Interval End"] - df["Interval Start"] == interval).all()
+        assert (
+            (df["Interval End"] - df["Interval Start"]).dt.total_minutes()
+            == interval / pd.Timedelta(minutes=1)
+        ).all()
 
         assert (df["Forecast Type"] == forecast_type).all()
 
     """ get_hourly_load_historical (wide format, before 2026-03-24) """
 
     def _check_hourly_load_historical(self, df):
-        assert isinstance(df, pd.DataFrame)
+        assert isinstance(df, pl.DataFrame)
 
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Time",
             "Interval Start",
             "Interval End",
@@ -2597,7 +2647,7 @@ class TestSPP(BaseTestISO):
             self.iso.get_hourly_load_historical(pd.Timestamp("2026-03-24"))
 
     def test_get_hourly_load_historical_process_raises_on_new_data(self):
-        new_format_df = pd.DataFrame(
+        new_format_df = pl.DataFrame(
             {
                 "Market Hour": ["03/24/2026 06:00:00"],
                 "Balancing Area Name": ["SPP"],
@@ -2612,9 +2662,9 @@ class TestSPP(BaseTestISO):
     """ get_hourly_load (long format, >= 2026-03-24) """
 
     def _check_hourly_load(self, df):
-        assert isinstance(df, pd.DataFrame)
+        assert isinstance(df, pl.DataFrame)
 
-        assert df.columns.tolist() == [
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Balancing Area Name",
@@ -2623,13 +2673,13 @@ class TestSPP(BaseTestISO):
             "Load",
         ]
 
-        assert df["Interval Start"].dtype == "datetime64[ns, US/Central]"
-        assert df["Interval End"].dtype == "datetime64[ns, US/Central]"
-        assert df["Balancing Area Name"].dtype == "object"
-        assert df["Control Zone Name"].dtype == "object"
-        assert df["Forecast Area Type"].dtype == "object"
-        assert df["Load"].dtype == "float64"
-        assert set(df["Forecast Area Type"].unique()).issubset({"CF", "NC"})
+        for col in ("Interval Start", "Interval End"):
+            assert df[col].dtype.time_zone == "US/Central"
+        assert df["Balancing Area Name"].dtype == pl.Utf8
+        assert df["Control Zone Name"].dtype == pl.Utf8
+        assert df["Forecast Area Type"].dtype == pl.Utf8
+        assert df["Load"].dtype == pl.Float64
+        assert set(df["Forecast Area Type"].unique().to_list()).issubset({"CF", "NC"})
 
     def test_get_hourly_load(self):
         date = pd.Timestamp("2026-03-24")
@@ -2641,7 +2691,7 @@ class TestSPP(BaseTestISO):
         self._check_hourly_load(df)
         assert df["Interval Start"].min().date() == date.date()
         assert df["Interval Start"].max().date() == date.date()
-        assert len(df) > 0
+        assert df.height > 0
 
     def test_get_hourly_load_raises_on_old_date(self):
         with pytest.raises(NoDataFoundException):
@@ -2657,8 +2707,8 @@ class TestSPP(BaseTestISO):
 
     """get_market_clearing_real_time"""
 
-    def _check_market_clearing_real_time(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_market_clearing_real_time(self, df: pl.DataFrame):
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Generation",
@@ -2678,7 +2728,7 @@ class TestSPP(BaseTestISO):
         ]
 
         assert (
-            df["Interval End"] - df["Interval Start"] == pd.Timedelta(minutes=5)
+            (df["Interval End"] - df["Interval Start"]).dt.total_minutes() == 5
         ).all()
 
     def test_market_clearing_real_time_latest(self):
@@ -2702,8 +2752,8 @@ class TestSPP(BaseTestISO):
 
     """get_market_clearing_day_ahead"""
 
-    def _check_market_clearing_day_ahead(self, df: pd.DataFrame):
-        assert df.columns.tolist() == [
+    def _check_market_clearing_day_ahead(self, df: pl.DataFrame):
+        assert df.columns == [
             "Interval Start",
             "Interval End",
             "Generation",
@@ -2768,11 +2818,9 @@ class TestSPP(BaseTestISO):
         "Contingency Name",
     ]
 
-    def _check_binding_constraints_day_ahead(self, df: pd.DataFrame):
+    def _check_binding_constraints_day_ahead(self, df: pl.DataFrame):
         assert list(df.columns) == self.DAY_AHEAD_BINDING_CONSTRAINTS_COLUMNS
-        assert (
-            df["Interval End"] - df["Interval Start"] == pd.Timedelta(hours=1)
-        ).all()
+        assert ((df["Interval End"] - df["Interval Start"]).dt.total_hours() == 1).all()
 
     def test_get_binding_constraints_day_ahead_latest(self):
         with api_vcr.use_cassette(
@@ -2814,13 +2862,13 @@ class TestSPP(BaseTestISO):
         "Contingent Facility",
     ]
 
-    def _check_binding_constraints_real_time(self, df: pd.DataFrame):
+    def _check_binding_constraints_real_time(self, df: pl.DataFrame):
         assert list(df.columns) == self.REAL_TIME_BINDING_CONSTRAINTS_COLUMNS
         assert (
-            df["Interval End"] - df["Interval Start"] == pd.Timedelta(minutes=5)
+            (df["Interval End"] - df["Interval Start"]).dt.total_minutes() == 5
         ).all()
         # check that NERC ID is integer type and non-negative
-        assert pd.api.types.is_integer_dtype(df["NERC ID"]), (
+        assert df["NERC ID"].dtype in (pl.Int64, pl.Int32, pl.UInt64, pl.UInt32), (
             "NERC ID column must be of integer type"
         )
 
@@ -2876,7 +2924,7 @@ class TestSPP(BaseTestISO):
 
         def fake_intervals_fetch(date, end=None, verbose=False):
             calls.append((date, end))
-            return pd.DataFrame(
+            return pl.DataFrame(
                 {
                     "Interval Start": [start_date],
                     "Interval End": [start_date + pd.Timedelta(minutes=5)],
@@ -2923,15 +2971,18 @@ class TestSPP(BaseTestISO):
     ]
 
     def _check_interchange_real_time(self, df):
-        assert len(df) > 0
-        assert df["Time"].dt.tz is not None
+        assert df.height > 0
+        assert (
+            isinstance(df.schema["Time"], pl.Datetime)
+            and df.schema["Time"].time_zone is not None
+        )
         assert list(df.columns) == self.interchange_real_time_cols
         # Core interchange regions are present
         regions = df["Region"].unique()
         assert "SPP NSI" in regions
         assert "SPP NAI" in regions
         # No null interchange values
-        assert df["Interchange"].notna().all()
+        assert df["Interchange"].is_not_null().all()
 
     def test_get_interchange_real_time_latest(self):
         with api_vcr.use_cassette("test_get_interchange_real_time_latest.yaml"):
@@ -2993,15 +3044,18 @@ class TestSPP(BaseTestISO):
     ]
 
     def _check_west_interchange_real_time(self, df):
-        assert len(df) > 0
-        assert df["Time"].dt.tz is not None
+        assert df.height > 0
+        assert (
+            isinstance(df.schema["Time"], pl.Datetime)
+            and df.schema["Time"].time_zone is not None
+        )
         assert list(df.columns) == self.west_interchange_real_time_cols
         # Core interchange regions are present
         regions = df["Region"].unique()
         assert "SWPW NSI" in regions
         assert "SWPW NAI" in regions
         # No null interchange values
-        assert df["Interchange"].notna().all()
+        assert df["Interchange"].is_not_null().all()
 
     def test_get_west_interchange_real_time_latest(self):
         with api_vcr.use_cassette(
@@ -3062,72 +3116,71 @@ class TestFillBaaColumn:
     """Tests for the fill_baa_column utility function."""
 
     def test_creates_baa_column_when_missing(self):
-        df = pd.DataFrame({"Load": [2000.0, 25000.0, 3000.0]})
+        df = pl.DataFrame({"Load": [2000.0, 25000.0, 3000.0]})
         result = fill_baa_column(df, "Load")
         assert "BAA" in result.columns
-        assert result["BAA"].tolist() == [
+        assert result["BAA"].to_list() == [
             BAAEnum.SWPW.value,
             BAAEnum.SPP.value,
             BAAEnum.SWPW.value,
         ]
 
     def test_fills_nan_baa_values(self):
-        df = pd.DataFrame(
+        df = pl.DataFrame(
             {
                 "Load": [2000.0, 25000.0, 3000.0],
                 "BAA": [BAAEnum.SWPW.value, None, None],
             },
         )
         result = fill_baa_column(df, "Load")
-        assert result["BAA"].tolist() == [
+        assert result["BAA"].to_list() == [
             BAAEnum.SWPW.value,
             BAAEnum.SPP.value,
             BAAEnum.SWPW.value,
         ]
 
     def test_preserves_existing_baa_values(self):
-        df = pd.DataFrame(
+        df = pl.DataFrame(
             {
                 "Load": [2000.0, 25000.0],
                 "BAA": [BAAEnum.SPP.value, BAAEnum.SWPW.value],
             },
         )
         result = fill_baa_column(df, "Load")
-        # Existing non-null values should not be overwritten
-        assert result["BAA"].tolist() == [
+        assert result["BAA"].to_list() == [
             BAAEnum.SPP.value,
             BAAEnum.SWPW.value,
         ]
 
     def test_nan_load_maps_to_spp(self):
-        df = pd.DataFrame({"Load": [float("nan"), 2000.0]})
+        df = pl.DataFrame({"Load": [float("nan"), 2000.0]})
         result = fill_baa_column(df, "Load")
-        assert result["BAA"].tolist() == [
+        assert result["BAA"].to_list() == [
             BAAEnum.SPP.value,
             BAAEnum.SWPW.value,
         ]
 
     def test_threshold_boundary(self):
-        df = pd.DataFrame(
+        df = pl.DataFrame(
             {"Load": [BAA_LOAD_THRESHOLD_MW - 1, BAA_LOAD_THRESHOLD_MW]},
         )
         result = fill_baa_column(df, "Load")
-        assert result["BAA"].tolist() == [
+        assert result["BAA"].to_list() == [
             BAAEnum.SWPW.value,
             BAAEnum.SPP.value,
         ]
 
     def test_returns_same_dataframe(self):
-        df = pd.DataFrame({"Load": [2000.0]})
+        df = pl.DataFrame({"Load": [2000.0]})
         result = fill_baa_column(df, "Load")
-        assert result is df
+        assert result["BAA"].to_list() == [BAAEnum.SWPW.value]
 
     def test_all_baa_present_no_changes(self):
-        df = pd.DataFrame(
+        df = pl.DataFrame(
             {
                 "Load": [2000.0, 25000.0],
                 "BAA": [BAAEnum.SPP.value, BAAEnum.SPP.value],
             },
         )
         result = fill_baa_column(df, "Load")
-        assert result["BAA"].tolist() == [BAAEnum.SPP.value, BAAEnum.SPP.value]
+        assert result["BAA"].to_list() == [BAAEnum.SPP.value, BAAEnum.SPP.value]

--- a/gridstatus/tests/test_isone_polars.py
+++ b/gridstatus/tests/test_isone_polars.py
@@ -12,29 +12,17 @@ from gridstatus.isone import ISONE
 TZ = ISONE.default_timezone
 
 
-def _to_pandas(df: object) -> pd.DataFrame:
-    if utils.is_polars(df):
-        return df.to_pandas()
-    return df.reset_index(drop=True)
+def _to_pandas(df: pl.DataFrame) -> pd.DataFrame:
+    return df.to_pandas()
 
 
 class TestUtilsDispatch:
-    def test_is_polars(self):
-        assert utils.is_polars(pl.DataFrame({"a": [1]}))
-        assert not utils.is_polars(pd.DataFrame({"a": [1]}))
-
-    def test_concat_dataframes_dispatch(self):
+    def test_concat_dataframes(self):
         pl_out = utils.concat_dataframes(
             [pl.DataFrame({"a": [1]}), pl.DataFrame({"a": [2]})],
         )
-        assert utils.is_polars(pl_out)
+        assert isinstance(pl_out, pl.DataFrame)
         assert pl_out.shape == (2, 1)
-
-        pd_out = utils.concat_dataframes(
-            [pd.DataFrame({"a": [1]}), pd.DataFrame({"a": [2]})],
-        )
-        assert isinstance(pd_out, pd.DataFrame)
-        assert pd_out.shape == (2, 1)
 
     def test_move_cols_to_front_polars(self):
         df = pl.DataFrame({"a": [1], "Time": [2], "b": [3]})
@@ -143,7 +131,7 @@ class TestISONEPolarsMethods:
             lambda url, skiprows, verbose: raw_factory().copy(),
         )
         df = ISONE().get_fuel_mix(date="2024-01-01")
-        assert utils.is_polars(df)
+        assert isinstance(df, pl.DataFrame)
         assert df.columns == ["Time", "Solar", "Wind"]
         assert df.height == 2
 
@@ -155,7 +143,7 @@ class TestISONEPolarsMethods:
             lambda url, skiprows, verbose: raw_factory().copy(),
         )
         df = ISONE().get_load(date="2023-11-05")
-        assert utils.is_polars(df)
+        assert isinstance(df, pl.DataFrame)
         assert list(df.columns) == [
             "Time",
             "Interval Start",
@@ -171,7 +159,7 @@ class TestISONEPolarsMethods:
             lambda url, data, verbose=False: _system_load_records("forecast"),
         )
         df = ISONE().get_load_forecast(date="2024-01-01")
-        assert utils.is_polars(df)
+        assert isinstance(df, pl.DataFrame)
         assert set(df.columns) == {
             "Time",
             "Interval Start",
@@ -187,7 +175,7 @@ class TestISONEPolarsMethods:
             lambda url, data, verbose=False: _system_load_records("actual"),
         )
         df = ISONE().get_btm_solar(date="2024-01-01")
-        assert utils.is_polars(df)
+        assert isinstance(df, pl.DataFrame)
         out = _to_pandas(df)
         assert list(out.columns) == [
             "Time",

--- a/gridstatus/tests/test_viz.py
+++ b/gridstatus/tests/test_viz.py
@@ -1,4 +1,5 @@
 import plotly
+import polars as pl
 import pytest
 
 import gridstatus
@@ -23,7 +24,7 @@ def test_dam_heat_map():
     # check if works with hour too
     # not the best test since we dont know if
     # the viz is actually using it instead of time
-    df["Hour"] = df["Time"].dt.hour
+    df = df.with_columns(pl.col("Time").dt.hour().alias("Hour"))
     fig = gridstatus.viz.dam_heat_map(df)
     assert isinstance(fig, plotly.graph_objs._figure.Figure)
 

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -99,7 +99,7 @@ def concat_dataframes(dfs: list) -> object:
     whether the decorated method produced pandas or polars frames.
     """
     if not dfs:
-        return pl.DataFrame()
+        raise ValueError("No objects to concatenate")
 
     if is_polars(dfs[0]):
         return pl.concat(dfs, how="diagonal_relaxed")

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -28,11 +28,6 @@ RED_X_HTML_ENTITY: str = "&#10060;"
 all_isos: list[ISOBase] = [MISO, CAISO, PJM, Ercot, SPP, NYISO, ISONE, IESO]
 
 
-def is_polars(obj: object) -> bool:
-    """Return whether ``obj`` is a polars DataFrame."""
-    return isinstance(obj, pl.DataFrame)
-
-
 def read_html_via_pandas(
     io: object,
     process: Callable[[pd.DataFrame], pd.DataFrame] | None = None,
@@ -92,19 +87,15 @@ def read_csv_exotic_via_pandas(
     return pl.from_pandas(df)
 
 
-def concat_dataframes(dfs: list) -> object:
-    """Concatenate a list of frames, dispatching on pandas vs polars.
+def concat_dataframes(dfs: list[pl.DataFrame]) -> pl.DataFrame:
+    """Concatenate a list of polars frames.
 
-    Used by ``support_date_range`` to combine per-chunk results regardless of
-    whether the decorated method produced pandas or polars frames.
+    Used by ``support_date_range`` to combine per-chunk results.
     """
     if not dfs:
         raise ValueError("No objects to concatenate")
 
-    if is_polars(dfs[0]):
-        return pl.concat(dfs, how="diagonal_relaxed")
-
-    return pd.concat(dfs).reset_index(drop=True)
+    return pl.concat(dfs, how="diagonal_relaxed")
 
 
 def list_isos() -> pl.DataFrame:
@@ -293,36 +284,24 @@ def make_lmp_availability_table() -> str:
 
 
 def filter_lmp_locations(
-    df: pd.DataFrame,
+    df: pl.DataFrame,
     locations: list[str] | None = None,
     location_type: str | None = None,
-) -> pd.DataFrame:
+) -> pl.DataFrame:
     """
     Filters DataFrame by locations, which can be a list, "ALL" or None
 
     Arguments:
-        df (pandas.DataFrame): DataFrame to filter
+        df (polars.DataFrame): DataFrame to filter
         locations: "ALL" or list of locations to filter "Location" column by
     """
-    if is_polars(df):
-        if location_type != "ALL" and location_type is not None:
-            if isinstance(location_type, str):
-                location_type = [location_type]
-            df = df.filter(pl.col("Location Type").is_in(location_type))
-
-        if locations != "ALL" and locations is not None:
-            df = df.filter(pl.col("Location").is_in(locations))
-
-        return df
-
     if location_type != "ALL" and location_type is not None:
         if isinstance(location_type, str):
             location_type = [location_type]
-
-        df = df[df["Location Type"].isin(location_type)]
+        df = df.filter(pl.col("Location Type").is_in(location_type))
 
     if locations != "ALL" and locations is not None:
-        df = df[df["Location"].isin(locations)]
+        df = df.filter(pl.col("Location").is_in(locations))
 
     return df
 
@@ -392,47 +371,30 @@ def is_within_last_days(date: pd.Timestamp, days: int, tz: str) -> bool:
 
 
 def format_interconnection_df(
-    queue: pd.DataFrame,
+    queue: pl.DataFrame,
     rename: dict[str, str],
     extra: list[str] | None = None,
     missing: list[str] | None = None,
-) -> pd.DataFrame:
+) -> pl.DataFrame:
     """Format interconnection queue data"""
     assert set(rename.keys()).issubset(queue.columns), set(
         rename.keys(),
     ) - set(queue.columns)
 
-    if is_polars(queue):
-        queue = queue.rename(rename)
-        columns = _interconnection_columns.copy()
-
-        if extra:
-            for e in extra:
-                assert e in queue.columns, f"Extra column {e} does not exist"
-            columns += extra
-
-        if missing:
-            for m in missing:
-                assert m not in queue.columns, "Missing column already exists"
-                queue = queue.with_columns(pl.lit(None).alias(m))
-
-        return queue.select(columns)
-
-    queue = queue.rename(columns=rename)
+    queue = queue.rename(rename)
     columns = _interconnection_columns.copy()
 
     if extra:
         for e in extra:
             assert e in queue.columns, f"Extra column {e} does not exist"
-
         columns += extra
 
     if missing:
         for m in missing:
             assert m not in queue.columns, "Missing column already exists"
-            queue[m] = None
+            queue = queue.with_columns(pl.lit(None).alias(m))
 
-    return queue[columns].reset_index(drop=True)
+    return queue.select(columns)
 
 
 def is_dst_end(date: pd.Timestamp) -> bool:
@@ -500,16 +462,10 @@ def get_interconnection_queues() -> pl.DataFrame:
     return all_queues
 
 
-def move_cols_to_front(df: pd.DataFrame, cols_to_move: list[str]) -> pd.DataFrame:
+def move_cols_to_front(df: pl.DataFrame, cols_to_move: list[str]) -> pl.DataFrame:
     """Move columns to front of DataFrame"""
-    if is_polars(df):
-        rest = [c for c in df.columns if c not in cols_to_move]
-        return df.select(cols_to_move + rest)
-
-    cols = list(df.columns)
-    for c in cols_to_move:
-        cols.remove(c)
-    return df[cols_to_move + cols]
+    rest = [c for c in df.columns if c not in cols_to_move]
+    return df.select(cols_to_move + rest)
 
 
 def localize_ambiguous_infer_polars(

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -99,7 +99,7 @@ def concat_dataframes(dfs: list) -> object:
     whether the decorated method produced pandas or polars frames.
     """
     if not dfs:
-        return pd.DataFrame()
+        return pl.DataFrame()
 
     if is_polars(dfs[0]):
         return pl.concat(dfs, how="diagonal")

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -102,7 +102,7 @@ def concat_dataframes(dfs: list) -> object:
         return pl.DataFrame()
 
     if is_polars(dfs[0]):
-        return pl.concat(dfs, how="diagonal")
+        return pl.concat(dfs, how="diagonal_relaxed")
 
     return pd.concat(dfs).reset_index(drop=True)
 

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -10,7 +10,7 @@ import requests
 import tqdm
 
 import gridstatus
-from gridstatus.base import ISOBase, Markets, NotSupported, _interconnection_columns
+from gridstatus.base import ISOBase, NotSupported, _interconnection_columns
 from gridstatus.caiso import CAISO
 from gridstatus.ercot import Ercot
 from gridstatus.gs_logging import log
@@ -33,6 +33,65 @@ def is_polars(obj: object) -> bool:
     return isinstance(obj, pl.DataFrame)
 
 
+def read_html_via_pandas(
+    io: object,
+    process: Callable[[pd.DataFrame], pd.DataFrame] | None = None,
+    **kwargs,
+) -> list[pl.DataFrame]:
+    """Parse HTML tables with ``pandas.read_html`` and return polars DataFrames.
+
+    pandas is retained only for IO parse edges that have no polars equivalent
+    (HTML tables, Excel workbooks, exotic CSVs); the parsed frames are converted
+    to polars immediately at the boundary. ``process`` runs on each pandas frame
+    before conversion, for pandas-specific fixups like flattening MultiIndex
+    columns.
+    """
+    tables = pd.read_html(io, **kwargs)
+    if process is not None:
+        tables = [process(t) for t in tables]
+    return [pl.from_pandas(t) for t in tables]
+
+
+def read_excel_via_pandas(
+    io: object,
+    process: Callable[[pd.DataFrame], pd.DataFrame] | None = None,
+    **kwargs,
+) -> pl.DataFrame | dict[str, pl.DataFrame]:
+    """Parse an Excel workbook with ``pandas.read_excel`` and return polars.
+
+    One of the sanctioned pandas IO edges (see ``read_html_via_pandas``).
+    Returns a dict of frames when ``sheet_name=None`` or a list of sheets is
+    requested, mirroring pandas. ``process`` runs on each pandas frame before
+    conversion, for pandas-specific fixups like flattening MultiIndex columns.
+    """
+    result = pd.read_excel(io, **kwargs)
+    if isinstance(result, dict):
+        if process is not None:
+            result = {k: process(v) for k, v in result.items()}
+        return {k: pl.from_pandas(v) for k, v in result.items()}
+    if process is not None:
+        result = process(result)
+    return pl.from_pandas(result)
+
+
+def read_csv_exotic_via_pandas(
+    io: object,
+    process: Callable[[pd.DataFrame], pd.DataFrame] | None = None,
+    **kwargs,
+) -> pl.DataFrame:
+    """Parse a CSV with ``pandas.read_csv`` and return a polars DataFrame.
+
+    One of the sanctioned pandas IO edges (see ``read_html_via_pandas``), for
+    CSVs that polars cannot read directly: ``skipfooter``, ``engine="python"``,
+    multi-row headers, etc. Simple CSVs should use ``pl.read_csv`` instead.
+    ``process`` runs on the pandas frame before conversion.
+    """
+    df = pd.read_csv(io, **kwargs)
+    if process is not None:
+        df = process(df)
+    return pl.from_pandas(df)
+
+
 def concat_dataframes(dfs: list) -> object:
     """Concatenate a list of frames, dispatching on pandas vs polars.
 
@@ -48,12 +107,16 @@ def concat_dataframes(dfs: list) -> object:
     return pd.concat(dfs).reset_index(drop=True)
 
 
-def list_isos() -> pd.DataFrame:
+def list_isos() -> pl.DataFrame:
     """List available ISOs"""
 
     isos = [[i.name, i.iso_id, i.__name__] for i in all_isos]
 
-    return pd.DataFrame(isos, columns=["Name", "Id", "Class"])
+    return pl.DataFrame(
+        isos,
+        schema=["Name", "Id", "Class"],
+        orient="row",
+    )
 
 
 def get_iso(iso_id: str) -> ISOBase:
@@ -65,7 +128,21 @@ def get_iso(iso_id: str) -> ISOBase:
     raise KeyError
 
 
-def make_availability_df() -> dict[str, pd.DataFrame]:
+def _df_to_markdown(df: pl.DataFrame) -> str:
+    """Render a polars DataFrame as a GitHub-flavored markdown table."""
+    headers = df.columns
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "|" + "|".join("---" for _ in headers) + "|",
+    ]
+    for row in df.iter_rows():
+        lines.append(
+            "| " + " | ".join("" if v is None else str(v) for v in row) + " |",
+        )
+    return "\n".join(lines) + "\n"
+
+
+def make_availability_df() -> dict[str, pl.DataFrame]:
     methods = [
         "get_status",
         "get_fuel_mix",
@@ -103,9 +180,15 @@ def make_availability_df() -> dict[str, pd.DataFrame]:
 
                 availability[i.__name__][method][date] = is_defined
 
+    dates = ["latest", "today", "historical"]
     availability_dfs = {}
     for i in all_isos:
-        availability_dfs[i.__name__] = pd.DataFrame(availability[i.__name__])
+        if i.__name__ not in availability:
+            continue
+        data: dict[str, list[str]] = {"": dates}
+        for method in methods:
+            data[method] = [availability[i.__name__][method][d] for d in dates]
+        availability_dfs[i.__name__] = pl.DataFrame(data)
 
     return availability_dfs
 
@@ -116,8 +199,7 @@ def make_availability_table() -> str:
     markdown = ""
     for method, df in sorted(dfs.items()):
         markdown += "## " + method + "\n"
-        # df.index = ["`" + v + "`" for v in df.index.values]
-        markdown += df.to_markdown() + "\n"
+        markdown += _df_to_markdown(df) + "\n"
 
     return markdown
 
@@ -148,7 +230,7 @@ def _handle_date(
 LMP_METHOD_NAMES: list[str] = ["get_lmp", "get_spp"]
 
 
-def make_lmp_availability_df() -> pd.DataFrame:
+def make_lmp_availability_df() -> pl.DataFrame:
     availability = {}
     DOES_NOT_EXIST_SENTINEL = "dne"
     for iso in tqdm.tqdm(gridstatus.all_isos):
@@ -171,7 +253,18 @@ def make_lmp_availability_df() -> pd.DataFrame:
                 supported_dates,
             )
 
-    return pd.DataFrame(availability).fillna("-")
+    market_cols: list[str] = []
+    for iso_availability in availability.values():
+        for col in iso_availability:
+            if col != "Method" and col not in market_cols:
+                market_cols.append(col)
+
+    columns = ["Method", *market_cols]
+    rows = [
+        {"": iso_name, **{c: iso_availability.get(c, "-") for c in columns}}
+        for iso_name, iso_availability in availability.items()
+    ]
+    return pl.DataFrame(rows)
 
 
 def convert_bool_to_emoji(value: bool) -> str:
@@ -186,19 +279,13 @@ def convert_bool_to_emoji(value: bool) -> str:
 
 
 def make_lmp_availability_table() -> str:
-    transposed = make_lmp_availability_df().transpose()
-    transposed = transposed.rename(
-        columns={
-            Markets.REAL_TIME_5_MIN: "REAL_TIME_5_MIN",
-            Markets.REAL_TIME_15_MIN: "REAL_TIME_15_MIN",
-            Markets.REAL_TIME_HOURLY: "REAL_TIME_HOURLY",
-            Markets.DAY_AHEAD_HOURLY: "DAY_AHEAD_HOURLY",
-        },
+    df = make_lmp_availability_df().sort("")
+    df = df.with_columns(
+        pl.col(c).map_elements(convert_bool_to_emoji, return_dtype=pl.String)
+        for c in df.columns
+        if c != ""
     )
-
-    transposed = transposed.sort_index().apply(lambda x: x.map(convert_bool_to_emoji))
-
-    return transposed.to_markdown() + "\n"
+    return _df_to_markdown(df)
 
 
 # todo require locations and location_type arguments
@@ -260,27 +347,27 @@ def get_response_blob(resp: requests.Response) -> io.BytesIO:
 
 def download_csvs_from_zip_url(
     url: str,
-    process_csv: Callable[[pd.DataFrame, str], pd.DataFrame] | None = None,
+    process_csv: Callable[[pl.DataFrame, str], pl.DataFrame] | None = None,
     verbose: bool = False,
     strip_whitespace_from_cols: bool = False,
-):
+) -> pl.DataFrame:
     z = get_zip_folder(url, verbose=verbose)
 
     all_dfs = []
 
     for f in z.filelist:
         if f.filename.endswith(".csv"):
-            df = pd.read_csv(z.open(f.filename))
+            df = pl.read_csv(z.open(f.filename).read(), infer_schema_length=None)
             if process_csv:
                 df = process_csv(df, f.filename)
 
             if strip_whitespace_from_cols:
                 # Some data files have leading whitespace in header - remove it
-                df = df.rename(columns=lambda x: x.strip())
+                df = df.rename({c: c.strip() for c in df.columns})
 
             all_dfs.append(df)
 
-    df = pd.concat(all_dfs, ignore_index=True)
+    df = pl.concat(all_dfs, how="diagonal")
 
     return df
 
@@ -355,7 +442,7 @@ def load_folder(
     path: str,
     time_zone: str | None = None,
     verbose: bool = True,
-) -> pd.DataFrame:
+) -> pl.DataFrame:
     """Load a single DataFrame for same schema csv files in a folder
 
     Arguments:
@@ -365,23 +452,25 @@ def load_folder(
         verbose (bool, optional): print verbose output. Defaults to True.
 
     Returns:
-        pandas.DataFrame: A DataFrame of all files
+        polars.DataFrame: A DataFrame of all files
     """
     all_files = glob.glob(os.path.join(path, "*.csv"))
     all_files = sorted(all_files)
 
     dfs = []
     for f in tqdm.tqdm(all_files, disable=not verbose):
-        df = pd.read_csv(f, parse_dates=True)
+        df = pl.read_csv(f, infer_schema_length=None)
         dfs.append(df)
 
-    data = pd.concat(dfs).reset_index(drop=True)
+    data = pl.concat(dfs, how="diagonal")
 
     for time_col in ["Time", "Interval Start", "Interval End"]:
         if time_col in data.columns:
-            data[time_col] = pd.to_datetime(data[time_col], utc=True)
-            if time_zone:
-                data[time_col] = data[time_col].dt.tz_convert(time_zone)
+            data = data.with_columns(
+                pl.col(time_col)
+                .str.to_datetime(time_zone="UTC")
+                .dt.convert_time_zone(time_zone or "UTC"),
+            )
 
     # todo make sure dates get parsed
     # todo make sure rows are sorted by time
@@ -389,7 +478,7 @@ def load_folder(
     return data
 
 
-def get_interconnection_queues() -> pd.DataFrame:
+def get_interconnection_queues() -> pl.DataFrame:
     """Get interconnection queue data for all ISOs"""
     all_queues = []
     for iso in tqdm.tqdm(all_isos):
@@ -398,16 +487,15 @@ def get_interconnection_queues() -> pd.DataFrame:
         # add error handling for IESO
 
         try:
-            queue = iso.get_interconnection_queue()[_interconnection_columns]
+            queue = iso.get_interconnection_queue().select(_interconnection_columns)
         except NotImplementedError:
-            queue = pd.DataFrame()
+            queue = pl.DataFrame()
 
-        queue.insert(0, "ISO", iso.name)
-        queue.reset_index(drop=True, inplace=True)
+        queue = queue.with_columns(pl.lit(iso.name).alias("ISO"))
+        queue = move_cols_to_front(queue, ["ISO"])
         all_queues.append(queue)
-        pd.concat(all_queues)
 
-    all_queues = pd.concat(all_queues).reset_index(drop=True)
+    all_queues = pl.concat(all_queues, how="diagonal_relaxed")
     return all_queues
 
 
@@ -456,6 +544,37 @@ def localize_ambiguous_infer_polars(
         pl.col(time_col).dt.replace_time_zone(tz, ambiguous=pl.col("_ambiguous")),
     )
     return df.drop(["_dup_rank", "_ambiguous"])
+
+
+def localize_shift_forward_polars(
+    df: pl.DataFrame,
+    time_col: str,
+    tz: str,
+    ambiguous: str = "earliest",
+) -> pl.DataFrame:
+    """Localize a naive polars datetime column, mimicking pandas
+    ``nonexistent="shift_forward"``.
+
+    polars has no shift_forward option for spring-forward gaps, so nonexistent
+    wall-clock times are localized to null and replaced by the same wall time
+    plus one hour (the first valid instant after the gap), matching pandas.
+    Used by the ERCOT/PJM patterns that combine ``ambiguous`` handling with
+    ``nonexistent="shift_forward"``.
+
+    Note: pandas ``merge_asof`` equivalents should use ``pl.DataFrame.join_asof``
+    (AESO pattern).
+    """
+    localized = pl.col(time_col).dt.replace_time_zone(
+        tz,
+        ambiguous=ambiguous,
+        non_existent="null",
+    )
+    shifted = (pl.col(time_col) + pl.duration(hours=1)).dt.replace_time_zone(
+        tz,
+        ambiguous=ambiguous,
+        non_existent="null",
+    )
+    return df.with_columns(pl.coalesce(localized, shifted).alias(time_col))
 
 
 _ISONE_DATE_FORMAT = "%m/%d/%Y"

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -199,6 +199,7 @@ def make_availability_table() -> str:
     markdown = ""
     for method, df in sorted(dfs.items()):
         markdown += "## " + method + "\n"
+        # df.index = ["`" + v + "`" for v in df.index.values]
         markdown += _df_to_markdown(df) + "\n"
 
     return markdown

--- a/gridstatus/viz.py
+++ b/gridstatus/viz.py
@@ -1,11 +1,12 @@
 import plotly.express as px
+import polars as pl
 
 
-def dam_heat_map(df):
+def dam_heat_map(df: pl.DataFrame):
     """Create a heat map of day-ahead location marginal prices.
 
     Arguments:
-        df (pandas.DataFrame): A DataFrame with columns "Time", "Location", and "LMP".
+        df (polars.DataFrame): A DataFrame with columns "Time", "Location", and "LMP".
             If Hour is specified, it will be used as the x-axis.
             Otherwise, the hour ending will be used instead of Time
 
@@ -15,19 +16,23 @@ def dam_heat_map(df):
     """
 
     if "Hour" not in df.columns:
-        df["Hour"] = df["Time"].dt.hour
+        df = df.with_columns(pl.col("Time").dt.hour().alias("Hour"))
 
-    date_str = df["Time"].dt.date[0].strftime("%m/%d/%Y")
+    date_str = df["Time"].dt.date()[0].strftime("%m/%d/%Y")
     title = "Day-Ahead Location Marginal Prices on " + date_str + " ($/MWh)"
 
-    heat_map_data = df.pivot(
-        index="Location",
-        columns="Hour",
-        values="LMP",
-    ).round(0)
+    heat_map_data = (
+        df.pivot(on="Hour", index="Location", values="LMP")
+        .sort("Location")
+        .with_columns(pl.exclude("Location").round(0))
+    )
+
+    hours = [c for c in heat_map_data.columns if c != "Location"]
 
     fig = px.imshow(
-        heat_map_data,
+        heat_map_data.select(hours).to_numpy(),
+        x=[int(h) for h in hours],
+        y=heat_map_data["Location"].to_list(),
         text_auto=True,
         title=title,
         template="plotly_dark",
@@ -42,7 +47,7 @@ def dam_heat_map(df):
     return fig
 
 
-def load_over_time(df, iso=None):
+def load_over_time(df: pl.DataFrame, iso: str | None = None):
     """Create a line graph of load dataframe"""
     y = "Load"
     if len(df.columns) > 3:
@@ -54,7 +59,7 @@ def load_over_time(df, iso=None):
 
     fig = px.line(
         df,
-        x=df["Time"],
+        x="Time",
         y=y,
         title=title,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ keywords = ["energy", "independent system operator"]
 license = { file = "LICENSE" }
 dependencies = [
     "requests >=2.33,<3",
+    # pandas is retained only for IO parse edges polars cannot read directly
+    # (read_html, read_excel, exotic read_csv) and scalar date math
+    # (pd.Timestamp/DateOffset); all DataFrames returned by the library are polars
     "pandas ~=2.2",
     "beautifulsoup4 ~=4.13",
     "tabulate ~=0.9",

--- a/scripts/schema_parity.py
+++ b/scripts/schema_parity.py
@@ -1,0 +1,311 @@
+"""Schema-parity harness for the pandas -> polars migration.
+
+Snapshots the output schema (columns, dtypes, row count) of ISO ``get_*``
+methods called with fixed dates, and diffs snapshots across branches.
+
+Intended workflow:
+
+1. Baseline (pre-migration branch, own venv via git worktree)::
+
+       git worktree add ../gridstatus-baseline main
+       cd ../gridstatus-baseline && uv sync
+       uv run python <this repo>/scripts/schema_parity.py snapshot \
+           --iso ISONE --output /tmp/isone_baseline.json
+
+2. Converted (working tree)::
+
+       uv run python scripts/schema_parity.py snapshot \
+           --iso ISONE --output gridstatus/tests/schema_snapshots/isone.json
+
+3. Diff::
+
+       uv run python scripts/schema_parity.py diff \
+           /tmp/isone_baseline.json gridstatus/tests/schema_snapshots/isone.json
+
+Columns and normalized dtypes must match exactly; row-count drift is reported
+but not fatal (real-time feeds move between runs). The script is standalone so
+the identical file can be executed in the baseline worktree.
+"""
+
+import argparse
+import json
+import re
+import sys
+import traceback
+from typing import Any
+
+FIXED_DATE = "2026-06-15"
+FIXED_END = "2026-06-17"
+DST_DATE = "2026-03-08"
+
+SKIP_METHODS = {
+    "get_raw_interconnection_queue",
+    "get_status",
+}
+
+# Methods that need extra kwargs beyond date/end. Keyed by (iso, method);
+# iso=None applies to any ISO exposing the method.
+KWARG_OVERRIDES: dict[tuple[str | None, str], dict[str, Any]] = {
+    (None, "get_lmp"): {"market": "DAY_AHEAD_HOURLY"},
+    ("CAISO", "get_lmp"): {
+        "market": "DAY_AHEAD_HOURLY",
+        "locations": ["TH_NP15_GEN-APND"],
+    },
+    ("Ercot", "get_lmp"): {"market": "REAL_TIME_SCED"},
+    ("SPP", "get_lmp"): {"market": "REAL_TIME_5_MIN", "location_type": "Hub"},
+    (None, "get_spp"): {"market": "DAY_AHEAD_HOURLY"},
+}
+
+
+def _normalize_dtype(dtype: object) -> str:
+    """Map pandas and polars dtypes onto a shared vocabulary for diffing."""
+    s = str(dtype)
+
+    m = re.match(r"datetime64\[\w+(?:, (?P<tz>.+))?\]", s)
+    if m:
+        return f"datetime[{m.group('tz') or 'naive'}]"
+
+    m = re.match(r"Datetime\(time_unit='\w+', time_zone=(?P<tz>.+)\)", s)
+    if m:
+        tz = m.group("tz").strip("'\"")
+        return f"datetime[{'naive' if tz == 'None' else tz}]"
+    if s == "Datetime":
+        return "datetime[naive]"
+
+    mapping = {
+        "object": "string",
+        "string": "string",
+        "str": "string",
+        "String": "string",
+        "Utf8": "string",
+        "category": "string",
+        "Categorical": "string",
+        "bool": "bool",
+        "boolean": "bool",
+        "Boolean": "bool",
+        "date": "date",
+        "Date": "date",
+    }
+    if s in mapping:
+        return mapping[s]
+
+    if re.match(r"(Int|UInt|int|uint)\d+", s):
+        return "int"
+    if re.match(r"(Float|float)\d+", s):
+        return "float"
+    if s == "Null":
+        return "null"
+
+    return s
+
+
+def _frame_schema(df: object) -> dict[str, Any] | None:
+    """Return the schema dict for a pandas or polars DataFrame, else None."""
+    try:
+        import polars as pl
+
+        if isinstance(df, pl.DataFrame):
+            return {
+                "columns": df.columns,
+                "dtypes": {c: _normalize_dtype(t) for c, t in df.schema.items()},
+                "row_count": df.height,
+                "frame_type": "polars",
+            }
+    except ImportError:
+        pass
+
+    try:
+        import pandas as pd
+
+        if isinstance(df, pd.DataFrame):
+            return {
+                "columns": list(df.columns),
+                "dtypes": {
+                    c: _normalize_dtype(t) for c, t in df.dtypes.to_dict().items()
+                },
+                "row_count": len(df),
+                "frame_type": "pandas",
+            }
+    except ImportError:
+        pass
+
+    return None
+
+
+def _snapshot_result(result: object) -> dict[str, Any]:
+    schema = _frame_schema(result)
+    if schema is not None:
+        return schema
+    if isinstance(result, dict):
+        return {
+            "frame_type": "dict",
+            "keys": {
+                str(k): _frame_schema(v) or {"type": type(v).__name__}
+                for k, v in result.items()
+            },
+        }
+    return {"frame_type": type(result).__name__}
+
+
+def _call_method(iso: object, method_name: str) -> dict[str, Any]:
+    import inspect
+
+    method = getattr(iso, method_name)
+    sig = inspect.signature(method)
+    params = sig.parameters
+
+    kwargs: dict[str, Any] = {}
+    override = KWARG_OVERRIDES.get(
+        (type(iso).__name__, method_name),
+    ) or KWARG_OVERRIDES.get((None, method_name))
+    if override:
+        kwargs.update(override)
+
+    if "date" in params:
+        kwargs["date"] = FIXED_DATE
+
+    required = [
+        p
+        for name, p in params.items()
+        if p.default is inspect.Parameter.empty
+        and p.kind
+        in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+        and name not in kwargs
+        and name != "self"
+    ]
+    if required:
+        return {
+            "skipped": f"requires args: {[p.name for p in required]}",
+        }
+
+    try:
+        result = method(**kwargs)
+    except NotImplementedError:
+        return {"skipped": "NotImplementedError"}
+    except Exception as e:
+        return {"error": f"{type(e).__name__}: {e}"}
+
+    return _snapshot_result(result)
+
+
+def snapshot(iso_name: str, output: str, methods: list[str] | None) -> None:
+    import gridstatus
+
+    iso_cls = getattr(gridstatus, iso_name)
+    iso = iso_cls()
+
+    method_names = sorted(
+        name
+        for name in dir(iso)
+        if name.startswith("get_")
+        and callable(getattr(iso, name))
+        and name not in SKIP_METHODS
+    )
+    if methods:
+        method_names = [m for m in method_names if m in methods]
+
+    snap: dict[str, Any] = {"iso": iso_name, "fixed_date": FIXED_DATE, "methods": {}}
+    for name in method_names:
+        print(f"  {iso_name}.{name} ...", flush=True)
+        try:
+            snap["methods"][name] = _call_method(iso, name)
+        except Exception:
+            snap["methods"][name] = {"error": traceback.format_exc(limit=3)}
+
+    with open(output, "w") as f:
+        json.dump(snap, f, indent=2, default=str)
+    print(f"wrote {output}")
+
+
+def diff(baseline_path: str, converted_path: str) -> int:
+    with open(baseline_path) as f:
+        baseline = json.load(f)
+    with open(converted_path) as f:
+        converted = json.load(f)
+
+    failures = 0
+    warnings = 0
+    base_methods = baseline["methods"]
+    conv_methods = converted["methods"]
+
+    for name in sorted(set(base_methods) | set(conv_methods)):
+        b = base_methods.get(name)
+        c = conv_methods.get(name)
+        if b is None or c is None:
+            print(f"[WARN] {name}: only present in one snapshot")
+            warnings += 1
+            continue
+        if "skipped" in b or "skipped" in c:
+            continue
+        if "error" in b or "error" in c:
+            if ("error" in b) != ("error" in c):
+                print(
+                    f"[FAIL] {name}: error mismatch "
+                    f"(baseline: {b.get('error', 'ok')!r}, "
+                    f"converted: {c.get('error', 'ok')!r})",
+                )
+                failures += 1
+            continue
+
+        if "columns" not in b or "columns" not in c:
+            continue
+
+        if b["columns"] != c["columns"]:
+            print(f"[FAIL] {name}: columns differ")
+            print(f"       baseline:  {b['columns']}")
+            print(f"       converted: {c['columns']}")
+            failures += 1
+            continue
+
+        dtype_mismatches = {
+            col: (b["dtypes"][col], c["dtypes"][col])
+            for col in b["columns"]
+            if b["dtypes"][col] != c["dtypes"][col]
+        }
+        if dtype_mismatches:
+            print(f"[FAIL] {name}: dtypes differ: {dtype_mismatches}")
+            failures += 1
+            continue
+
+        if b["row_count"] != c["row_count"]:
+            print(
+                f"[WARN] {name}: row count drift "
+                f"({b['row_count']} -> {c['row_count']})",
+            )
+            warnings += 1
+
+        print(f"[OK]   {name}")
+
+    print(f"\n{failures} failures, {warnings} warnings")
+    return 1 if failures else 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    snap_p = sub.add_parser("snapshot", help="snapshot get_* schemas for an ISO")
+    snap_p.add_argument("--iso", required=True, help="ISO class name, e.g. ISONE")
+    snap_p.add_argument("--output", required=True)
+    snap_p.add_argument(
+        "--methods",
+        nargs="*",
+        help="only snapshot these method names",
+    )
+
+    diff_p = sub.add_parser("diff", help="diff two snapshot files")
+    diff_p.add_argument("baseline")
+    diff_p.add_argument("converted")
+
+    args = parser.parse_args()
+    if args.command == "snapshot":
+        snapshot(args.iso, args.output, args.methods)
+    else:
+        sys.exit(diff(args.baseline, args.converted))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Completes the pandas-to-polars migration started in the ISONE POC (#908). Every public `get_*` method across all ISO modules now returns `pl.DataFrame`. Stacked on `eng-3958-polars-poc-isone`; merge that first.

## Decision log

- **Polars-only API, no transitional flags**: no `return_polars` kwarg, no `_polars` method duplicates. Callers wanting pandas use `.to_pandas()`.
- **Pandas stays at unavoidable IO edges only**: `pd.read_html`, `pd.read_excel`, exotic `pd.read_csv` (skipfooter, multi-header), immediately converted via `pl.from_pandas`. Wrappers live in `utils.py` (`read_html_via_pandas`, `read_excel_via_pandas`, `read_csv_exotic_via_pandas`).
- **ERCOT boundary-wrapper strategy**: `ercot.py` (~7,600 lines) keeps its pandas DST logic (`parse_doc` DSTFlag/RepeatedHourFlag handling) byte-for-byte, with `pl.from_pandas` at every public exit. The DST semantics are too risky to rewrite natively in one pass; `ambiguous_based_on_dstflag` and `localize_sced_timestamp` are AST-identical to the pandas baseline.
- **Datetime parsing routed through pandas where polars differs**: SPP MM/DD/YYYY (polars infers DD/MM), EIA hour-terminated periods (polars requires minutes; padded before parse). Datetime columns normalized to microsecond time unit at pandas boundaries.
- **`pl.concat(how="diagonal_relaxed")`** everywhere schemas can evolve across chunks (all-null columns, varying fuel columns).
- **`utils.concat_dataframes([])` raises** `ValueError`, matching `pd.concat([])`, so date-range errors are not masked as empty frames.
- **Dual-dispatch machinery removed**: `is_polars`, pandas branches in `concat_dataframes`, `filter_lmp_locations`, `format_interconnection_df`, `move_cols_to_front`, `_latest_lmp_from_today`, `_latest_from_today`.

## Validation

Schema-parity harness (`scripts/schema_parity.py`) diffs columns/dtypes/rowcounts per method against a pandas-baseline worktree. Per-ISO test suites were run against the baseline to separate conversion regressions from environmental failures.

| Module | Suite status | Notes |
|--------|-------------|-------|
| NYISO, EIA, AESO | Clean | Wave 1 |
| MISO, MISO API, ISONE API | Clean | MTLF dtype improvement: comma-strings now Int64 (gs-etl handled) |
| PJM | Not network-validated here | api.pjm.com unreachable from dev machine; only one VCR cassette exists |
| IESO | Clean | 2 wall-clock cassette failures (environmental) |
| SPP | Clean | 3 wall-clock failures (environmental) |
| CAISO | Clean | 6 OASIS rate-limit cassette failures (environmental) |
| ERCOT | 16 failures, all reproduce on pandas baseline | Docs rolled off ERCOT MIS + wall-clock cassettes |
| ERCOT API | 5 failures | Missing ESR API credentials / recorded 401s |

Intentional schema changes:
- ERCOT curve columns (`Offer Curve`, `Bid Curve - *`) surface as `pl.List(pl.Float64)` instead of object dtype
- MISO MTLF columns: `Int64` instead of comma-formatted strings
- `get_60_day_*_disclosure` dicts contain `pl.DataFrame` values

## Test plan

- [x] Per-ISO suites vs pandas baseline (see matrix)
- [x] Shared suites (`test_utils`, `test_decorators`, `test_base`, `test_viz`) green
- [x] Live smoke calls per ISO where network allows
- [ ] PJM suite in an environment with api.pjm.com access
- [ ] Downstream E2E validation (companion PR)