### PR TITLE
Fix ERCOT fuel mix crash when an interval is split across two timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@
 #### MISO
 * MISO Area Control Error dataset via `MISO.get_area_control_error`
 
+### Fixes
+
+#### ERCOT
+* `Ercot.get_fuel_mix_detailed` no longer raises `AttributeError: 'float' object has no attribute 'get'` when Ercot reports one interval under two timestamps a few seconds apart and splits the fuel types between them. The fuel types missing from each timestamp are now returned as null instead of failing the whole request, matching the behavior `Ercot.get_fuel_mix` already had.
+* `Ercot.get_fuel_mix` and `Ercot.get_fuel_mix_detailed` now sort by `Time`. Ercot publishes the two halves of a split interval out of chronological order, which previously produced an unsorted `Time` column.
+
 #### Maintenance
 
 * Removed unused runtime dependencies (`setuptools`, `virtualenv`, `h11`, `zipp`, `filelock`) — none are imported and nothing in the runtime tree requires them, so they no longer ship to consumers. Resolves the `setuptools <79` cap reported in [#901](https://github.com/gridstatus/gridstatus/issues/901).

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -681,6 +681,11 @@ class Ercot(ISOBase):
 
         data = data[columns]
 
+        # ercot does not always publish intervals in chronological order. when it
+        # reports one interval under two timestamps a few seconds apart, the later
+        # timestamp can come first
+        data = data.sort_values("Time").reset_index(drop=True)
+
         if date == "latest":
             return data
 
@@ -708,11 +713,17 @@ class Ercot(ISOBase):
         mix = pd.concat(dfs)
 
         # Each col is a tuple of (gen, hsl, seasonalCapacity). We want to split this
-        # to separate columns
+        # to separate columns. A fuel type can be absent from an interval when ercot
+        # reports the interval under two timestamps a few seconds apart and splits the
+        # fuel types between them, which leaves NaN rather than a dict after the concat
         cols_to_drop = []
         for col in mix.columns:
-            mix[col + " Gen"] = mix[col].apply(lambda x: x.get("gen"))
-            mix[col + " HSL"] = mix[col].apply(lambda x: x.get("hsl"))
+            mix[col + " Gen"] = mix[col].apply(
+                lambda x: x.get("gen") if isinstance(x, dict) else pd.NA,
+            )
+            mix[col + " HSL"] = mix[col].apply(
+                lambda x: x.get("hsl") if isinstance(x, dict) else pd.NA,
+            )
             mix[col + " Seasonal Capacity"] = capacity[col]
             cols_to_drop.append(col)
 

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -524,6 +524,58 @@ class TestErcot(BaseTestISO):
         assert df.columns.tolist() == self.fuel_mix_detailed_columns
         assert df["Time"].dt.date.nunique() == 1
 
+    def test_get_fuel_mix_detailed_interval_split_across_timestamps(self):
+        # Ercot sometimes reports a single interval under two timestamps a few seconds
+        # apart and splits the fuel types between them. The fuel types absent from each
+        # timestamp come through as NaN rather than a dict
+        fuel_types = [
+            "Coal and Lignite",
+            "Hydro",
+            "Nuclear",
+            "Power Storage",
+            "Solar",
+            "Wind",
+            "Natural Gas",
+            "Other",
+        ]
+        complete_interval = {fuel: {"gen": 100.0} for fuel in fuel_types}
+
+        payload = {
+            "monthlyCapacity": {fuel: 500 for fuel in fuel_types},
+            "data": {
+                "2026-07-28": {
+                    "2026-07-28 09:39:56-0500": complete_interval,
+                    # Ercot publishes these two halves of the 09:44 interval out of
+                    # chronological order, with Solar on its own two seconds earlier
+                    "2026-07-28 09:44:58-0500": {
+                        fuel: {"gen": 100.0} for fuel in fuel_types if fuel != "Solar"
+                    },
+                    "2026-07-28 09:44:56-0500": {"Solar": {"gen": 200.0}},
+                },
+            },
+        }
+
+        with mock.patch.object(Ercot, "_get_fuel_mix", return_value=payload):
+            df = self.iso.get_fuel_mix_detailed("latest")
+
+        assert df.columns.tolist() == self.fuel_mix_detailed_columns
+        assert len(df) == 3
+        # ercot published the two halves of the 09:44 interval out of order
+        assert df["Time"].is_monotonic_increasing
+
+        solar_only = df[df["Time"] == pd.Timestamp("2026-07-28 09:44:56-0500")].iloc[0]
+        assert solar_only["Solar Gen"] == 200.0
+        assert pd.isna(solar_only["Wind Gen"])
+        # Seasonal capacity comes from monthlyCapacity, not the interval, so it is
+        # populated even for the fuel types missing from this timestamp
+        assert solar_only["Wind Seasonal Capacity"] == 500
+
+        everything_else = df[
+            df["Time"] == pd.Timestamp("2026-07-28 09:44:58-0500")
+        ].iloc[0]
+        assert everything_else["Wind Gen"] == 100.0
+        assert pd.isna(everything_else["Solar Gen"])
+
     """get_lmp"""
 
     @pytest.mark.skip(reason="Not Applicable")


### PR DESCRIPTION
## What changed

ERCOT sometimes reports a single fuel mix interval under two timestamps a few seconds apart, splitting the fuel types between them. Today's payload has this at `09:44:56` (Solar, Natural Gas) and `09:44:58` (the other seven fuel types).

Transposing that payload leaves `NaN` where a fuel type is absent from a timestamp, which broke two things:

- **`get_fuel_mix_detailed` raised `AttributeError: 'float' object has no attribute 'get'`.** The `gen`/`hsl` lookups now guard with `isinstance(x, dict)` and fall back to `pd.NA`, matching what `get_fuel_mix` has done since #345. Fuel types missing from a timestamp come back null instead of failing the whole request.
- **`get_fuel_mix` and `get_fuel_mix_detailed` returned an unsorted `Time` column.** The two halves of a split interval are not published in chronological order, so `_handle_fuel_mix` now sorts by `Time`. This fixes `test_get_fuel_mix_latest` and `test_get_fuel_mix_today`, which are currently failing on `main` against the live endpoint.

The split interval is preserved as two rows with complementary nulls rather than merged into one.

## How to validate

```
pytest gridstatus/tests/source_specific/test_ercot.py -k fuel_mix
```

`test_get_fuel_mix_detailed_interval_split_across_timestamps` covers the regression with a synthetic payload; it fails with `AttributeError: 'float' object has no attribute 'get'` without the `ercot.py` change. The two live-endpoint `get_fuel_mix` tests pass with the sort and fail without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNNN96ytH1hS97Ju1cGzo7