### PR TITLE
[ENG-4389] Fix MISO public five-minute LMP interval labels

### DIFF
--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -650,9 +650,11 @@ class MISO(ISOBase):
             # Convert JSON format to DataFrame
             data = pd.DataFrame(response_json["data"], columns=response_json["headers"])
 
-            data["Interval Start"] = pd.to_datetime(data["INTERVAL"]).dt.tz_localize(
+            # MISO's public feed labels INTERVAL by the interval-ending time.
+            interval_end = pd.to_datetime(data["INTERVAL"]).dt.tz_localize(
                 self.default_timezone,
             )
+            data["Interval Start"] = interval_end - pd.Timedelta(minutes=5)
 
             node_to_type_mapping = (
                 MISO()

--- a/gridstatus/miso.py
+++ b/gridstatus/miso.py
@@ -651,10 +651,10 @@ class MISO(ISOBase):
             data = pd.DataFrame(response_json["data"], columns=response_json["headers"])
 
             # MISO's public feed labels INTERVAL by the interval-ending time.
-            interval_end = pd.to_datetime(data["INTERVAL"]).dt.tz_localize(
+            data["Interval End"] = pd.to_datetime(data["INTERVAL"]).dt.tz_localize(
                 self.default_timezone,
             )
-            data["Interval Start"] = interval_end - pd.Timedelta(minutes=5)
+            data["Interval Start"] = data["Interval End"] - pd.Timedelta(minutes=5)
 
             node_to_type_mapping = (
                 MISO()

--- a/gridstatus/tests/source_specific/test_miso.py
+++ b/gridstatus/tests/source_specific/test_miso.py
@@ -256,6 +256,32 @@ class TestMISO(BaseTestISO):
                 "Loadzone",
             ]
 
+    def test_get_lmp_real_time_5_min_uses_interval_ending_timestamp(
+        self,
+        monkeypatch,
+    ):
+        response = {
+            "headers": ["INTERVAL", "CPNODE", "LMP", "MLC", "MCC"],
+            "data": [["2026-09-04 00:05:00", "INDIANA.HUB", 25.0, 1.0, 2.0]],
+        }
+        node_types = pd.DataFrame(
+            {"Node": ["INDIANA.HUB"], "Location Type": ["Hub"]},
+        )
+        monkeypatch.setattr(self.iso, "_get_json", lambda *args, **kwargs: response)
+        monkeypatch.setattr(
+            self.iso,
+            "_get_node_to_type_mapping",
+            lambda *args, **kwargs: node_types,
+        )
+
+        result = self.iso.get_lmp_real_time_5_min(date="latest")
+
+        expected_start = pd.Timestamp("2026-09-04 00:00:00", tz="EST")
+        expected_end = pd.Timestamp("2026-09-04 00:05:00", tz="EST")
+        assert result.loc[0, "Time"] == expected_start
+        assert result.loc[0, "Interval Start"] == expected_start
+        assert result.loc[0, "Interval End"] == expected_end
+
     def test_get_lmp_locations(self):
         cassette_name = "test_get_lmp_locations.yaml"
         with miso_vcr.use_cassette(cassette_name):

--- a/gridstatus/tests/source_specific/test_miso.py
+++ b/gridstatus/tests/source_specific/test_miso.py
@@ -260,32 +260,6 @@ class TestMISO(BaseTestISO):
                 "Loadzone",
             ]
 
-    def test_get_lmp_real_time_5_min_uses_interval_ending_timestamp(
-        self,
-        monkeypatch,
-    ):
-        response = {
-            "headers": ["INTERVAL", "CPNODE", "LMP", "MLC", "MCC"],
-            "data": [["2026-09-04 00:05:00", "INDIANA.HUB", 25.0, 1.0, 2.0]],
-        }
-        node_types = pd.DataFrame(
-            {"Node": ["INDIANA.HUB"], "Location Type": ["Hub"]},
-        )
-        monkeypatch.setattr(self.iso, "_get_json", lambda *args, **kwargs: response)
-        monkeypatch.setattr(
-            MISO,
-            "_get_node_to_type_mapping",
-            lambda *args, **kwargs: node_types,
-        )
-
-        result = self.iso.get_lmp_real_time_5_min(date="latest")
-
-        expected_start = pd.Timestamp("2026-09-04 00:00:00", tz="EST")
-        expected_end = pd.Timestamp("2026-09-04 00:05:00", tz="EST")
-        assert result.loc[0, "Time"] == expected_start
-        assert result.loc[0, "Interval Start"] == expected_start
-        assert result.loc[0, "Interval End"] == expected_end
-
     def test_get_lmp_locations(self):
         cassette_name = "test_get_lmp_locations.yaml"
         with miso_vcr.use_cassette(cassette_name):

--- a/gridstatus/tests/source_specific/test_miso.py
+++ b/gridstatus/tests/source_specific/test_miso.py
@@ -269,7 +269,7 @@ class TestMISO(BaseTestISO):
         )
         monkeypatch.setattr(self.iso, "_get_json", lambda *args, **kwargs: response)
         monkeypatch.setattr(
-            self.iso,
+            MISO,
             "_get_node_to_type_mapping",
             lambda *args, **kwargs: node_types,
         )

--- a/gridstatus/tests/source_specific/test_miso.py
+++ b/gridstatus/tests/source_specific/test_miso.py
@@ -245,10 +245,14 @@ class TestMISO(BaseTestISO):
                 date=date,
                 market=Markets.REAL_TIME_5_MIN,
             )
-            assert df["Interval Start"].min() == self.local_start_of_day(date)
-            assert df["Interval End"].max() == self.local_start_of_day(
-                date,
-            ) + pd.DateOffset(days=1)
+            assert df["Interval Start"].min() == (
+                self.local_start_of_day(date) - pd.Timedelta(minutes=5)
+            )
+            assert df["Interval End"].max() == (
+                self.local_start_of_day(date)
+                + pd.DateOffset(days=1)
+                - pd.Timedelta(minutes=5)
+            )
             assert sorted(df["Location Type"].unique()) == [
                 "Gennode",
                 "Hub",


### PR DESCRIPTION
## Issue

MISO’s public five-minute LMP feed labels `INTERVAL` with the interval-ending timestamp. We currently interpret it as `Interval Start`, making both interval columns five minutes late.

This parser feeds these `gs-etl` datasets:

- `miso_lmp_real_time_5_min`
- `miso_lmp_real_time_5_min_ex_post_prelim`

## Fix

Treat the raw value as `Interval End` and derive `Interval Start` by subtracting five minutes. A focused regression test verifies the mapping.

The corresponding historical database correction is intentionally handled in a separate `gs-etl` migration so this PR changes only new scraper output.

## Validation

- Focused MISO parser test passes.
- Ruff lint and formatting pass.