### PR TITLE
[ENG-4387] Support Black Hills Energy and SPP West for EIA Grid Monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 #### EIA
 * EIA Facility Fuel (EIA-923) dataset in [#912](https://github.com/gridstatus/gridstatus/pull/912)
+* `EIA.get_grid_monitor` support for the Black Hills Energy (`BHBA`) and Southwest Power Pool West (`SWPW`) balancing authorities, which EIA began publishing on June 22, 2026
 
 #### PJM
 * PJM Emergency Postings now includes `Is Drill` from the XML `pjmDrill` flag

--- a/gridstatus/eia_data/grid_monitor_files.json
+++ b/gridstatus/eia_data/grid_monitor_files.json
@@ -496,5 +496,17 @@
       "Type": "BA",
       "Name": "Sikeston Board of Municipal Utilities",
       "URL": "https://www.eia.gov/electricity/gridmonitor/knownissues/xls/SIKE.xlsx"
+    },
+    "BHBA": {
+      "ID": "BHBA",
+      "Type": "BA",
+      "Name": "Black Hills Energy",
+      "URL": "https://www.eia.gov/electricity/gridmonitor/knownissues/xls/BHBA.xlsx"
+    },
+    "SWPW": {
+      "ID": "SWPW",
+      "Type": "BA",
+      "Name": "Southwest Power Pool West Balancing Authority Area",
+      "URL": "https://www.eia.gov/electricity/gridmonitor/knownissues/xls/SWPW.xlsx"
     }
   }


### PR DESCRIPTION
EIA began publishing grid monitor files for the `BHBA` (Black Hills Energy) and `SWPW` (Southwest Power Pool West) balancing authorities on 2026-06-22. `grid_monitor_files.json` is a static list, so `EIA.get_grid_monitor(area_id="BHBA")` raises a bare `KeyError` for them.

## What changed

- **`gridstatus/eia_data/grid_monitor_files.json`** — added `BHBA` and `SWPW`. Appended rather than inserted alphabetically, matching #713 and the file's existing EIA dashboard ordering.
- **`CHANGELOG.md`** — one line under `v.Next`.

The `Name` values are EIA's own labels, confirmed against EIA's respondent names for the 73 areas already in the file (72 match exactly; only `LGEE` is shortened in this file).

## How to validate

```python
import gridstatus

for area in ["BHBA", "SWPW"]:
    df = gridstatus.EIA().get_grid_monitor(area_id=area)
    print(area, len(df), df["Area Name"].unique(), df["Area Type"].unique())
```

Both return 2784 rows and 33 columns, with all four `CO2 Emissions` columns populated. Note EIA publishes these two from 2026-04-01 only, a shorter history than long-established areas.

```
make lint
uv run pytest gridstatus/tests/source_specific/test_eia.py::test_eia_grid_monitor
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBKPhqHoBQGXRPYWLDddFr