### PR TITLE
[ENG-4634] Keep retired PJM pnodes in LMP results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@
 #### NYISO
 * `NYISO.get_lmp` with `market=REAL_TIME_15_MIN` no longer mislabels the newest 5-minute RTD interval as 15-minute RTC data when the daily realtime file updates before the latest-interval file. Mislabeled rows produced 15-minute intervals starting off the quarter-hour grid (e.g. 05:25-05:40). 15-minute rows are now required to end on a quarter-hour boundary, and the affected rows stay in the `REAL_TIME_5_MIN` output.
 
+#### PJM
+* PJM LMP methods no longer drop prices for pnodes PJM has since retired. The pnode directory used to be fetched with an active-only filter and inner-merged onto the prices, so any node retired after a delivery date lost its entire history from that date's results whenever the data was fetched again. Fetching one historical day-ahead hour now returns 13,018 nodes where it previously returned 11,681. `PJM.get_pnode_ids` takes a new `include_terminated` argument for the same reason, defaulting to `False` so its existing output is unchanged.
+
 #### ERCOT
 * `Ercot.get_fuel_mix_detailed` no longer raises `AttributeError: 'float' object has no attribute 'get'` when Ercot reports one interval under two timestamps a few seconds apart and splits the fuel types between them. The fuel types missing from each timestamp are now returned as null instead of failing the whole request, matching the behavior `Ercot.get_fuel_mix` already had.
 * `Ercot.get_fuel_mix` and `Ercot.get_fuel_mix_detailed` now sort by `Time`. Ercot publishes the two halves of a split interval out of chronological order, which previously produced an unsorted `Time` column.

--- a/gridstatus/pjm.py
+++ b/gridstatus/pjm.py
@@ -365,16 +365,35 @@ class PJM(ISOBase):
             drop=True,
         )
 
-    def get_pnode_ids(self) -> pd.DataFrame:
+    def get_pnode_ids(self, include_terminated: bool = False) -> pd.DataFrame:
+        """Returns the pnode directory.
+
+        Arguments:
+            include_terminated: Include pnodes PJM has retired. Defaults to
+                False, which returns only pnodes that are currently active.
+                Pass True when labelling historical data, since a node that
+                has since been retired still appears in LMPs for the dates it
+                was in service.
+
+        Returns:
+            pd.DataFrame: One row per pnode id, carrying its most recent
+            effective date.
+        """
         data = {
             "fields": "effective_date,pnode_id,pnode_name,pnode_subtype,pnode_type\
                 ,termination_date,voltage_level,zone",
-            "termination_date": "12/31/9999exact",
         }
+
+        if not include_terminated:
+            data["termination_date"] = "12/31/9999exact"
+
         nodes = self._get_pjm_json("pnode", start=None, params=data)
 
-        # only keep most recent effective date for each id
-        # return sorted by pnode_id
+        # PJM publishes one row per effective-date window, so a node that has
+        # been revised carries several. Keeping the most recent window per id
+        # leaves one row each: a pnode's name never differs across its own
+        # windows, so this labels historical data the same as current data.
+        # Returned sorted by pnode_id.
         nodes = (
             nodes.sort_values("effective_date", ascending=False)
             .drop_duplicates(
@@ -693,11 +712,17 @@ class PJM(ISOBase):
         # will get full name by merge with pnode data later
         data = data.drop(columns=["pnode_name"])
 
-        p_nodes = self.get_pnode_ids()[
+        # Terminated pnodes are included because historical LMPs contain nodes
+        # PJM has since retired. An inner merge against the active-only list
+        # dropped their rows outright, so a backfill run after a node was
+        # retired silently lost its whole history.
+        p_nodes = self.get_pnode_ids(include_terminated=True)[
             ["pnode_id", "pnode_name", "voltage_level", "pnode_short_name"]
         ]
 
-        data = data.merge(p_nodes, on="pnode_id")
+        # Left so an id missing from the directory keeps its prices rather
+        # than vanishing; the name columns are simply null for it.
+        data = data.merge(p_nodes, on="pnode_id", how="left")
 
         return data
 

--- a/gridstatus/tests/source_specific/test_pjm.py
+++ b/gridstatus/tests/source_specific/test_pjm.py
@@ -223,6 +223,31 @@ class TestPJM(BaseTestISO):
 
             assert len(df) > 0
 
+    def test_get_lmp_keeps_retired_pnodes(self):
+        """Historical LMPs cover nodes PJM has since retired.
+
+        Those rows used to be dropped by an inner merge against the
+        active-only pnode directory, so a node retired after the fact lost its
+        whole price history.
+        """
+        with pjm_vcr.use_cassette("test_get_lmp_keeps_retired_pnodes.yaml"):
+            df = self.iso.get_lmp_day_ahead_hourly(
+                date="2021-06-03",
+                end="2021-06-04",
+            )
+            active = self.iso.get_pnode_ids()
+            everything = self.iso.get_pnode_ids(include_terminated=True)
+
+        first_hour = df[df["Interval Start"] == df["Interval Start"].min()]
+        retired = set(everything["pnode_id"]) - set(active["pnode_id"])
+
+        # The day predates the retirement of some of the nodes priced on it.
+        assert len(set(first_hour["Location Id"]) & retired) > 0
+        # Every row is labelled, retired nodes included, and the merge on a
+        # unique id adds no rows.
+        assert first_hour["Location Name"].notna().all()
+        assert first_hour["Location Id"].is_unique
+
     """get_it_sced_lmp_5_min"""
 
     def _check_it_sced_lmp_5_min(self, df):
@@ -463,6 +488,18 @@ class TestPJM(BaseTestISO):
         with pjm_vcr.use_cassette("test_get_pnode_ids.yaml"):
             df = self.iso.get_pnode_ids()
             assert len(df) > 0
+            assert df["pnode_id"].is_unique
+
+    def test_get_pnode_ids_include_terminated(self):
+        with pjm_vcr.use_cassette("test_get_pnode_ids_include_terminated.yaml"):
+            active = self.iso.get_pnode_ids()
+            everything = self.iso.get_pnode_ids(include_terminated=True)
+
+        # Retired pnodes are a superset of the active ones, and the dedup still
+        # leaves exactly one row per id so a merge on it cannot fan out.
+        assert len(everything) > len(active)
+        assert everything["pnode_id"].is_unique
+        assert set(active["pnode_id"]) <= set(everything["pnode_id"])
 
     """get_status"""
 


### PR DESCRIPTION
PJM LMP results dropped prices for pnodes PJM has since retired.

`get_pnode_ids` fetched the directory with an active-only filter (`termination_date = "12/31/9999exact"`), and `_add_pnode_info_to_lmp_data` inner-merged that onto the prices. Any node retired after a delivery date was therefore absent from the directory, and its rows for that date were dropped on the next fetch. The loss was silent and grows over time: the older the data, the more of its nodes have since been retired.

Fetching 2021-06-03 hour 1 returned 11,681 nodes against the 13,018 PJM published for it. 1,337 nodes were dropped purely because they no longer exist today.

## The change

`get_pnode_ids` takes `include_terminated`, defaulting to `False` so its existing output is unchanged. The LMP path passes `True`, and the merge is now a left join so an id missing from the directory keeps its prices rather than disappearing.

## Why this is right for historical data

Checked against the live pnode feed (23,711 rows, 21,237 ids):

- 0 ids have more than one distinct `pnode_name` across their effective-date windows, so keeping the most recent window labels historical rows exactly as it labels current ones.
- Windows never overlap: 0 rows begin before the previous window ended.
- The dedup leaves `pnode_id` unique, so the merge cannot fan out and inflate row counts.
- 6,787 ids appear only when terminated nodes are included. Those are the nodes being dropped today.

## Verification

Same code path, one historical day-ahead hour, before and after:

| | 2021-06-03 hour 1 |
|---|---|
| before | 11,681 rows / 11,681 locations |
| after | 13,018 rows / 13,018 locations |

13,018 matches what PJM published for that hour. No null names, and no nulls in `LMP` or `Congestion`.

Tests added: `test_get_pnode_ids_include_terminated`, and `test_get_lmp_keeps_retired_pnodes`, which asserts a historical day contains nodes that have since been retired, that every row is labelled, and that ids stay unique.

`gridstatus/tests/source_specific/test_pjm.py`: 159 passed, 4 failed. Those 4 (`solar_forecast_hourly_historical_date`, `solar_forecast_5_min_historical_date`, `wind_forecast_5_min_historical_date`, `tie_flows_5_min_historical_date`) fail identically on unmodified `main`.

## Known limitation

`voltage_level` differs across windows for 103 of 21,237 ids, and `pnode_short_name` is derived from it, so those few rows can carry a current voltage label on an old date. Fixing that would require merging on the effective-date window rather than on `pnode_id` alone, which puts a range join on a hot path; the node name, which is the field callers key on, is already exact.
