### PR TITLE
Handle ERCOT's capped/uncapped SCED price column split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * ERCOT 2-Day Aggregate Gen Summary, Load Summary, and Output Schedule datasets via `Ercot.get_aggregate_gen_summary_2_day`, `Ercot.get_aggregate_load_summary_2_day`, and `Ercot.get_aggregate_output_schedule_2_day`
 * ERCOT LMP Price Corrections by settlement point and by electrical bus via `Ercot.get_lmp_by_settlement_point_price_corrections` and `Ercot.get_lmp_by_bus_price_corrections`
 * ERCOT price correction getters accept `published_after` to skip documents already ingested
+* ERCOT uncapped SCED prices via the new `Uncapped System Lambda`, `Uncapped LMP`, and `Uncapped MCPC` columns on `Ercot.get_sced_system_lambda`, `Ercot.get_lmp_by_bus`, and `Ercot.get_mcpc_sced`. ERCOT began publishing these alongside the capped prices on August 27, 2026 with NPRR1290 and NPRR1323. The two values differ only when the price would exceed the Value of Lost Load. Files published before that date have no uncapped value, so the column is null for earlier data.
 
 #### MISO
 * MISO Area Control Error dataset via `MISO.get_area_control_error`
@@ -45,6 +46,7 @@
 * `Ercot.get_fuel_mix_detailed` no longer raises `AttributeError: 'float' object has no attribute 'get'` when Ercot reports one interval under two timestamps a few seconds apart and splits the fuel types between them. The fuel types missing from each timestamp are now returned as null instead of failing the whole request, matching the behavior `Ercot.get_fuel_mix` already had.
 * `Ercot.get_fuel_mix` and `Ercot.get_fuel_mix_detailed` now sort by `Time`. Ercot publishes the two halves of a split interval out of chronological order, which previously produced an unsorted `Time` column.
 * `Ercot.get_hourly_load_post_settlements` no longer raises `BadZipFile: Bad CRC-32` on zip archives whose central directory disagrees with the local file header, as published for the 2026 Native_Load archive. Reading now falls back to the local file header's CRC and sizes, which are still validated against the data.
+* `Ercot.get_sced_system_lambda`, `Ercot.get_lmp_by_bus`, and `Ercot.get_mcpc_sced` no longer raise `KeyError` on files published from August 27, 2026 onward. ERCOT renamed the price column in each of these reports to `CappedSystemLambda`, `CappedLMP`, and `CappedMCPC` when NPRR1290 and NPRR1323 were implemented. The capped value is the same series these methods have always returned, so it keeps its existing column name and no output changes meaning. Older files that use the original names still parse.
 * `Ercot.get_60_day_sced_disclosure` no longer raises `ValueError: Unknown curve type found` on Resource AS Offers files starting with Operating Day June 25, 2026. These files carry an explicit `Offer Type` column (`ONRES`/`OFFNS`/`REGDN`), which is now mapped directly to the curve type instead of inferring it from which price columns hold values. The explicit column is also required to classify the ECRS-only rows these files contain under both `ONRES` and `OFFNS`. Padding rows holding no price or quantity values are dropped to keep the output consistent with earlier files.
 
 #### EIA

--- a/gridstatus/ercot.py
+++ b/gridstatus/ercot.py
@@ -455,6 +455,16 @@ RESOURCE_NODE_SETTLEMENT_TYPES = ["RN", "PCCRN", "LCCRN", "PUN"]
 LOAD_ZONE_SETTLEMENT_TYPES = ["LZ", "LZ_DC"]
 HUB_SETTLEMENT_TYPES = ["HU", "SH", "AH"]
 
+# On 2026-08-27, when NPRR1290 and NPRR1323 were implemented, ERCOT renamed the
+# price column in each of these SCED reports with a "Capped" prefix and added an
+# "Uncapped" counterpart. Files published before that date carry only the legacy
+# name, so the rename is applied when the capped name is present.
+CAPPED_TO_LEGACY_COLUMNS = {
+    "CappedSystemLambda": "SystemLambda",
+    "CappedLMP": "LMP",
+    "CappedMCPC": "MCPC",
+}
+
 
 @dataclass
 class Document:
@@ -1956,7 +1966,11 @@ class Ercot(ISOBase):
             verbose=verbose,
         )
 
-        return self._handle_lmp(docs=docs, verbose=verbose)
+        return self._handle_lmp(
+            docs=docs,
+            verbose=verbose,
+            location_type=location_type,
+        )
 
     @support_date_range(frequency=None)
     def get_lmp(
@@ -2015,33 +2029,51 @@ class Ercot(ISOBase):
         docs: list[Document],
         verbose: bool = False,
         sced: bool = True,
+        location_type: str = SETTLEMENT_POINT_LOCATION_TYPE,
     ) -> pd.DataFrame:
+        empty_columns = [
+            "SCEDTimestamp",
+            "RepeatedHourFlag",
+            "Location",
+            "Location Type",
+            "LMP",
+        ]
+
+        if location_type.lower() == ELECTRICAL_BUS_LOCATION_TYPE.lower():
+            empty_columns.append("UncappedLMP")
+
         df = self.read_docs(
             docs,
             parse=False,
             # need to return a DF that works with the
             # logic in rest of function
-            empty_df=pd.DataFrame(
-                columns=[
-                    "SCEDTimestamp",
-                    "RepeatedHourFlag",
-                    "Location",
-                    "Location Type",
-                    "LMP",
-                ],
-            ),
+            empty_df=pd.DataFrame(columns=empty_columns),
             verbose=verbose,
         )
 
-        return self._handle_lmp_df(df, verbose=verbose, sced=sced)
+        return self._handle_lmp_df(
+            df,
+            verbose=verbose,
+            sced=sced,
+            location_type=location_type,
+        )
 
     def _handle_lmp_df(
         self,
         df: pd.DataFrame,
         verbose: bool = False,
         sced: bool = True,
+        location_type: str = SETTLEMENT_POINT_LOCATION_TYPE,
     ) -> pd.DataFrame:
+        df = df.rename(columns=CAPPED_TO_LEGACY_COLUMNS)
+
         df = self._handle_sced_timestamp(df=df, verbose=verbose)
+
+        # Only the electrical bus report gained an uncapped price. The settlement
+        # point report is unchanged, so its columns must stay as they are.
+        is_electrical_bus = (
+            location_type.lower() == ELECTRICAL_BUS_LOCATION_TYPE.lower()
+        )
 
         if "SettlementPoint" in df.columns:
             df = self._handle_settlement_point_name_and_type(df, verbose=verbose)
@@ -2057,21 +2089,34 @@ class Ercot(ISOBase):
             df["Location"] = df["Location"].astype("string")
             df["Location Type"] = df["Location Type"].astype("category")
 
+        if is_electrical_bus:
+            # Only published from 2026-08-27 onward.
+            if "UncappedLMP" not in df.columns:
+                df["UncappedLMP"] = pd.NA
+
+            df["Uncapped LMP"] = pd.to_numeric(
+                df["UncappedLMP"],
+                errors="coerce",
+            ).astype("float64")
+
         df["Market"] = (
             Markets.REAL_TIME_SCED.value if sced else Markets.DAY_AHEAD_HOURLY.value
         )
 
-        df = df[
-            [
-                "Interval Start",
-                "Interval End",
-                "SCED Timestamp",
-                "Market",
-                "Location",
-                "Location Type",
-                "LMP",
-            ]
+        columns = [
+            "Interval Start",
+            "Interval End",
+            "SCED Timestamp",
+            "Market",
+            "Location",
+            "Location Type",
+            "LMP",
         ]
+
+        if is_electrical_bus:
+            columns.append("Uncapped LMP")
+
+        df = df[columns]
         # sort by SCED Timestamp and Location
         df = df.sort_values(
             [
@@ -5400,23 +5445,55 @@ class Ercot(ISOBase):
 
         if len(all_dfs) == 0:
             df = pd.DataFrame(
-                columns=["SCEDTimeStamp", "RepeatedHourFlag", "SystemLambda"],
+                columns=[
+                    "SCEDTimeStamp",
+                    "RepeatedHourFlag",
+                    "SystemLambda",
+                    "UncappedSystemLambda",
+                ],
             )
         else:
             df = pd.concat(all_dfs)
+
+        return self._handle_sced_system_lambda_df(df, verbose=verbose)
+
+    def _handle_sced_system_lambda_df(
+        self,
+        df: pd.DataFrame,
+        verbose: bool = False,
+    ) -> pd.DataFrame:
+        df = df.rename(columns=CAPPED_TO_LEGACY_COLUMNS)
 
         df = self._handle_sced_timestamp(df, verbose=verbose)
 
         df["SystemLambda"] = df["SystemLambda"].astype("float64")
 
+        # Only published from 2026-08-27 onward. Older files have no uncapped value.
+        if "UncappedSystemLambda" not in df.columns:
+            df["UncappedSystemLambda"] = pd.NA
+
+        df["UncappedSystemLambda"] = pd.to_numeric(
+            df["UncappedSystemLambda"],
+            errors="coerce",
+        ).astype("float64")
+
         df = df.rename(
             columns={
                 "SystemLambda": "System Lambda",
+                "UncappedSystemLambda": "Uncapped System Lambda",
             },
         )
 
         df.sort_values("SCED Timestamp", inplace=True)
-        return df[["Interval Start", "Interval End", "SCED Timestamp", "System Lambda"]]
+        return df[
+            [
+                "Interval Start",
+                "Interval End",
+                "SCED Timestamp",
+                "System Lambda",
+                "Uncapped System Lambda",
+            ]
+        ]
 
     @support_date_range("DAY_START")
     def get_highest_price_as_offer_selected(
@@ -7608,14 +7685,23 @@ class Ercot(ISOBase):
         return self._handle_mcpc_sced(df)
 
     def _handle_mcpc_sced(self, df: pd.DataFrame) -> pd.DataFrame:
-        df = df.rename(columns={"ASType": "AS Type"})
+        df = df.rename(columns={"ASType": "AS Type", **CAPPED_TO_LEGACY_COLUMNS})
         df = self._handle_sced_timestamp(df)
 
         df["MCPC"] = pd.to_numeric(df["MCPC"], errors="coerce")
 
+        # Only published from 2026-08-27 onward. Older files have no uncapped value.
+        if "UncappedMCPC" not in df.columns:
+            df["UncappedMCPC"] = pd.NA
+
+        df["Uncapped MCPC"] = pd.to_numeric(
+            df["UncappedMCPC"],
+            errors="coerce",
+        ).astype("float64")
+
         return (
             # Only need the SCED Timestamps
-            df[["SCED Timestamp", "AS Type", "MCPC"]]
+            df[["SCED Timestamp", "AS Type", "MCPC", "Uncapped MCPC"]]
             .sort_values(["SCED Timestamp", "AS Type"])
             .reset_index(drop=True)
         )

--- a/gridstatus/ercot_api/ercot_api.py
+++ b/gridstatus/ercot_api/ercot_api.py
@@ -16,6 +16,7 @@ from gridstatus import utils
 from gridstatus.base import Markets, NoDataFoundException
 from gridstatus.decorators import support_date_range
 from gridstatus.ercot import (
+    CAPPED_TO_LEGACY_COLUMNS,
     ELECTRICAL_BUS_LOCATION_TYPE,
     Ercot,
 )
@@ -1470,11 +1471,27 @@ class ErcotAPI:
         return self._handle_lmp_by_bus(data, verbose=verbose)
 
     def _handle_lmp_by_bus(self, data, verbose=False):
+        data = data.rename(columns=CAPPED_TO_LEGACY_COLUMNS)
+
         data = self.ercot._handle_sced_timestamp(data, verbose=verbose)
 
-        data = data.rename(columns={"ElectricalBus": "Location"})
+        data = data.rename(
+            columns={
+                "ElectricalBus": "Location",
+                "UncappedLMP": "Uncapped LMP",
+            },
+        )
         data["Location Type"] = ELECTRICAL_BUS_LOCATION_TYPE
         data["Market"] = Markets.REAL_TIME_SCED.value
+
+        # Only published from 2026-08-27 onward. Older data has no uncapped value.
+        if "Uncapped LMP" not in data.columns:
+            data["Uncapped LMP"] = pd.NA
+
+        data["Uncapped LMP"] = pd.to_numeric(
+            data["Uncapped LMP"],
+            errors="coerce",
+        ).astype("float64")
 
         data = utils.move_cols_to_front(
             data,
@@ -1486,6 +1503,7 @@ class ErcotAPI:
                 "Location",
                 "Location Type",
                 "LMP",
+                "Uncapped LMP",
             ],
         )
 

--- a/gridstatus/tests/source_specific/test_ercot.py
+++ b/gridstatus/tests/source_specific/test_ercot.py
@@ -148,6 +148,7 @@ class TestErcot(BaseTestISO):
             "Interval End",
             "SCED Timestamp",
             "System Lambda",
+            "Uncapped System Lambda",
         ]
         today = pd.Timestamp.now(tz=self.iso.default_timezone).date()
         assert df["SCED Timestamp"].unique()[0].date() == today
@@ -3710,10 +3711,12 @@ class TestErcot(BaseTestISO):
             "SCED Timestamp",
             "AS Type",
             "MCPC",
+            "Uncapped MCPC",
         ]
         assert df.dtypes["SCED Timestamp"] == "datetime64[ns, US/Central]"
         assert df.dtypes["AS Type"] == "object"
         assert df.dtypes["MCPC"] == "float64"
+        assert df.dtypes["Uncapped MCPC"] == "float64"
 
     def test_get_mcpc_sced_date_range(self):
         # Choose a date range that spans two days to test we handle day transitions
@@ -5368,3 +5371,179 @@ class TestCategorizeStrings:
         df = pd.DataFrame({"Resource Name": ["RES_A", "RES_B", "RES_A"]})
         result = _categorize_strings(df)
         assert list(result["Resource Name"]) == ["RES_A", "RES_B", "RES_A"]
+
+
+class TestCappedUncappedSCEDColumns:
+    """On 2026-08-27, when NPRR1290 and NPRR1323 were implemented, ERCOT renamed
+    the price column in SCED System Lambda (NP6-322-CD), LMPs by Electrical Bus
+    (NP6-787-CD) and Real-Time MCPC by SCED Interval (NP6-332-CD) with a
+    "Capped" prefix and added an "Uncapped" counterpart. The capped value is the
+    series gridstatus has always published, so it keeps the original name and the
+    uncapped value is exposed as a new column. Files published before the cutover
+    carry only the legacy name and get a null uncapped value.
+    """
+
+    iso = Ercot()
+
+    _TIMESTAMPS = ["08/27/2026 22:45:23", "08/27/2026 22:50:23"]
+
+    def _system_lambda_source(self, capped: bool) -> pd.DataFrame:
+        df = pd.DataFrame(
+            {
+                "SCEDTimeStamp": self._TIMESTAMPS,
+                "RepeatedHourFlag": ["N", "N"],
+                "SystemLambda": [83.89810, 79.89353],
+            },
+        )
+
+        if capped:
+            df = df.rename(columns={"SystemLambda": "CappedSystemLambda"})
+            df["UncappedSystemLambda"] = [120.5, 79.89353]
+
+        return df
+
+    def _lmp_by_bus_source(self, capped: bool) -> pd.DataFrame:
+        df = pd.DataFrame(
+            {
+                "SCEDTimestamp": self._TIMESTAMPS,
+                "RepeatedHourFlag": ["N", "N"],
+                "ElectricalBus": ["0001", "0001"],
+                "LMP": [84.14, 80.90],
+            },
+        )
+
+        if capped:
+            df = df.rename(columns={"LMP": "CappedLMP"})
+            df["UncappedLMP"] = [120.5, 80.90]
+
+        return df
+
+    def _mcpc_sced_source(self, capped: bool) -> pd.DataFrame:
+        df = pd.DataFrame(
+            {
+                "SCEDTimestamp": self._TIMESTAMPS,
+                "RepeatedHourFlag": ["N", "N"],
+                "ASType": ["ECRS", "ECRS"],
+                "MCPC": [14.98, 13.97],
+            },
+        )
+
+        if capped:
+            df = df.rename(columns={"MCPC": "CappedMCPC"})
+            df["UncappedMCPC"] = [120.5, 13.97]
+
+        return df
+
+    def _settlement_point_source(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "SCEDTimestamp": self._TIMESTAMPS,
+                "RepeatedHourFlag": ["N", "N"],
+                "SettlementPoint": ["A4_DGR1_RN", "A4_DGR1_RN"],
+                "SettlementPointType": ["RN", "RN"],
+                "LMP": [84.08, 80.12],
+            },
+        )
+
+    """system lambda"""
+
+    def test_system_lambda_capped_maps_to_existing_column(self):
+        result = self.iso._handle_sced_system_lambda_df(
+            self._system_lambda_source(capped=True),
+        )
+
+        assert result.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "SCED Timestamp",
+            "System Lambda",
+            "Uncapped System Lambda",
+        ]
+        assert result["System Lambda"].tolist() == [83.89810, 79.89353]
+        assert result["Uncapped System Lambda"].tolist() == [120.5, 79.89353]
+
+    def test_system_lambda_pre_cutover_files_still_parse(self):
+        """Files without the capped rename produce a null uncapped value."""
+        old = self.iso._handle_sced_system_lambda_df(
+            self._system_lambda_source(capped=False),
+        )
+        new = self.iso._handle_sced_system_lambda_df(
+            self._system_lambda_source(capped=True),
+        )
+
+        assert old.columns.tolist() == new.columns.tolist()
+        assert old["Uncapped System Lambda"].isna().all()
+        assert old["System Lambda"].tolist() == new["System Lambda"].tolist()
+        assert old.dtypes["Uncapped System Lambda"] == "float64"
+
+    """lmp by bus"""
+
+    def test_lmp_by_bus_capped_maps_to_existing_column(self):
+        result = self.iso._handle_lmp_df(
+            self._lmp_by_bus_source(capped=True),
+            location_type=ELECTRICAL_BUS_LOCATION_TYPE,
+        )
+
+        assert result.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "SCED Timestamp",
+            "Market",
+            "Location",
+            "Location Type",
+            "LMP",
+            "Uncapped LMP",
+        ]
+        assert result["LMP"].tolist() == [84.14, 80.90]
+        assert result["Uncapped LMP"].tolist() == [120.5, 80.90]
+
+    def test_lmp_by_bus_pre_cutover_files_still_parse(self):
+        old = self.iso._handle_lmp_df(
+            self._lmp_by_bus_source(capped=False),
+            location_type=ELECTRICAL_BUS_LOCATION_TYPE,
+        )
+        new = self.iso._handle_lmp_df(
+            self._lmp_by_bus_source(capped=True),
+            location_type=ELECTRICAL_BUS_LOCATION_TYPE,
+        )
+
+        assert old.columns.tolist() == new.columns.tolist()
+        assert old["Uncapped LMP"].isna().all()
+        assert old["LMP"].tolist() == new["LMP"].tolist()
+
+    def test_lmp_by_settlement_point_columns_unchanged(self):
+        """Only the electrical bus report changed. The settlement point report
+        must not gain a permanently null uncapped column."""
+        result = self.iso._handle_lmp_df(self._settlement_point_source())
+
+        assert result.columns.tolist() == [
+            "Interval Start",
+            "Interval End",
+            "SCED Timestamp",
+            "Market",
+            "Location",
+            "Location Type",
+            "LMP",
+        ]
+
+    """mcpc sced"""
+
+    def test_mcpc_sced_capped_maps_to_existing_column(self):
+        result = self.iso._handle_mcpc_sced(self._mcpc_sced_source(capped=True))
+
+        assert result.columns.tolist() == [
+            "SCED Timestamp",
+            "AS Type",
+            "MCPC",
+            "Uncapped MCPC",
+        ]
+        assert result["MCPC"].tolist() == [14.98, 13.97]
+        assert result["Uncapped MCPC"].tolist() == [120.5, 13.97]
+
+    def test_mcpc_sced_pre_cutover_files_still_parse(self):
+        old = self.iso._handle_mcpc_sced(self._mcpc_sced_source(capped=False))
+        new = self.iso._handle_mcpc_sced(self._mcpc_sced_source(capped=True))
+
+        assert old.columns.tolist() == new.columns.tolist()
+        assert old["Uncapped MCPC"].isna().all()
+        assert old["MCPC"].tolist() == new["MCPC"].tolist()

--- a/gridstatus/tests/source_specific/test_ercot_api.py
+++ b/gridstatus/tests/source_specific/test_ercot_api.py
@@ -1026,6 +1026,7 @@ class TestErcotAPI(TestHelperMixin):
             "Location",
             "Location Type",
             "LMP",
+            "Uncapped LMP",
         ]
 
         assert df.dtypes["Interval Start"] == "datetime64[ns, US/Central]"
@@ -1035,6 +1036,7 @@ class TestErcotAPI(TestHelperMixin):
         assert (df["Location Type"] == ELECTRICAL_BUS_LOCATION_TYPE).all()
 
         assert df.dtypes["LMP"] == "float64"
+        assert df.dtypes["Uncapped LMP"] == "float64"
 
         assert (
             (df["Interval End"] - df["Interval Start"]) == pd.Timedelta(minutes=5)


### PR DESCRIPTION
## What changed

On 2026-08-27 ERCOT implemented NPRR1290 and NPRR1323 and renamed the price column in three SCED reports with a `Capped` prefix, adding an `Uncapped` counterpart:

| Report | Before | Now |
|---|---|---|
| SCED System Lambda (NP6-322-CD) | `SystemLambda` | `CappedSystemLambda`, `UncappedSystemLambda` |
| LMPs by Electrical Bus (NP6-787-CD) | `LMP` | `CappedLMP`, `UncappedLMP` |
| Real-Time MCPC by SCED Interval (NP6-332-CD) | `MCPC` | `CappedMCPC`, `UncappedMCPC` |

All three parsers index the price column by name, so they raised `KeyError` on every file published after the cutover.

The capped value is the same series these methods have always returned, so it keeps its existing column name and no existing output changes meaning. The uncapped value is exposed as a new column (`Uncapped System Lambda`, `Uncapped LMP`, `Uncapped MCPC`). The rename is applied only when the capped name is present, so pre-cutover files still parse and get a null uncapped value.

Only the electrical bus LMP report changed. `_handle_lmp_df` is shared with `get_lmp_by_settlement_point`, so the uncapped column is gated on `location_type` (threaded down from `_get_lmp`) rather than sniffed from the frame. That keeps settlement point output exactly as it was, and keeps the bus output schema stable across the cutover boundary instead of flickering by fetch date.

`ErcotAPI._handle_lmp_by_bus` gets the same treatment, since that path serves older dates.

`_handle_sced_system_lambda` is split into a `_handle_sced_system_lambda_df` taking a DataFrame, matching the existing `_handle_lmp` / `_handle_lmp_df` split, so the frame logic is unit-testable without cassettes.

## How to validate

Against live ERCOT data:

```python
iso = gridstatus.Ercot()
now = pd.Timestamp.now(tz=iso.default_timezone)

# Post-cutover: uncapped column populated
iso.get_sced_system_lambda(now - pd.Timedelta(minutes=30), now)
iso.get_mcpc_sced(now - pd.Timedelta(minutes=30), now)
iso.get_lmp_by_bus(now - pd.Timedelta(minutes=30), now)

# Pre-cutover (MIS retains ~5 days): parses, uncapped is NaN
pre = (now - pd.Timedelta(days=4)).normalize() + pd.Timedelta(hours=12)
iso.get_sced_system_lambda(pre, pre + pd.Timedelta(minutes=30))

# Unchanged
iso.get_lmp_by_settlement_point(now - pd.Timedelta(minutes=30), now)
```

I ran all of the above. Post-cutover rows carry both values (identical right now, since they only diverge when the price would exceed VOLL), pre-cutover rows return the uncapped column as NaN, and `get_lmp_by_settlement_point` columns are unchanged.

Unit tests:

```
uv run pytest gridstatus/tests/source_specific/test_ercot.py -k CappedUncapped
```

7 tests covering both layouts for each of the three reports, plus a guard that settlement point output does not gain the column.