### PR TITLE
Raise NoDataFoundException for missing ISO-NE LMP data

### DIFF
--- a/gridstatus/isone.py
+++ b/gridstatus/isone.py
@@ -12,6 +12,7 @@ from gridstatus.base import (
     InterconnectionQueueStatus,
     ISOBase,
     Markets,
+    NoDataFoundException,
     NotSupported,
 )
 from gridstatus.decorators import support_date_range
@@ -474,6 +475,11 @@ class ISONE(ISOBase):
                     ]
                     data = data_current.copy()
             else:
+                if data_intervals is None:
+                    raise NoDataFoundException(
+                        f"No {market.value} LMP data found for {date.date()}",
+                    )
+
                 data = data_intervals.copy()
 
             data = data.rename(columns={"Local Time": "Interval Start"})

--- a/gridstatus/tests/source_specific/test_isone.py
+++ b/gridstatus/tests/source_specific/test_isone.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 
 from gridstatus import ISONE
-from gridstatus.base import Markets
+from gridstatus.base import Markets, NoDataFoundException
 from gridstatus.tests.base_test_iso import BaseTestISO
 from gridstatus.tests.decorators import with_markets
 from gridstatus.tests.vcr_utils import RECORD_MODE, setup_vcr
@@ -148,6 +148,20 @@ class TestISONE(BaseTestISO):
         # Rolling data goes back 4 hours and should go up to the current time or close
         assert df["Interval Start"].min() < self.local_now() - pd.DateOffset(hours=3)
         assert df["Interval Start"].max() > self.local_now() - pd.DateOffset(minutes=15)
+
+    def test_get_lmp_real_time_historical_no_data(self):
+        with patch(
+            "gridstatus.isone.pd.read_csv",
+            side_effect=Exception("Failed to download interval"),
+        ):
+            with pytest.raises(
+                NoDataFoundException,
+                match="No REAL_TIME_5_MIN LMP data found for 2024-01-01",
+            ):
+                self.iso.get_lmp_real_time_5_min(
+                    date="2024-01-01",
+                    verbose=VERBOSE,
+                )
 
     """get_load"""
 


### PR DESCRIPTION
## Summary

- Raise `NoDataFoundException` when every ISO-NE historical real-time five-minute LMP interval download fails.
- Add a network-free regression test covering the all-downloads-failed path.

### Details

When all historical interval downloads fail, `data_intervals` remains `None` and the historical path calls `.copy()` on it, exposing an internal `AttributeError` to users.

This change detects that state and raises a descriptive `NoDataFoundException` containing the requested market and date. The current-day rolling-data fallback is unchanged.

Related to #174.

### Testing

- `uv run pytest -vv gridstatus/tests/source_specific/test_isone.py::TestISONE::test_get_lmp_real_time_historical_no_data`
- `make test-base` — 12 passed, 1 skipped
- `uv run ruff check gridstatus/isone.py gridstatus/tests/source_specific/test_isone.py`
- `uv run ruff format gridstatus/isone.py gridstatus/tests/source_specific/test_isone.py --check`