### PR TITLE
Add aggregate Makefile test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,20 @@ PYTEST_CMD := uv run pytest -s -vv -n auto --reruns 5 --reruns-delay 3 --duratio
 NOT_SLOW := -m "not slow"
 UNIT_ONLY := -m "not integration"
 
+.PHONY: test
+test: test-base \
+	test-aeso \
+	test-caiso \
+	test-ercot \
+	test-isone \
+	test-miso \
+	test-nyiso \
+	test-pjm \
+	test-spp \
+	test-eia \
+	test-ieso \
+	test-misc
+
 .PHONY: test-base
 test-base:
 	$(PYTEST_CMD) gridstatus/tests/test_*.py --ignore=gridstatus/tests/source_specific/


### PR DESCRIPTION
## Summary

- Add an aggregate `make test` target matching the test groups used by the pull-request CI workflow.
- Make the documented full-test command in `CONTRIBUTING.md` functional.
- Keep the existing individual test targets available for focused runs.

Closes #926.

## Testing

- `make -n test` — confirmed all 12 expected test groups are invoked.
- `make test-base` — 12 passed, 1 skipped.
- `git diff --check`
