### PR TITLE
Add Energy Storage to SPP fuel mix combine

### DIFF
--- a/gridstatus/spp.py
+++ b/gridstatus/spp.py
@@ -3084,6 +3084,7 @@ def process_gen_mix(df: pd.DataFrame, detailed: bool = False) -> pd.DataFrame:
         "Waste Disposal Services",
         "Wind",
         "Waste Heat",
+        "Energy Storage",
         "Other",
     ]
 

--- a/gridstatus/tests/source_specific/test_spp.py
+++ b/gridstatus/tests/source_specific/test_spp.py
@@ -79,6 +79,15 @@ class TestSPP(BaseTestISO):
         "Other Self",
     ]
 
+    FUEL_MIX_OPTIONAL_COLS = [
+        "Energy Storage",
+    ]
+
+    FUEL_MIX_DETAILED_OPTIONAL_COLS = [
+        "Energy Storage Market",
+        "Energy Storage Self",
+    ]
+
     FUEL_MIX_BAA_COLS = [
         "Interval Start",
         "Interval End",
@@ -120,6 +129,15 @@ class TestSPP(BaseTestISO):
         "Other Market",
         "Other Self",
     ]
+
+    def _assert_fuel_mix_columns(
+        self,
+        df: pd.DataFrame,
+        required: list[str],
+        optional: list[str],
+    ) -> None:
+        assert all(c in df.columns for c in required)
+        assert set(df.columns) <= set(required) | set(optional)
 
     def _check_fuel_mix(self, df):
         assert isinstance(df, pd.DataFrame)
@@ -169,7 +187,11 @@ class TestSPP(BaseTestISO):
             fm = self.iso.get_fuel_mix(date="latest")
 
         assert len(fm) > 0
-        assert fm.columns.tolist() == self.FUEL_MIX_COLS
+        self._assert_fuel_mix_columns(
+            fm,
+            self.FUEL_MIX_COLS,
+            self.FUEL_MIX_OPTIONAL_COLS,
+        )
         assert fm["Interval Start"].iloc[0].tz.zone == self.iso.default_timezone
         assert "BAA" not in fm.columns
 
@@ -178,7 +200,11 @@ class TestSPP(BaseTestISO):
             fm = self.iso.get_fuel_mix(date="today")
 
         assert len(fm) > 0
-        assert fm.columns.tolist() == self.FUEL_MIX_COLS
+        self._assert_fuel_mix_columns(
+            fm,
+            self.FUEL_MIX_COLS,
+            self.FUEL_MIX_OPTIONAL_COLS,
+        )
         assert "BAA" not in fm.columns
 
     def test_get_fuel_mix_detailed_latest(self):
@@ -186,7 +212,11 @@ class TestSPP(BaseTestISO):
             fm = self.iso.get_fuel_mix_detailed(date="latest")
 
         assert len(fm) > 0
-        assert fm.columns.tolist() == self.FUEL_MIX_DETAILED_COLS
+        self._assert_fuel_mix_columns(
+            fm,
+            self.FUEL_MIX_DETAILED_COLS,
+            self.FUEL_MIX_DETAILED_OPTIONAL_COLS,
+        )
         assert "BAA" not in fm.columns
 
     def test_get_fuel_mix_too_old_raises(self):
@@ -204,7 +234,11 @@ class TestSPP(BaseTestISO):
             fm = self.iso.get_fuel_mix(date=yesterday)
 
         assert len(fm) > 0
-        assert fm.columns.tolist() == self.FUEL_MIX_COLS
+        self._assert_fuel_mix_columns(
+            fm,
+            self.FUEL_MIX_COLS,
+            self.FUEL_MIX_OPTIONAL_COLS,
+        )
         assert "BAA" not in fm.columns
         assert fm["Interval Start"].min() >= yesterday
 
@@ -215,7 +249,11 @@ class TestSPP(BaseTestISO):
             fm = self.iso.get_fuel_mix_by_baa(date="latest")
 
         assert len(fm) > 0
-        assert fm.columns.tolist() == self.FUEL_MIX_BAA_COLS
+        self._assert_fuel_mix_columns(
+            fm,
+            self.FUEL_MIX_BAA_COLS,
+            self.FUEL_MIX_OPTIONAL_COLS,
+        )
         assert fm["Interval Start"].iloc[0].tz.zone == self.iso.default_timezone
         assert set(fm["BAA"].unique()) == {"SPP", "SWPW"}
 
@@ -224,7 +262,11 @@ class TestSPP(BaseTestISO):
             fm = self.iso.get_fuel_mix_by_baa(date="today")
 
         assert len(fm) > 0
-        assert fm.columns.tolist() == self.FUEL_MIX_BAA_COLS
+        self._assert_fuel_mix_columns(
+            fm,
+            self.FUEL_MIX_BAA_COLS,
+            self.FUEL_MIX_OPTIONAL_COLS,
+        )
         assert set(fm["BAA"].unique()) == {"SPP", "SWPW"}
 
     def test_get_fuel_mix_by_baa_historical_recent(self):
@@ -237,7 +279,11 @@ class TestSPP(BaseTestISO):
             fm = self.iso.get_fuel_mix_by_baa(date=yesterday)
 
         assert len(fm) > 0
-        assert fm.columns.tolist() == self.FUEL_MIX_BAA_COLS
+        self._assert_fuel_mix_columns(
+            fm,
+            self.FUEL_MIX_BAA_COLS,
+            self.FUEL_MIX_OPTIONAL_COLS,
+        )
         assert set(fm["BAA"].unique()).issubset({"SPP", "SWPW"})
         assert "SPP" in fm["BAA"].values
         assert fm["Interval Start"].min() >= yesterday
@@ -249,7 +295,11 @@ class TestSPP(BaseTestISO):
             fm = self.iso.get_fuel_mix_by_baa_detailed(date="latest")
 
         assert len(fm) > 0
-        assert fm.columns.tolist() == self.FUEL_MIX_DETAILED_BAA_COLS
+        self._assert_fuel_mix_columns(
+            fm,
+            self.FUEL_MIX_DETAILED_BAA_COLS,
+            self.FUEL_MIX_DETAILED_OPTIONAL_COLS,
+        )
         assert set(fm["BAA"].unique()) == {"SPP", "SWPW"}
 
     """get_lmp_real_time_5_min_by_location"""


### PR DESCRIPTION
## Summary
- GenMix2Hour includes `Energy Storage Market` / `Energy Storage Self`
- Add Energy Storage to `process_gen_mix` `columns_to_combine` so non-detailed fuel mix exposes a single `Energy Storage` column
- Tests allow Energy Storage as an optional column (present in GenMix2Hour, absent from GenMix365)

## Test plan
- [ ] `get_fuel_mix(date="latest")` includes `Energy Storage` and not Market/Self columns
- [ ] `get_fuel_mix_detailed(date="latest")` keeps `Energy Storage Market` / `Energy Storage Self`
- [ ] Historical GenMix365 fetches still succeed without Energy Storage columns