### PR TITLE
[ENG-2977] Add ERCOT SCED AS Price Corrections scraper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 #### ERCOT
 * ERCOT Available Resource Planned Outage Capacity 7 Day and Future datasets in [#884](https://github.com/gridstatus/gridstatus/pull/884)
+* ERCOT SCED AS Price Corrections via `Ercot.get_mcpc_sced_price_corrections`
 
 #### MISO
 * MISO Area Control Error dataset via `MISO.get_area_control_error`

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -5630,6 +5630,37 @@ class Ercot(ISOBase):
 
         return df
 
+    def get_mcpc_sced_price_corrections(
+        self,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """
+        Get Market Clearing Price for Capacity (MCPC) corrections for SCED.
+
+        MCPC (Market Clearing Price for Capacity) corrections contain
+        ancillary service prices at the system level for each SCED run.
+
+        Returns:
+            pd.DataFrame: DataFrame with columns:
+                - Price Correction Time
+                - SCED Timestamp
+                - Interval Start
+                - Interval End
+                - AS Type
+                - MCPC Original
+                - MCPC Corrected
+        """
+        docs = self._get_documents(
+            report_type_id=RTM_PRICE_CORRECTIONS_RTID,
+            constructed_name_contains="RTM_MCPC_SCED",
+            extension="csv",
+            verbose=verbose,
+        )
+
+        df = self._handle_mcpc_sced_price_corrections(docs, verbose=verbose)
+
+        return df
+
     def _handle_price_corrections(
         self,
         docs: list[Document],
@@ -5700,6 +5731,52 @@ class Ercot(ISOBase):
         df = df[
             [
                 "Price Correction Time",
+                "Interval Start",
+                "Interval End",
+                "AS Type",
+                "MCPC Original",
+                "MCPC Corrected",
+            ]
+        ]
+
+        return df
+
+    def _handle_mcpc_sced_price_corrections(
+        self,
+        docs: list[Document],
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Handle MCPC (Market Clearing Price for Capacity) SCED price corrections.
+
+        SCED MCPC corrections are keyed by the SCED run timestamp rather than
+        delivery intervals, so the files cannot go through parse_doc(). The
+        Interval Start/End columns are derived by flooring the SCED Timestamp
+        to five minutes and are approximations, not exact.
+        """
+        df = self.read_docs(docs, parse=False, verbose=verbose)
+
+        df = self._handle_sced_timestamp(df, verbose=verbose)
+
+        # Rename columns to match gridstatus conventions
+        df = df.rename(
+            columns={
+                "ASType": "AS Type",
+                "MCPCOriginal": "MCPC Original",
+                "MCPCCorrected": "MCPC Corrected",
+                "PriceCorrectionTime": "Price Correction Time",
+            },
+        )
+
+        # Parse Price Correction Time
+        df["Price Correction Time"] = pd.to_datetime(
+            df["Price Correction Time"],
+        ).dt.tz_localize(self.default_timezone)
+
+        # Select and order final columns
+        df = df[
+            [
+                "Price Correction Time",
+                "SCED Timestamp",
                 "Interval Start",
                 "Interval End",
                 "AS Type",

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -2231,10 +2231,10 @@ class TestErcot(BaseTestISO):
         assert pd.api.types.is_float_dtype(df["MCPC Original"])
         assert pd.api.types.is_float_dtype(df["MCPC Corrected"])
 
-    @pytest.mark.integration
     def test_get_mcpc_sced_price_corrections(self):
         """Test SCED AS Price Corrections (MCPC)."""
-        df = self.iso.get_mcpc_sced_price_corrections()
+        with api_vcr.use_cassette("test_get_mcpc_sced_price_corrections.yaml"):
+            df = self.iso.get_mcpc_sced_price_corrections()
 
         cols = [
             "Price Correction Time",

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -2231,6 +2231,40 @@ class TestErcot(BaseTestISO):
         assert pd.api.types.is_float_dtype(df["MCPC Original"])
         assert pd.api.types.is_float_dtype(df["MCPC Corrected"])
 
+    @pytest.mark.integration
+    def test_get_mcpc_sced_price_corrections(self):
+        """Test SCED AS Price Corrections (MCPC)."""
+        df = self.iso.get_mcpc_sced_price_corrections()
+
+        cols = [
+            "Price Correction Time",
+            "SCED Timestamp",
+            "Interval Start",
+            "Interval End",
+            "AS Type",
+            "MCPC Original",
+            "MCPC Corrected",
+        ]
+
+        assert df.shape[0] > 0
+        assert df.columns.tolist() == cols
+
+        assert pd.api.types.is_datetime64_any_dtype(df["Price Correction Time"])
+        assert pd.api.types.is_datetime64_any_dtype(df["SCED Timestamp"])
+        assert pd.api.types.is_datetime64_any_dtype(df["Interval Start"])
+        assert pd.api.types.is_datetime64_any_dtype(df["Interval End"])
+        assert pd.api.types.is_object_dtype(df["AS Type"])
+        assert pd.api.types.is_float_dtype(df["MCPC Original"])
+        assert pd.api.types.is_float_dtype(df["MCPC Corrected"])
+
+        assert (df["Interval Start"] == df["SCED Timestamp"].dt.floor("5min")).all()
+        assert (
+            df["Interval End"] == df["Interval Start"] + pd.Timedelta(minutes=5)
+        ).all()
+        assert not df.duplicated(
+            subset=["SCED Timestamp", "AS Type", "Price Correction Time"],
+        ).any()
+
     """get_system_wide_actuals"""
 
     @pytest.mark.integration

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -2170,9 +2170,12 @@ class TestErcot(BaseTestISO):
 
     """get_price_corrections"""
 
-    @pytest.mark.integration
     def test_get_rtm_price_corrections(self):
-        df = self.iso.get_rtm_price_corrections(rtm_type="RTM_SPP")
+        with api_vcr.use_cassette("test_get_rtm_price_corrections.yaml"):
+            try:
+                df = self.iso.get_rtm_price_corrections(rtm_type="RTM_SPP")
+            except NoDataFoundException:
+                pytest.skip("No RTM_SPP price correction files currently listed")
 
         cols = [
             "Price Correction Time",
@@ -2184,15 +2187,15 @@ class TestErcot(BaseTestISO):
             "SPP Corrected",
         ]
 
-        assert df.shape[0] >= 0
+        assert df.shape[0] > 0
         assert df.columns.tolist() == cols
 
-    # TODO: this url has no DocumentList
-    # https://www.ercot.com/misapp/servlets/IceDocListJsonWS?reportTypeId=13044
-    @pytest.mark.skip(reason="Failing")
-    @pytest.mark.integration
     def test_get_dam_price_corrections(self):
-        df = self.iso.get_dam_price_corrections(dam_type="DAM_SPP")
+        with api_vcr.use_cassette("test_get_dam_price_corrections.yaml"):
+            try:
+                df = self.iso.get_dam_price_corrections(dam_type="DAM_SPP")
+            except NoDataFoundException:
+                pytest.skip("No DAM_SPP price correction files currently listed")
 
         cols = [
             "Price Correction Time",
@@ -2204,13 +2207,16 @@ class TestErcot(BaseTestISO):
             "SPP Corrected",
         ]
 
-        assert df.shape[0] >= 0
+        assert df.shape[0] > 0
         assert df.columns.tolist() == cols
 
-    @pytest.mark.integration
     def test_get_mcpc_dam_price_corrections(self):
         """Test DAM AS Price Corrections (MCPC)."""
-        df = self.iso.get_mcpc_dam_price_corrections()
+        with api_vcr.use_cassette("test_get_mcpc_dam_price_corrections.yaml"):
+            try:
+                df = self.iso.get_mcpc_dam_price_corrections()
+            except NoDataFoundException:
+                pytest.skip("No DAM_MCPC price correction files currently listed")
 
         cols = [
             "Price Correction Time",
@@ -2221,7 +2227,7 @@ class TestErcot(BaseTestISO):
             "MCPC Corrected",
         ]
 
-        assert df.shape[0] >= 0
+        assert df.shape[0] > 0
         assert df.columns.tolist() == cols
 
         assert pd.api.types.is_datetime64_any_dtype(df["Price Correction Time"])


### PR DESCRIPTION
## Summary
- Adds `Ercot.get_mcpc_sced_price_corrections` for SCED MCPC (ancillary service) price corrections from the ERCOT RTM Price Corrections report (NP4-197-M)
- Converts the existing ERCOT price corrections tests to VCR cassettes, un-skipping `test_get_dam_price_corrections`

### Details
SCED MCPC correction files are keyed by the SCED run timestamp rather than delivery intervals, so the handler reuses `_handle_sced_timestamp` (RepeatedHourFlag DST disambiguation plus approximate 5-minute Interval Start/End) instead of `parse_doc`. The name filter is exactly `RTM_MCPC_SCED` to avoid matching `RTM_MCPC_SPP` files published to the same report. Price corrections tests skip gracefully via `NoDataFoundException` when no correction files are currently listed, since these reports only carry files when ERCOT publishes a correction.

To run tests:
```bash
VCR_RECORD_MODE=all uv run pytest -vvv gridstatus/tests/ -k "ercot and price_corrections"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)