### PR TITLE
Fix CAISO historical CSV SSL verification

### DIFF
--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -106,7 +106,9 @@ def _get_historical(
         url: str = f"{HISTORY_BASE}/{date_str}/{file}.csv?_={cache_buster}"
         latest = False
     logger.info(f"Fetching URL: {url}")
-    df = pd.read_csv(url)
+    r = requests.get(url, timeout=120)
+    r.raise_for_status()
+    df = pd.read_csv(io.StringIO(r.text))
 
     # sometimes there are extra rows at the end, so this lets us ignore them
     df = df.dropna(subset=["Time"])

--- a/gridstatus/caiso/caiso.py
+++ b/gridstatus/caiso/caiso.py
@@ -106,6 +106,7 @@ def _get_historical(
         url: str = f"{HISTORY_BASE}/{date_str}/{file}.csv?_={cache_buster}"
         latest = False
     logger.info(f"Fetching URL: {url}")
+    # NOTE: Use requests instead of pd.read_csv(url); urllib fails SSL verify on CAISO's Sectigo R46 chain with macOS system CAs.
     r = requests.get(url, timeout=120)
     r.raise_for_status()
     df = pd.read_csv(io.StringIO(r.text))


### PR DESCRIPTION
## Summary
Fetch CAISO outlook CSVs with `requests` instead of `pd.read_csv(url)`, so urllib no longer fails against Sectigo Root R46 (missing from macOS system CAs).

**Before**
```
Error: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:1032)>
```

**After**
```
Fetching URL: https://www.caiso.com/outlook/history/20260826/fuelsource.csv
rows 288
```

## Test plan
- [ ] `CAISO().get_fuel_mix("2026-08-26")` returns data without SSL errors

Made with [Cursor](https://cursor.com)