### PR TITLE
Handle the Offer Type column in ERCOT 60-day SCED Resource AS Offers files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * `Ercot.get_fuel_mix_detailed` no longer raises `AttributeError: 'float' object has no attribute 'get'` when Ercot reports one interval under two timestamps a few seconds apart and splits the fuel types between them. The fuel types missing from each timestamp are now returned as null instead of failing the whole request, matching the behavior `Ercot.get_fuel_mix` already had.
 * `Ercot.get_fuel_mix` and `Ercot.get_fuel_mix_detailed` now sort by `Time`. Ercot publishes the two halves of a split interval out of chronological order, which previously produced an unsorted `Time` column.
 * `Ercot.get_hourly_load_post_settlements` no longer raises `BadZipFile: Bad CRC-32` on zip archives whose central directory disagrees with the local file header, as published for the 2026 Native_Load archive. Reading now falls back to the local file header's CRC and sizes, which are still validated against the data.
+* `Ercot.get_60_day_sced_disclosure` no longer raises `ValueError: Unknown curve type found` on Resource AS Offers files starting with Operating Day June 25, 2026. These files carry an explicit `Offer Type` column (`ONRES`/`OFFNS`/`REGDN`), which is now mapped directly to the curve type instead of inferring it from which price columns hold values. The explicit column is also required to classify the ECRS-only rows these files contain under both `ONRES` and `OFFNS`. Padding rows holding no price or quantity values are dropped to keep the output consistent with earlier files.
 
 #### EIA
 

--- a/gridstatus/ercot_60d_utils.py
+++ b/gridstatus/ercot_60d_utils.py
@@ -1501,32 +1501,63 @@ def process_sced_resource_as_offers(
 
     df = df.rename(columns=_rename_suffix)
 
-    # First create a curve_type column with the logic:
-    # regulation down : values only in _DRS columns and not in other columns
-    # offline: values in _NS and optionally _ECRS columns and not in other columns
-    # online : values in any column except for _DRS
     price_cols = [c for c in df.columns if c.startswith("PRICE")]
-    drs_cols = [c for c in price_cols if c.endswith("_DRS")]
-    ns_cols = [c for c in price_cols if c.endswith("_NS")]
-    non_drs_cols = [c for c in price_cols if not c.endswith("_DRS")]
+    quantity_cols = [c for c in df.columns if c.startswith("QUANTITY_MW")]
 
-    # Use fillna(0) so that NaN values are treated as "no value" (same as zero).
-    # ERCOT corrected files (April 4, 2026+) use NaN instead of zero for empty
-    # AS Sub-Type Offer Prices (see ERCOT notice M-B040326-01).
-    has_drs = (df[drs_cols].fillna(0) != 0).any(axis=1)
-    has_non_drs = (df[non_drs_cols].fillna(0) != 0).any(axis=1)
-    has_ns = (df[ns_cols].fillna(0) != 0).any(axis=1)
+    if "Offer Type" in df.columns:
+        # Files starting with Operating Day June 25, 2026 carry an explicit
+        # Offer Type column, so the curve type no longer needs to be inferred
+        # from which price columns hold values. The explicit column is also
+        # required: these files contain ECRS-only rows under both ONRES and
+        # OFFNS, which no price-column pattern can tell apart.
+        offer_type_to_curve_type = {
+            "ONRES": "Online",
+            "OFFNS": "Offline",
+            "REGDN": "Regulation Down",
+        }
+        unknown_offer_types = set(df["Offer Type"].dropna().unique()) - set(
+            offer_type_to_curve_type,
+        )
+        if unknown_offer_types:
+            raise ValueError(
+                f"Unknown offer type(s) found: {sorted(unknown_offer_types)}",
+            )
+        df["Curve Type"] = df["Offer Type"].map(offer_type_to_curve_type)
 
-    non_drs_ns_ecrs_cols = [c for c in non_drs_cols if not c.endswith(("_NS", "_ECRS"))]
-    has_non_drs_ns_ecrs = (df[non_drs_ns_ecrs_cols].fillna(0) != 0).any(axis=1)
+        # These files also pad every resource out to all three offer types with
+        # rows holding no price or quantity values. Earlier files had no such
+        # rows, so drop them to keep the output consistent.
+        has_any_value = (df[price_cols + quantity_cols].fillna(0) != 0).any(axis=1)
+        df = df[has_any_value].copy()
+    else:
+        # First create a curve_type column with the logic:
+        # regulation down : values only in _DRS columns and not in other columns
+        # offline: values in _NS and optionally _ECRS columns and not in other
+        # columns
+        # online : values in any column except for _DRS
+        drs_cols = [c for c in price_cols if c.endswith("_DRS")]
+        ns_cols = [c for c in price_cols if c.endswith("_NS")]
+        non_drs_cols = [c for c in price_cols if not c.endswith("_DRS")]
 
-    df["Curve Type"] = "unknown"
-    df.loc[has_drs & ~has_non_drs, "Curve Type"] = "Regulation Down"
-    df.loc[has_non_drs & has_non_drs_ns_ecrs, "Curve Type"] = "Online"
-    df.loc[has_ns & ~has_drs & ~has_non_drs_ns_ecrs, "Curve Type"] = "Offline"
+        # Use fillna(0) so that NaN values are treated as "no value" (same as
+        # zero). ERCOT corrected files (April 4, 2026+) use NaN instead of zero
+        # for empty AS Sub-Type Offer Prices (see ERCOT notice M-B040326-01).
+        has_drs = (df[drs_cols].fillna(0) != 0).any(axis=1)
+        has_non_drs = (df[non_drs_cols].fillna(0) != 0).any(axis=1)
+        has_ns = (df[ns_cols].fillna(0) != 0).any(axis=1)
 
-    if any(df["Curve Type"] == "unknown"):
-        raise ValueError("Unknown curve type found")
+        non_drs_ns_ecrs_cols = [
+            c for c in non_drs_cols if not c.endswith(("_NS", "_ECRS"))
+        ]
+        has_non_drs_ns_ecrs = (df[non_drs_ns_ecrs_cols].fillna(0) != 0).any(axis=1)
+
+        df["Curve Type"] = "unknown"
+        df.loc[has_drs & ~has_non_drs, "Curve Type"] = "Regulation Down"
+        df.loc[has_non_drs & has_non_drs_ns_ecrs, "Curve Type"] = "Online"
+        df.loc[has_ns & ~has_drs & ~has_non_drs_ns_ecrs, "Curve Type"] = "Offline"
+
+        if any(df["Curve Type"] == "unknown"):
+            raise ValueError("Unknown curve type found")
 
     # Map source column suffixes to output curve names
     as_type_mapping = {

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -4901,6 +4901,116 @@ class TestProcessScedResourceAsOffersNewSuffixes:
             assert old[col].iloc[0] == new[col].iloc[0], col
 
 
+def _with_offer_type(rows):
+    """Build a raw AS offers DataFrame carrying the Offer Type column that
+    files starting with Operating Day June 25, 2026 include."""
+    df = _to_new_suffixes(_make_sced_resource_as_offers_df(rows))
+    df["Offer Type"] = [row["Offer Type"] for row in rows]
+    return df
+
+
+class TestProcessScedResourceAsOffersOfferTypeColumn:
+    """Files starting with Operating Day June 25, 2026 carry an explicit
+    Offer Type column (ONRES/OFFNS/REGDN) which maps directly to the curve
+    type. They also contain ECRS-only rows under both ONRES and OFFNS, which
+    the price-column inference cannot classify, and pad every resource out to
+    all three offer types with rows holding no price or quantity values.
+    """
+
+    def test_offer_type_maps_to_curve_type(self):
+        df = _with_offer_type(
+            [
+                {**_AEEC_ANTLP_3_ONRES_CORRECTED, "Offer Type": "ONRES"},
+                {**_AEEC_ANTLP_3_REGDN_CORRECTED, "Offer Type": "REGDN"},
+                {**_AEEC_ANTLP_3_OFFNS_CORRECTED, "Offer Type": "OFFNS"},
+            ],
+        )
+        result = process_sced_resource_as_offers(df)
+        assert list(result["Curve Type"]) == [
+            "Online",
+            "Regulation Down",
+            "Offline",
+        ]
+
+    # The new-format files use NaN for empty price and quantity cells, like the
+    # corrected-period files (ERCOT notice M-B040326-01).
+    _NAN_CELLS = {
+        **{
+            f"PRICE{i}_{suffix}": _N
+            for i in range(1, 7)
+            for suffix in ["URS", "DRS", "RRSPF", "RRSUF", "RRSFF", "NS", "ECRS"]
+        },
+        **{f"QUANTITY_MW{i}": _N for i in range(1, 7)},
+    }
+
+    def test_ecrs_only_rows_classified_by_offer_type(self):
+        """ECRS-only rows appear under both ONRES and OFFNS; only the Offer
+        Type column can tell them apart (inference raised on them)."""
+        ecrs_only = {
+            **self._NAN_CELLS,
+            "SCED Timestamp": "2026-06-25 15:50:22",
+            "Resource Name": "7RNCHSLR_UNIT1",
+            "QUANTITY_MW1": 10.0,
+            "PRICE1_ECRS": 5.0,
+        }
+        df = _with_offer_type(
+            [
+                {**ecrs_only, "Offer Type": "ONRES"},
+                {**ecrs_only, "Offer Type": "OFFNS"},
+            ],
+        )
+        result = process_sced_resource_as_offers(df)
+        assert list(result["Curve Type"]) == ["Online", "Offline"]
+        assert result["ECRS Offer Curve"].iloc[0] == [[10.0, 5.0]]
+
+    def test_empty_padding_rows_dropped(self):
+        """Rows with no price or quantity values are dropped."""
+        empty = {
+            **self._NAN_CELLS,
+            "SCED Timestamp": "2026-06-25 15:50:22",
+            "Resource Name": "7RNCHSLR_UNIT1",
+        }
+        df = _with_offer_type(
+            [
+                {**_AEEC_ANTLP_3_ONRES_CORRECTED, "Offer Type": "ONRES"},
+                {**empty, "Offer Type": "REGDN"},
+                {**empty, "Offer Type": "OFFNS"},
+            ],
+        )
+        result = process_sced_resource_as_offers(df)
+        assert len(result) == 1
+        assert result["Curve Type"].iloc[0] == "Online"
+
+    def test_unknown_offer_type_raises(self):
+        df = _with_offer_type(
+            [{**_AEEC_ANTLP_3_ONRES_CORRECTED, "Offer Type": "ONECRS"}],
+        )
+        with pytest.raises(ValueError, match="Unknown offer type"):
+            process_sced_resource_as_offers(df)
+
+    def test_output_columns(self):
+        """Offer Type is dropped from the processed output."""
+        df = _with_offer_type(
+            [{**_AEEC_ANTLP_3_ONRES_CORRECTED, "Offer Type": "ONRES"}],
+        )
+        result = process_sced_resource_as_offers(df)
+        assert result.columns.tolist() == SCED_RESOURCE_AS_OFFERS_COLUMNS
+
+    def test_curves_match_inference_path(self):
+        """The same row produces identical curves through both paths."""
+        inferred = process_sced_resource_as_offers(
+            _make_sced_resource_as_offers_df([_AEEC_ANTLP_3_ONRES_CORRECTED]),
+        )
+        mapped = process_sced_resource_as_offers(
+            _with_offer_type(
+                [{**_AEEC_ANTLP_3_ONRES_CORRECTED, "Offer Type": "ONRES"}],
+            ),
+        )
+        assert mapped["Curve Type"].iloc[0] == inferred["Curve Type"].iloc[0]
+        for col in [c for c in mapped.columns if c.endswith("Offer Curve")]:
+            assert inferred[col].iloc[0] == mapped[col].iloc[0], col
+
+
 def check_60_day_dam_disclosure(df_dict):
     assert df_dict is not None
 


### PR DESCRIPTION
## What changed

ERCOT's 60-Day SCED Disclosure Resource AS Offers files starting with Operating Day June 25, 2026 (published August 24, 2026) carry an explicit `Offer Type` column (`ONRES`/`OFFNS`/`REGDN`). The previous logic inferred the curve type from which price columns held values and raised `ValueError: Unknown curve type found` on these files, because they contain:

- 370,400 padding rows with no price or quantity values (every resource is padded out to all three offer types)
- 2,700 ECRS-only rows appearing under both `ONRES` and `OFFNS`, which no price-column pattern can tell apart

`process_sced_resource_as_offers` now maps `Offer Type` directly to the curve type when the column is present, drops the empty padding rows, and raises on unrecognized offer type values. Files without the column keep the existing inference path unchanged.

## How to validate

- `pytest gridstatus/tests/source_specific/test_ercot.py -k TestProcessScedResourceAsOffers` (6 new tests, 12 existing pass unchanged)
- `Ercot().get_60_day_sced_disclosure(date=pd.Timestamp('2026-06-25', tz='US/Central'), process=True)` completes against the real file: 1,188,350 rows, curve type counts match the per-offer-type non-empty row counts, no duplicate (SCED Timestamp, Resource Name, Curve Type) keys, no all-empty curve rows.