### PR TITLE
Tolerate corrupt zip central directory in ERCOT hourly load post settlements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 #### ERCOT
 * `Ercot.get_fuel_mix_detailed` no longer raises `AttributeError: 'float' object has no attribute 'get'` when Ercot reports one interval under two timestamps a few seconds apart and splits the fuel types between them. The fuel types missing from each timestamp are now returned as null instead of failing the whole request, matching the behavior `Ercot.get_fuel_mix` already had.
 * `Ercot.get_fuel_mix` and `Ercot.get_fuel_mix_detailed` now sort by `Time`. Ercot publishes the two halves of a split interval out of chronological order, which previously produced an unsorted `Time` column.
+* `Ercot.get_hourly_load_post_settlements` no longer raises `BadZipFile: Bad CRC-32` on zip archives whose central directory disagrees with the local file header, as published for the 2026 Native_Load archive. Reading now falls back to the local file header's CRC and sizes, which are still validated against the data.
 
 #### Maintenance
 

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -1000,7 +1000,13 @@ class Ercot(ISOBase):
         if year_link.endswith(".zip"):
             zip_file = utils.get_zip_folder(year_link)
             filename = zip_file.namelist()[0]
-            df = pd.read_excel(zip_file.open(filename))
+            # ERCOT has published zips whose central directory disagrees with
+            # the local file header, which zipfile rejects on read
+            excel_bytes = utils.read_zip_member_with_local_header_fallback(
+                zip_file,
+                filename,
+            )
+            df = pd.read_excel(io.BytesIO(excel_bytes))
         elif year_link.endswith((".xls", ".xlsx")):
             response = requests.get(year_link)
             response.raise_for_status()

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -3585,6 +3585,22 @@ class TestErcot(BaseTestISO):
         assert df["Interval Start"].min() == pd.Timestamp(date, tz="US/Central")
         assert df["Interval End"].max() == pd.Timestamp(end, tz="US/Central")
 
+    @pytest.mark.parametrize("date", [("2026-01-01")])
+    def test_get_hourly_load_post_settlements_corrupt_zip_central_directory(
+        self,
+        date,
+    ):
+        """The 2026 Native_Load zip has a central directory whose CRC and
+        sizes disagree with the local file header, so reading it falls back
+        to the local file header metadata."""
+        with api_vcr.use_cassette(
+            "test_get_hourly_load_post_settlements_corrupt_zip_central_directory.yaml",
+        ):
+            df = self.iso.get_hourly_load_post_settlements(date)
+        self._check_hourly_load_post_settlements(df)
+
+        assert df["Interval Start"].min() == pd.Timestamp(date, tz="US/Central")
+
     """get_mcpc_dam"""
 
     def _check_get_mcpc_dam(self, df: pd.DataFrame):

--- a/gridstatus/tests/test_utils.py
+++ b/gridstatus/tests/test_utils.py
@@ -1,8 +1,18 @@
+import io
+import struct
+import zipfile
+
 import pandas as pd
+import pytest
 import time_machine
 
 import gridstatus
-from gridstatus.utils import is_dst_end, is_today, is_yesterday
+from gridstatus.utils import (
+    is_dst_end,
+    is_today,
+    is_yesterday,
+    read_zip_member_with_local_header_fallback,
+)
 
 
 def test_is_dst_end():
@@ -154,3 +164,70 @@ def test_is_yesterday():
             start_of_utc_yesterday + pd.DateOffset(days=1) + pd.Timedelta(hours=6),
             tz=central_timezone,
         )
+
+
+ZIP_MEMBER_NAME = "Native_Load_2026.xlsx"
+ZIP_MEMBER_CONTENT = b"hour_ending,coast,east,far_west\n" * 500
+ZIP_CENTRAL_DIRECTORY_SIGNATURE = b"PK\x01\x02"
+ZIP_CENTRAL_DIRECTORY_CRC_OFFSET = 16
+ZIP_LOCAL_HEADER_CRC_OFFSET = 14
+
+
+def _build_zip_with_corrupt_central_directory() -> bytearray:
+    """Build a zip whose central directory CRC and sizes disagree with the
+    local file header, mimicking ERCOT's corrupt Native_Load archives."""
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+        zip_file.writestr(ZIP_MEMBER_NAME, ZIP_MEMBER_CONTENT)
+    zip_bytes = bytearray(buffer.getvalue())
+    central_directory_offset = zip_bytes.find(ZIP_CENTRAL_DIRECTORY_SIGNATURE)
+    correct_crc, correct_compressed_size, correct_uncompressed_size = (
+        struct.unpack_from(
+            "<3I",
+            zip_bytes,
+            central_directory_offset + ZIP_CENTRAL_DIRECTORY_CRC_OFFSET,
+        )
+    )
+    struct.pack_into(
+        "<3I",
+        zip_bytes,
+        central_directory_offset + ZIP_CENTRAL_DIRECTORY_CRC_OFFSET,
+        correct_crc ^ 0xFFFFFFFF,
+        correct_compressed_size + 40,
+        correct_uncompressed_size + 100,
+    )
+    return zip_bytes
+
+
+def test_read_zip_member_with_local_header_fallback_recovers_member():
+    zip_bytes = bytes(_build_zip_with_corrupt_central_directory())
+
+    # Precondition: a plain read rejects the corrupt central directory
+    with pytest.raises(zipfile.BadZipFile):
+        zipfile.ZipFile(io.BytesIO(zip_bytes)).read(ZIP_MEMBER_NAME)
+
+    zip_file = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    recovered = read_zip_member_with_local_header_fallback(zip_file, ZIP_MEMBER_NAME)
+    assert recovered == ZIP_MEMBER_CONTENT
+
+
+def test_read_zip_member_with_local_header_fallback_intact_zip():
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+        zip_file.writestr(ZIP_MEMBER_NAME, ZIP_MEMBER_CONTENT)
+
+    zip_file = zipfile.ZipFile(io.BytesIO(buffer.getvalue()))
+    recovered = read_zip_member_with_local_header_fallback(zip_file, ZIP_MEMBER_NAME)
+    assert recovered == ZIP_MEMBER_CONTENT
+
+
+def test_read_zip_member_with_local_header_fallback_corrupt_data_still_raises():
+    zip_bytes = _build_zip_with_corrupt_central_directory()
+    # Corrupt the local file header CRC as well so neither header matches the
+    # data and the fallback cannot validate it
+    (local_crc,) = struct.unpack_from("<I", zip_bytes, ZIP_LOCAL_HEADER_CRC_OFFSET)
+    struct.pack_into("<I", zip_bytes, ZIP_LOCAL_HEADER_CRC_OFFSET, local_crc ^ 0xFFFF)
+
+    zip_file = zipfile.ZipFile(io.BytesIO(bytes(zip_bytes)))
+    with pytest.raises(zipfile.BadZipFile):
+        read_zip_member_with_local_header_fallback(zip_file, ZIP_MEMBER_NAME)

--- a/gridstatus/utils.py
+++ b/gridstatus/utils.py
@@ -1,8 +1,9 @@
 import glob
 import io
 import os
+import struct
 from collections.abc import Callable
-from zipfile import ZipFile
+from zipfile import BadZipFile, ZipFile
 
 import pandas as pd
 import requests
@@ -218,6 +219,58 @@ def get_zip_folder(url: str, verbose: bool = False, **kwargs) -> ZipFile:
     r = requests.get(url, **kwargs)
     z = ZipFile(io.BytesIO(r.content))
     return z
+
+
+ZIP_LOCAL_FILE_HEADER_FORMAT = "<4s5H3I2H"
+ZIP_LOCAL_FILE_HEADER_SIGNATURE = b"PK\x03\x04"
+ZIP_LOCAL_FILE_HEADER_SIZE = 30
+ZIP_FLAG_USES_DATA_DESCRIPTOR = 0x08
+
+
+def read_zip_member_with_local_header_fallback(
+    zip_file: ZipFile,
+    filename: str,
+) -> bytes:
+    """Read a zip member, tolerating a corrupt central directory.
+
+    Some sources publish zip files whose central directory CRC and sizes
+    disagree with the compressed data (for example ERCOT's Native_Load
+    archives). Python's zipfile validates reads against the central
+    directory, so those archives raise BadZipFile even though the data is
+    intact. On failure, retry the read using the local file header's CRC and
+    sizes, which zipfile validates against instead — genuinely corrupt data
+    still raises BadZipFile.
+    """
+    try:
+        return zip_file.read(filename)
+    except BadZipFile:
+        member_info = zip_file.getinfo(filename)
+        zip_file.fp.seek(member_info.header_offset)
+        local_header = zip_file.fp.read(ZIP_LOCAL_FILE_HEADER_SIZE)
+        if len(local_header) < ZIP_LOCAL_FILE_HEADER_SIZE:
+            raise
+        (
+            signature,
+            _version,
+            flags,
+            _compression_method,
+            _modified_time,
+            _modified_date,
+            local_crc,
+            local_compressed_size,
+            local_uncompressed_size,
+            _filename_length,
+            _extra_field_length,
+        ) = struct.unpack(ZIP_LOCAL_FILE_HEADER_FORMAT, local_header)
+        if (
+            signature != ZIP_LOCAL_FILE_HEADER_SIGNATURE
+            or flags & ZIP_FLAG_USES_DATA_DESCRIPTOR
+        ):
+            raise
+        member_info.CRC = local_crc
+        member_info.compress_size = local_compressed_size
+        member_info.file_size = local_uncompressed_size
+        return zip_file.read(filename)
 
 
 def get_response_blob(resp: requests.Response) -> io.BytesIO:


### PR DESCRIPTION
## What changed

ERCOT's 2026 Native_Load zip has a central directory whose CRC and sizes disagree with the local file header, so `Ercot.get_hourly_load_post_settlements` fails with `BadZipFile: Bad CRC-32`. Added `utils.read_zip_member_with_local_header_fallback`, which retries a failed member read using the local file header's CRC and sizes — still CRC-validated, so genuinely corrupt data raises as before.

## How to validate

- `uv run pytest gridstatus/tests/test_utils.py -k read_zip_member` — unit tests against a synthetically corrupted zip
- `uv run pytest gridstatus/tests/source_specific/test_ercot.py -k corrupt_zip_central_directory` — records the live 2026 archive and exercises the fallback

The pre-existing `post_settlements_xls`/`post_settlements_zip` test failures (whole-year data returned untrimmed to the requested range) reproduce on unmodified main and are unrelated.