### PR TITLE
feat(ENG 4302): Add ERCOT 2-Day Aggregate Gen/Load/Output Schedule scrapers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 #### ERCOT
 * ERCOT Available Resource Planned Outage Capacity 7 Day and Future datasets in [#884](https://github.com/gridstatus/gridstatus/pull/884)
 * ERCOT SCED AS Price Corrections via `Ercot.get_mcpc_sced_price_corrections`
+* ERCOT 2-Day Aggregate Gen Summary, Load Summary, and Output Schedule datasets via `Ercot.get_aggregate_gen_summary_2_day`, `Ercot.get_aggregate_load_summary_2_day`, and `Ercot.get_aggregate_output_schedule_2_day`
 
 #### MISO
 * MISO Area Control Error dataset via `MISO.get_area_control_error`

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -325,7 +325,7 @@ TWO_DAY_RT_GEN_LOAD_REPORTS_RTID = 13056
 
 AGGREGATE_GEN_SUMMARY_2_DAY_COLUMNS = [
     "SCED Timestamp",
-    "Load Zone",
+    "Area",
     "Sum Base Point Non IRR",
     "Sum Base Point WGR",
     "Sum Base Point PVGR",
@@ -5174,15 +5174,12 @@ class Ercot(ISOBase):
         if product == "gen":
             column_map = _AGGREGATE_2_DAY_GEN_COLUMN_MAP
             output_columns = AGGREGATE_GEN_SUMMARY_2_DAY_COLUMNS
-            geo_column = "Load Zone"
         elif product == "load":
             column_map = _AGGREGATE_2_DAY_LOAD_COLUMN_MAP
             output_columns = AGGREGATE_LOAD_SUMMARY_2_DAY_COLUMNS
-            geo_column = "Area"
         else:
             column_map = _AGGREGATE_2_DAY_OUTPUT_SCHEDULE_COLUMN_MAP
             output_columns = AGGREGATE_OUTPUT_SCHEDULE_2_DAY_COLUMNS
-            geo_column = "Area"
 
         all_dfs: list[pd.DataFrame] = []
 
@@ -5205,7 +5202,7 @@ class Ercot(ISOBase):
             ):
                 continue
 
-            df[geo_column] = self._area_from_aggregate_2_day_filename(file_name)
+            df["Area"] = self._area_from_aggregate_2_day_filename(file_name)
             df = self._localize_aggregate_2_day_sced_timestamp(df)
             all_dfs.append(df)
 
@@ -5216,7 +5213,7 @@ class Ercot(ISOBase):
 
         df = pd.concat(all_dfs, ignore_index=True)
         df = df.reindex(columns=output_columns)
-        df = df.sort_values(["SCED Timestamp", geo_column]).reset_index(drop=True)
+        df = df.sort_values(["SCED Timestamp", "Area"]).reset_index(drop=True)
 
         return df
 

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -324,8 +324,8 @@ TWO_DAY_SCED_ANCILLARY_SERVICES_REPORTS_RTID = 25814
 TWO_DAY_RT_GEN_LOAD_REPORTS_RTID = 13056
 
 AGGREGATE_GEN_SUMMARY_2_DAY_COLUMNS = [
-    "SCED Time Stamp",
-    "Area",
+    "SCED Timestamp",
+    "Load Zone",
     "Sum Base Point Non IRR",
     "Sum Base Point WGR",
     "Sum Base Point PVGR",
@@ -337,7 +337,7 @@ AGGREGATE_GEN_SUMMARY_2_DAY_COLUMNS = [
 ]
 
 AGGREGATE_LOAD_SUMMARY_2_DAY_COLUMNS = [
-    "SCED Time Stamp",
+    "SCED Timestamp",
     "Area",
     "Sum Telem Gen MW",
     "Sum Telem DC Tie MW",
@@ -345,7 +345,7 @@ AGGREGATE_LOAD_SUMMARY_2_DAY_COLUMNS = [
 ]
 
 AGGREGATE_OUTPUT_SCHEDULE_2_DAY_COLUMNS = [
-    "SCED Time Stamp",
+    "SCED Timestamp",
     "Area",
     "Sum LSL Output Schedule",
     "Sum HSL Output Schedule",
@@ -353,7 +353,7 @@ AGGREGATE_OUTPUT_SCHEDULE_2_DAY_COLUMNS = [
 ]
 
 _AGGREGATE_2_DAY_GEN_COLUMN_MAP = {
-    "SCED TIME STAMP": "SCED Time Stamp",
+    "SCED TIME STAMP": "SCED Timestamp",
     "REPEATED HOUR FLAG": "Repeated Hour Flag",
     "SUM BASE POINT NON IRR": "Sum Base Point Non IRR",
     "SUM BASE POINT WGR": "Sum Base Point WGR",
@@ -367,7 +367,7 @@ _AGGREGATE_2_DAY_GEN_COLUMN_MAP = {
 }
 
 _AGGREGATE_2_DAY_LOAD_COLUMN_MAP = {
-    "SCED TIME STAMP": "SCED Time Stamp",
+    "SCED TIME STAMP": "SCED Timestamp",
     "REPEATED HOUR FLAG": "Repeated Hour Flag",
     "SUM TELEM GEN MW": "Sum Telem Gen MW",
     "SUM TELEM DCTIE MW": "Sum Telem DC Tie MW",
@@ -375,7 +375,7 @@ _AGGREGATE_2_DAY_LOAD_COLUMN_MAP = {
 }
 
 _AGGREGATE_2_DAY_OUTPUT_SCHEDULE_COLUMN_MAP = {
-    "SCED TIME STAMP": "SCED Time Stamp",
+    "SCED TIME STAMP": "SCED Timestamp",
     "REPEATED HOUR FLAG": "Repeated Hour Flag",
     "SUM LSL OUTPUT SCHEDULE": "Sum LSL Output Schedule",
     "SUM HSL OUTPUT SCHEDULE": "Sum HSL Output Schedule",
@@ -5140,23 +5140,23 @@ class Ercot(ISOBase):
                 rename_map[col] = column_map[normalized]
         return df.rename(columns=rename_map)
 
-    def _localize_aggregate_2_day_sced_time_stamp(
+    def _localize_aggregate_2_day_sced_timestamp(
         self,
         df: pd.DataFrame,
     ) -> pd.DataFrame:
-        df["SCED Time Stamp"] = pd.to_datetime(
-            df["SCED Time Stamp"],
+        df["SCED Timestamp"] = pd.to_datetime(
+            df["SCED Timestamp"],
             errors="coerce",
         )
-        df = df.dropna(subset=["SCED Time Stamp"])
+        df = df.dropna(subset=["SCED Timestamp"])
 
-        if df["SCED Time Stamp"].dt.tz is None:
-            df["SCED Time Stamp"] = df["SCED Time Stamp"].dt.tz_localize(
+        if df["SCED Timestamp"].dt.tz is None:
+            df["SCED Timestamp"] = df["SCED Timestamp"].dt.tz_localize(
                 self.default_timezone,
                 ambiguous=df["Repeated Hour Flag"] == "N",
             )
         else:
-            df["SCED Time Stamp"] = df["SCED Time Stamp"].dt.tz_convert(
+            df["SCED Timestamp"] = df["SCED Timestamp"].dt.tz_convert(
                 self.default_timezone,
             )
 
@@ -5174,12 +5174,15 @@ class Ercot(ISOBase):
         if product == "gen":
             column_map = _AGGREGATE_2_DAY_GEN_COLUMN_MAP
             output_columns = AGGREGATE_GEN_SUMMARY_2_DAY_COLUMNS
+            geo_column = "Load Zone"
         elif product == "load":
             column_map = _AGGREGATE_2_DAY_LOAD_COLUMN_MAP
             output_columns = AGGREGATE_LOAD_SUMMARY_2_DAY_COLUMNS
+            geo_column = "Area"
         else:
             column_map = _AGGREGATE_2_DAY_OUTPUT_SCHEDULE_COLUMN_MAP
             output_columns = AGGREGATE_OUTPUT_SCHEDULE_2_DAY_COLUMNS
+            geo_column = "Area"
 
         all_dfs: list[pd.DataFrame] = []
 
@@ -5197,13 +5200,13 @@ class Ercot(ISOBase):
 
             df = self._rename_aggregate_2_day_columns(df, column_map)
             if (
-                "SCED Time Stamp" not in df.columns
+                "SCED Timestamp" not in df.columns
                 or "Repeated Hour Flag" not in df.columns
             ):
                 continue
 
-            df["Area"] = self._area_from_aggregate_2_day_filename(file_name)
-            df = self._localize_aggregate_2_day_sced_time_stamp(df)
+            df[geo_column] = self._area_from_aggregate_2_day_filename(file_name)
+            df = self._localize_aggregate_2_day_sced_timestamp(df)
             all_dfs.append(df)
 
         if not all_dfs:
@@ -5213,7 +5216,7 @@ class Ercot(ISOBase):
 
         df = pd.concat(all_dfs, ignore_index=True)
         df = df.reindex(columns=output_columns)
-        df = df.sort_values(["SCED Time Stamp", "Area"]).reset_index(drop=True)
+        df = df.sort_values(["SCED Timestamp", geo_column]).reset_index(drop=True)
 
         return df
 

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -319,6 +319,71 @@ TWO_DAY_ANCILLARY_SERVICES_REPORTS_RTID = 13057
 # https://www.ercot.com/mp/data-products/data-product-details?id=np3-906-ex
 TWO_DAY_SCED_ANCILLARY_SERVICES_REPORTS_RTID = 25814
 
+# 2-Day Real Time Gen and Load Data Reports
+# https://www.ercot.com/mp/data-products/data-product-details?id=NP3-910-ER
+TWO_DAY_RT_GEN_LOAD_REPORTS_RTID = 13056
+
+AGGREGATE_GEN_SUMMARY_2_DAY_COLUMNS = [
+    "SCED Time Stamp",
+    "Area",
+    "Sum Base Point Non IRR",
+    "Sum Base Point WGR",
+    "Sum Base Point PVGR",
+    "Sum Base Point Remaining Res",
+    "Sum Gen Telem MW",
+    "Sum Base Point ESR",
+    "Sum Base Point ESR Charging",
+    "Sum Base Point ESR Discharging",
+]
+
+AGGREGATE_LOAD_SUMMARY_2_DAY_COLUMNS = [
+    "SCED Time Stamp",
+    "Area",
+    "Sum Telem Gen MW",
+    "Sum Telem DC Tie MW",
+    "Agg Load Summary",
+]
+
+AGGREGATE_OUTPUT_SCHEDULE_2_DAY_COLUMNS = [
+    "SCED Time Stamp",
+    "Area",
+    "Sum LSL Output Schedule",
+    "Sum HSL Output Schedule",
+    "Sum Output Schedule",
+]
+
+_AGGREGATE_2_DAY_GEN_COLUMN_MAP = {
+    "SCED TIME STAMP": "SCED Time Stamp",
+    "REPEATED HOUR FLAG": "Repeated Hour Flag",
+    "SUM BASE POINT NON IRR": "Sum Base Point Non IRR",
+    "SUM BASE POINT WGR": "Sum Base Point WGR",
+    "SUM BASE POINT PVGR": "Sum Base Point PVGR",
+    "SUM BASE POINT REMAINING RES": "Sum Base Point Remaining Res",
+    "SUM BASE POINT REMAINING RESOURCES": "Sum Base Point Remaining Res",
+    "SUM GEN TELEM MW": "Sum Gen Telem MW",
+    "SUM BASE POINT ESR": "Sum Base Point ESR",
+    "SUM BASE POINT ESR CHARGING": "Sum Base Point ESR Charging",
+    "SUM BASE POINT ESR DISCHARGING": "Sum Base Point ESR Discharging",
+}
+
+_AGGREGATE_2_DAY_LOAD_COLUMN_MAP = {
+    "SCED TIME STAMP": "SCED Time Stamp",
+    "REPEATED HOUR FLAG": "Repeated Hour Flag",
+    "SUM TELEM GEN MW": "Sum Telem Gen MW",
+    "SUM TELEM DCTIE MW": "Sum Telem DC Tie MW",
+    "AGG LOAD SUMMARY": "Agg Load Summary",
+}
+
+_AGGREGATE_2_DAY_OUTPUT_SCHEDULE_COLUMN_MAP = {
+    "SCED TIME STAMP": "SCED Time Stamp",
+    "REPEATED HOUR FLAG": "Repeated Hour Flag",
+    "SUM LSL OUTPUT SCHEDULE": "Sum LSL Output Schedule",
+    "SUM HSL OUTPUT SCHEDULE": "Sum HSL Output Schedule",
+    "SUM OUTPUTSCHEDULE": "Sum Output Schedule",
+}
+
+_AGGREGATE_2_DAY_AREAS = ("Houston", "North", "South", "West")
+
 # Ancillary Services products - used across multiple AS report methods
 AS_PRODUCTS = [
     "RRSPFR",
@@ -4944,6 +5009,211 @@ class Ercot(ISOBase):
 
         df = df[["SCED Timestamp", "AS Type", "Offer Curve"]]
         df = df.sort_values("SCED Timestamp").reset_index(drop=True)
+
+        return df
+
+    @support_date_range("DAY_START")
+    def get_aggregate_gen_summary_2_day(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Get 2-Day Aggregate Generation Summary by disclosure area.
+
+        Published with a 2 day delay around 3-4am central from NP3-910-ER.
+
+        Arguments:
+            date: date to fetch reports for (delivery / content date)
+            end: end date for a range. Defaults to None.
+            verbose: print verbose output
+
+        Returns:
+            pandas.DataFrame: Aggregate generation summary by Area
+        """
+        return self._get_2_day_rt_gen_load_reports(
+            date=date,
+            product="gen",
+            verbose=verbose,
+        )
+
+    @support_date_range("DAY_START")
+    def get_aggregate_load_summary_2_day(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Get 2-Day Aggregate Load Summary by disclosure area.
+
+        Published with a 2 day delay around 3-4am central from NP3-910-ER.
+
+        Arguments:
+            date: date to fetch reports for (delivery / content date)
+            end: end date for a range. Defaults to None.
+            verbose: print verbose output
+
+        Returns:
+            pandas.DataFrame: Aggregate load summary by Area
+        """
+        return self._get_2_day_rt_gen_load_reports(
+            date=date,
+            product="load",
+            verbose=verbose,
+        )
+
+    @support_date_range("DAY_START")
+    def get_aggregate_output_schedule_2_day(
+        self,
+        date: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp],
+        end: str | pd.Timestamp | tuple[pd.Timestamp, pd.Timestamp] | None = None,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Get 2-Day Aggregate Output Schedules by disclosure area.
+
+        Published with a 2 day delay around 3-4am central from NP3-910-ER.
+
+        Arguments:
+            date: date to fetch reports for (delivery / content date)
+            end: end date for a range. Defaults to None.
+            verbose: print verbose output
+
+        Returns:
+            pandas.DataFrame: Aggregate output schedule by Area
+        """
+        return self._get_2_day_rt_gen_load_reports(
+            date=date,
+            product="output_schedule",
+            verbose=verbose,
+        )
+
+    def _get_2_day_rt_gen_load_reports(
+        self,
+        date: pd.Timestamp,
+        product: Literal["gen", "load", "output_schedule"],
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        doc = self._get_as_report_document(
+            date=date,
+            report_type_id=TWO_DAY_RT_GEN_LOAD_REPORTS_RTID,
+            verbose=verbose,
+        )
+
+        return self._handle_2_day_rt_gen_load_reports_file(
+            doc.url,
+            product=product,
+            verbose=verbose,
+        )
+
+    @staticmethod
+    def _normalize_aggregate_2_day_header(col: str) -> str:
+        return " ".join(col.replace("-", " ").split()).upper()
+
+    @staticmethod
+    def _area_from_aggregate_2_day_filename(file_name: str) -> str:
+        for area in _AGGREGATE_2_DAY_AREAS:
+            if f"_{area}-" in file_name:
+                return area
+        return "System"
+
+    @staticmethod
+    def _product_from_aggregate_2_day_filename(
+        file_name: str,
+    ) -> Literal["gen", "load", "output_schedule"] | None:
+        if "Gen_Summary" in file_name:
+            return "gen"
+        if "Load_Summary" in file_name:
+            return "load"
+        if "Output_Sched" in file_name:
+            return "output_schedule"
+        return None
+
+    def _rename_aggregate_2_day_columns(
+        self,
+        df: pd.DataFrame,
+        column_map: dict[str, str],
+    ) -> pd.DataFrame:
+        rename_map: dict[str, str] = {}
+        for col in df.columns:
+            normalized = self._normalize_aggregate_2_day_header(col)
+            if normalized in column_map:
+                rename_map[col] = column_map[normalized]
+        return df.rename(columns=rename_map)
+
+    def _localize_aggregate_2_day_sced_time_stamp(
+        self,
+        df: pd.DataFrame,
+    ) -> pd.DataFrame:
+        df["SCED Time Stamp"] = pd.to_datetime(
+            df["SCED Time Stamp"],
+            errors="coerce",
+        )
+        df = df.dropna(subset=["SCED Time Stamp"])
+
+        if df["SCED Time Stamp"].dt.tz is None:
+            df["SCED Time Stamp"] = df["SCED Time Stamp"].dt.tz_localize(
+                self.default_timezone,
+                ambiguous=df["Repeated Hour Flag"] == "N",
+            )
+        else:
+            df["SCED Time Stamp"] = df["SCED Time Stamp"].dt.tz_convert(
+                self.default_timezone,
+            )
+
+        return df.drop(columns=["Repeated Hour Flag"])
+
+    def _handle_2_day_rt_gen_load_reports_file(
+        self,
+        file_path: str,
+        product: Literal["gen", "load", "output_schedule"],
+        verbose: bool = False,
+        **kwargs,
+    ) -> pd.DataFrame:
+        z = utils.get_zip_folder(file_path, verbose=verbose, **kwargs)
+
+        if product == "gen":
+            column_map = _AGGREGATE_2_DAY_GEN_COLUMN_MAP
+            output_columns = AGGREGATE_GEN_SUMMARY_2_DAY_COLUMNS
+        elif product == "load":
+            column_map = _AGGREGATE_2_DAY_LOAD_COLUMN_MAP
+            output_columns = AGGREGATE_LOAD_SUMMARY_2_DAY_COLUMNS
+        else:
+            column_map = _AGGREGATE_2_DAY_OUTPUT_SCHEDULE_COLUMN_MAP
+            output_columns = AGGREGATE_OUTPUT_SCHEDULE_2_DAY_COLUMNS
+
+        all_dfs: list[pd.DataFrame] = []
+
+        for file_name in z.namelist():
+            if not file_name.endswith(".csv"):
+                continue
+
+            file_product = self._product_from_aggregate_2_day_filename(file_name)
+            if file_product != product:
+                continue
+
+            df = pd.read_csv(z.open(file_name))
+            if df.empty:
+                continue
+
+            df = self._rename_aggregate_2_day_columns(df, column_map)
+            if (
+                "SCED Time Stamp" not in df.columns
+                or "Repeated Hour Flag" not in df.columns
+            ):
+                continue
+
+            df["Area"] = self._area_from_aggregate_2_day_filename(file_name)
+            df = self._localize_aggregate_2_day_sced_time_stamp(df)
+            all_dfs.append(df)
+
+        if not all_dfs:
+            raise NoDataFoundException(
+                f"No {product} files found in NP3-910-ER zip",
+            )
+
+        df = pd.concat(all_dfs, ignore_index=True)
+        df = df.reindex(columns=output_columns)
+        df = df.sort_values(["SCED Time Stamp", "Area"]).reset_index(drop=True)
 
         return df
 

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -5164,12 +5164,17 @@ class Ercot(ISOBase):
 
     def _handle_2_day_rt_gen_load_reports_file(
         self,
-        file_path: str,
+        file_path: str | bytes | BinaryIO,
         product: Literal["gen", "load", "output_schedule"],
         verbose: bool = False,
         **kwargs,
     ) -> pd.DataFrame:
-        z = utils.get_zip_folder(file_path, verbose=verbose, **kwargs)
+        if isinstance(file_path, (bytes, bytearray)):
+            z = ZipFile(io.BytesIO(file_path))
+        elif hasattr(file_path, "read"):
+            z = ZipFile(file_path)
+        else:
+            z = utils.get_zip_folder(file_path, verbose=verbose, **kwargs)
 
         if product == "gen":
             column_map = _AGGREGATE_2_DAY_GEN_COLUMN_MAP

--- a/gridstatus/ercot_api/ercot_api.py
+++ b/gridstatus/ercot_api/ercot_api.py
@@ -1221,12 +1221,10 @@ class ErcotAPI:
             for url in urls
         ]
 
-        geo_column = "Load Zone" if product == "gen" else "Area"
-
         return (
             pd.concat(dfs)
             .reset_index(drop=True)
-            .sort_values(["SCED Timestamp", geo_column])
+            .sort_values(["SCED Timestamp", "Area"])
         )
 
     @support_date_range(frequency=None)

--- a/gridstatus/ercot_api/ercot_api.py
+++ b/gridstatus/ercot_api/ercot_api.py
@@ -1221,10 +1221,12 @@ class ErcotAPI:
             for url in urls
         ]
 
+        geo_column = "Load Zone" if product == "gen" else "Area"
+
         return (
             pd.concat(dfs)
             .reset_index(drop=True)
-            .sort_values(["SCED Time Stamp", "Area"])
+            .sort_values(["SCED Timestamp", geo_column])
         )
 
     @support_date_range(frequency=None)

--- a/gridstatus/ercot_api/ercot_api.py
+++ b/gridstatus/ercot_api/ercot_api.py
@@ -1211,15 +1211,22 @@ class ErcotAPI:
 
         urls = [tup[0] for tup in links_and_posted_datetimes]
 
-        dfs = [
-            self.ercot._handle_2_day_rt_gen_load_reports_file(
-                url,
-                product=product,
-                verbose=verbose,
-                headers=self.headers(),
+        dfs = []
+        for url in urls:
+            content = self.make_api_call(url, parse_json=False)
+            dfs.append(
+                self.ercot._handle_2_day_rt_gen_load_reports_file(
+                    content,
+                    product=product,
+                    verbose=verbose,
+                ),
             )
-            for url in urls
-        ]
+            time.sleep(self.sleep_seconds)
+
+        if not dfs:
+            raise NoDataFoundException(
+                f"No NP3-910-ER archives found for {report_date} to {end}",
+            )
 
         return (
             pd.concat(dfs)

--- a/gridstatus/ercot_api/ercot_api.py
+++ b/gridstatus/ercot_api/ercot_api.py
@@ -82,6 +82,9 @@ AS_REPORTS_DAM_EMIL_ID = "np3-911-er"
 # https://data.ercot.com/data-product-archive/NP3-906-EX
 AS_REPORTS_SCED_EMIL_ID = "np3-906-ex"
 
+# https://data.ercot.com/data-product-archive/NP3-910-ER
+TWO_DAY_RT_GEN_LOAD_REPORTS_EMIL_ID = "np3-910-er"
+
 # https://data.ercot.com/data-product-archive/NP4-33-CD
 AS_PLAN_ENDPOINT = "/np4-33-cd/dam_as_plan"
 
@@ -1182,6 +1185,86 @@ class ErcotAPI:
         ]
 
         return pd.concat(dfs).reset_index(drop=True).sort_values("SCED Timestamp")
+
+    def _get_2_day_rt_gen_load_reports(
+        self,
+        date,
+        end=None,
+        product: str = "gen",
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        offset = pd.DateOffset(days=2)
+
+        report_date = date.normalize() + offset
+
+        if end:
+            end = end + offset
+        else:
+            end = self._handle_end_date(report_date, end, days_to_add_if_no_end=1)
+
+        links_and_posted_datetimes = self._get_historical_data_links(
+            emil_id=TWO_DAY_RT_GEN_LOAD_REPORTS_EMIL_ID,
+            start_date=report_date,
+            end_date=end,
+            verbose=verbose,
+        )
+
+        urls = [tup[0] for tup in links_and_posted_datetimes]
+
+        dfs = [
+            self.ercot._handle_2_day_rt_gen_load_reports_file(
+                url,
+                product=product,
+                verbose=verbose,
+                headers=self.headers(),
+            )
+            for url in urls
+        ]
+
+        return (
+            pd.concat(dfs)
+            .reset_index(drop=True)
+            .sort_values(["SCED Time Stamp", "Area"])
+        )
+
+    @support_date_range(frequency=None)
+    def get_aggregate_gen_summary_2_day(self, date, end=None, verbose=False):
+        """Get 2-Day Aggregate Generation Summary by disclosure area.
+
+        Published with a 2 day delay around 3-4am central from NP3-910-ER.
+        """
+        return self._get_2_day_rt_gen_load_reports(
+            date=date,
+            end=end,
+            product="gen",
+            verbose=verbose,
+        )
+
+    @support_date_range(frequency=None)
+    def get_aggregate_load_summary_2_day(self, date, end=None, verbose=False):
+        """Get 2-Day Aggregate Load Summary by disclosure area.
+
+        Published with a 2 day delay around 3-4am central from NP3-910-ER.
+        """
+        return self._get_2_day_rt_gen_load_reports(
+            date=date,
+            end=end,
+            product="load",
+            verbose=verbose,
+        )
+
+    @support_date_range(frequency=None)
+    def get_aggregate_output_schedule_2_day(self, date, end=None, verbose=False):
+        """Get 2-Day Aggregate Output Schedules by disclosure area.
+
+        Published with a 2 day delay around 3-4am central from NP3-910-ER.
+        """
+        return self._get_2_day_rt_gen_load_reports(
+            date=date,
+            end=end,
+            product="output_schedule",
+            verbose=verbose,
+        )
 
     @support_date_range(frequency=None)
     def get_as_plan(self, date, end=None, verbose=False):

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -1783,8 +1783,8 @@ class TestErcot(BaseTestISO):
 
     def _check_aggregate_gen_summary_2_day(self, df):
         assert df.columns.tolist() == [
-            "SCED Time Stamp",
-            "Area",
+            "SCED Timestamp",
+            "Load Zone",
             "Sum Base Point Non IRR",
             "Sum Base Point WGR",
             "Sum Base Point PVGR",
@@ -1794,35 +1794,35 @@ class TestErcot(BaseTestISO):
             "Sum Base Point ESR Charging",
             "Sum Base Point ESR Discharging",
         ]
-        assert df.dtypes["SCED Time Stamp"] == "datetime64[ns, US/Central]"
-        assert set(df["Area"]) == {"Houston", "North", "South", "System", "West"}
-        assert not df.duplicated(subset=["SCED Time Stamp", "Area"]).any()
+        assert df.dtypes["SCED Timestamp"] == "datetime64[ns, US/Central]"
+        assert set(df["Load Zone"]) == {"Houston", "North", "South", "System", "West"}
+        assert not df.duplicated(subset=["SCED Timestamp", "Load Zone"]).any()
         assert len(df) > 0
 
     def _check_aggregate_load_summary_2_day(self, df):
         assert df.columns.tolist() == [
-            "SCED Time Stamp",
+            "SCED Timestamp",
             "Area",
             "Sum Telem Gen MW",
             "Sum Telem DC Tie MW",
             "Agg Load Summary",
         ]
-        assert df.dtypes["SCED Time Stamp"] == "datetime64[ns, US/Central]"
+        assert df.dtypes["SCED Timestamp"] == "datetime64[ns, US/Central]"
         assert set(df["Area"]) == {"Houston", "North", "South", "System", "West"}
-        assert not df.duplicated(subset=["SCED Time Stamp", "Area"]).any()
+        assert not df.duplicated(subset=["SCED Timestamp", "Area"]).any()
         assert len(df) > 0
 
     def _check_aggregate_output_schedule_2_day(self, df):
         assert df.columns.tolist() == [
-            "SCED Time Stamp",
+            "SCED Timestamp",
             "Area",
             "Sum LSL Output Schedule",
             "Sum HSL Output Schedule",
             "Sum Output Schedule",
         ]
-        assert df.dtypes["SCED Time Stamp"] == "datetime64[ns, US/Central]"
+        assert df.dtypes["SCED Timestamp"] == "datetime64[ns, US/Central]"
         assert set(df["Area"]) == {"Houston", "North", "South", "System", "West"}
-        assert not df.duplicated(subset=["SCED Time Stamp", "Area"]).any()
+        assert not df.duplicated(subset=["SCED Timestamp", "Area"]).any()
         assert len(df) > 0
 
     def test_get_aggregate_gen_summary_2_day(self):
@@ -1834,7 +1834,7 @@ class TestErcot(BaseTestISO):
             df = self.iso.get_aggregate_gen_summary_2_day(date)
 
         self._check_aggregate_gen_summary_2_day(df)
-        assert df["SCED Time Stamp"].dt.date.unique() == [date.date()]
+        assert df["SCED Timestamp"].dt.date.unique() == [date.date()]
         assert df["Sum Base Point ESR"].notna().any()
 
     def test_get_aggregate_load_summary_2_day(self):
@@ -1846,7 +1846,7 @@ class TestErcot(BaseTestISO):
             df = self.iso.get_aggregate_load_summary_2_day(date)
 
         self._check_aggregate_load_summary_2_day(df)
-        assert df["SCED Time Stamp"].dt.date.unique() == [date.date()]
+        assert df["SCED Timestamp"].dt.date.unique() == [date.date()]
 
     def test_get_aggregate_output_schedule_2_day(self):
         date = pd.Timestamp("2026-07-13", tz=self.iso.default_timezone)
@@ -1857,7 +1857,7 @@ class TestErcot(BaseTestISO):
             df = self.iso.get_aggregate_output_schedule_2_day(date)
 
         self._check_aggregate_output_schedule_2_day(df)
-        assert df["SCED Time Stamp"].dt.date.unique() == [date.date()]
+        assert df["SCED Timestamp"].dt.date.unique() == [date.date()]
 
     """get_reported_outages"""
 

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -1779,6 +1779,86 @@ class TestErcot(BaseTestISO):
 
         assert df["SCED Timestamp"].dt.date.unique() == test_date.date()
 
+    """get_aggregate_*_2_day"""
+
+    def _check_aggregate_gen_summary_2_day(self, df):
+        assert df.columns.tolist() == [
+            "SCED Time Stamp",
+            "Area",
+            "Sum Base Point Non IRR",
+            "Sum Base Point WGR",
+            "Sum Base Point PVGR",
+            "Sum Base Point Remaining Res",
+            "Sum Gen Telem MW",
+            "Sum Base Point ESR",
+            "Sum Base Point ESR Charging",
+            "Sum Base Point ESR Discharging",
+        ]
+        assert df.dtypes["SCED Time Stamp"] == "datetime64[ns, US/Central]"
+        assert set(df["Area"]) == {"Houston", "North", "South", "System", "West"}
+        assert not df.duplicated(subset=["SCED Time Stamp", "Area"]).any()
+        assert len(df) > 0
+
+    def _check_aggregate_load_summary_2_day(self, df):
+        assert df.columns.tolist() == [
+            "SCED Time Stamp",
+            "Area",
+            "Sum Telem Gen MW",
+            "Sum Telem DC Tie MW",
+            "Agg Load Summary",
+        ]
+        assert df.dtypes["SCED Time Stamp"] == "datetime64[ns, US/Central]"
+        assert set(df["Area"]) == {"Houston", "North", "South", "System", "West"}
+        assert not df.duplicated(subset=["SCED Time Stamp", "Area"]).any()
+        assert len(df) > 0
+
+    def _check_aggregate_output_schedule_2_day(self, df):
+        assert df.columns.tolist() == [
+            "SCED Time Stamp",
+            "Area",
+            "Sum LSL Output Schedule",
+            "Sum HSL Output Schedule",
+            "Sum Output Schedule",
+        ]
+        assert df.dtypes["SCED Time Stamp"] == "datetime64[ns, US/Central]"
+        assert set(df["Area"]) == {"Houston", "North", "South", "System", "West"}
+        assert not df.duplicated(subset=["SCED Time Stamp", "Area"]).any()
+        assert len(df) > 0
+
+    def test_get_aggregate_gen_summary_2_day(self):
+        date = pd.Timestamp("2026-07-13", tz=self.iso.default_timezone)
+
+        with api_vcr.use_cassette(
+            f"test_get_aggregate_gen_summary_2_day_{date.date()}.yaml",
+        ):
+            df = self.iso.get_aggregate_gen_summary_2_day(date)
+
+        self._check_aggregate_gen_summary_2_day(df)
+        assert df["SCED Time Stamp"].dt.date.unique() == [date.date()]
+        assert df["Sum Base Point ESR"].notna().any()
+
+    def test_get_aggregate_load_summary_2_day(self):
+        date = pd.Timestamp("2026-07-13", tz=self.iso.default_timezone)
+
+        with api_vcr.use_cassette(
+            f"test_get_aggregate_load_summary_2_day_{date.date()}.yaml",
+        ):
+            df = self.iso.get_aggregate_load_summary_2_day(date)
+
+        self._check_aggregate_load_summary_2_day(df)
+        assert df["SCED Time Stamp"].dt.date.unique() == [date.date()]
+
+    def test_get_aggregate_output_schedule_2_day(self):
+        date = pd.Timestamp("2026-07-13", tz=self.iso.default_timezone)
+
+        with api_vcr.use_cassette(
+            f"test_get_aggregate_output_schedule_2_day_{date.date()}.yaml",
+        ):
+            df = self.iso.get_aggregate_output_schedule_2_day(date)
+
+        self._check_aggregate_output_schedule_2_day(df)
+        assert df["SCED Time Stamp"].dt.date.unique() == [date.date()]
+
     """get_reported_outages"""
 
     @pytest.mark.integration

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -1784,7 +1784,7 @@ class TestErcot(BaseTestISO):
     def _check_aggregate_gen_summary_2_day(self, df):
         assert df.columns.tolist() == [
             "SCED Timestamp",
-            "Load Zone",
+            "Area",
             "Sum Base Point Non IRR",
             "Sum Base Point WGR",
             "Sum Base Point PVGR",
@@ -1795,8 +1795,8 @@ class TestErcot(BaseTestISO):
             "Sum Base Point ESR Discharging",
         ]
         assert df.dtypes["SCED Timestamp"] == "datetime64[ns, US/Central]"
-        assert set(df["Load Zone"]) == {"Houston", "North", "South", "System", "West"}
-        assert not df.duplicated(subset=["SCED Timestamp", "Load Zone"]).any()
+        assert set(df["Area"]) == {"Houston", "North", "South", "System", "West"}
+        assert not df.duplicated(subset=["SCED Timestamp", "Area"]).any()
         assert len(df) > 0
 
     def _check_aggregate_load_summary_2_day(self, df):

--- a/gridstatus/tests/source_specific/test_ercot_api.py
+++ b/gridstatus/tests/source_specific/test_ercot_api.py
@@ -727,6 +727,45 @@ class TestErcotAPI(TestHelperMixin):
 
         assert df["SCED Timestamp"].dt.date.unique() == date.date()
 
+    """get_aggregate_*_2_day"""
+
+    def test_get_aggregate_gen_summary_2_day(self):
+        date = pd.Timestamp("2025-11-01", tz=self.iso.default_timezone)
+
+        with api_vcr.use_cassette(
+            f"test_get_aggregate_gen_summary_2_day_historical_{date.date()}.yaml",
+        ):
+            df = self.iso.get_aggregate_gen_summary_2_day(date, verbose=True)
+
+        _ErcotChecks()._check_aggregate_gen_summary_2_day(df)
+        assert df["SCED Time Stamp"].dt.date.unique() == [date.date()]
+        assert df["Sum Base Point ESR"].isna().all()
+        assert df["Sum Base Point ESR Charging"].isna().all()
+        assert df["Sum Base Point ESR Discharging"].isna().all()
+        assert df["Sum Base Point Non IRR"].notna().any()
+
+    def test_get_aggregate_load_summary_2_day(self):
+        date = pd.Timestamp("2025-11-01", tz=self.iso.default_timezone)
+
+        with api_vcr.use_cassette(
+            f"test_get_aggregate_load_summary_2_day_historical_{date.date()}.yaml",
+        ):
+            df = self.iso.get_aggregate_load_summary_2_day(date, verbose=True)
+
+        _ErcotChecks()._check_aggregate_load_summary_2_day(df)
+        assert df["SCED Time Stamp"].dt.date.unique() == [date.date()]
+
+    def test_get_aggregate_output_schedule_2_day(self):
+        date = pd.Timestamp("2025-11-01", tz=self.iso.default_timezone)
+
+        with api_vcr.use_cassette(
+            f"test_get_aggregate_output_schedule_2_day_historical_{date.date()}.yaml",
+        ):
+            df = self.iso.get_aggregate_output_schedule_2_day(date, verbose=True)
+
+        _ErcotChecks()._check_aggregate_output_schedule_2_day(df)
+        assert df["SCED Time Stamp"].dt.date.unique() == [date.date()]
+
     """get_as_plan"""
 
     def _check_as_plan(self, df):

--- a/gridstatus/tests/source_specific/test_ercot_api.py
+++ b/gridstatus/tests/source_specific/test_ercot_api.py
@@ -738,7 +738,7 @@ class TestErcotAPI(TestHelperMixin):
             df = self.iso.get_aggregate_gen_summary_2_day(date, verbose=True)
 
         _ErcotChecks()._check_aggregate_gen_summary_2_day(df)
-        assert df["SCED Time Stamp"].dt.date.unique() == [date.date()]
+        assert df["SCED Timestamp"].dt.date.unique() == [date.date()]
         assert df["Sum Base Point ESR"].isna().all()
         assert df["Sum Base Point ESR Charging"].isna().all()
         assert df["Sum Base Point ESR Discharging"].isna().all()
@@ -753,7 +753,7 @@ class TestErcotAPI(TestHelperMixin):
             df = self.iso.get_aggregate_load_summary_2_day(date, verbose=True)
 
         _ErcotChecks()._check_aggregate_load_summary_2_day(df)
-        assert df["SCED Time Stamp"].dt.date.unique() == [date.date()]
+        assert df["SCED Timestamp"].dt.date.unique() == [date.date()]
 
     def test_get_aggregate_output_schedule_2_day(self):
         date = pd.Timestamp("2025-11-01", tz=self.iso.default_timezone)
@@ -764,7 +764,7 @@ class TestErcotAPI(TestHelperMixin):
             df = self.iso.get_aggregate_output_schedule_2_day(date, verbose=True)
 
         _ErcotChecks()._check_aggregate_output_schedule_2_day(df)
-        assert df["SCED Time Stamp"].dt.date.unique() == [date.date()]
+        assert df["SCED Timestamp"].dt.date.unique() == [date.date()]
 
     """get_as_plan"""
 


### PR DESCRIPTION
## Summary
- Adds `get_aggregate_gen_summary_2_day`, `get_aggregate_load_summary_2_day`, and `get_aggregate_output_schedule_2_day` for ERCOT NP3-910-ER (2-Day Real Time Gen and Load Data Reports)

### Details
These datasets share one daily zip with system-wide and Houston/North/South/West disclosure-area CSVs. Area is derived from the filename (no zone suffix means System). Gen summary had a schema change with RTC+B (zip posted 2025-12-07); legacy files map NON-IRR / Remaining Resources aliases and leave ESR columns null. Load and output schedule schemas are stable. SCED Time Stamp is localized with Repeated Hour Flag. Historical data uses the public archive API (`np3-910-er`).

To run tests:
```bash
VCR_RECORD_MODE=all uv run pytest -vvv gridstatus/tests/ -k "aggregate_gen_summary_2_day or aggregate_load_summary_2_day or aggregate_output_schedule_2_day"
```

Made with [Cursor](https://cursor.com)