### PR TITLE
Support to fetch Area Control Error (ACE) data for NYISO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 ### Additions (New Features/Datasets)
 
+#### NYISO
+* NYISO Area Control Error (ACE) data available at https://mis.nyiso.com/public/P-38list.htm requested in [#906](https://github.com/gridstatus/gridstatus/issues/906)
+
 #### EIA
 * EIA Facility Fuel (EIA-923) dataset in [#912](https://github.com/gridstatus/gridstatus/pull/912)
 

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -48,9 +48,6 @@ AS_PRICES_DAY_AHEAD_HOURLY_DATASET = "damasp"
 AS_PRICES_REAL_TIME_5_MIN_DATASET = "rtasp"
 LIMITING_CONSTRAINTS_REAL_TIME_DATASET = "LimitingConstraints"
 LIMITING_CONSTRAINTS_DAY_AHEAD_DATASET = "DAMLimitingConstraints"
-# ACE is published as monthly archives only. Unlike other NYISO datasets, the
-# zips live directly under /public (not /public/csv) and hold a single monthly
-# CSV named ace-<YYYYMM01>.csv. See https://mis.nyiso.com/public/P-38list.htm
 AREA_CONTROL_ERROR_DATASET = "ace_data"
 
 """
@@ -1755,9 +1752,8 @@ class NYISO(ISOBase):
         """Retrieves the NYISO-wide area control error (ACE) in ~6 second
         intervals.
 
-        Data is published as monthly archives only, added after each month
-        completes, so the most recent month is not available until the
-        following month. Source: https://mis.nyiso.com/public/P-38list.htm
+        Data is published as monthly archives, added after each month
+        completes. Source: https://mis.nyiso.com/public/P-38list.htm
 
         Arguments:
             date (str or pandas.Timestamp): Start datetime for data. If ``end``
@@ -1782,9 +1778,6 @@ class NYISO(ISOBase):
         end: pd.Timestamp | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
-        # The @support_date_range(frequency="MONTH_START") decorator splits any
-        # request into per-month calls, so each invocation here covers a single
-        # monthly zip. The archive lives under /public (not /public/csv) and the
         # zip/csv are named ace-<YYYYMM01> rather than the usual <YYYYMMDD>.
         date = gridstatus.utils._handle_date(date, self.default_timezone)
         month = date.strftime("%Y%m01")
@@ -1807,8 +1800,6 @@ class NYISO(ISOBase):
     ) -> pd.DataFrame:
         df = df.rename(columns={"value": "Area Control Error"})
 
-        # The time column carries an EDT/EST suffix. Use it to resolve the
-        # fall-back DST ambiguity, then drop it before localizing.
         parsed = df["time"].str.rsplit(" ", n=1, expand=True)
         is_dst = parsed[1] == "EDT"
         df["Time"] = pd.to_datetime(parsed[0]).dt.tz_localize(
@@ -1818,8 +1809,7 @@ class NYISO(ISOBase):
 
         df = df[["Time", "Area Control Error"]].sort_values("Time")
 
-        # A monthly zip holds the whole month; trim to the requested window. The
-        # decorator passes end exclusive, matching other NYISO datasets.
+        # trim to the requested window
         if end is not None:
             df = df[(df["Time"] >= date) & (df["Time"] < end)]
         else:

--- a/gridstatus/nyiso.py
+++ b/gridstatus/nyiso.py
@@ -48,6 +48,10 @@ AS_PRICES_DAY_AHEAD_HOURLY_DATASET = "damasp"
 AS_PRICES_REAL_TIME_5_MIN_DATASET = "rtasp"
 LIMITING_CONSTRAINTS_REAL_TIME_DATASET = "LimitingConstraints"
 LIMITING_CONSTRAINTS_DAY_AHEAD_DATASET = "DAMLimitingConstraints"
+# ACE is published as monthly archives only. Unlike other NYISO datasets, the
+# zips live directly under /public (not /public/csv) and hold a single monthly
+# CSV named ace-<YYYYMM01>.csv. See https://mis.nyiso.com/public/P-38list.htm
+AREA_CONTROL_ERROR_DATASET = "ace_data"
 
 """
 Pricing data:
@@ -1740,3 +1744,85 @@ class NYISO(ISOBase):
         )
 
         return df
+
+    @support_date_range(frequency="MONTH_START")
+    def get_area_control_error(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Retrieves the NYISO-wide area control error (ACE) in ~6 second
+        intervals.
+
+        Data is published as monthly archives only, added after each month
+        completes, so the most recent month is not available until the
+        following month. Source: https://mis.nyiso.com/public/P-38list.htm
+
+        Arguments:
+            date (str or pandas.Timestamp): Start datetime for data. If ``end``
+                is provided, this is the start date.
+            end (str or pandas.Timestamp, optional): End datetime for data.
+                Defaults to one month past ``date`` if not specified.
+            verbose (bool, optional): print out requested url. Defaults to False.
+
+        Returns:
+            pandas.DataFrame: A DataFrame with columns ``Time`` and
+                ``Area Control Error`` (MW).
+        """
+        return self._download_area_control_error_archive(
+            date=date,
+            end=end,
+            verbose=verbose,
+        )
+
+    def _download_area_control_error_archive(
+        self,
+        date: pd.Timestamp,
+        end: pd.Timestamp | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        # The @support_date_range(frequency="MONTH_START") decorator splits any
+        # request into per-month calls, so each invocation here covers a single
+        # monthly zip. The archive lives under /public (not /public/csv) and the
+        # zip/csv are named ace-<YYYYMM01> rather than the usual <YYYYMMDD>.
+        date = gridstatus.utils._handle_date(date, self.default_timezone)
+        month = date.strftime("%Y%m01")
+
+        zip_url = (
+            f"http://mis.nyiso.com/public/{AREA_CONTROL_ERROR_DATASET}/ace-{month}.zip"
+        )
+        z = utils.get_zip_folder(zip_url, verbose=verbose)
+
+        csv_filename = f"ace-{month}.csv"
+        df = pd.read_csv(z.open(csv_filename))
+
+        return self._handle_area_control_error(df, date=date, end=end)
+
+    def _handle_area_control_error(
+        self,
+        df: pd.DataFrame,
+        date: pd.Timestamp,
+        end: pd.Timestamp | None = None,
+    ) -> pd.DataFrame:
+        df = df.rename(columns={"value": "Area Control Error"})
+
+        # The time column carries an EDT/EST suffix. Use it to resolve the
+        # fall-back DST ambiguity, then drop it before localizing.
+        parsed = df["time"].str.rsplit(" ", n=1, expand=True)
+        is_dst = parsed[1] == "EDT"
+        df["Time"] = pd.to_datetime(parsed[0]).dt.tz_localize(
+            self.default_timezone,
+            ambiguous=is_dst,
+        )
+
+        df = df[["Time", "Area Control Error"]].sort_values("Time")
+
+        # A monthly zip holds the whole month; trim to the requested window. The
+        # decorator passes end exclusive, matching other NYISO datasets.
+        if end is not None:
+            df = df[(df["Time"] >= date) & (df["Time"] < end)]
+        else:
+            df = df[df["Time"] >= date]
+
+        return df.reset_index(drop=True)

--- a/gridstatus/tests/source_specific/test_nyiso.py
+++ b/gridstatus/tests/source_specific/test_nyiso.py
@@ -1,5 +1,6 @@
 from typing import Literal
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -1257,3 +1258,74 @@ class TestNYISO(BaseTestISO):
         assert df["Interval End"].dt.date.max() <= (
             pd.Timestamp(end).date() + pd.Timedelta(days=1)
         )
+
+    """get_area_control_error"""
+
+    expected_area_control_error_cols = [
+        "Time",
+        "Area Control Error",
+    ]
+
+    def test_get_area_control_error(self):
+        date = "2025-06-01"
+        with nyiso_vcr.use_cassette(
+            f"test_get_area_control_error_{date}.yaml",
+        ):
+            df = self.iso.get_area_control_error(date=date)
+
+        assert isinstance(df, pd.DataFrame)
+        assert df.columns.tolist() == self.expected_area_control_error_cols
+        assert df["Area Control Error"].dtype in [np.float64, np.int64]
+        assert df["Time"].dt.tz is not None
+        assert df["Time"].min() >= pd.Timestamp(date, tz=self.iso.default_timezone)
+        assert df["Time"].max() < pd.Timestamp(
+            "2025-07-01",
+            tz=self.iso.default_timezone,
+        )
+
+    def test_get_area_control_error_date_range(self):
+        start = "2025-06-05"
+        end = "2025-06-07"
+        with nyiso_vcr.use_cassette(
+            f"test_get_area_control_error_{start}_{end}.yaml",
+        ):
+            df = self.iso.get_area_control_error(date=start, end=end)
+
+        assert df.columns.tolist() == self.expected_area_control_error_cols
+        assert df["Time"].min() >= pd.Timestamp(start, tz=self.iso.default_timezone)
+        assert df["Time"].max() < pd.Timestamp(end, tz=self.iso.default_timezone)
+
+    def test_get_area_control_error_range_across_months(self):
+        # A range spanning two months exercises the MONTH_START decorator
+        # splitting into two per-month archive downloads.
+        start = "2025-05-30"
+        end = "2025-06-02"
+        with nyiso_vcr.use_cassette(
+            f"test_get_area_control_error_{start}_{end}.yaml",
+        ):
+            df = self.iso.get_area_control_error(date=start, end=end)
+
+        assert df.columns.tolist() == self.expected_area_control_error_cols
+        # Data from both months is present and ordered.
+        assert df["Time"].min() >= pd.Timestamp(start, tz=self.iso.default_timezone)
+        assert df["Time"].max() < pd.Timestamp(end, tz=self.iso.default_timezone)
+        assert set(df["Time"].dt.month.unique()) == {5, 6}
+        assert df["Time"].is_monotonic_increasing
+
+    def test_get_area_control_error_dst_fall_back(self):
+        # November 2025 contains the DST fall-back (Nov 2, 02:00 -> 01:00). The
+        # EDT/EST suffix in the source must resolve the ambiguous 1am hour.
+        date = "2025-11-01"
+        with nyiso_vcr.use_cassette(
+            f"test_get_area_control_error_{date}.yaml",
+        ):
+            df = self.iso.get_area_control_error(date=date)
+
+        assert df.columns.tolist() == self.expected_area_control_error_cols
+        assert df["Time"].dt.tz is not None
+        # The repeated 1am hour should carry both UTC offsets (EDT then EST).
+        repeat = df[
+            (df["Time"] >= pd.Timestamp("2025-11-02 00:59", tz="US/Eastern"))
+            & (df["Time"] <= pd.Timestamp("2025-11-02 02:01", tz="US/Eastern"))
+        ]
+        assert repeat["Time"].apply(lambda t: t.utcoffset()).nunique() == 2


### PR DESCRIPTION
## Summary
As requsted in #906, added support to fetch Area Control Error (ACE) data for NYISO 

### Details
- NYISO offers monthly data in the form of CSV
- Granularity: Every 6 seconds
- Only uploaded after a month is complete i.e. data for June 2026 will be available in July 2026
- Added test cases for single month, range of months and out of bound months