### PR TITLE
Raise Correct Error When No Data Found for EIA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@
 * `Ercot.get_fuel_mix_detailed` no longer raises `AttributeError: 'float' object has no attribute 'get'` when Ercot reports one interval under two timestamps a few seconds apart and splits the fuel types between them. The fuel types missing from each timestamp are now returned as null instead of failing the whole request, matching the behavior `Ercot.get_fuel_mix` already had.
 * `Ercot.get_fuel_mix` and `Ercot.get_fuel_mix_detailed` now sort by `Time`. Ercot publishes the two halves of a split interval out of chronological order, which previously produced an unsorted `Time` column.
 
+#### EIA
+
+* `EIA.get_dataset` now raises `NoDataFoundException` when the API returns no rows for the requested window, instead of `KeyError: 'period'`. Requesting a window past the end of published data is a normal condition — EIA's hourly datasets each have their own ragged reporting edge — and callers can now distinguish it from a genuine failure. `EIA.get_facility_fuel` already behaved this way.
+
 #### Maintenance
 
 * Removed unused runtime dependencies (`setuptools`, `virtualenv`, `h11`, `zipp`, `filelock`) — none are imported and nothing in the runtime tree requires them, so they no longer ship to consumers. Resolves the `setuptools <79` cap reported in [#901](https://github.com/gridstatus/gridstatus/issues/901).

--- a/gridstatus/eia.py
+++ b/gridstatus/eia.py
@@ -197,6 +197,11 @@ class EIA:
 
         raw_df, total_records = self._fetch_page(url, headers)
 
+        if total_records == 0:
+            raise NoDataFoundException(
+                f"No EIA data found for {dataset} between {start_str} and {end_str}",
+            )
+
         # Calculate the number of pages
         page_size = 5000
         total_pages = (total_records + page_size - 1) // page_size

--- a/gridstatus/tests/source_specific/test_eia.py
+++ b/gridstatus/tests/source_specific/test_eia.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 import gridstatus
+from gridstatus.base import NoDataFoundException
 from gridstatus.eia import EIA, HENRY_HUB_TIMEZONE
 from gridstatus.eia_constants import (
     CANCELED_OR_POSTPONED_GENERATOR_COLUMNS,
@@ -184,6 +185,27 @@ def test_fuel_type():
     assert df["Interval End"].max() == end
 
     _check_fuel_type(df)
+
+
+@pytest.mark.integration
+def test_get_dataset_no_data_found():
+    eia = gridstatus.EIA()
+
+    # Far enough ahead that EIA cannot have published data for the window. A
+    # request past the end of published data returns zero rows, which used to
+    # surface as a KeyError on the missing "period" column.
+    start = (pd.Timestamp.utcnow() + pd.Timedelta(days=30)).normalize()
+    end = start + pd.Timedelta(days=1)
+
+    with pytest.raises(
+        NoDataFoundException,
+        match="No EIA data found for electricity/rto/interchange-data",
+    ):
+        eia.get_dataset(
+            dataset="electricity/rto/interchange-data",
+            start=start,
+            end=end,
+        )
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

- Raises `NoDataFoundException` when no data is found for an EIA dataset allowing downstream callers to handle this exception

### Details
