### PR TITLE
feat(ERCOT): Add LMP price corrections by settlement point and electrical bus scrapers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * ERCOT SCED AS Price Corrections via `Ercot.get_mcpc_sced_price_corrections`
 * ERCOT Real Time AS, SCED Shadow Price, and Settlement Only Generator Price Corrections via `Ercot.get_mcpc_spp_real_time_price_corrections`, `Ercot.get_shadow_price_real_time_price_corrections`, and `Ercot.get_sog_price_real_time_price_corrections`
 * ERCOT 2-Day Aggregate Gen Summary, Load Summary, and Output Schedule datasets via `Ercot.get_aggregate_gen_summary_2_day`, `Ercot.get_aggregate_load_summary_2_day`, and `Ercot.get_aggregate_output_schedule_2_day`
+* ERCOT LMP Price Corrections by settlement point and by electrical bus via `Ercot.get_lmp_by_settlement_point_price_corrections` and `Ercot.get_lmp_by_bus_price_corrections`
 
 #### MISO
 * MISO Area Control Error dataset via `MISO.get_area_control_error`

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -6037,6 +6037,64 @@ class Ercot(ISOBase):
 
         return df
 
+    def get_lmp_by_settlement_point_price_corrections(
+        self,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """
+        Get LMP corrections by settlement point for each SCED run.
+
+        Returns:
+            pd.DataFrame: DataFrame with columns:
+                - Price Correction Time
+                - SCED Timestamp
+                - Interval Start
+                - Interval End
+                - Location
+                - Location Type
+                - LMP Original
+                - LMP Corrected
+        """
+        docs = self._get_documents(
+            report_type_id=RTM_PRICE_CORRECTIONS_RTID,
+            constructed_name_contains="RTM_SPLMP",
+            extension="csv",
+            verbose=verbose,
+        )
+
+        df = self._handle_lmp_price_corrections(docs, verbose=verbose)
+
+        return df
+
+    def get_lmp_by_bus_price_corrections(
+        self,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """
+        Get LMP corrections by electrical bus for each SCED run.
+
+        Returns:
+            pd.DataFrame: DataFrame with columns:
+                - Price Correction Time
+                - SCED Timestamp
+                - Interval Start
+                - Interval End
+                - Location
+                - Location Type
+                - LMP Original
+                - LMP Corrected
+        """
+        docs = self._get_documents(
+            report_type_id=RTM_PRICE_CORRECTIONS_RTID,
+            constructed_name_contains="RTM_EBLMP",
+            extension="csv",
+            verbose=verbose,
+        )
+
+        df = self._handle_lmp_price_corrections(docs, verbose=verbose)
+
+        return df
+
     def _handle_price_corrections(
         self,
         docs: list[Document],
@@ -6269,6 +6327,64 @@ class Ercot(ISOBase):
                 "Meter Name",
                 "Price Original",
                 "Price Corrected",
+            ]
+        ]
+
+        return df
+
+    def _handle_lmp_price_corrections(
+        self,
+        docs: list[Document],
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        """Handle LMP price corrections by settlement point or electrical bus.
+
+        LMP corrections are keyed by the SCED run timestamp rather than
+        delivery intervals, so the files cannot go through parse_doc(). The
+        Interval Start/End columns are derived by flooring the SCED Timestamp
+        to five minutes and are approximations, not exact.
+        """
+        df = self.read_docs(docs, parse=False, verbose=verbose)
+
+        # The files use DSTFlag but _handle_sced_timestamp expects
+        # RepeatedHourFlag. The semantics are the same.
+        df = df.rename(columns={"DSTFlag": "RepeatedHourFlag"})
+
+        df = self._handle_sced_timestamp(df, verbose=verbose)
+
+        if "SettlementPoint" in df.columns:
+            df = self._handle_settlement_point_name_and_type(df, verbose=verbose)
+        elif "ElectricBusName" in df.columns:
+            df = df.rename(columns={"ElectricBusName": "Location"})
+            df["Location Type"] = ELECTRICAL_BUS_LOCATION_TYPE
+            df["Location"] = df["Location"].astype("string")
+            df["Location Type"] = df["Location Type"].astype("category")
+
+        # Rename columns to match gridstatus conventions
+        df = df.rename(
+            columns={
+                "LMPOriginal": "LMP Original",
+                "LMPCorrected": "LMP Corrected",
+                "PriceCorrectionTime": "Price Correction Time",
+            },
+        )
+
+        # Parse Price Correction Time
+        df["Price Correction Time"] = pd.to_datetime(
+            df["Price Correction Time"],
+        ).dt.tz_localize(self.default_timezone)
+
+        # Select and order final columns
+        df = df[
+            [
+                "Price Correction Time",
+                "SCED Timestamp",
+                "Interval Start",
+                "Interval End",
+                "Location",
+                "Location Type",
+                "LMP Original",
+                "LMP Corrected",
             ]
         ]
 

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -2491,6 +2491,73 @@ class TestErcot(BaseTestISO):
             ],
         ).any()
 
+    def _check_lmp_price_corrections(self, df):
+        cols = [
+            "Price Correction Time",
+            "SCED Timestamp",
+            "Interval Start",
+            "Interval End",
+            "Location",
+            "Location Type",
+            "LMP Original",
+            "LMP Corrected",
+        ]
+
+        assert df.shape[0] > 0
+        assert df.columns.tolist() == cols
+
+        assert pd.api.types.is_datetime64_any_dtype(df["Price Correction Time"])
+        assert pd.api.types.is_datetime64_any_dtype(df["SCED Timestamp"])
+        assert pd.api.types.is_datetime64_any_dtype(df["Interval Start"])
+        assert pd.api.types.is_datetime64_any_dtype(df["Interval End"])
+        assert pd.api.types.is_float_dtype(df["LMP Original"])
+        assert pd.api.types.is_float_dtype(df["LMP Corrected"])
+
+        assert (df["Interval Start"] == df["SCED Timestamp"].dt.floor("5min")).all()
+        assert (
+            df["Interval End"] == df["Interval Start"] + pd.Timedelta(minutes=5)
+        ).all()
+        assert not df.duplicated(
+            subset=["SCED Timestamp", "Location", "Price Correction Time"],
+        ).any()
+
+    def test_get_lmp_by_settlement_point_price_corrections(self):
+        """Test LMP Price Corrections by settlement point."""
+        with api_vcr.use_cassette(
+            "test_get_lmp_by_settlement_point_price_corrections.yaml",
+        ):
+            try:
+                df = self.iso.get_lmp_by_settlement_point_price_corrections()
+            except NoDataFoundException:
+                pytest.skip(
+                    "No RTM_SPLMP price correction files currently listed",
+                )
+
+        self._check_lmp_price_corrections(df)
+
+        assert set(df["Location Type"].unique()) <= {
+            "Trading Hub",
+            "Load Zone",
+            "Load Zone DC Tie",
+            "Resource Node",
+        }
+
+    def test_get_lmp_by_bus_price_corrections(self):
+        """Test LMP Price Corrections by electrical bus."""
+        with api_vcr.use_cassette(
+            "test_get_lmp_by_bus_price_corrections.yaml",
+        ):
+            try:
+                df = self.iso.get_lmp_by_bus_price_corrections()
+            except NoDataFoundException:
+                pytest.skip(
+                    "No RTM_EBLMP price correction files currently listed",
+                )
+
+        self._check_lmp_price_corrections(df)
+
+        assert (df["Location Type"] == "Electrical Bus").all()
+
     """get_system_wide_actuals"""
 
     @pytest.mark.integration


### PR DESCRIPTION
## What changed

Adds scrapers for the two remaining RTM price correction file types (MIS report NP4-197-M):

- `Ercot.get_lmp_by_settlement_point_price_corrections` — `RTM_SPLMP` files, LMPs by settlement point for each SCED run
- `Ercot.get_lmp_by_bus_price_corrections` — `RTM_EBLMP` files, LMPs by electrical bus for each SCED run

Both share a handler that parses the SCED timestamp (with `DSTFlag` disambiguation), maps locations to `Location`/`Location Type`, and derives approximate five-minute `Interval Start`/`Interval End`.

## How to validate

```
uv run pytest gridstatus/tests/source_specific/test_ercot.py -k "lmp_by_settlement_point_price_corrections or lmp_by_bus_price_corrections"
```

Tests record VCR cassettes against the live MIS on first run and skip gracefully when no correction files are currently listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)