### PR TITLE
feat(ERCOT): Add published_after to price correction getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * ERCOT Real Time AS, SCED Shadow Price, and Settlement Only Generator Price Corrections via `Ercot.get_mcpc_spp_real_time_price_corrections`, `Ercot.get_shadow_price_real_time_price_corrections`, and `Ercot.get_sog_price_real_time_price_corrections`
 * ERCOT 2-Day Aggregate Gen Summary, Load Summary, and Output Schedule datasets via `Ercot.get_aggregate_gen_summary_2_day`, `Ercot.get_aggregate_load_summary_2_day`, and `Ercot.get_aggregate_output_schedule_2_day`
 * ERCOT LMP Price Corrections by settlement point and by electrical bus via `Ercot.get_lmp_by_settlement_point_price_corrections` and `Ercot.get_lmp_by_bus_price_corrections`
+* ERCOT price correction getters accept `published_after` to skip documents already ingested
 
 #### MISO
 * MISO Area Control Error dataset via `MISO.get_area_control_error`

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -6361,7 +6361,14 @@ class Ercot(ISOBase):
         delivery intervals, so the files cannot go through parse_doc(). The
         Interval Start/End columns are derived by flooring the SCED Timestamp
         to five minutes and are approximations, not exact.
+
+        Distinct electrical buses can share a name, and a batch can revise a
+        key published minutes earlier in the same batch, so only one row per
+        (SCED Timestamp, Location, Price Correction Time) is kept — the last
+        one in publish order.
         """
+        docs = sorted(docs, key=lambda doc: doc.publish_date)
+
         df = self.read_docs(docs, parse=False, verbose=verbose)
 
         # The files use DSTFlag but _handle_sced_timestamp expects
@@ -6391,6 +6398,11 @@ class Ercot(ISOBase):
         df["Price Correction Time"] = pd.to_datetime(
             df["Price Correction Time"],
         ).dt.tz_localize(self.default_timezone)
+
+        df = df.drop_duplicates(
+            subset=["SCED Timestamp", "Location", "Price Correction Time"],
+            keep="last",
+        )
 
         # Select and order final columns
         df = df[

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -5831,6 +5831,7 @@ class Ercot(ISOBase):
     def get_dam_price_corrections(
         self,
         dam_type: str,
+        published_after: pd.Timestamp | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
         """
@@ -5841,6 +5842,7 @@ class Ercot(ISOBase):
 
         """
         docs = self._get_documents(
+            published_after=published_after,
             report_type_id=DAM_PRICE_CORRECTIONS_RTID,
             constructed_name_contains=dam_type,
             extension="csv",
@@ -5854,6 +5856,7 @@ class Ercot(ISOBase):
     def get_rtm_price_corrections(
         self,
         rtm_type: str,
+        published_after: pd.Timestamp | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
         """
@@ -5865,6 +5868,7 @@ class Ercot(ISOBase):
 
         """
         docs = self._get_documents(
+            published_after=published_after,
             report_type_id=RTM_PRICE_CORRECTIONS_RTID,
             constructed_name_contains=rtm_type,
             extension="csv",
@@ -5877,6 +5881,7 @@ class Ercot(ISOBase):
 
     def get_mcpc_dam_price_corrections(
         self,
+        published_after: pd.Timestamp | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
         """
@@ -5895,6 +5900,7 @@ class Ercot(ISOBase):
                 - MCPC Corrected
         """
         docs = self._get_documents(
+            published_after=published_after,
             report_type_id=DAM_PRICE_CORRECTIONS_RTID,
             constructed_name_contains="DAM_MCPC",
             extension="csv",
@@ -5907,6 +5913,7 @@ class Ercot(ISOBase):
 
     def get_mcpc_sced_price_corrections(
         self,
+        published_after: pd.Timestamp | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
         """
@@ -5926,6 +5933,7 @@ class Ercot(ISOBase):
                 - MCPC Corrected
         """
         docs = self._get_documents(
+            published_after=published_after,
             report_type_id=RTM_PRICE_CORRECTIONS_RTID,
             constructed_name_contains="RTM_MCPC_SCED",
             extension="csv",
@@ -5938,6 +5946,7 @@ class Ercot(ISOBase):
 
     def get_mcpc_spp_real_time_price_corrections(
         self,
+        published_after: pd.Timestamp | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
         """
@@ -5957,6 +5966,7 @@ class Ercot(ISOBase):
                 - MCPC Corrected
         """
         docs = self._get_documents(
+            published_after=published_after,
             report_type_id=RTM_PRICE_CORRECTIONS_RTID,
             constructed_name_contains="RTM_MCPC_SPP",
             extension="csv",
@@ -5969,6 +5979,7 @@ class Ercot(ISOBase):
 
     def get_shadow_price_real_time_price_corrections(
         self,
+        published_after: pd.Timestamp | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
         """
@@ -5991,6 +6002,7 @@ class Ercot(ISOBase):
                 - Value Corrected
         """
         docs = self._get_documents(
+            published_after=published_after,
             report_type_id=RTM_PRICE_CORRECTIONS_RTID,
             constructed_name_contains="RTM_ShadowPrice",
             extension="csv",
@@ -6006,6 +6018,7 @@ class Ercot(ISOBase):
 
     def get_sog_price_real_time_price_corrections(
         self,
+        published_after: pd.Timestamp | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
         """
@@ -6024,6 +6037,7 @@ class Ercot(ISOBase):
                 - Price Corrected
         """
         docs = self._get_documents(
+            published_after=published_after,
             report_type_id=RTM_PRICE_CORRECTIONS_RTID,
             constructed_name_contains="RTM_SOGPRICE",
             extension="csv",
@@ -6039,6 +6053,7 @@ class Ercot(ISOBase):
 
     def get_lmp_by_settlement_point_price_corrections(
         self,
+        published_after: pd.Timestamp | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
         """
@@ -6056,6 +6071,7 @@ class Ercot(ISOBase):
                 - LMP Corrected
         """
         docs = self._get_documents(
+            published_after=published_after,
             report_type_id=RTM_PRICE_CORRECTIONS_RTID,
             constructed_name_contains="RTM_SPLMP",
             extension="csv",
@@ -6068,6 +6084,7 @@ class Ercot(ISOBase):
 
     def get_lmp_by_bus_price_corrections(
         self,
+        published_after: pd.Timestamp | None = None,
         verbose: bool = False,
     ) -> pd.DataFrame:
         """
@@ -6085,6 +6102,7 @@ class Ercot(ISOBase):
                 - LMP Corrected
         """
         docs = self._get_documents(
+            published_after=published_after,
             report_type_id=RTM_PRICE_CORRECTIONS_RTID,
             constructed_name_contains="RTM_EBLMP",
             extension="csv",

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -6361,14 +6361,7 @@ class Ercot(ISOBase):
         delivery intervals, so the files cannot go through parse_doc(). The
         Interval Start/End columns are derived by flooring the SCED Timestamp
         to five minutes and are approximations, not exact.
-
-        Distinct electrical buses can share a name, and a batch can revise a
-        key published minutes earlier in the same batch, so only one row per
-        (SCED Timestamp, Location, Price Correction Time) is kept — the last
-        one in publish order.
         """
-        docs = sorted(docs, key=lambda doc: doc.publish_date)
-
         df = self.read_docs(docs, parse=False, verbose=verbose)
 
         # The files use DSTFlag but _handle_sced_timestamp expects
@@ -6398,11 +6391,6 @@ class Ercot(ISOBase):
         df["Price Correction Time"] = pd.to_datetime(
             df["Price Correction Time"],
         ).dt.tz_localize(self.default_timezone)
-
-        df = df.drop_duplicates(
-            subset=["SCED Timestamp", "Location", "Price Correction Time"],
-            keep="last",
-        )
 
         # Select and order final columns
         df = df[

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -6361,7 +6361,13 @@ class Ercot(ISOBase):
         delivery intervals, so the files cannot go through parse_doc(). The
         Interval Start/End columns are derived by flooring the SCED Timestamp
         to five minutes and are approximations, not exact.
+
+        Files are processed in publish order, so when multiple files carry a
+        row for the same key, the row from the latest published file appears
+        last. No rows are dropped.
         """
+        docs = sorted(docs, key=lambda doc: doc.publish_date)
+
         df = self.read_docs(docs, parse=False, verbose=verbose)
 
         # The files use DSTFlag but _handle_sced_timestamp expects

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -2517,9 +2517,9 @@ class TestErcot(BaseTestISO):
         assert (
             df["Interval End"] == df["Interval Start"] + pd.Timedelta(minutes=5)
         ).all()
-        assert not df.duplicated(
-            subset=["SCED Timestamp", "Location", "Price Correction Time"],
-        ).any()
+        # NB: no uniqueness assertion on (SCED Timestamp, Location,
+        # Price Correction Time) — source files can carry multiple rows for
+        # the same key and they are returned as-is.
 
     def test_get_lmp_by_settlement_point_price_corrections(self):
         """Test LMP Price Corrections by settlement point."""

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -2558,6 +2558,50 @@ class TestErcot(BaseTestISO):
 
         assert (df["Location Type"] == "Electrical Bus").all()
 
+    def test_price_corrections_published_after_filters_documents(self):
+        """A far-future published_after excludes every listed document, so every
+        getter raises NoDataFoundException without downloading any files."""
+        published_after = pd.Timestamp("2100-01-01", tz=self.iso.default_timezone)
+
+        fetchers = [
+            lambda: self.iso.get_dam_price_corrections(
+                dam_type="DAM_SPP",
+                published_after=published_after,
+            ),
+            lambda: self.iso.get_rtm_price_corrections(
+                rtm_type="RTM_SPP",
+                published_after=published_after,
+            ),
+            lambda: self.iso.get_mcpc_dam_price_corrections(
+                published_after=published_after,
+            ),
+            lambda: self.iso.get_mcpc_sced_price_corrections(
+                published_after=published_after,
+            ),
+            lambda: self.iso.get_mcpc_spp_real_time_price_corrections(
+                published_after=published_after,
+            ),
+            lambda: self.iso.get_shadow_price_real_time_price_corrections(
+                published_after=published_after,
+            ),
+            lambda: self.iso.get_sog_price_real_time_price_corrections(
+                published_after=published_after,
+            ),
+            lambda: self.iso.get_lmp_by_settlement_point_price_corrections(
+                published_after=published_after,
+            ),
+            lambda: self.iso.get_lmp_by_bus_price_corrections(
+                published_after=published_after,
+            ),
+        ]
+
+        with api_vcr.use_cassette(
+            "test_price_corrections_published_after_filters_documents.yaml",
+        ):
+            for fetch in fetchers:
+                with pytest.raises(NoDataFoundException):
+                    fetch()
+
     """get_system_wide_actuals"""
 
     @pytest.mark.integration


### PR DESCRIPTION
## What changed

All nine ERCOT price correction getters accept an optional `published_after` timestamp, passed through to `_get_documents`, which filters the MIS document listing before any file is downloaded. Callers that track what they have already ingested can skip re-reading every listed file — the electrical bus corrections alone are ~9M rows across 80+ files per run. When nothing new is listed, the getters raise `NoDataFoundException` as they already do for an empty listing.

The LMP price correction handler now processes files in publish order, so when multiple files carry a row for the same key the latest published row appears last. Rows are returned as-is — duplicate-key rows in the source files are left for consumers to resolve.

## How to validate

```
uv run pytest gridstatus/tests/source_specific/test_ercot.py -k "published_after or price_corrections"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


